### PR TITLE
Use processedInput* metrics in PipelineContext#getInput*

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
@@ -272,7 +272,7 @@ public class PipelineContext
     public CounterStat getInputDataSize()
     {
         CounterStat stat = new CounterStat();
-        stat.merge(rawInputDataSize);
+        stat.merge(processedInputDataSize);
         for (DriverContext driver : drivers) {
             stat.merge(driver.getInputDataSize());
         }
@@ -282,7 +282,7 @@ public class PipelineContext
     public CounterStat getInputPositions()
     {
         CounterStat stat = new CounterStat();
-        stat.merge(rawInputPositions);
+        stat.merge(processedInputPositions);
         for (DriverContext driver : drivers) {
             stat.merge(driver.getInputPositions());
         }


### PR DESCRIPTION
This makes it compatible with PipelineContext#getOutput*
methods as they don't use raw metrics.
Additionally, PipelineContext#GetInput* metrics
were merging rawInput* with processedInput* from driver.