### PR TITLE
Pass access tokens for connectors to Presto

### DIFF
--- a/presto-atop/src/test/java/io/prestosql/plugin/atop/TestAtopSecurity.java
+++ b/presto-atop/src/test/java/io/prestosql/plugin/atop/TestAtopSecurity.java
@@ -64,6 +64,6 @@ public class TestAtopSecurity
         return testSessionBuilder()
                 .setCatalog(queryRunner.getDefaultSession().getCatalog().get())
                 .setSchema(queryRunner.getDefaultSession().getSchema().get())
-                .setIdentity(new Identity(user, Optional.empty())).build();
+                .setIdentity(new Identity(user, Optional.empty(), Optional.empty())).build();
     }
 }

--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
@@ -102,6 +102,7 @@ public class BenchmarkDriverOptions
                 ImmutableMap.of(),
                 toProperties(this.sessionProperties),
                 ImmutableMap.of(),
+                ImmutableMap.of(),
                 null,
                 clientRequestTimeout);
     }

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -165,6 +165,7 @@ public class ClientOptions
                 toResourceEstimates(resourceEstimates),
                 toProperties(sessionProperties),
                 emptyMap(),
+                emptyMap(),
                 null,
                 clientRequestTimeout);
     }

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -122,6 +122,9 @@ public class ClientOptions
     @Option(name = "--resource-estimate", title = "resource-estimate", description = "Resource estimate (property can be used multiple times; format is key=value)")
     public final List<ClientResourceEstimate> resourceEstimates = new ArrayList<>();
 
+    @Option(name = "--connector-token", title = "connector-token", description = "Connector token (property can be used multiple times; format is key=value)")
+    public final List<ClientConnectorToken> connectorTokens = new ArrayList<>();
+
     @Option(name = "--session", title = "session", description = "Session property (property can be used multiple times; format is key=value; use 'SHOW SESSION' to see available properties)")
     public final List<ClientSessionProperty> sessionProperties = new ArrayList<>();
 
@@ -164,7 +167,7 @@ public class ClientOptions
                 Locale.getDefault(),
                 toResourceEstimates(resourceEstimates),
                 toProperties(sessionProperties),
-                emptyMap(),
+                toConnectorTokens(connectorTokens),
                 emptyMap(),
                 null,
                 clientRequestTimeout);
@@ -210,6 +213,15 @@ public class ClientOptions
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         for (ClientResourceEstimate estimate : estimates) {
             builder.put(estimate.getResource(), estimate.getEstimate());
+        }
+        return builder.build();
+    }
+
+    public static Map<String, String> toConnectorTokens(List<ClientConnectorToken> connectorTokens)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (ClientConnectorToken connectorToken : connectorTokens) {
+            builder.put(connectorToken.getName(), connectorToken.getValue());
         }
         return builder.build();
     }
@@ -274,6 +286,68 @@ public class ClientOptions
         public int hashCode()
         {
             return Objects.hash(resource, estimate);
+        }
+    }
+
+    public static final class ClientConnectorToken
+    {
+        private final String name;
+        private final String value;
+
+        public ClientConnectorToken(String connectorToken)
+        {
+            List<String> nameValue = NAME_VALUE_SPLITTER.splitToList(connectorToken);
+            checkArgument(nameValue.size() == 2, "Connector token: %s", connectorToken);
+
+            this.name = nameValue.get(0);
+            this.value = nameValue.get(1);
+            checkArgument(!name.isEmpty(), "Connector token name is empty");
+            checkArgument(!value.isEmpty(), "Connector token value is empty");
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(name), "Connector token name contains spaces or is not US_ASCII: %s", name);
+            checkArgument(name.indexOf('=') < 0, "Connector token name must not contain '=': %s", name);
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "Connector token value contains space or is not US_ASCII: %s", name);
+        }
+
+        @VisibleForTesting
+        public ClientConnectorToken(String name, String value)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.value = value;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name + '=' + value;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ClientConnectorToken other = (ClientConnectorToken) o;
+            return Objects.equals(name, other.name) && Objects.equals(value, other.value);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, value);
         }
     }
 

--- a/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
@@ -99,6 +99,16 @@ public class TestClientOptions
     }
 
     @Test
