### PR TITLE
Make hive temporary staging directory location configurable

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientConfig.java
@@ -149,6 +149,7 @@ public class HiveClientConfig
     private int s3SelectPushdownMaxConnections = 500;
 
     private boolean isTemporaryStagingDirectoryEnabled = true;
+    private String temporaryStagingDirectoryPath = "/tmp/presto-${USER}";
 
     public int getMaxInitialSplits()
     {
@@ -1204,5 +1205,19 @@ public class HiveClientConfig
     public boolean isTemporaryStagingDirectoryEnabled()
     {
         return isTemporaryStagingDirectoryEnabled;
+    }
+
+    @Config("hive.temporary-staging-directory-path")
+    @ConfigDescription("Location of temporary staging directory for write operations. Use ${USER} placeholder to use different location for each user.")
+    public HiveClientConfig setTemporaryStagingDirectoryPath(String temporaryStagingDirectoryPath)
+    {
+        this.temporaryStagingDirectoryPath = temporaryStagingDirectoryPath;
+        return this;
+    }
+
+    @NotNull
+    public String getTemporaryStagingDirectoryPath()
+    {
+        return temporaryStagingDirectoryPath;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientConfig.java
@@ -148,6 +148,8 @@ public class HiveClientConfig
     private boolean s3SelectPushdownEnabled;
     private int s3SelectPushdownMaxConnections = 500;
 
+    private boolean isTemporaryStagingDirectoryEnabled = true;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1189,5 +1191,18 @@ public class HiveClientConfig
     {
         this.s3SelectPushdownMaxConnections = s3SelectPushdownMaxConnections;
         return this;
+    }
+
+    @Config("hive.temporary-staging-directory-enabled")
+    @ConfigDescription("Should use (if possible) temporary staging directory for write operations")
+    public HiveClientConfig setTemporaryStagingDirectoryEnabled(boolean temporaryStagingDirectoryEnabled)
+    {
+        this.isTemporaryStagingDirectoryEnabled = temporaryStagingDirectoryEnabled;
+        return this;
+    }
+
+    public boolean isTemporaryStagingDirectoryEnabled()
+    {
+        return isTemporaryStagingDirectoryEnabled;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -61,7 +61,7 @@ public class HiveLocationService
         }
 
         if (shouldUseTemporaryDirectory(session, context, targetPath)) {
-            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {
@@ -76,7 +76,7 @@ public class HiveLocationService
         Path targetPath = new Path(table.getStorage().getLocation());
 
         if (shouldUseTemporaryDirectory(session, context, targetPath)) {
-            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PATH_ALREADY_EXISTS;
+import static io.prestosql.plugin.hive.HiveSessionProperties.isTemporaryStagingDirectoryEnabled;
 import static io.prestosql.plugin.hive.HiveWriteUtils.createTemporaryPath;
 import static io.prestosql.plugin.hive.HiveWriteUtils.getTableDefaultLocation;
 import static io.prestosql.plugin.hive.HiveWriteUtils.isS3FileSystem;
@@ -59,7 +60,7 @@ public class HiveLocationService
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
 
-        if (shouldUseTemporaryDirectory(context, targetPath)) {
+        if (shouldUseTemporaryDirectory(session, context, targetPath)) {
             Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
@@ -74,7 +75,7 @@ public class HiveLocationService
         HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         Path targetPath = new Path(table.getStorage().getLocation());
 
-        if (shouldUseTemporaryDirectory(context, targetPath)) {
+        if (shouldUseTemporaryDirectory(session, context, targetPath)) {
             Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
@@ -83,10 +84,11 @@ public class HiveLocationService
         }
     }
 
-    private boolean shouldUseTemporaryDirectory(HdfsContext context, Path path)
+    private boolean shouldUseTemporaryDirectory(ConnectorSession session, HdfsContext context, Path path)
     {
-        // skip using temporary directory for S3
-        return !isS3FileSystem(context, hdfsEnvironment, path);
+        return isTemporaryStagingDirectoryEnabled(session)
+                // skip using temporary directory for S3
+                && !isS3FileSystem(context, hdfsEnvironment, path);
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -76,6 +76,7 @@ public final class HiveSessionProperties
     private static final String COLLECT_COLUMN_STATISTICS_ON_WRITE = "collect_column_statistics_on_write";
     private static final String OPTIMIZE_MISMATCHED_BUCKET_COUNT = "optimize_mismatched_bucket_count";
     private static final String S3_SELECT_PUSHDOWN_ENABLED = "s3_select_pushdown_enabled";
+    private static final String TEMPORARY_STAGING_DIRECTORY_ENABLED = "temporary_staging_directory_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -296,6 +297,11 @@ public final class HiveSessionProperties
                         S3_SELECT_PUSHDOWN_ENABLED,
                         "S3 Select pushdown enabled",
                         hiveClientConfig.isS3SelectPushdownEnabled(),
+                        false),
+                booleanProperty(
+                        TEMPORARY_STAGING_DIRECTORY_ENABLED,
+                        "Should use temporary staging directory for write operations",
+                        hiveClientConfig.isTemporaryStagingDirectoryEnabled(),
                         false));
     }
 
@@ -493,6 +499,11 @@ public final class HiveSessionProperties
     public static boolean isOptimizedMismatchedBucketCount(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZE_MISMATCHED_BUCKET_COUNT, Boolean.class);
+    }
+
+    public static boolean isTemporaryStagingDirectoryEnabled(ConnectorSession session)
+    {
+        return session.getProperty(TEMPORARY_STAGING_DIRECTORY_ENABLED, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -77,6 +77,7 @@ public final class HiveSessionProperties
     private static final String OPTIMIZE_MISMATCHED_BUCKET_COUNT = "optimize_mismatched_bucket_count";
     private static final String S3_SELECT_PUSHDOWN_ENABLED = "s3_select_pushdown_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_ENABLED = "temporary_staging_directory_enabled";
+    private static final String TEMPORARY_STAGING_DIRECTORY_PATH = "temporary_staging_directory_path";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -302,6 +303,11 @@ public final class HiveSessionProperties
                         TEMPORARY_STAGING_DIRECTORY_ENABLED,
                         "Should use temporary staging directory for write operations",
                         hiveClientConfig.isTemporaryStagingDirectoryEnabled(),
+                        false),
+                stringProperty(
+                        TEMPORARY_STAGING_DIRECTORY_PATH,
+                        "Temporary staging directory location",
+                        hiveClientConfig.getTemporaryStagingDirectoryPath(),
                         false));
     }
 
@@ -504,6 +510,11 @@ public final class HiveSessionProperties
     public static boolean isTemporaryStagingDirectoryEnabled(ConnectorSession session)
     {
         return session.getProperty(TEMPORARY_STAGING_DIRECTORY_ENABLED, Boolean.class);
+    }
+
+    public static String getTemporaryStagingDirectoryPath(ConnectorSession session)
+    {
+        return session.getProperty(TEMPORARY_STAGING_DIRECTORY_PATH, String.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
@@ -116,6 +116,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALU
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_SERDE_NOT_FOUND;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.prestosql.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTemporaryStagingDirectoryPath;
 import static io.prestosql.plugin.hive.HiveUtil.checkCondition;
 import static io.prestosql.plugin.hive.HiveUtil.isArrayType;
 import static io.prestosql.plugin.hive.HiveUtil.isMapType;
@@ -546,10 +547,11 @@ public final class HiveWriteUtils
         }
     }
 
-    public static Path createTemporaryPath(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
+    public static Path createTemporaryPath(ConnectorSession session, HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems
-        String temporaryPrefix = "/tmp/presto-" + context.getIdentity().getUser();
+        String temporaryPrefix = getTemporaryStagingDirectoryPath(session)
+                .replace("${USER}", context.getIdentity().getUser());
 
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(context, hdfsEnvironment, targetPath)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationHandle.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationHandle.java
@@ -107,15 +107,15 @@ public class LocationHandle
     public enum WriteMode
     {
         /**
-         * common mode for new table or existing table (both new and existing partition)
+         * common mode for new table or existing table (both new and existing partition) and when staging directory is enabled
          */
         STAGE_AND_MOVE_TO_TARGET_DIRECTORY(false),
         /**
-         * for new table in S3
+         * for new table in S3 or when staging directory is disabled
          */
         DIRECT_TO_TARGET_NEW_DIRECTORY(true),
         /**
-         * for existing table in S3 (both new and existing partition)
+         * for existing table in S3 (both new and existing partition) or when staging directory is disabled
          */
         DIRECT_TO_TARGET_EXISTING_DIRECTORY(true),
         /**/;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientConfig.java
@@ -116,7 +116,8 @@ public class TestHiveClientConfig
                 .setCollectColumnStatisticsOnWrite(false)
                 .setS3SelectPushdownEnabled(false)
                 .setS3SelectPushdownMaxConnections(500)
-                .setTemporaryStagingDirectoryEnabled(true));
+                .setTemporaryStagingDirectoryEnabled(true)
+                .setTemporaryStagingDirectoryPath("/tmp/presto-${USER}"));
     }
 
     @Test
@@ -201,6 +202,7 @@ public class TestHiveClientConfig
                 .put("hive.s3select-pushdown.enabled", "true")
                 .put("hive.s3select-pushdown.max-connections", "1234")
                 .put("hive.temporary-staging-directory-enabled", "false")
+                .put("hive.temporary-staging-directory-path", "updated")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -282,7 +284,8 @@ public class TestHiveClientConfig
                 .setCollectColumnStatisticsOnWrite(true)
                 .setS3SelectPushdownEnabled(true)
                 .setS3SelectPushdownMaxConnections(1234)
-                .setTemporaryStagingDirectoryEnabled(false);
+                .setTemporaryStagingDirectoryEnabled(false)
+                .setTemporaryStagingDirectoryPath("updated");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientConfig.java
@@ -115,7 +115,8 @@ public class TestHiveClientConfig
                 .setCollectColumnStatisticsOnWrite(false)
                 .setCollectColumnStatisticsOnWrite(false)
                 .setS3SelectPushdownEnabled(false)
-                .setS3SelectPushdownMaxConnections(500));
+                .setS3SelectPushdownMaxConnections(500)
+                .setTemporaryStagingDirectoryEnabled(true));
     }
 
     @Test
