### PR TITLE
Add write_hive_metastore_recording procedure

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/WriteHiveMetastoreRecordingProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/WriteHiveMetastoreRecordingProcedure.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.RateLimiter;
+import io.prestosql.spi.procedure.Procedure;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+
+import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
+import static java.util.Objects.requireNonNull;
+
+public class WriteHiveMetastoreRecordingProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle WRITE_HIVE_METASTORE_RECORDING = methodHandle(
+            WriteHiveMetastoreRecordingProcedure.class,
+            "writeHiveMetastoreRecording");
+
+    private final RateLimiter rateLimiter = RateLimiter.create(0.2);
+    private final RecordingHiveMetastore recordingHiveMetastore;
+
+    @Inject
+    public WriteHiveMetastoreRecordingProcedure(RecordingHiveMetastore recordingHiveMetastore)
+    {
+        this.recordingHiveMetastore = requireNonNull(recordingHiveMetastore, "recordingHiveMetastore is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "write_hive_metastore_recording",
+                ImmutableList.of(),
+                WRITE_HIVE_METASTORE_RECORDING.bindTo(this));
+    }
+
+    public void writeHiveMetastoreRecording()
+    {
+        try {
+            // limit rate of recording dumps to prevent IO and Presto saturation
+            rateLimiter.acquire();
+            recordingHiveMetastore.writeRecording();
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.prestosql.plugin.hive.ForCachingHiveMetastore;
 import io.prestosql.plugin.hive.ForRecordingHiveMetastore;
@@ -22,7 +23,10 @@ import io.prestosql.plugin.hive.HiveClientConfig;
 import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.RecordingHiveMetastore;
+import io.prestosql.plugin.hive.metastore.WriteHiveMetastoreRecordingProcedure;
+import io.prestosql.spi.procedure.Procedure;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
@@ -49,6 +53,9 @@ public class ThriftMetastoreModule
                     .in(Scopes.SINGLETON);
             binder.bind(RecordingHiveMetastore.class).in(Scopes.SINGLETON);
             newExporter(binder).export(RecordingHiveMetastore.class);
+
+            Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
+            procedures.addBinding().toProvider(WriteHiveMetastoreRecordingProcedure.class).in(Scopes.SINGLETON);
         }
         else {
             binder.bind(ExtendedHiveMetastore.class)


### PR DESCRIPTION
The procedure will cause Hive metastore recording
to be written. This is more user friendly than JMX endpoint.