+    public void testConnectorTokens()
+    {
+        Console console = singleCommand(Console.class).parse("--connector-token", "test.token.a=hello", "--connector-token", "test.token.b=world");
+        ClientOptions options = console.clientOptions;
+        assertEquals(options.connectorTokens, ImmutableList.of(
+                new ClientOptions.ClientConnectorToken("test.token.a", "hello"),
+                new ClientOptions.ClientConnectorToken("test.token.b", "world")));
+    }
+
+    @Test
     public void testSessionProperties()
     {
         Console console = singleCommand(Console.class).parse("--session", "system=system-value", "--session", "catalog.name=catalog-property");

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -97,6 +97,7 @@ public class TestQueryRunner
                         ImmutableMap.of(),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        ImmutableMap.of(),
                         null,
                         new Duration(2, MINUTES)));
         try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {

--- a/presto-client/src/main/java/io/prestosql/client/ClientSession.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientSession.java
@@ -46,6 +46,7 @@ public class ClientSession
     private final Locale locale;
     private final Map<String, String> resourceEstimates;
     private final Map<String, String> properties;
+    private final Map<String, String> connectorTokens;
     private final Map<String, String> preparedStatements;
     private final String transactionId;
     private final Duration clientRequestTimeout;
@@ -76,6 +77,7 @@ public class ClientSession
             Locale locale,
             Map<String, String> resourceEstimates,
             Map<String, String> properties,
+            Map<String, String> connectorTokens,
             Map<String, String> preparedStatements,
             String transactionId,
             Duration clientRequestTimeout)
@@ -94,6 +96,7 @@ public class ClientSession
         this.transactionId = transactionId;
         this.resourceEstimates = ImmutableMap.copyOf(requireNonNull(resourceEstimates, "resourceEstimates is null"));
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.connectorTokens = ImmutableMap.copyOf(requireNonNull(connectorTokens, "connectorTokens is null"));
         this.preparedStatements = ImmutableMap.copyOf(requireNonNull(preparedStatements, "preparedStatements is null"));
         this.clientRequestTimeout = clientRequestTimeout;
 
@@ -115,6 +118,14 @@ public class ClientSession
             checkArgument(entry.getKey().indexOf('=') < 0, "Session property name must not contain '=': %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getKey()), "Session property name is not US_ASCII: %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getValue()), "Session property value is not US_ASCII: %s", entry.getValue());
+        }
+
+        // verify the connector tokens are valid
+        for (Entry<String, String> entry : connectorTokens.entrySet()) {
+            checkArgument(!entry.getKey().isEmpty(), "Connector token name is empty");
+            checkArgument(entry.getKey().indexOf('=') < 0, "Connector token name must not contain '=': %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getKey()), "Connector token name is not US_ASCII: %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getValue()), "Connector token value is not US_ASCII: %s", entry.getValue());
         }
     }
 
@@ -183,6 +194,11 @@ public class ClientSession
         return properties;
     }
 
+    public Map<String, String> getConnectorTokens()
+    {
+        return connectorTokens;
+    }
+
     public Map<String, String> getPreparedStatements()
     {
         return preparedStatements;
@@ -238,6 +254,7 @@ public class ClientSession
         private Locale locale;
         private Map<String, String> resourceEstimates;
         private Map<String, String> properties;
+        private Map<String, String> connectorTokens;
         private Map<String, String> preparedStatements;
         private String transactionId;
         private Duration clientRequestTimeout;
@@ -258,6 +275,7 @@ public class ClientSession
             locale = clientSession.getLocale();
             resourceEstimates = clientSession.getResourceEstimates();
             properties = clientSession.getProperties();
+            connectorTokens = clientSession.getConnectorTokens();
             preparedStatements = clientSession.getPreparedStatements();
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
@@ -284,6 +302,12 @@ public class ClientSession
         public Builder withProperties(Map<String, String> properties)
         {
             this.properties = requireNonNull(properties, "properties is null");
+            return this;
+        }
+
+        public Builder withConnectorTokens(Map<String, String> connectorTokens)
+        {
+            this.connectorTokens = requireNonNull(connectorTokens, "connectorTokens is null");
             return this;
         }
 
@@ -321,6 +345,7 @@ public class ClientSession
                     locale,
                     resourceEstimates,
                     properties,
+                    connectorTokens,
                     preparedStatements,
                     transactionId,
                     clientRequestTimeout);

