### PR TITLE
Preserve quotedness for Identifier when formatting Query 

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataUtil.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataUtil.java
@@ -153,11 +153,6 @@ public final class MetadataUtil
         return new QualifiedObjectName(catalogName, schemaName, objectName);
     }
 
-    public static QualifiedName createQualifiedName(QualifiedObjectName name)
-    {
-        return QualifiedName.of(name.getCatalogName(), name.getSchemaName(), name.getObjectName());
-    }
-
     public static PrestoPrincipal createPrincipal(Session session, GrantorSpecification specification)
     {
         GrantorSpecification.Type type = specification.getType();

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -1672,7 +1672,7 @@ class StatementAnalyzer
 
                     if (!field.isPresent()) {
                         if (name != null) {
-                            field = Optional.of(new Identifier(getLast(name.getOriginalParts())));
+                            field = Optional.of(getLast(name.getOriginalParts()));
                         }
                     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
@@ -94,7 +94,6 @@ import static io.prestosql.connector.informationSchema.InformationSchemaMetadata
 import static io.prestosql.metadata.MetadataListing.listCatalogs;
 import static io.prestosql.metadata.MetadataListing.listSchemas;
 import static io.prestosql.metadata.MetadataUtil.createCatalogSchemaName;
-import static io.prestosql.metadata.MetadataUtil.createQualifiedName;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.prestosql.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 import static io.prestosql.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
@@ -432,7 +431,11 @@ final class ShowQueriesRewrite
                 }
 
                 Query query = parseView(viewDefinition.get().getOriginalSql(), objectName, node);
-                String sql = formatSql(new CreateView(createQualifiedName(objectName), query, false, Optional.empty()), Optional.of(parameters)).trim();
+                List<Identifier> parts = node.getName().getOriginalParts();
+                Identifier tableName = parts.get(0);
+                Identifier schemaName = (parts.size() > 1) ? parts.get(1) : new Identifier(objectName.getSchemaName());
+                Identifier catalogName = (parts.size() > 2) ? parts.get(2) : new Identifier(objectName.getCatalogName());
+                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, Optional.empty()), Optional.of(parameters)).trim();
                 return singleValueQuery("Create View", sql);
             }
 

--- a/presto-main/src/test/java/io/prestosql/sql/TestSqlFormatter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestSqlFormatter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql;
+
+import io.prestosql.sql.parser.ParsingOptions;
+import io.prestosql.sql.parser.SqlParser;
+import io.prestosql.sql.tree.Statement;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.SqlFormatterUtil.getFormattedSql;
+import static org.testng.Assert.assertEquals;
+
+public class TestSqlFormatter
+{
+    @Test
+    public void testSimpleExpression()
+    {
+        assetQuery("SELECT id\nFROM\n  public.orders\n");
+        assetQuery("SELECT id\nFROM\n  \"public\".\"order\"\n");
+        assetQuery("SELECT id\nFROM\n  \"public\".\"order\"\"2\"\n");
+    }
+
+    private void assetQuery(String query)
+    {
+        SqlParser parser = new SqlParser();
+        Statement statement = parser.createStatement(query, new ParsingOptions());
+        String formattedQuery = getFormattedSql(statement, parser, Optional.empty());
+        assertEquals(formattedQuery, query);
+    }
+}

--- a/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
@@ -858,12 +858,10 @@ public final class SqlFormatter
             return " WITH ( " + propertyList + " )";
         }
 
-        private static String formatName(String name)
+        private static String formatName(Identifier name)
         {
-            if (NAME_PATTERN.matcher(name).matches()) {
-                return name;
-            }
-            return "\"" + name.replace("\"", "\"\"") + "\"";
+            String delimiter = name.isDelimited() ? "\"" : "";
+            return delimiter + name.getValue().replace("\"", "\"\"") + delimiter;
         }
 
         private static String formatName(QualifiedName name)

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
@@ -1933,11 +1933,7 @@ class AstBuilder
 
     private QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
     {
-        List<String> parts = visit(context.identifier(), Identifier.class).stream()
-                .map(Identifier::getValue) // TODO: preserve quotedness
-                .collect(Collectors.toList());
-
-        return QualifiedName.of(parts);
+        return QualifiedName.of(visit(context.identifier(), Identifier.class));
     }
 
     private static boolean isDistinct(SqlBaseParser.SetQuantifierContext setQuantifier)

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/DereferenceExpression.java
@@ -15,9 +15,7 @@ package io.prestosql.sql.tree;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -76,7 +74,20 @@ public class DereferenceExpression
      */
     public static QualifiedName getQualifiedName(DereferenceExpression expression)
     {
-        List<String> parts = tryParseParts(expression.base, expression.field.getValue().toLowerCase(Locale.ENGLISH));
+        List<Identifier> parts = null;
+        if (expression.base instanceof Identifier) {
+            parts = ImmutableList.of((Identifier) expression.base, expression.field);
+        }
+        else if (expression.base instanceof DereferenceExpression) {
+            QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) expression.base);
+            if (baseQualifiedName != null) {
+                ImmutableList.Builder<Identifier> builder = ImmutableList.builder();
+                builder.addAll(baseQualifiedName.getOriginalParts());
+                builder.add(expression.field);
+                parts = builder.build();
+            }
+        }
+
         return parts == null ? null : QualifiedName.of(parts);
     }
 
@@ -94,22 +105,6 @@ public class DereferenceExpression
         }
 
         return result;
