### PR TITLE
Add configuration for JMX base name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
+        <dep.jmxutils.version>1.20</dep.jmxutils.version>
 
         <!--
           America/Bahia_Banderas has:

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ConnectorObjectNameGeneratorModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ConnectorObjectNameGeneratorModule.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.configuration.Config;
+import org.weakref.jmx.ObjectNameBuilder;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+// Note: There are multiple copies of this class in the codebase.  If you change one you, should change them all.
+public class ConnectorObjectNameGeneratorModule
+        implements Module
+{
+    private static final String CONNECTOR_PACKAGE_NAME = "io.prestosql.plugin.hive";
+    private static final String DEFAULT_DOMAIN_BASE = "presto.plugin.hive";
+
+    private final String catalogName;
+
+    public ConnectorObjectNameGeneratorModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(ConnectorObjectNameGeneratorConfig.class);
+    }
+
+    @Provides
+    ObjectNameGenerator createPrefixObjectNameGenerator(ConnectorObjectNameGeneratorConfig config)
+    {
+        String domainBase = firstNonNull(config.getDomainBase(), DEFAULT_DOMAIN_BASE);
+        return new ConnectorObjectNameGenerator(domainBase, catalogName);
+    }
+
+    public static class ConnectorObjectNameGeneratorConfig
+    {
+        private String domainBase;
+
+        public String getDomainBase()
+        {
+            return domainBase;
+        }
+
+        @Config("jmx.base-name")
+        public ConnectorObjectNameGeneratorConfig setDomainBase(String domainBase)
+        {
+            this.domainBase = domainBase;
+            return this;
+        }
+    }
+
+    public static final class ConnectorObjectNameGenerator
+            implements ObjectNameGenerator
+    {
+        private final String domainBase;
+        private final String catalogName;
+
+        public ConnectorObjectNameGenerator(String domainBase, String catalogName)
+        {
+            this.domainBase = domainBase;
+            this.catalogName = catalogName;
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .put("type", type.getSimpleName())
+                    .put("name", catalogName)
+                    .build())
+                    .build();
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .putAll(properties)
+                    .put("catalog", catalogName)
+                    .build())
+                    .build();
+        }
+
+        private String toDomain(Class<?> type)
+        {
+            String domain = type.getPackage().getName();
+            if (domain.startsWith(CONNECTOR_PACKAGE_NAME)) {
+                domain = domainBase + domain.substring(CONNECTOR_PACKAGE_NAME.length());
+            }
+            return domain;
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
@@ -43,7 +43,6 @@ import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newFixedThreadPool;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class HiveClientModule
@@ -73,7 +72,7 @@ public class HiveClientModule
         binder.bind(HiveTableProperties.class).in(Scopes.SINGLETON);
 
         binder.bind(NamenodeStats.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(NamenodeStats.class).as(generatedNameOf(NamenodeStats.class, connectorId));
+        newExporter(binder).export(NamenodeStats.class).withGeneratedName();
 
         binder.bind(PrestoS3ClientFactory.class).in(Scopes.SINGLETON);
 
@@ -82,7 +81,7 @@ public class HiveClientModule
         recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
 
         binder.bind(HiveWriterStats.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(HiveWriterStats.class).as(generatedNameOf(HiveWriterStats.class, connectorId));
+        newExporter(binder).export(HiveWriterStats.class).withGeneratedName();
 
         newSetBinder(binder, EventClient.class).addBinding().to(HiveEventClient.class).in(Scopes.SINGLETON);
         binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
@@ -92,7 +91,7 @@ public class HiveClientModule
         binder.bind(new TypeLiteral<Supplier<TransactionalMetadata>>() {}).to(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(HiveSplitManager.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(ConnectorSplitManager.class).as(generatedNameOf(HiveSplitManager.class, connectorId));
+        newExporter(binder).export(ConnectorSplitManager.class).as(generator -> generator.generatedNameOf(HiveSplitManager.class));
         binder.bind(ConnectorPageSourceProvider.class).to(HivePageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(HivePageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorNodePartitioningProvider.class).to(HiveNodePartitioningProvider.class).in(Scopes.SINGLETON);
@@ -100,7 +99,7 @@ public class HiveClientModule
         jsonCodecBinder(binder).bindJsonCodec(PartitionUpdate.class);
 
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(FileFormatDataSourceStats.class).as(generatedNameOf(FileFormatDataSourceStats.class, connectorId));
+        newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
         Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
@@ -110,7 +109,7 @@ public class HiveClientModule
 
         Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
         binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(OrcFileWriterFactory.class).as(generatedNameOf(OrcFileWriterFactory.class, connectorId));
+        newExporter(binder).export(OrcFileWriterFactory.class).withGeneratedName();
         configBinder(binder).bindConfig(OrcFileWriterConfig.class);
         fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
@@ -96,10 +96,11 @@ public class HiveConnectorFactory
             Bootstrap app = new Bootstrap(
                     new EventModule(),
                     new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName),
                     new JsonModule(),
                     new HiveClientModule(catalogName),
-                    new HiveS3Module(catalogName),
-                    new HiveMetastoreModule(catalogName, metastore),
+                    new HiveS3Module(),
+                    new HiveMetastoreModule(metastore),
                     new HiveSecurityModule(),
                     new HiveAuthenticationModule(),
                     new HiveProcedureModule(),

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastoreModule.java
@@ -27,12 +27,10 @@ import static io.airlift.configuration.ConditionalModule.installModuleIf;
 public class HiveMetastoreModule
         extends AbstractConfigurationAwareModule
 {
-    private final String connectorId;
     private final Optional<ExtendedHiveMetastore> metastore;
 
-    public HiveMetastoreModule(String connectorId, Optional<ExtendedHiveMetastore> metastore)
+    public HiveMetastoreModule(Optional<ExtendedHiveMetastore> metastore)
     {
-        this.connectorId = connectorId;
         this.metastore = metastore;
     }
 
@@ -43,9 +41,9 @@ public class HiveMetastoreModule
             binder.bind(ExtendedHiveMetastore.class).toInstance(metastore.get());
         }
         else {
-            bindMetastoreModule("thrift", new ThriftMetastoreModule(connectorId));
-            bindMetastoreModule("file", new FileMetastoreModule(connectorId));
-            bindMetastoreModule("glue", new GlueMetastoreModule(connectorId));
+            bindMetastoreModule("thrift", new ThriftMetastoreModule());
+            bindMetastoreModule("file", new FileMetastoreModule());
+            bindMetastoreModule("glue", new GlueMetastoreModule());
         }
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileMetastoreModule.java
@@ -21,20 +21,11 @@ import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class FileMetastoreModule
         implements Module
 {
-    private final String connectorId;
-
-    public FileMetastoreModule(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
@@ -42,6 +33,6 @@ public class FileMetastoreModule
         binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(FileHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)
-                .as(generatedNameOf(CachingHiveMetastore.class, connectorId));
+                .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -19,26 +19,17 @@ import com.google.inject.Scopes;
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class GlueMetastoreModule
         implements Module
 {
-    private final String connectorId;
-
-    public GlueMetastoreModule(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
         binder.bind(ExtendedHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)
-                .as(generatedNameOf(GlueHiveMetastore.class, connectorId));
+                .as(generator -> generator.generatedNameOf(GlueHiveMetastore.class));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -24,20 +24,11 @@ import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.RecordingHiveMetastore;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class ThriftMetastoreModule
         extends AbstractConfigurationAwareModule
 {
-    private final String connectorId;
-
-    public ThriftMetastoreModule(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
-
     @Override
     protected void setup(Binder binder)
     {
@@ -57,8 +48,7 @@ public class ThriftMetastoreModule
                     .to(RecordingHiveMetastore.class)
                     .in(Scopes.SINGLETON);
             binder.bind(RecordingHiveMetastore.class).in(Scopes.SINGLETON);
-            newExporter(binder).export(RecordingHiveMetastore.class)
-                    .as(generatedNameOf(RecordingHiveMetastore.class, connectorId));
+            newExporter(binder).export(RecordingHiveMetastore.class);
         }
         else {
             binder.bind(ExtendedHiveMetastore.class)
@@ -69,8 +59,8 @@ public class ThriftMetastoreModule
 
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(HiveMetastore.class)
-                .as(generatedNameOf(ThriftHiveMetastore.class, connectorId));
+                .as(generator -> generator.generatedNameOf(ThriftHiveMetastore.class));
         newExporter(binder).export(ExtendedHiveMetastore.class)
-                .as(generatedNameOf(CachingHiveMetastore.class, connectorId));
+                .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
@@ -21,21 +21,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JavaUtils;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class HiveS3Module
         extends AbstractConfigurationAwareModule
 {
     private static final String EMR_FS_CLASS_NAME = "com.amazon.ws.emr.hadoop.fs.EmrFileSystem";
-
-    private final String connectorId;
-
-    public HiveS3Module(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
 
     @Override
     protected void setup(Binder binder)
@@ -46,7 +37,8 @@ public class HiveS3Module
             configBinder(binder).bindConfig(HiveS3Config.class);
 
             binder.bind(PrestoS3FileSystemStats.class).toInstance(PrestoS3FileSystem.getFileSystemStats());
-            newExporter(binder).export(PrestoS3FileSystemStats.class).as(generatedNameOf(PrestoS3FileSystem.class, connectorId));
+            newExporter(binder).export(PrestoS3FileSystemStats.class)
+                    .as(generator -> generator.generatedNameOf(PrestoS3FileSystem.class));
         }
         else if (type == S3FileSystemType.EMRFS) {
             validateEmrFsClass();

--- a/presto-main/etc/catalog/thrift.properties
+++ b/presto-main/etc/catalog/thrift.properties
@@ -1,0 +1,9 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+connector.name=presto-thrift
+presto.thrift.client.addresses=127.0.0.1:1234

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -39,6 +39,7 @@ plugin.bundles=\
   ../presto-mysql/pom.xml,\
   ../presto-sqlserver/pom.xml, \
   ../presto-postgresql/pom.xml, \
+  ../presto-thrift/pom.xml, \
   ../presto-tpcds/pom.xml
 
 presto.version=testversion

--- a/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
@@ -169,7 +169,7 @@ public class ConnectorManager
     {
         requireNonNull(connectorName, "connectorName is null");
         ConnectorFactory connectorFactory = connectorFactories.get(connectorName);
-        checkArgument(connectorFactory != null, "No factory for connector %s", connectorName);
+        checkArgument(connectorFactory != null, "No factory for connector [%s].  Available factories: %s", connectorName, connectorFactories.keySet());
         return createConnection(catalogName, connectorFactory, properties);
     }
 

--- a/presto-main/src/main/java/io/prestosql/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourceGroups/InternalResourceGroupManager.java
@@ -32,7 +32,6 @@ import io.prestosql.sql.tree.Statement;
 import org.weakref.jmx.JmxException;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.Managed;
-import org.weakref.jmx.ObjectNames;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -237,13 +236,12 @@ public final class InternalResourceGroupManager<C>
 
     private void exportGroup(InternalResourceGroup group, Boolean export)
     {
-        String objectName = ObjectNames.builder(InternalResourceGroup.class, group.getId().toString()).build();
         try {
             if (export) {
-                exporter.export(objectName, group);
+                exporter.exportWithGeneratedName(group, InternalResourceGroup.class, group.getId().toString());
             }
             else {
-                exporter.unexport(objectName);
+                exporter.unexportWithGeneratedName(InternalResourceGroup.class, group.getId().toString());
             }
         }
         catch (JmxException e) {

--- a/presto-main/src/main/java/io/prestosql/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/io/prestosql/memory/ClusterMemoryManager.java
@@ -186,7 +186,7 @@ public class ClusterMemoryManager
             ClusterMemoryPool pool = new ClusterMemoryPool(poolId);
             builder.put(poolId, pool);
             try {
-                exporter.export(generatedNameOf(ClusterMemoryPool.class, poolId.toString()), pool);
+                exporter.exportWithGeneratedName(pool, ClusterMemoryPool.class, poolId.toString());
             }
             catch (JmxException e) {
                 log.error(e, "Error exporting memory pool %s", poolId);

--- a/presto-main/src/main/java/io/prestosql/memory/LocalMemoryManagerExporter.java
+++ b/presto-main/src/main/java/io/prestosql/memory/LocalMemoryManagerExporter.java
@@ -44,8 +44,7 @@ public final class LocalMemoryManagerExporter
     private synchronized void addPool(MemoryPool pool)
     {
         try {
-            String objectName = ObjectNames.builder(MemoryPool.class, pool.getId().toString()).build();
-            exporter.export(objectName, pool);
+            exporter.exportWithGeneratedName(pool, MemoryPool.class, pool.getId().toString());
             pools.add(pool);
         }
         catch (JmxException e) {

--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -152,7 +152,6 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class CoordinatorModule
@@ -268,7 +267,8 @@ public class CoordinatorModule
         binder.bind(ExecutorService.class).annotatedWith(ForQueryExecution.class)
                 .toInstance(newCachedThreadPool(threadsNamed("query-execution-%s")));
         binder.bind(QueryExecutionMBean.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(QueryExecutionMBean.class).as(generatedNameOf(QueryExecution.class));
+        newExporter(binder).export(QueryExecutionMBean.class)
+                .as(generator -> generator.generatedNameOf(QueryExecution.class));
 
         MapBinder<Class<? extends Statement>, QueryExecutionFactory<?>> executionBinder = newMapBinder(binder,
                 new TypeLiteral<Class<? extends Statement>>() {}, new TypeLiteral<QueryExecutionFactory<?>>() {});

--- a/presto-main/src/main/java/io/prestosql/server/JmxNamingConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/JmxNamingConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import io.airlift.configuration.Config;
+
+public class JmxNamingConfig
+{
+    private String domainBase = "presto";
+
+    public String getDomainBase()
+    {
+        return domainBase;
+    }
+
+    @Config("jmx.base-name")
+    public JmxNamingConfig setDomainBase(String domainBase)
+    {
+        this.domainBase = domainBase;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/PrefixObjectNameGeneratorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrefixObjectNameGeneratorModule.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import org.weakref.jmx.ObjectNameBuilder;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Replaces the prefix given by {@code packagePrefix} with the domain base provided via configuration.
+ */
+public class PrefixObjectNameGeneratorModule
+        implements Module
+{
+    private final String packagePrefix;
+
+    public PrefixObjectNameGeneratorModule(String packagePrefix)
+    {
+        this.packagePrefix = requireNonNull(packagePrefix, "packagePrefix is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(JmxNamingConfig.class);
+    }
+
+    @Provides
+    ObjectNameGenerator createPrefixObjectNameGenerator(JmxNamingConfig jmxNamingConfig)
+    {
+        return new PrefixObjectNameGenerator(packagePrefix, jmxNamingConfig.getDomainBase());
+    }
+
+    public static final class PrefixObjectNameGenerator
+            implements ObjectNameGenerator
+    {
+        private final String packagePrefix;
+        private final String replacement;
+
+        public PrefixObjectNameGenerator(String packagePrefix, String replacement)
+        {
+            this.packagePrefix = packagePrefix;
+            this.replacement = replacement;
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            String domain = type.getPackage().getName();
+            if (domain.startsWith(packagePrefix)) {
+                domain = replacement + domain.substring(packagePrefix.length());
+            }
+
+            return new ObjectNameBuilder(domain)
+                    .withProperties(properties)
+                    .build();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
@@ -96,6 +96,7 @@ public class PrestoServer
                 new JsonModule(),
                 new JaxrsModule(true),
                 new MBeanModule(),
+                new PrefixObjectNameGeneratorModule("io.prestosql"),
                 new JmxModule(),
                 new JmxHttpModule(),
                 new LogJmxModule(),

--- a/presto-main/src/test/java/io/prestosql/server/TestJmxNamingConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestJmxNamingConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestJmxNamingConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(JmxNamingConfig.class)
+                .setDomainBase("presto"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("jmx.base-name", "my.stuff")
+                .build();
+
+        JmxNamingConfig expected = new JmxNamingConfig()
+                .setDomainBase("my.stuff");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/ConnectorObjectNameGeneratorModule.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/ConnectorObjectNameGeneratorModule.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.raptor.legacy;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.configuration.Config;
+import org.weakref.jmx.ObjectNameBuilder;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+// Note: There are multiple copies of this class in the codebase.  If you change one you, should change them all.
+public class ConnectorObjectNameGeneratorModule
+        implements Module
+{
+    private static final String CONNECTOR_PACKAGE_NAME = "io.prestosql.plugin.raptor.legacy";
+    private static final String DEFAULT_DOMAIN_BASE = "presto.plugin.raptor.legacy";
+
+    private final String catalogName;
+
+    public ConnectorObjectNameGeneratorModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(ConnectorObjectNameGeneratorConfig.class);
+    }
+
+    @Provides
+    ObjectNameGenerator createPrefixObjectNameGenerator(ConnectorObjectNameGeneratorConfig config)
+    {
+        String domainBase = firstNonNull(config.getDomainBase(), DEFAULT_DOMAIN_BASE);
+        return new ConnectorObjectNameGenerator(domainBase, catalogName);
+    }
+
+    public static class ConnectorObjectNameGeneratorConfig
+    {
+        private String domainBase;
+
+        public String getDomainBase()
+        {
+            return domainBase;
+        }
+
+        @Config("jmx.base-name")
+        public ConnectorObjectNameGeneratorConfig setDomainBase(String domainBase)
+        {
+            this.domainBase = domainBase;
+            return this;
+        }
+    }
+
+    public static final class ConnectorObjectNameGenerator
+            implements ObjectNameGenerator
+    {
+        private final String domainBase;
+        private final String catalogName;
+
+        public ConnectorObjectNameGenerator(String domainBase, String catalogName)
+        {
+            this.domainBase = domainBase;
+            this.catalogName = catalogName;
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .put("type", type.getSimpleName())
+                    .put("name", catalogName)
+                    .build())
+                    .build();
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .putAll(properties)
+                    .put("catalog", catalogName)
+                    .build())
+                    .build();
+        }
+
+        private String toDomain(Class<?> type)
+        {
+            String domain = type.getPackage().getName();
+            if (domain.startsWith(CONNECTOR_PACKAGE_NAME)) {
+                domain = domainBase + domain.substring(CONNECTOR_PACKAGE_NAME.length());
+            }
+            return domain;
+        }
+    }
+}

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorConnectorFactory.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorConnectorFactory.java
@@ -76,6 +76,7 @@ public class RaptorConnectorFactory
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName),
                     binder -> {
                         MBeanServer mbeanServer = new RebindSafeMBeanServer(getPlatformMBeanServer());
                         binder.bind(MBeanServer.class).toInstance(mbeanServer);
@@ -85,7 +86,7 @@ public class RaptorConnectorFactory
                     },
                     metadataModule,
                     new BackupModule(backupProviders),
-                    new StorageModule(catalogName),
+                    new StorageModule(),
                     new RaptorModule(catalogName),
                     new RaptorSecurityModule());
 

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/backup/BackupModule.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/backup/BackupModule.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 
 public class BackupModule
         extends AbstractConfigurationAwareModule
@@ -95,7 +94,7 @@ public class BackupModule
         lifeCycleManager.addInstance(proxy);
 
         BackupStore managed = new ManagedBackupStore(proxy);
-        exporter.export(generatedNameOf(BackupStore.class, connectorId.toString()), managed);
+        exporter.exportWithGeneratedName(managed, BackupStore.class, connectorId.toString());
 
         return Optional.of(managed);
     }

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/StorageModule.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/StorageModule.java
@@ -35,20 +35,11 @@ import io.prestosql.plugin.raptor.legacy.storage.organization.ShardOrganizer;
 import io.prestosql.plugin.raptor.legacy.storage.organization.TemporalFunction;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static java.util.Objects.requireNonNull;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class StorageModule
         implements Module
 {
-    private final String connectorId;
-
-    public StorageModule(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
@@ -79,15 +70,15 @@ public class StorageModule
         binder.bind(AssignmentLimiter.class).in(Scopes.SINGLETON);
         binder.bind(TemporalFunction.class).in(Scopes.SINGLETON);
 
-        newExporter(binder).export(ShardRecoveryManager.class).as(generatedNameOf(ShardRecoveryManager.class, connectorId));
-        newExporter(binder).export(BackupManager.class).as(generatedNameOf(BackupManager.class, connectorId));
-        newExporter(binder).export(StorageManager.class).as(generatedNameOf(OrcStorageManager.class, connectorId));
-        newExporter(binder).export(ShardCompactionManager.class).as(generatedNameOf(ShardCompactionManager.class, connectorId));
-        newExporter(binder).export(ShardOrganizer.class).as(generatedNameOf(ShardOrganizer.class, connectorId));
-        newExporter(binder).export(ShardCompactor.class).as(generatedNameOf(ShardCompactor.class, connectorId));
-        newExporter(binder).export(ShardEjector.class).as(generatedNameOf(ShardEjector.class, connectorId));
-        newExporter(binder).export(ShardCleaner.class).as(generatedNameOf(ShardCleaner.class, connectorId));
-        newExporter(binder).export(BucketBalancer.class).as(generatedNameOf(BucketBalancer.class, connectorId));
+        newExporter(binder).export(ShardRecoveryManager.class).withGeneratedName();
+        newExporter(binder).export(BackupManager.class).withGeneratedName();
+        newExporter(binder).export(StorageManager.class).as(generator -> generator.generatedNameOf(OrcStorageManager.class));
+        newExporter(binder).export(ShardCompactionManager.class).withGeneratedName();
+        newExporter(binder).export(ShardOrganizer.class).withGeneratedName();
+        newExporter(binder).export(ShardCompactor.class).withGeneratedName();
+        newExporter(binder).export(ShardEjector.class).withGeneratedName();
+        newExporter(binder).export(ShardCleaner.class).withGeneratedName();
+        newExporter(binder).export(BucketBalancer.class).withGeneratedName();
         newExporter(binder).export(JobFactory.class).withGeneratedName();
     }
 }

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -42,6 +42,7 @@ public class DbResourceGroupConfigurationManagerFactory
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new DbResourceGroupsModule(),
+                    new PrefixObjectNameGeneratorModule(),
                     binder -> binder.bind(String.class).annotatedWith(ForEnvironment.class).toInstance(context.getEnvironment()),
                     binder -> binder.bind(ClusterMemoryPoolManager.class).toInstance(context.getMemoryPoolManager()));
 

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/PrefixObjectNameGeneratorModule.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/PrefixObjectNameGeneratorModule.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.resourcegroups.db;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.configuration.Config;
+import org.weakref.jmx.ObjectNameBuilder;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class PrefixObjectNameGeneratorModule
+        implements Module
+{
+    private static final String CONNECTOR_PACKAGE_NAME = "io.prestosql.plugin.resourcegroups.db";
+    private static final String DEFAULT_DOMAIN_BASE = "presto.plugin.resourcegroups.db";
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(PrefixObjectNameGeneratorConfig.class);
+    }
+
+    @Provides
+    ObjectNameGenerator createPrefixObjectNameGenerator(PrefixObjectNameGeneratorConfig config)
+    {
+        String domainBase = DEFAULT_DOMAIN_BASE;
+        if (config.getDomainBase() != null) {
+            domainBase = config.getDomainBase();
+        }
+        return new PrefixObjectNameGenerator(domainBase);
+    }
+
+    public static class PrefixObjectNameGeneratorConfig
+    {
+        private String domainBase;
+
+        public String getDomainBase()
+        {
+            return domainBase;
+        }
+
+        @Config("jmx.base-name")
+        public PrefixObjectNameGeneratorConfig setDomainBase(String domainBase)
+        {
+            this.domainBase = domainBase;
+            return this;
+        }
+    }
+
+    public static final class PrefixObjectNameGenerator
+            implements ObjectNameGenerator
+    {
+        private final String domainBase;
+
+        public PrefixObjectNameGenerator(String domainBase)
+        {
+            this.domainBase = domainBase;
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(properties)
+                    .build();
+        }
+
+        private String toDomain(Class<?> type)
+        {
+            String domain = type.getPackage().getName();
+            if (domain.startsWith(CONNECTOR_PACKAGE_NAME)) {
+                domain = domainBase + domain.substring(CONNECTOR_PACKAGE_NAME.length());
+            }
+            return domain;
+        }
+    }
+}

--- a/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ConnectorObjectNameGeneratorModule.java
+++ b/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ConnectorObjectNameGeneratorModule.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.configuration.Config;
+import org.weakref.jmx.ObjectNameBuilder;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+// Note: There are multiple copies of this class in the codebase.  If you change one you, should change them all.
+public class ConnectorObjectNameGeneratorModule
+        implements Module
+{
+    private static final String CONNECTOR_PACKAGE_NAME = "io.prestosql.plugin.thrift";
+    private static final String DEFAULT_DOMAIN_BASE = "presto.plugin.thrift";
+
+    private final String catalogName;
+
+    public ConnectorObjectNameGeneratorModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(ConnectorObjectNameGeneratorConfig.class);
+    }
+
+    @Provides
+    ObjectNameGenerator createPrefixObjectNameGenerator(ConnectorObjectNameGeneratorConfig config)
+    {
+        String domainBase = firstNonNull(config.getDomainBase(), DEFAULT_DOMAIN_BASE);
+        return new ConnectorObjectNameGenerator(domainBase, catalogName);
+    }
+
+    public static class ConnectorObjectNameGeneratorConfig
+    {
+        private String domainBase;
+
+        public String getDomainBase()
+        {
+            return domainBase;
+        }
+
+        @Config("jmx.base-name")
+        public ConnectorObjectNameGeneratorConfig setDomainBase(String domainBase)
+        {
+            this.domainBase = domainBase;
+            return this;
+        }
+    }
+
+    public static final class ConnectorObjectNameGenerator
+            implements ObjectNameGenerator
+    {
+        private final String domainBase;
+        private final String catalogName;
+
+        public ConnectorObjectNameGenerator(String domainBase, String catalogName)
+        {
+            this.domainBase = domainBase;
+            this.catalogName = catalogName;
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .put("type", type.getSimpleName())
+                    .put("name", catalogName)
+                    .build())
+                    .build();
+        }
+
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                    .putAll(properties)
+                    .put("catalog", catalogName)
+                    .build())
+                    .build();
+        }
+
+        private String toDomain(Class<?> type)
+        {
+            String domain = type.getPackage().getName();
+            if (domain.startsWith(CONNECTOR_PACKAGE_NAME)) {
+                domain = domainBase + domain.substring(CONNECTOR_PACKAGE_NAME.length());
+            }
+            return domain;
+        }
+    }
+}

--- a/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ThriftConnectorFactory.java
@@ -63,13 +63,14 @@ public class ThriftConnectorFactory
         try {
             Bootstrap app = new Bootstrap(
                     new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName),
                     new DriftNettyClientModule(),
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                     },
                     locationModule,
-                    new ThriftModule(catalogName));
+                    new ThriftModule());
 
             Injector injector = app
                     .strictConfig()

--- a/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ThriftModule.java
+++ b/presto-thrift/src/main/java/io/prestosql/plugin/thrift/ThriftModule.java
@@ -32,21 +32,12 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.drift.client.ExceptionClassification.NORMAL_EXCEPTION;
 import static io.airlift.drift.client.guice.DriftClientBinder.driftClientBinder;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
-import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class ThriftModule
         implements Module
 {
-    private final String connectorId;
-
-    public ThriftModule(String connectorId)
-    {
-        this.connectorId = requireNonNull(connectorId, "connectorId is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
@@ -68,8 +59,7 @@ public class ThriftModule
         binder.bind(ThriftSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(ThriftIndexProvider.class).in(Scopes.SINGLETON);
         binder.bind(ThriftConnectorStats.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(ThriftConnectorStats.class)
-                .as(generatedNameOf(ThriftConnectorStats.class, connectorId));
+        newExporter(binder).export(ThriftConnectorStats.class).withGeneratedName();
     }
 
     @Provides


### PR DESCRIPTION
This PR uses the new JMX Utils apis to replace the automatic object name generator.  This PR does the following:
* Move all JMX objects from `io.prestosql.*` to just `presto.*`
* Adds `jmx.base-name` config so `presto.*` can be changed to something else
* Modifies built-in plugins to move all JMX objects from `io.prestosql.plugin.NAME.*` to just `presto.plugin.NAME*`
* Adds to `jmx.base-name` config to all built-in plugins so `presto.plugin.NAME.*` can be changed to something else