--- a/presto-client/src/main/java/io/prestosql/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/io/prestosql/client/PrestoHeaders.java
@@ -24,6 +24,7 @@ public final class PrestoHeaders
     public static final String PRESTO_LANGUAGE = "X-Presto-Language";
     public static final String PRESTO_TRACE_TOKEN = "X-Presto-Trace-Token";
     public static final String PRESTO_SESSION = "X-Presto-Session";
+    public static final String PRESTO_CONNECTOR_TOKEN = "X-Presto-Connector-Token";
     public static final String PRESTO_SET_CATALOG = "X-Presto-Set-Catalog";
     public static final String PRESTO_SET_SCHEMA = "X-Presto-Set-Schema";
     public static final String PRESTO_SET_PATH = "X-Presto-Set-Path";

--- a/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
@@ -56,6 +56,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_CAPABILITIES;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_TAGS;
+import static io.prestosql.client.PrestoHeaders.PRESTO_CONNECTOR_TOKEN;
 import static io.prestosql.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
@@ -180,6 +181,11 @@ class StatementClientV1
         Map<String, String> resourceEstimates = session.getResourceEstimates();
         for (Entry<String, String> entry : resourceEstimates.entrySet()) {
             builder.addHeader(PRESTO_RESOURCE_ESTIMATE, entry.getKey() + "=" + entry.getValue());
+        }
+
+        Map<String, String> connectorTokens = session.getConnectorTokens();
+        for (Entry<String, String> entry : connectorTokens.entrySet()) {
+            builder.addHeader(PRESTO_CONNECTOR_TOKEN, entry.getKey() + "=" + entry.getValue());
         }
 
         Map<String, String> statements = session.getPreparedStatements();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -135,7 +135,7 @@ public class FileHiveMetastore
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.catalogDirectory = new Path(requireNonNull(catalogDirectory, "baseDirectory is null"));
-        this.hdfsContext = new HdfsContext(new Identity(metastoreUser, Optional.empty()));
+        this.hdfsContext = new HdfsContext(new Identity(metastoreUser, Optional.empty(), Optional.empty()));
         try {
             metadataFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, this.catalogDirectory);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -140,7 +140,7 @@ public class GlueHiveMetastore
     public GlueHiveMetastore(HdfsEnvironment hdfsEnvironment, GlueHiveMetastoreConfig glueConfig, AWSGlueAsync glueClient)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.hdfsContext = new HdfsContext(new Identity(DEFAULT_METASTORE_USER, Optional.empty()));
+        this.hdfsContext = new HdfsContext(new Identity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()));
         this.glueClient = requireNonNull(glueClient, "glueClient is null");
         this.defaultDir = glueConfig.getDefaultWarehouseDir();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -105,7 +105,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestHiveFileSystem
 {
-    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new Identity("test", Optional.empty()));
+    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new Identity("test", Optional.empty(), Optional.empty()));
 
     protected String database;
     protected SchemaTableName table;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileBasedSecurity.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileBasedSecurity.java
@@ -66,6 +66,6 @@ public class TestHiveFileBasedSecurity
         return testSessionBuilder()
                 .setCatalog(queryRunner.getDefaultSession().getCatalog().get())
                 .setSchema(queryRunner.getDefaultSession().getSchema().get())
-                .setIdentity(new Identity(user, Optional.empty())).build();
+                .setIdentity(new Identity(user, Optional.empty(), Optional.empty())).build();
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -2847,13 +2847,13 @@ public class TestHiveIntegrationSmokeTest
         Session user1 = testSessionBuilder()
                 .setCatalog(getSession().getCatalog().get())
                 .setSchema(getSession().getSchema().get())
-                .setIdentity(new Identity("user1", getSession().getIdentity().getPrincipal()))
+                .setIdentity(new Identity("user1", getSession().getIdentity().getPrincipal(), Optional.empty()))
                 .build();
 
         Session user2 = testSessionBuilder()
                 .setCatalog(getSession().getCatalog().get())
                 .setSchema(getSession().getSchema().get())