-    }
-
-    private static List<String> tryParseParts(Expression base, String fieldName)
-    {
-        if (base instanceof Identifier) {
-            return ImmutableList.of(((Identifier) base).getValue(), fieldName);
-        }
-        else if (base instanceof DereferenceExpression) {
-            QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) base);
-            if (baseQualifiedName != null) {
-                List<String> newList = new ArrayList<>(baseQualifiedName.getParts());
-                newList.add(fieldName);
-                return newList;
-            }
-        }
-        return null;
     }
 
     @Override

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/QualifiedName.java
@@ -20,43 +20,43 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.isEmpty;
-import static com.google.common.collect.Iterables.transform;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class QualifiedName
 {
     private final List<String> parts;
-    private final List<String> originalParts;
+    private final List<Identifier> originalParts;
 
     public static QualifiedName of(String first, String... rest)
     {
         requireNonNull(first, "first is null");
-        return of(ImmutableList.copyOf(Lists.asList(first, rest)));
+        return of(ImmutableList.copyOf(Lists.asList(first, rest).stream().map(Identifier::new).collect(Collectors.toList())));
     }
 
     public static QualifiedName of(String name)
     {
         requireNonNull(name, "name is null");
-        return of(ImmutableList.of(name));
+        return of(ImmutableList.of(new Identifier(name)));
     }
 
-    public static QualifiedName of(Iterable<String> originalParts)
+    public static QualifiedName of(Iterable<Identifier> originalParts)
     {
         requireNonNull(originalParts, "originalParts is null");
         checkArgument(!isEmpty(originalParts), "originalParts is empty");
-        List<String> parts = ImmutableList.copyOf(transform(originalParts, part -> part.toLowerCase(ENGLISH)));
 
-        return new QualifiedName(ImmutableList.copyOf(originalParts), parts);
+        return new QualifiedName(ImmutableList.copyOf(originalParts));
     }
 
-    private QualifiedName(List<String> originalParts, List<String> parts)
+    private QualifiedName(List<Identifier> originalParts)
     {
         this.originalParts = originalParts;
-        this.parts = parts;
+        this.parts = originalParts.stream().map(identifier -> identifier.getValue().toLowerCase(ENGLISH)).collect(toImmutableList());
     }
 
     public List<String> getParts()
@@ -64,7 +64,7 @@ public class QualifiedName
         return parts;
     }
 
-    public List<String> getOriginalParts()
+    public List<Identifier> getOriginalParts()
     {
         return originalParts;
     }
@@ -85,8 +85,8 @@ public class QualifiedName
             return Optional.empty();
         }
 
-        List<String> subList = parts.subList(0, parts.size() - 1);
-        return Optional.of(new QualifiedName(subList, subList));
+        List<Identifier> subList = originalParts.subList(0, originalParts.size() - 1);
+        return Optional.of(new QualifiedName(subList));
     }
 
     public boolean hasSuffix(QualifiedName suffix)

--- a/presto-verifier/src/main/java/io/prestosql/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/io/prestosql/verifier/QueryRewriter.java
@@ -142,14 +142,14 @@ public class QueryRewriter
 
     private QualifiedName generateTemporaryTableName(QualifiedName originalName)
     {
-        List<String> parts = new ArrayList<>();
+        List<Identifier> parts = new ArrayList<>();
         int originalSize = originalName.getOriginalParts().size();
         int prefixSize = rewritePrefix.getOriginalParts().size();
         if (originalSize > prefixSize) {
             parts.addAll(originalName.getOriginalParts().subList(0, originalSize - prefixSize));
         }
         parts.addAll(rewritePrefix.getOriginalParts());
-        parts.set(parts.size() - 1, createTemporaryTableName());
+        parts.set(parts.size() - 1, new Identifier(createTemporaryTableName()));
         return QualifiedName.of(parts);
     }
 

--- a/presto-verifier/src/main/java/io/prestosql/verifier/VerifierConfig.java
+++ b/presto-verifier/src/main/java/io/prestosql/verifier/VerifierConfig.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
+import io.prestosql.sql.tree.Identifier;
 import io.prestosql.sql.tree.QualifiedName;
 import org.joda.time.DateTime;
 
@@ -28,9 +29,11 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static io.prestosql.verifier.QueryType.CREATE;
 import static io.prestosql.verifier.QueryType.MODIFY;
@@ -734,7 +737,9 @@ public class VerifierConfig
 
     public QualifiedName getShadowTestTablePrefix()
     {
-        return QualifiedName.of(Splitter.on(".").splitToList(shadowTestTablePrefix));
+        return QualifiedName.of(Arrays.stream(shadowTestTablePrefix.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList()));
     }
 
     @ConfigDescription("The prefix to use for temporary test shadow tables. May be fully qualified like 'tmp_catalog.tmp_schema.tmp_'")
@@ -747,7 +752,9 @@ public class VerifierConfig
 
     public QualifiedName getShadowControlTablePrefix()
     {
-        return QualifiedName.of(Splitter.on(".").splitToList(shadowControlTablePrefix));
+        return QualifiedName.of(Arrays.stream(shadowControlTablePrefix.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList()));
     }
 
     @ConfigDescription("The prefix to use for temporary control shadow tables. May be fully qualified like 'tmp_catalog.tmp_schema.tmp_'")


### PR DESCRIPTION
Presto doesn't maintain the quotedness of an identifier when using SqlQueryFormatter so it results in throwing parsing error when we run prepare query of the syntax [https://github.com/prestodb/presto/issues/10739]. This PR solves that above issue