@@ -199,6 +200,7 @@ public class TestHiveClientConfig
                 .put("hive.collect-column-statistics-on-write", "true")
                 .put("hive.s3select-pushdown.enabled", "true")
                 .put("hive.s3select-pushdown.max-connections", "1234")
+                .put("hive.temporary-staging-directory-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -279,7 +281,8 @@ public class TestHiveClientConfig
                 .setCollectColumnStatisticsOnWrite(true)
                 .setCollectColumnStatisticsOnWrite(true)
                 .setS3SelectPushdownEnabled(true)
-                .setS3SelectPushdownMaxConnections(1234);
+                .setS3SelectPushdownMaxConnections(1234)
+                .setTemporaryStagingDirectoryEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -117,6 +117,7 @@ import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -3192,9 +3193,9 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testTemporaryStagingDirectorySessionProperty()
+    public void testTemporaryStagingDirectorySessionProperties()
     {
-        String tableName = "test_temporary_staging_directory_session_property";
+        String tableName = "test_temporary_staging_directory_session_properties";
         assertUpdate(format("CREATE TABLE %s(i int)", tableName));
 
         Session session = Session.builder(getSession())
@@ -3203,6 +3204,15 @@ public class TestHiveIntegrationSmokeTest
 
         HiveInsertTableHandle hiveInsertTableHandle = getHiveInsertTableHandle(session, tableName);
         assertEquals(hiveInsertTableHandle.getLocationHandle().getWritePath(), hiveInsertTableHandle.getLocationHandle().getTargetPath());
+
+        session = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", "temporary_staging_directory_enabled", "true")
+                .setCatalogSessionProperty("hive", "temporary_staging_directory_path", "/tmp/custom/temporary-${USER}")
+                .build();
+
+        hiveInsertTableHandle = getHiveInsertTableHandle(session, tableName);
+        assertNotEquals(hiveInsertTableHandle.getLocationHandle().getWritePath(), hiveInsertTableHandle.getLocationHandle().getTargetPath());
+        assertTrue(hiveInsertTableHandle.getLocationHandle().getWritePath().toString().startsWith("file:/tmp/custom/temporary-"));
 
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -19,6 +19,7 @@ import com.google.common.io.Files;
 import io.prestosql.Session;
 import io.prestosql.connector.ConnectorId;
 import io.prestosql.cost.StatsAndCosts;
+import io.prestosql.metadata.InsertTableHandle;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.metadata.TableHandle;
@@ -3188,6 +3189,37 @@ public class TestHiveIntegrationSmokeTest
                 "WHERE x < 0 AND cast(p AS int) > 0");
 
         assertUpdate("DROP TABLE test_prune_failure");
+    }
+
+    @Test
+    public void testTemporaryStagingDirectorySessionProperty()
+    {
+        String tableName = "test_temporary_staging_directory_session_property";
+        assertUpdate(format("CREATE TABLE %s(i int)", tableName));
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", "temporary_staging_directory_enabled", "false")
+                .build();
+
+        HiveInsertTableHandle hiveInsertTableHandle = getHiveInsertTableHandle(session, tableName);
+        assertEquals(hiveInsertTableHandle.getLocationHandle().getWritePath(), hiveInsertTableHandle.getLocationHandle().getTargetPath());
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private HiveInsertTableHandle getHiveInsertTableHandle(Session session, String tableName)
+    {
+        Metadata metadata = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getMetadata();
+        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+                .execute(session, transactionSession -> {
+                    QualifiedObjectName objectName = new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName);
+                    Optional<TableHandle> handle = metadata.getTableHandle(transactionSession, objectName);
+                    InsertTableHandle insertTableHandle = metadata.beginInsert(transactionSession, handle.get());
+                    HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) insertTableHandle.getConnectorHandle();
+
+                    metadata.finishInsert(transactionSession, insertTableHandle, ImmutableList.of(), ImmutableList.of());
+                    return hiveInsertTableHandle;
+                });
     }
 
     private Session getParallelWriteSession()


### PR DESCRIPTION
Make hive temporary staging directory location configurable

In some deployments, /tmp cannot be used to write temporary files.