-                .setIdentity(new Identity("user2", getSession().getIdentity().getPrincipal()))
+                .setIdentity(new Identity("user2", getSession().getIdentity().getPrincipal(), Optional.empty()))
                 .build();
 
         assertQuery(user1, "SELECT account_name FROM test_accounts_view", "VALUES 'account1'");

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -676,6 +676,7 @@ public class PrestoConnection
                 locale.get(),
                 ImmutableMap.of(),
                 ImmutableMap.copyOf(allProperties),
+                ImmutableMap.of(),
                 ImmutableMap.copyOf(preparedStatements),
                 transactionId.get(),
                 timeout);

--- a/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
@@ -265,7 +265,7 @@ public final class SessionRepresentation
                 new QueryId(queryId),
                 transactionId,
                 clientTransactionSupport,
-                new Identity(user, principal.map(BasicPrincipal::new)),
+                new Identity(user, principal.map(BasicPrincipal::new), Optional.empty()),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
@@ -261,11 +261,16 @@ public final class SessionRepresentation
 
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
+        return toSession(sessionPropertyManager, Optional.empty());
+    }
+
+    public Session toSession(SessionPropertyManager sessionPropertyManager, Optional<Map<String, String>> connectorTokens)
+    {
         return new Session(
                 new QueryId(queryId),
                 transactionId,
                 clientTransactionSupport,
-                new Identity(user, principal.map(BasicPrincipal::new), Optional.empty()),
+                new Identity(user, principal.map(BasicPrincipal::new), connectorTokens),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
@@ -107,7 +107,7 @@ public final class HttpRequestSessionContext
 
         String user = trimEmptyToNull(servletRequest.getHeader(PRESTO_USER));
         assertRequest(user != null, "User must be set");
-        identity = new Identity(user, Optional.ofNullable(servletRequest.getUserPrincipal()));
+        identity = new Identity(user, Optional.ofNullable(servletRequest.getUserPrincipal()), Optional.empty());
 
         source = servletRequest.getHeader(PRESTO_SOURCE);
         traceToken = Optional.ofNullable(trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN)));

--- a/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
@@ -53,6 +53,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_CATALOG;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_CAPABILITIES;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_TAGS;
+import static io.prestosql.client.PrestoHeaders.PRESTO_CONNECTOR_TOKEN;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -107,7 +108,7 @@ public final class HttpRequestSessionContext
 
         String user = trimEmptyToNull(servletRequest.getHeader(PRESTO_USER));
         assertRequest(user != null, "User must be set");
-        identity = new Identity(user, Optional.ofNullable(servletRequest.getUserPrincipal()), Optional.empty());
+        identity = new Identity(user, Optional.ofNullable(servletRequest.getUserPrincipal()), Optional.ofNullable(trimEmptyToNull(parseConnectorTokens(servletRequest))));
 
         source = servletRequest.getHeader(PRESTO_SOURCE);
         traceToken = Optional.ofNullable(trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN)));
@@ -285,13 +286,12 @@ public final class HttpRequestSessionContext
 
     private static Map<String, String> parseSessionHeaders(HttpServletRequest servletRequest)
     {
-        Map<String, String> sessionProperties = new HashMap<>();
-        for (String header : splitSessionHeader(servletRequest.getHeaders(PRESTO_SESSION))) {
-            List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
-            assertRequest(nameValue.size() == 2, "Invalid %s header", PRESTO_SESSION);
-            sessionProperties.put(nameValue.get(0), nameValue.get(1));
-        }
-        return sessionProperties;
+        return parsePropertyHeaders(servletRequest, PRESTO_SESSION);
+    }
+
+    private static Map<String, String> parseConnectorTokens(HttpServletRequest servletRequest)
+    {
+        return parsePropertyHeaders(servletRequest, PRESTO_CONNECTOR_TOKEN);
     }
 
     private Set<String> parseClientTags(HttpServletRequest servletRequest)
@@ -336,6 +336,17 @@ public final class HttpRequestSessionContext
         }
 
         return builder.build();
+    }
+
+    private static Map<String, String> parsePropertyHeaders(HttpServletRequest servletRequest, String headerName)
+    {
+        Map<String, String> properties = new HashMap<>();
+        for (String header : splitSessionHeader(servletRequest.getHeaders(headerName))) {
+            List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
+            assertRequest(nameValue.size() == 2, "Invalid %s header", headerName);
+            properties.put(nameValue.get(0), nameValue.get(1));
+        }
+        return properties;
     }
 
     private static void assertRequest(boolean expression, String format, Object... args)
