### PR TITLE
Configure defaults for coordinator in DistributedQueryRunner in one place

### DIFF
--- a/presto-tests/src/main/java/io/prestosql/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/DistributedQueryRunner.java
@@ -133,7 +133,6 @@ public class DistributedQueryRunner
             }
 
             Map<String, String> extraCoordinatorProperties = new HashMap<>();
-            extraCoordinatorProperties.put("experimental.iterative-optimizer-enabled", "true");
             extraCoordinatorProperties.putAll(extraProperties);
             extraCoordinatorProperties.putAll(coordinatorProperties);
             coordinator = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), true, extraCoordinatorProperties, parserOptions, environment));
@@ -191,6 +190,7 @@ public class DistributedQueryRunner
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");
             propertiesBuilder.put("join-distribution-type", "PARTITIONED");
+            propertiesBuilder.put("experimental.iterative-optimizer-enabled", "true");
         }
         HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
         properties.putAll(extraProperties);


### PR DESCRIPTION
Configure defaults for coordinator in DistributedQueryRunner in one place