@@ -402,6 +413,11 @@ public final class HttpRequestSessionContext
     private static String trimEmptyToNull(String value)
     {
         return emptyToNull(nullToEmpty(value).trim());
+    }
+
+    private static Map<String, String> trimEmptyToNull(Map<String, String> properties)
+    {
+        return properties.size() > 0 ? properties : null;
     }
 
     private static String urlDecode(String value)

--- a/presto-main/src/main/java/io/prestosql/server/TaskResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskResource.java
@@ -125,7 +125,7 @@ public class TaskResource
     {
         requireNonNull(taskUpdateRequest, "taskUpdateRequest is null");
 
-        Session session = taskUpdateRequest.getSession().toSession(sessionPropertyManager);
+        Session session = taskUpdateRequest.getSession().toSession(sessionPropertyManager, taskUpdateRequest.getConnectorTokens());
         TaskInfo taskInfo = taskManager.updateTask(session,
                 taskId,
                 taskUpdateRequest.getFragment(),

--- a/presto-main/src/main/java/io/prestosql/server/TaskUpdateRequest.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskUpdateRequest.java
@@ -22,6 +22,7 @@ import io.prestosql.TaskSource;
 import io.prestosql.sql.planner.PlanFragment;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -31,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 public class TaskUpdateRequest
 {
     private final SessionRepresentation session;
+    private final Optional<Map<String, String>> connectorTokens;
     private final Optional<PlanFragment> fragment;
     private final List<TaskSource> sources;
     private final OutputBuffers outputIds;
@@ -39,18 +41,21 @@ public class TaskUpdateRequest
     @JsonCreator
     public TaskUpdateRequest(
             @JsonProperty("session") SessionRepresentation session,
+            @JsonProperty("connectorTokens") Optional<Map<String, String>> connectorTokens,
             @JsonProperty("fragment") Optional<PlanFragment> fragment,
             @JsonProperty("sources") List<TaskSource> sources,
             @JsonProperty("outputIds") OutputBuffers outputIds,
             @JsonProperty("totalPartitions") OptionalInt totalPartitions)
     {
         requireNonNull(session, "session is null");
+        requireNonNull(connectorTokens, "connectorCredentials is null");
         requireNonNull(fragment, "fragment is null");
         requireNonNull(sources, "sources is null");
         requireNonNull(outputIds, "outputIds is null");
         requireNonNull(totalPartitions, "totalPartitions is null");
 
         this.session = session;
+        this.connectorTokens = connectorTokens;
         this.fragment = fragment;
         this.sources = ImmutableList.copyOf(sources);
         this.outputIds = outputIds;
@@ -61,6 +66,12 @@ public class TaskUpdateRequest
     public SessionRepresentation getSession()
     {
         return session;
+    }
+
+    @JsonProperty
+    public Optional<Map<String, String>> getConnectorTokens()
+    {
+        return connectorTokens;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/io/prestosql/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/io/prestosql/server/remotetask/HttpRemoteTask.java
@@ -504,6 +504,7 @@ public final class HttpRemoteTask
         Optional<PlanFragment> fragment = sendPlan.get() ? Optional.of(planFragment) : Optional.empty();
         TaskUpdateRequest updateRequest = new TaskUpdateRequest(
                 session.toSessionRepresentation(),
+                session.getIdentity().getConnectorTokens(),
                 fragment,
                 sources,
                 outputBuffers.get(),

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -1851,7 +1851,7 @@ class StatementAnalyzer
                 Identity identity;
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-                    identity = new Identity(owner.get(), Optional.empty());
+                    identity = new Identity(owner.get(), Optional.empty(), Optional.empty());
                     viewAccessControl = new ViewAccessControl(accessControl);
                 }
                 else {

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
@@ -69,7 +69,7 @@ public class TestingConnectorSession
             boolean isLegacyTimestamp)
     {
         this.queryId = queryIdGenerator.createNextQueryId().toString();
-        this.identity = new Identity(requireNonNull(user, "user is null"), Optional.empty());
+        this.identity = new Identity(requireNonNull(user, "user is null"), Optional.empty(), Optional.empty());
         this.source = requireNonNull(source, "source is null");
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");

--- a/presto-main/src/main/java/io/prestosql/testing/TestingSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingSession.java
@@ -62,7 +62,7 @@ public final class TestingSession
     {
         return Session.builder(sessionPropertyManager)
                 .setQueryId(queryIdGenerator.createNextQueryId())
-                .setIdentity(new Identity("user", Optional.empty()))
+                .setIdentity(new Identity("user", Optional.empty(), Optional.empty()))
                 .setSource("test")
                 .setCatalog("catalog")
                 .setSchema("schema")

--- a/presto-main/src/test/java/io/prestosql/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/io/prestosql/security/TestAccessControlManager.java
@@ -79,7 +79,7 @@ public class TestAccessControlManager
     @Test
     public void testReadOnlySystemAccessControl()
     {
-        Identity identity = new Identity(USER_NAME, Optional.of(PRINCIPAL));
+        Identity identity = new Identity(USER_NAME, Optional.of(PRINCIPAL), Optional.empty());
         QualifiedObjectName tableName = new QualifiedObjectName("catalog", "schema", "table");
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
@@ -140,7 +140,7 @@ public class TestAccessControlManager
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
-                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)), new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of("column"));
+                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL), Optional.empty()), new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of("column"));
                 });
     }
 
@@ -160,7 +160,7 @@ public class TestAccessControlManager
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
-                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)), new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of("column"));
+                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL), Optional.empty()), new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of("column"));
                 });
     }
 
@@ -180,7 +180,7 @@ public class TestAccessControlManager
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
-                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)), new QualifiedObjectName("secured_catalog", "schema", "table"), ImmutableSet.of("column"));
+                    accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL), Optional.empty()), new QualifiedObjectName("secured_catalog", "schema", "table"), ImmutableSet.of("column"));
                 });
     }
 

--- a/presto-main/src/test/java/io/prestosql/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/io/prestosql/security/TestFileBasedSystemAccessControl.java
@@ -45,18 +45,18 @@ import static org.testng.Assert.assertThrows;
 
 public class TestFileBasedSystemAccessControl
 {
-    private static final Identity alice = new Identity("alice", Optional.empty());
-    private static final Identity kerberosValidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("alice/example.com@EXAMPLE.COM")));
-    private static final Identity kerberosValidNonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.of(new KerberosPrincipal("\u0194\u0194\u0194/example.com@EXAMPLE.COM")));
-    private static final Identity kerberosInvalidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("mallory/example.com@EXAMPLE.COM")));
-    private static final Identity kerberosValidShare = new Identity("alice", Optional.of(new KerberosPrincipal("valid/example.com@EXAMPLE.COM")));
-    private static final Identity kerberosInValidShare = new Identity("alice", Optional.of(new KerberosPrincipal("invalid/example.com@EXAMPLE.COM")));
-    private static final Identity validSpecialRegexWildDot = new Identity(".*", Optional.of(new KerberosPrincipal("special/.*@EXAMPLE.COM")));
-    private static final Identity validSpecialRegexEndQuote = new Identity("\\E", Optional.of(new KerberosPrincipal("special/\\E@EXAMPLE.COM")));
-    private static final Identity invalidSpecialRegex = new Identity("alice", Optional.of(new KerberosPrincipal("special/.*@EXAMPLE.COM")));
-    private static final Identity bob = new Identity("bob", Optional.empty());
-    private static final Identity admin = new Identity("admin", Optional.empty());
-    private static final Identity nonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.empty());
+    private static final Identity alice = new Identity("alice", Optional.empty(), Optional.empty());
+    private static final Identity kerberosValidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("alice/example.com@EXAMPLE.COM")), Optional.empty());
+    private static final Identity kerberosValidNonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.of(new KerberosPrincipal("\u0194\u0194\u0194/example.com@EXAMPLE.COM")), Optional.empty());
+    private static final Identity kerberosInvalidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("mallory/example.com@EXAMPLE.COM")), Optional.empty());
+    private static final Identity kerberosValidShare = new Identity("alice", Optional.of(new KerberosPrincipal("valid/example.com@EXAMPLE.COM")), Optional.empty());
+    private static final Identity kerberosInValidShare = new Identity("alice", Optional.of(new KerberosPrincipal("invalid/example.com@EXAMPLE.COM")), Optional.empty());
+    private static final Identity validSpecialRegexWildDot = new Identity(".*", Optional.of(new KerberosPrincipal("special/.*@EXAMPLE.COM")), Optional.empty());
+    private static final Identity validSpecialRegexEndQuote = new Identity("\\E", Optional.of(new KerberosPrincipal("special/\\E@EXAMPLE.COM")), Optional.empty());
+    private static final Identity invalidSpecialRegex = new Identity("alice", Optional.of(new KerberosPrincipal("special/.*@EXAMPLE.COM")), Optional.empty());
+    private static final Identity bob = new Identity("bob", Optional.empty(), Optional.empty());
+    private static final Identity admin = new Identity("admin", Optional.empty(), Optional.empty());
+    private static final Identity nonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.empty(), Optional.empty());
     private static final Set<String> allCatalogs = ImmutableSet.of("secret", "open-to-all", "all-allowed", "alice-catalog", "allowed-absent", "\u0200\u0200\u0200");
     private static final QualifiedObjectName aliceTable = new QualifiedObjectName("alice-catalog", "schema", "table");
     private static final QualifiedObjectName aliceView = new QualifiedObjectName("alice-catalog", "schema", "view");

--- a/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
@@ -28,6 +28,7 @@ import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.prestosql.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CATALOG;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
+import static io.prestosql.client.PrestoHeaders.PRESTO_CONNECTOR_TOKEN;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -56,6 +57,7 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
                         .put(PRESTO_SESSION, JOIN_DISTRIBUTION_TYPE + "=partitioned," + HASH_PARTITION_COUNT + " = 43")
                         .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
+                        .put(PRESTO_CONNECTOR_TOKEN, "test.token=hello-world")
                         .build(),
                 "testRemote");
 
@@ -64,7 +66,7 @@ public class TestHttpRequestSessionContext
         assertEquals(context.getCatalog(), "testCatalog");
         assertEquals(context.getSchema(), "testSchema");
         assertEquals(context.getPath(), "testPath");
-        assertEquals(context.getIdentity(), new Identity("testUser", Optional.empty(), Optional.empty()));
+        assertEquals(context.getIdentity(), new Identity("testUser", Optional.empty(), Optional.of(ImmutableMap.of("test.token", "hello-world"))));
         assertEquals(context.getClientInfo(), "client-info");
         assertEquals(context.getLanguage(), "zh-TW");
         assertEquals(context.getTimeZoneId(), "Asia/Taipei");

--- a/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
@@ -64,7 +64,7 @@ public class TestHttpRequestSessionContext
         assertEquals(context.getCatalog(), "testCatalog");
         assertEquals(context.getSchema(), "testSchema");
         assertEquals(context.getPath(), "testPath");
-        assertEquals(context.getIdentity(), new Identity("testUser", Optional.empty()));
+        assertEquals(context.getIdentity(), new Identity("testUser", Optional.empty(), Optional.empty()));
         assertEquals(context.getClientInfo(), "client-info");
         assertEquals(context.getLanguage(), "zh-TW");
         assertEquals(context.getTimeZoneId(), "Asia/Taipei");

--- a/presto-main/src/test/java/io/prestosql/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestSessionPropertyDefaults.java
@@ -56,7 +56,7 @@ public class TestSessionPropertyDefaults
 
         Session session = Session.builder(new SessionPropertyManager())
                 .setQueryId(new QueryId("test_query_id"))
-                .setIdentity(new Identity("testUser", Optional.empty()))
+                .setIdentity(new Identity("testUser", Optional.empty(), Optional.empty()))
                 .setSystemProperty(QUERY_MAX_MEMORY, "1GB")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .setSystemProperty(HASH_PARTITION_COUNT, "43")

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSessionFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSessionFunctions.java
@@ -27,7 +27,7 @@ public class TestSessionFunctions
     @Test
     public void testCurrentUser()
     {
-        Session session = testSessionBuilder().setIdentity(new Identity("test_current_user", Optional.empty())).build();
+        Session session = testSessionBuilder().setIdentity(new Identity("test_current_user", Optional.empty(), Optional.empty())).build();
         try (QueryAssertions queryAssertions = new QueryAssertions(session)) {
             queryAssertions.assertQuery("SELECT CURRENT_USER", "SELECT CAST('" + session.getUser() + "' AS VARCHAR)");
         }

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedAccessControl.java
@@ -95,7 +95,7 @@ public class TestFileBasedAccessControl
 
     private static Identity user(String name)
     {
-        return new Identity(name, Optional.empty());
+        return new Identity(name, Optional.empty(), Optional.empty());
     }
 
     private ConnectorAccessControl createAccessControl(String fileName)

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/security/TestRaptorFileBasedSecurity.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/security/TestRaptorFileBasedSecurity.java
@@ -68,6 +68,6 @@ public class TestRaptorFileBasedSecurity
         return testSessionBuilder()
                 .setCatalog(queryRunner.getDefaultSession().getCatalog().get())
                 .setSchema(queryRunner.getDefaultSession().getSchema().get())
-                .setIdentity(new Identity(user, Optional.empty())).build();
+                .setIdentity(new Identity(user, Optional.empty(), Optional.empty())).build();
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.security;
 
 import java.security.Principal;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -23,11 +24,13 @@ public class Identity
 {
     private final String user;
     private final Optional<Principal> principal;
+    private final Optional<Map<String, String>> connectorTokens;
 
-    public Identity(String user, Optional<Principal> principal)
+    public Identity(String user, Optional<Principal> principal, Optional<Map<String, String>> connectorTokens)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
+        this.connectorTokens = requireNonNull(connectorTokens, "connectorTokens is null");
     }
 
     public String getUser()
@@ -38,6 +41,11 @@ public class Identity
     public Optional<Principal> getPrincipal()
     {
         return principal;
+    }
+
+    public Optional<Map<String, String>> getConnectorTokens()
+    {
+        return connectorTokens;
     }
 
     @Override

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
@@ -44,7 +44,7 @@ public final class TestingSession
         @Override
         public Identity getIdentity()
         {
-            return new Identity("user", Optional.empty());
+            return new Identity("user", Optional.empty(), Optional.empty());
         }
 
         @Override

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestDistributedQueries.java
@@ -884,7 +884,7 @@ public abstract class AbstractTestDistributedQueries
         skipTestUnless(supportsViews());
 
         Session viewOwnerSession = TestingSession.testSessionBuilder()
-                .setIdentity(new Identity("test_view_access_owner", Optional.empty()))
+                .setIdentity(new Identity("test_view_access_owner", Optional.empty(), Optional.empty()))
                 .setCatalog(getSession().getCatalog().get())
                 .setSchema(getSession().getSchema().get())
                 .build();
@@ -917,7 +917,7 @@ public abstract class AbstractTestDistributedQueries
                 privilege(getSession().getUser(), "orders", SELECT_COLUMN));
 
         Session nestedViewOwnerSession = TestingSession.testSessionBuilder()
-                .setIdentity(new Identity("test_nested_view_access_owner", Optional.empty()))
+                .setIdentity(new Identity("test_nested_view_access_owner", Optional.empty(), Optional.empty()))
                 .setCatalog(getSession().getCatalog().get())
                 .setSchema(getSession().getSchema().get())
                 .build();

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestingPrestoClient.java
@@ -150,6 +150,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getLocale(),
                 resourceEstimates.build(),
                 properties.build(),
+                ImmutableMap.of(),
                 session.getPreparedStatements(),
                 session.getTransactionId().map(Object::toString).orElse(null),
                 clientRequestTimeout);

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
@@ -77,6 +77,7 @@ public class TestFinalQueryInfo
                     ImmutableMap.of(),
                     ImmutableMap.of(),
                     ImmutableMap.of(),
+                    ImmutableMap.of(),
                     null,
                     new Duration(2, MINUTES));
 


### PR DESCRIPTION
@electrum I break down this PR into small commits. Hope this makes code review easier.

This PR adds the ability for Presto client to pass access tokens to connectors so that connector can use the token to authenticate with the data source. In our use case, user/client pass the [GCS access tokens](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials) to Hive connector and the connector will use the token to access GCS bucket.

This is the first PR for this feature. I will submite two more PR in the next few days:
- support connector token in JDBC driver
- use access token to authenticate with GCS in Hive connector