### PR TITLE
Let jdbc-based connectors control how data should be written and predicates pushed down

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -471,7 +471,8 @@ public class BaseJdbcClient
         }
     }
 
-    protected WriteMapping toWriteMapping(Type type)
+    @Override
+    public WriteMapping toWriteMapping(Type type)
     {
         if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -53,7 +53,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
-import static io.prestosql.plugin.jdbc.StandardReadMappings.jdbcTypeToPrestoType;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.jdbcTypeToPrestoType;
 import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -197,7 +197,7 @@ public class BaseJdbcClient
                             resultSet.getString("TYPE_NAME"),
                             resultSet.getInt("COLUMN_SIZE"),
                             resultSet.getInt("DECIMAL_DIGITS"));
-                    Optional<ReadMapping> columnMapping = toPrestoType(session, typeHandle);
+                    Optional<ColumnMapping> columnMapping = toPrestoType(session, typeHandle);
                     // skip unsupported column types
                     if (columnMapping.isPresent()) {
                         String columnName = resultSet.getString("COLUMN_NAME");
@@ -217,7 +217,7 @@ public class BaseJdbcClient
     }
 
     @Override
-    public Optional<ReadMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
     {
         return jdbcTypeToPrestoType(typeHandle);
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -265,11 +265,12 @@ public class BaseJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
         return new QueryBuilder(identifierQuote).buildSql(
                 this,
+                session,
                 connection,
                 split.getCatalogName(),
                 split.getSchemaName(),

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BooleanWriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BooleanWriteFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface BooleanWriteFunction
+        extends WriteFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return boolean.class;
+    }
+
+    void set(PreparedStatement statement, int index, boolean value)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
@@ -13,7 +13,10 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.type.Type;
+
+import java.util.function.UnaryOperator;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -23,29 +26,50 @@ public final class ColumnMapping
 {
     public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction, BooleanWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction);
+        return booleanMapping(prestoType, readFunction, writeFunction, UnaryOperator.identity());
+    }
+
+    public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction, BooleanWriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
+    {
+        return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
     }
 
     public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction, LongWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction);
+        return longMapping(prestoType, readFunction, writeFunction, UnaryOperator.identity());
+    }
+
+    public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction, LongWriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
+    {
+        return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
     }
 
     public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction, DoubleWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction);
+        return doubleMapping(prestoType, readFunction, writeFunction, UnaryOperator.identity());
+    }
+
+    public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction, DoubleWriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
+    {
+        return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
     }
 
     public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction, SliceWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction, writeFunction);
+        return sliceMapping(prestoType, readFunction, writeFunction, UnaryOperator.identity());
+    }
+
+    public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction, SliceWriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
+    {
+        return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
     }
 
     private final Type type;
     private final ReadFunction readFunction;
     private final WriteFunction writeFunction;
+    private final UnaryOperator<Domain> pushdownConverter;
 
-    private ColumnMapping(Type type, ReadFunction readFunction, WriteFunction writeFunction)
+    private ColumnMapping(Type type, ReadFunction readFunction, WriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
     {
         this.type = requireNonNull(type, "type is null");
         this.readFunction = requireNonNull(readFunction, "readFunction is null");
@@ -62,6 +86,7 @@ public final class ColumnMapping
                 type,
                 writeFunction,
                 writeFunction.getJavaType());
+        this.pushdownConverter = requireNonNull(pushdownConverter, "pushdownConverter is null");
     }
 
     public Type getType()
@@ -77,6 +102,11 @@ public final class ColumnMapping
     public WriteFunction getWriteFunction()
     {
         return writeFunction;
+    }
+
+    public UnaryOperator<Domain> getPushdownConverter()
+    {
+        return pushdownConverter;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
@@ -21,39 +21,47 @@ import static java.util.Objects.requireNonNull;
 
 public final class ColumnMapping
 {
-    public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction)
+    public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction, BooleanWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction, writeFunction);
     }
 
-    public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction)
+    public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction, LongWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction, writeFunction);
     }
 
-    public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction)
+    public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction, DoubleWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction, writeFunction);
     }
 
-    public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction)
+    public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction, SliceWriteFunction writeFunction)
     {
-        return new ColumnMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction, writeFunction);
     }
 
     private final Type type;
     private final ReadFunction readFunction;
+    private final WriteFunction writeFunction;
 
-    private ColumnMapping(Type type, ReadFunction readFunction)
+    private ColumnMapping(Type type, ReadFunction readFunction, WriteFunction writeFunction)
     {
         this.type = requireNonNull(type, "type is null");
         this.readFunction = requireNonNull(readFunction, "readFunction is null");
+        this.writeFunction = requireNonNull(writeFunction, "writeFunction is null");
         checkArgument(
                 type.getJavaType() == readFunction.getJavaType(),
                 "Presto type %s is not compatible with read function %s returning %s",
                 type,
                 readFunction,
                 readFunction.getJavaType());
+        checkArgument(
+                type.getJavaType() == writeFunction.getJavaType(),
+                "Presto type %s is not compatible with write function %s accepting %s",
+                type,
+                writeFunction,
+                writeFunction.getJavaType());
     }
 
     public Type getType()
@@ -64,6 +72,11 @@ public final class ColumnMapping
     public ReadFunction getReadFunction()
     {
         return readFunction;
+    }
+
+    public WriteFunction getWriteFunction()
+    {
+        return writeFunction;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
@@ -19,32 +19,32 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-public final class ReadMapping
+public final class ColumnMapping
 {
-    public static ReadMapping booleanReadMapping(Type prestoType, BooleanReadFunction readFunction)
+    public static ColumnMapping booleanMapping(Type prestoType, BooleanReadFunction readFunction)
     {
-        return new ReadMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction);
     }
 
-    public static ReadMapping longReadMapping(Type prestoType, LongReadFunction readFunction)
+    public static ColumnMapping longMapping(Type prestoType, LongReadFunction readFunction)
     {
-        return new ReadMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction);
     }
 
-    public static ReadMapping doubleReadMapping(Type prestoType, DoubleReadFunction readFunction)
+    public static ColumnMapping doubleMapping(Type prestoType, DoubleReadFunction readFunction)
     {
-        return new ReadMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction);
     }
 
-    public static ReadMapping sliceReadMapping(Type prestoType, SliceReadFunction readFunction)
+    public static ColumnMapping sliceMapping(Type prestoType, SliceReadFunction readFunction)
     {
-        return new ReadMapping(prestoType, readFunction);
+        return new ColumnMapping(prestoType, readFunction);
     }
 
     private final Type type;
     private final ReadFunction readFunction;
 
-    private ReadMapping(Type type, ReadFunction readFunction)
+    private ColumnMapping(Type type, ReadFunction readFunction)
     {
         this.type = requireNonNull(type, "type is null");
         this.readFunction = requireNonNull(readFunction, "readFunction is null");

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DoubleWriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DoubleWriteFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface DoubleWriteFunction
+        extends WriteFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return double.class;
+    }
+
+    void set(PreparedStatement statement, int index, double value)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.statistics.TableStatistics;
+import io.prestosql.spi.type.Type;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +48,8 @@ public interface JdbcClient
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
     Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle);
+
+    WriteMapping toWriteMapping(Type type);
 
     ConnectorSplitSource getSplits(JdbcTableLayoutHandle layoutHandle);
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -62,7 +62,7 @@ public interface JdbcClient
         // most drivers do not need this
     }
 
-    PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
 
     JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -46,7 +46,7 @@ public interface JdbcClient
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
-    Optional<ReadMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle);
+    Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle);
 
     ConnectorSplitSource getSplits(JdbcTableLayoutHandle layoutHandle);
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
@@ -63,10 +63,10 @@ public class JdbcRecordCursor
         sliceReadFunctions = new SliceReadFunction[columnHandles.size()];
 
         for (int i = 0; i < this.columnHandles.length; i++) {
-            ReadMapping readMapping = jdbcClient.toPrestoType(session, columnHandles.get(i).getJdbcTypeHandle())
+            ColumnMapping columnMapping = jdbcClient.toPrestoType(session, columnHandles.get(i).getJdbcTypeHandle())
                     .orElseThrow(() -> new VerifyException("Unsupported column type"));
-            Class<?> javaType = readMapping.getType().getJavaType();
-            ReadFunction readFunction = readMapping.getReadFunction();
+            Class<?> javaType = columnMapping.getType().getJavaType();
+            ReadFunction readFunction = columnMapping.getReadFunction();
 
             if (javaType == boolean.class) {
                 booleanReadFunctions[i] = (BooleanReadFunction) readFunction;

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
@@ -87,7 +87,7 @@ public class JdbcRecordCursor
 
         try {
             connection = jdbcClient.getConnection(split);
-            statement = jdbcClient.buildSql(connection, split, columnHandles);
+            statement = jdbcClient.buildSql(session, connection, split, columnHandles);
             log.debug("Executing: %s", statement.toString());
             resultSet = statement.executeQuery();
         }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/LongWriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/LongWriteFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface LongWriteFunction
+        extends WriteFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return long.class;
+    }
+
+    void set(PreparedStatement statement, int index, long value)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -14,9 +14,11 @@
 package io.prestosql.plugin.jdbc;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -33,14 +35,10 @@ import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
-import org.joda.time.DateTimeZone;
 
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -49,12 +47,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.stream.Collectors.joining;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class QueryBuilder
 {
@@ -67,17 +63,24 @@ public class QueryBuilder
     private static class TypeAndValue
     {
         private final Type type;
+        private final JdbcTypeHandle typeHandle;
         private final Object value;
 
-        public TypeAndValue(Type type, Object value)
+        public TypeAndValue(Type type, JdbcTypeHandle typeHandle, Object value)
         {
             this.type = requireNonNull(type, "type is null");
+            this.typeHandle = requireNonNull(typeHandle, "typeHandle is null");
             this.value = requireNonNull(value, "value is null");
         }
 
         public Type getType()
         {
             return type;
+        }
+
+        public JdbcTypeHandle getTypeHandle()
+        {
+            return typeHandle;
         }
 
         public Object getValue()
@@ -93,6 +96,7 @@ public class QueryBuilder
 
     public PreparedStatement buildSql(
             JdbcClient client,
+            ConnectorSession session,
             Connection connection,
             String catalog,
             String schema,
@@ -142,45 +146,27 @@ public class QueryBuilder
 
         for (int i = 0; i < accumulator.size(); i++) {
             TypeAndValue typeAndValue = accumulator.get(i);
-            if (typeAndValue.getType().equals(BigintType.BIGINT)) {
-                statement.setLong(i + 1, (long) typeAndValue.getValue());
+            int parameterIndex = i + 1;
+            Type type = typeAndValue.getType();
+            WriteFunction writeFunction = client.toPrestoType(session, typeAndValue.getTypeHandle())
+                    .orElseThrow(() -> new VerifyException(format("Unsupported type %s with handle %s", type, typeAndValue.getTypeHandle())))
+                    .getWriteFunction();
+            Class<?> javaType = type.getJavaType();
+            Object value = typeAndValue.getValue();
+            if (javaType == boolean.class) {
+                ((BooleanWriteFunction) writeFunction).set(statement, parameterIndex, (boolean) value);
             }
-            else if (typeAndValue.getType().equals(IntegerType.INTEGER)) {
-                statement.setInt(i + 1, ((Number) typeAndValue.getValue()).intValue());
+            else if (javaType == long.class) {
+                ((LongWriteFunction) writeFunction).set(statement, parameterIndex, (long) value);
             }
-            else if (typeAndValue.getType().equals(SmallintType.SMALLINT)) {
-                statement.setShort(i + 1, ((Number) typeAndValue.getValue()).shortValue());
+            else if (javaType == double.class) {
+                ((DoubleWriteFunction) writeFunction).set(statement, parameterIndex, (double) value);
             }
-            else if (typeAndValue.getType().equals(TinyintType.TINYINT)) {
-                statement.setByte(i + 1, ((Number) typeAndValue.getValue()).byteValue());
-            }
-            else if (typeAndValue.getType().equals(DoubleType.DOUBLE)) {
-                statement.setDouble(i + 1, (double) typeAndValue.getValue());
-            }
-            else if (typeAndValue.getType().equals(RealType.REAL)) {
-                statement.setFloat(i + 1, intBitsToFloat(((Number) typeAndValue.getValue()).intValue()));
-            }
-            else if (typeAndValue.getType().equals(BooleanType.BOOLEAN)) {
-                statement.setBoolean(i + 1, (boolean) typeAndValue.getValue());
-            }
-            else if (typeAndValue.getType().equals(DateType.DATE)) {
-                long millis = DAYS.toMillis((long) typeAndValue.getValue());
-                statement.setDate(i + 1, new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis)));
-            }
-            else if (typeAndValue.getType().equals(TimeType.TIME)) {
-                statement.setTime(i + 1, new Time((long) typeAndValue.getValue()));
-            }
-            else if (typeAndValue.getType().equals(TimestampType.TIMESTAMP)) {
-                statement.setTimestamp(i + 1, new Timestamp((long) typeAndValue.getValue()));
-            }
-            else if (typeAndValue.getType() instanceof VarcharType) {
-                statement.setString(i + 1, ((Slice) typeAndValue.getValue()).toStringUtf8());
-            }
-            else if (typeAndValue.getType() instanceof CharType) {
-                statement.setString(i + 1, ((Slice) typeAndValue.getValue()).toStringUtf8());
+            else if (javaType == Slice.class) {
+                ((SliceWriteFunction) writeFunction).set(statement, parameterIndex, (Slice) value);
             }
             else {
-                throw new UnsupportedOperationException("Can't handle type: " + typeAndValue.getType());
+                throw new VerifyException(format("Unexpected type %s with java type %s", type, javaType.getName()));
             }
         }
 
@@ -212,14 +198,14 @@ public class QueryBuilder
             if (isAcceptedType(type)) {
                 Domain domain = tupleDomain.getDomains().get().get(column);
                 if (domain != null) {
-                    builder.add(toPredicate(column.getColumnName(), domain, type, accumulator));
+                    builder.add(toPredicate(column.getColumnName(), domain, column, accumulator));
                 }
             }
         }
         return builder.build();
     }
 
-    private String toPredicate(String columnName, Domain domain, Type type, List<TypeAndValue> accumulator)
+    private String toPredicate(String columnName, Domain domain, JdbcColumnHandle column, List<TypeAndValue> accumulator)
     {
         checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
 
@@ -243,10 +229,10 @@ public class QueryBuilder
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
                         case ABOVE:
-                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), type, accumulator));
+                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), column, accumulator));
                             break;
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), type, accumulator));
+                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), column, accumulator));
                             break;
                         case BELOW:
                             throw new IllegalArgumentException("Low marker should never use BELOW bound");
@@ -259,10 +245,10 @@ public class QueryBuilder
                         case ABOVE:
                             throw new IllegalArgumentException("High marker should never use ABOVE bound");
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), type, accumulator));
+                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), column, accumulator));
                             break;
                         case BELOW:
-                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), type, accumulator));
+                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), column, accumulator));
                             break;
                         default:
                             throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
@@ -276,11 +262,11 @@ public class QueryBuilder
 
         // Add back all of the possible single values either as an equality or an IN predicate
         if (singleValues.size() == 1) {
-            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues), type, accumulator));
+            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues), column, accumulator));
         }
         else if (singleValues.size() > 1) {
             for (Object value : singleValues) {
-                bindValue(value, type, accumulator);
+                bindValue(value, column, accumulator);
             }
             String values = Joiner.on(",").join(nCopies(singleValues.size(), "?"));
             disjuncts.add(quote(columnName) + " IN (" + values + ")");
@@ -295,9 +281,9 @@ public class QueryBuilder
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
 
-    private String toPredicate(String columnName, String operator, Object value, Type type, List<TypeAndValue> accumulator)
+    private String toPredicate(String columnName, String operator, Object value, JdbcColumnHandle column, List<TypeAndValue> accumulator)
     {
-        bindValue(value, type, accumulator);
+        bindValue(value, column, accumulator);
         return quote(columnName) + " " + operator + " ?";
     }
 
@@ -307,9 +293,10 @@ public class QueryBuilder
         return quote + name + quote;
     }
 
-    private static void bindValue(Object value, Type type, List<TypeAndValue> accumulator)
+    private static void bindValue(Object value, JdbcColumnHandle column, List<TypeAndValue> accumulator)
     {
+        Type type = column.getColumnType();
         checkArgument(isAcceptedType(type), "Can't handle type: %s", type);
-        accumulator.add(new TypeAndValue(type, value));
+        accumulator.add(new TypeAndValue(type, column.getJdbcTypeHandle(), value));
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SliceWriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SliceWriteFunction.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.slice.Slice;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface SliceWriteFunction
+        extends WriteFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return Slice.class;
+    }
+
+    void set(PreparedStatement statement, int index, Slice value)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -14,18 +14,27 @@
 package io.prestosql.plugin.jdbc;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.VarcharType;
+import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.sql.Date;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -33,6 +42,7 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
+import static io.prestosql.spi.type.Decimals.decodeUnscaledValue;
 import static io.prestosql.spi.type.Decimals.encodeScaledValue;
 import static io.prestosql.spi.type.Decimals.encodeShortScaledValue;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
@@ -46,9 +56,12 @@ import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -60,37 +73,72 @@ public final class StandardColumnMappings
 
     public static ColumnMapping booleanColumnMapping()
     {
-        return ColumnMapping.booleanMapping(BOOLEAN, ResultSet::getBoolean);
+        return ColumnMapping.booleanMapping(BOOLEAN, ResultSet::getBoolean, booleanWriteFunction());
+    }
+
+    public static BooleanWriteFunction booleanWriteFunction()
+    {
+        return PreparedStatement::setBoolean;
     }
 
     public static ColumnMapping tinyintColumnMapping()
     {
-        return ColumnMapping.longMapping(TINYINT, ResultSet::getByte);
+        return ColumnMapping.longMapping(TINYINT, ResultSet::getByte, tinyintWriteFunction());
+    }
+
+    public static LongWriteFunction tinyintWriteFunction()
+    {
+        return (statement, index, value) -> statement.setByte(index, SignedBytes.checkedCast(value));
     }
 
     public static ColumnMapping smallintColumnMapping()
     {
-        return ColumnMapping.longMapping(SMALLINT, ResultSet::getShort);
+        return ColumnMapping.longMapping(SMALLINT, ResultSet::getShort, smallintWriteFunction());
+    }
+
+    public static LongWriteFunction smallintWriteFunction()
+    {
+        return (statement, index, value) -> statement.setShort(index, Shorts.checkedCast(value));
     }
 
     public static ColumnMapping integerColumnMapping()
     {
-        return ColumnMapping.longMapping(INTEGER, ResultSet::getInt);
+        return ColumnMapping.longMapping(INTEGER, ResultSet::getInt, integerWriteFunction());
+    }
+
+    public static LongWriteFunction integerWriteFunction()
+    {
+        return (statement, index, value) -> statement.setInt(index, toIntExact(value));
     }
 
     public static ColumnMapping bigintColumnMapping()
     {
-        return ColumnMapping.longMapping(BIGINT, ResultSet::getLong);
+        return ColumnMapping.longMapping(BIGINT, ResultSet::getLong, bigintWriteFunction());
+    }
+
+    public static LongWriteFunction bigintWriteFunction()
+    {
+        return PreparedStatement::setLong;
     }
 
     public static ColumnMapping realColumnMapping()
     {
-        return ColumnMapping.longMapping(REAL, (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)));
+        return ColumnMapping.longMapping(REAL, (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)), realWriteFunction());
+    }
+
+    public static LongWriteFunction realWriteFunction()
+    {
+        return (statement, index, value) -> statement.setFloat(index, intBitsToFloat(toIntExact(value)));
     }
 
     public static ColumnMapping doubleColumnMapping()
     {
-        return ColumnMapping.doubleMapping(DOUBLE, ResultSet::getDouble);
+        return ColumnMapping.doubleMapping(DOUBLE, ResultSet::getDouble, doubleWriteFunction());
+    }
+
+    public static DoubleWriteFunction doubleWriteFunction()
+    {
+        return PreparedStatement::setDouble;
     }
 
     public static ColumnMapping decimalColumnMapping(DecimalType decimalType)
@@ -98,71 +146,159 @@ public final class StandardColumnMappings
         // JDBC driver can return BigDecimal with lower scale than column's scale when there are trailing zeroes
         int scale = decimalType.getScale();
         if (decimalType.isShort()) {
-            return ColumnMapping.longMapping(decimalType, (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale));
+            return ColumnMapping.longMapping(
+                    decimalType,
+                    (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale),
+                    shortDecimalWriteFunction(decimalType));
         }
-        return ColumnMapping.sliceMapping(decimalType, (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale));
+        return ColumnMapping.sliceMapping(
+                decimalType,
+                (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale),
+                longDecimalWriteFunction(decimalType));
+    }
+
+    public static LongWriteFunction shortDecimalWriteFunction(DecimalType decimalType)
+    {
+        requireNonNull(decimalType, "decimalType is null");
+        checkArgument(decimalType.isShort());
+        return (statement, index, value) -> {
+            BigInteger unscaledValue = BigInteger.valueOf(value);
+            BigDecimal bigDecimal = new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+            statement.setBigDecimal(index, bigDecimal);
+        };
+    }
+
+    public static SliceWriteFunction longDecimalWriteFunction(DecimalType decimalType)
+    {
+        requireNonNull(decimalType, "decimalType is null");
+        checkArgument(!decimalType.isShort());
+        return (statement, index, value) -> {
+            BigInteger unscaledValue = decodeUnscaledValue(value);
+            BigDecimal bigDecimal = new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+            statement.setBigDecimal(index, bigDecimal);
+        };
     }
 
     public static ColumnMapping charColumnMapping(CharType charType)
     {
         requireNonNull(charType, "charType is null");
-        return ColumnMapping.sliceMapping(charType, (resultSet, columnIndex) -> utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(columnIndex))));
+        return ColumnMapping.sliceMapping(
+                charType,
+                (resultSet, columnIndex) -> utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(columnIndex))),
+                charWriteFunction(charType));
+    }
+
+    public static SliceWriteFunction charWriteFunction(CharType charType)
+    {
+        requireNonNull(charType, "charType is null");
+        return (statement, index, value) -> {
+            statement.setString(index, value.toStringUtf8());
+        };
     }
 
     public static ColumnMapping varcharColumnMapping(VarcharType varcharType)
     {
-        return ColumnMapping.sliceMapping(varcharType, (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)));
+        return ColumnMapping.sliceMapping(varcharType, (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)), varcharWriteFunction());
+    }
+
+    public static SliceWriteFunction varcharWriteFunction()
+    {
+        return (statement, index, value) -> statement.setString(index, value.toStringUtf8());
     }
 
     public static ColumnMapping varbinaryColumnMapping()
     {
-        return ColumnMapping.sliceMapping(VARBINARY, (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)));
+        return ColumnMapping.sliceMapping(
+                VARBINARY,
+                (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)),
+                varbinaryWriteFunction());
+    }
+
+    public static SliceWriteFunction varbinaryWriteFunction()
+    {
+        return (statement, index, value) -> statement.setBytes(index, value.getBytes());
     }
 
     public static ColumnMapping dateColumnMapping()
     {
-        return ColumnMapping.longMapping(DATE, (resultSet, columnIndex) -> {
-            /*
-             * JDBC returns a date using a timestamp at midnight in the JVM timezone, or earliest time after that if there was no midnight.
-             * This works correctly for all dates and zones except when the missing local times 'gap' is 24h. I.e. this fails when JVM time
-             * zone is Pacific/Apia and date to be returned is 2011-12-30.
-             *
-             * `return resultSet.getObject(columnIndex, LocalDate.class).toEpochDay()` avoids these problems but
-             * is currently known not to work with Redshift (old Postgres connector) and SQL Server.
-             */
-            long localMillis = resultSet.getDate(columnIndex).getTime();
-            // Convert it to a ~midnight in UTC.
-            long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
-            // convert to days
-            return MILLISECONDS.toDays(utcMillis);
-        });
+        return ColumnMapping.longMapping(
+                DATE,
+                (resultSet, columnIndex) -> {
+                    /*
+                     * JDBC returns a date using a timestamp at midnight in the JVM timezone, or earliest time after that if there was no midnight.
+                     * This works correctly for all dates and zones except when the missing local times 'gap' is 24h. I.e. this fails when JVM time
+                     * zone is Pacific/Apia and date to be returned is 2011-12-30.
+                     *
+                     * `return resultSet.getObject(columnIndex, LocalDate.class).toEpochDay()` avoids these problems but
+                     * is currently known not to work with Redshift (old Postgres connector) and SQL Server.
+                     */
+                    long localMillis = resultSet.getDate(columnIndex).getTime();
+                    // Convert it to a ~midnight in UTC.
+                    long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+                    // convert to days
+                    return MILLISECONDS.toDays(utcMillis);
+                },
+                dateWriteFunction());
+    }
+
+    public static LongWriteFunction dateWriteFunction()
+    {
+        return (statement, index, value) -> {
+            // convert to midnight in default time zone
+            long millis = DAYS.toMillis(value);
+            statement.setDate(index, new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis)));
+        };
     }
 
     public static ColumnMapping timeColumnMapping()
     {
-        return ColumnMapping.longMapping(TIME, (resultSet, columnIndex) -> {
-            /*
-             * TODO `resultSet.getTime(columnIndex)` returns wrong value if JVM's zone had forward offset change during 1970-01-01
-             * and the time value being retrieved was not present in local time (a 'gap'), e.g. time retrieved is 00:10:00 and JVM zone is America/Hermosillo
-             * The problem can be averted by using `resultSet.getObject(columnIndex, LocalTime.class)` -- but this is not universally supported by JDBC drivers.
-             */
-            Time time = resultSet.getTime(columnIndex);
-            return UTC_CHRONOLOGY.millisOfDay().get(time.getTime());
-        });
+        return ColumnMapping.longMapping(
+                TIME,
+                (resultSet, columnIndex) -> {
+                    /*
+                     * TODO `resultSet.getTime(columnIndex)` returns wrong value if JVM's zone had forward offset change during 1970-01-01
+                     * and the time value being retrieved was not present in local time (a 'gap'), e.g. time retrieved is 00:10:00 and JVM zone is America/Hermosillo
+                     * The problem can be averted by using `resultSet.getObject(columnIndex, LocalTime.class)` -- but this is not universally supported by JDBC drivers.
+                     */
+                    Time time = resultSet.getTime(columnIndex);
+                    return UTC_CHRONOLOGY.millisOfDay().get(time.getTime());
+                },
+                timeWriteFunction());
+    }
+
+    public static LongWriteFunction timeWriteFunction()
+    {
+        return (statement, index, value) -> {
+            // Copied from `QueryBuilder.buildSql`
+            // TODO verify correctness, add tests and support non-legacy timestamp
+            statement.setTime(index, new Time(value));
+        };
     }
 
     public static ColumnMapping timestampColumnMapping()
     {
-        return ColumnMapping.longMapping(TIMESTAMP, (resultSet, columnIndex) -> {
-            /*
-             * TODO `resultSet.getTimestamp(columnIndex)` returns wrong value if JVM's zone had forward offset change and the local time
-             * corresponding to timestamp value being retrieved was not present (a 'gap'), this includes regular DST changes (e.g. Europe/Warsaw)
-             * and one-time policy changes (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
-             * The problem can be averted by using `resultSet.getObject(columnIndex, LocalDateTime.class)` -- but this is not universally supported by JDBC drivers.
-             */
-            Timestamp timestamp = resultSet.getTimestamp(columnIndex);
-            return timestamp.getTime();
-        });
+        return ColumnMapping.longMapping(
+                TIMESTAMP,
+                (resultSet, columnIndex) -> {
+                    /*
+                     * TODO `resultSet.getTimestamp(columnIndex)` returns wrong value if JVM's zone had forward offset change and the local time
+                     * corresponding to timestamp value being retrieved was not present (a 'gap'), this includes regular DST changes (e.g. Europe/Warsaw)
+                     * and one-time policy changes (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
+                     * The problem can be averted by using `resultSet.getObject(columnIndex, LocalDateTime.class)` -- but this is not universally supported by JDBC drivers.
+                     */
+                    Timestamp timestamp = resultSet.getTimestamp(columnIndex);
+                    return timestamp.getTime();
+                },
+                timestampWriteFunction());
+    }
+
+    public static LongWriteFunction timestampWriteFunction()
+    {
+        return (statement, index, value) -> {
+            // Copied from `QueryBuilder.buildSql`
+            // TODO verify correctness, add tests and support non-legacy timestamp
+            statement.setTimestamp(index, new Timestamp(value));
+        };
     }
 
     public static Optional<ColumnMapping> jdbcTypeToPrestoType(JdbcTypeHandle type)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -28,8 +28,6 @@ import java.util.Optional;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.prestosql.plugin.jdbc.ReadMapping.longReadMapping;
-import static io.prestosql.plugin.jdbc.ReadMapping.sliceReadMapping;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
@@ -54,76 +52,76 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.joda.time.DateTimeZone.UTC;
 
-public final class StandardReadMappings
+public final class StandardColumnMappings
 {
-    private StandardReadMappings() {}
+    private StandardColumnMappings() {}
 
     private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
 
-    public static ReadMapping booleanReadMapping()
+    public static ColumnMapping booleanColumnMapping()
     {
-        return ReadMapping.booleanReadMapping(BOOLEAN, ResultSet::getBoolean);
+        return ColumnMapping.booleanMapping(BOOLEAN, ResultSet::getBoolean);
     }
 
-    public static ReadMapping tinyintReadMapping()
+    public static ColumnMapping tinyintColumnMapping()
     {
-        return longReadMapping(TINYINT, ResultSet::getByte);
+        return ColumnMapping.longMapping(TINYINT, ResultSet::getByte);
     }
 
-    public static ReadMapping smallintReadMapping()
+    public static ColumnMapping smallintColumnMapping()
     {
-        return longReadMapping(SMALLINT, ResultSet::getShort);
+        return ColumnMapping.longMapping(SMALLINT, ResultSet::getShort);
     }
 
-    public static ReadMapping integerReadMapping()
+    public static ColumnMapping integerColumnMapping()
     {
-        return longReadMapping(INTEGER, ResultSet::getInt);
+        return ColumnMapping.longMapping(INTEGER, ResultSet::getInt);
     }
 
-    public static ReadMapping bigintReadMapping()
+    public static ColumnMapping bigintColumnMapping()
     {
-        return longReadMapping(BIGINT, ResultSet::getLong);
+        return ColumnMapping.longMapping(BIGINT, ResultSet::getLong);
     }
 
-    public static ReadMapping realReadMapping()
+    public static ColumnMapping realColumnMapping()
     {
-        return longReadMapping(REAL, (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)));
+        return ColumnMapping.longMapping(REAL, (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)));
     }
 
-    public static ReadMapping doubleReadMapping()
+    public static ColumnMapping doubleColumnMapping()
     {
-        return ReadMapping.doubleReadMapping(DOUBLE, ResultSet::getDouble);
+        return ColumnMapping.doubleMapping(DOUBLE, ResultSet::getDouble);
     }
 
-    public static ReadMapping decimalReadMapping(DecimalType decimalType)
+    public static ColumnMapping decimalColumnMapping(DecimalType decimalType)
     {
         // JDBC driver can return BigDecimal with lower scale than column's scale when there are trailing zeroes
         int scale = decimalType.getScale();
         if (decimalType.isShort()) {
-            return longReadMapping(decimalType, (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale));
+            return ColumnMapping.longMapping(decimalType, (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale));
         }
-        return sliceReadMapping(decimalType, (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale));
+        return ColumnMapping.sliceMapping(decimalType, (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale));
     }
 
-    public static ReadMapping charReadMapping(CharType charType)
+    public static ColumnMapping charColumnMapping(CharType charType)
     {
         requireNonNull(charType, "charType is null");
-        return sliceReadMapping(charType, (resultSet, columnIndex) -> utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(columnIndex))));
+        return ColumnMapping.sliceMapping(charType, (resultSet, columnIndex) -> utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(columnIndex))));
     }
 
-    public static ReadMapping varcharReadMapping(VarcharType varcharType)
+    public static ColumnMapping varcharColumnMapping(VarcharType varcharType)
     {
-        return sliceReadMapping(varcharType, (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)));
+        return ColumnMapping.sliceMapping(varcharType, (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)));
     }
 
-    public static ReadMapping varbinaryReadMapping()
+    public static ColumnMapping varbinaryColumnMapping()
     {
-        return sliceReadMapping(VARBINARY, (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)));
+        return ColumnMapping.sliceMapping(VARBINARY, (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)));
     }
 
-    public static ReadMapping dateReadMapping()
+    public static ColumnMapping dateColumnMapping()
     {
-        return longReadMapping(DATE, (resultSet, columnIndex) -> {
+        return ColumnMapping.longMapping(DATE, (resultSet, columnIndex) -> {
             /*
              * JDBC returns a date using a timestamp at midnight in the JVM timezone, or earliest time after that if there was no midnight.
              * This works correctly for all dates and zones except when the missing local times 'gap' is 24h. I.e. this fails when JVM time
@@ -140,9 +138,9 @@ public final class StandardReadMappings
         });
     }
 
-    public static ReadMapping timeReadMapping()
+    public static ColumnMapping timeColumnMapping()
     {
-        return longReadMapping(TIME, (resultSet, columnIndex) -> {
+        return ColumnMapping.longMapping(TIME, (resultSet, columnIndex) -> {
             /*
              * TODO `resultSet.getTime(columnIndex)` returns wrong value if JVM's zone had forward offset change during 1970-01-01
              * and the time value being retrieved was not present in local time (a 'gap'), e.g. time retrieved is 00:10:00 and JVM zone is America/Hermosillo
@@ -153,9 +151,9 @@ public final class StandardReadMappings
         });
     }
 
-    public static ReadMapping timestampReadMapping()
+    public static ColumnMapping timestampColumnMapping()
     {
-        return longReadMapping(TIMESTAMP, (resultSet, columnIndex) -> {
+        return ColumnMapping.longMapping(TIMESTAMP, (resultSet, columnIndex) -> {
             /*
              * TODO `resultSet.getTimestamp(columnIndex)` returns wrong value if JVM's zone had forward offset change and the local time
              * corresponding to timestamp value being retrieved was not present (a 'gap'), this includes regular DST changes (e.g. Europe/Warsaw)
@@ -167,32 +165,32 @@ public final class StandardReadMappings
         });
     }
 
-    public static Optional<ReadMapping> jdbcTypeToPrestoType(JdbcTypeHandle type)
+    public static Optional<ColumnMapping> jdbcTypeToPrestoType(JdbcTypeHandle type)
     {
         int columnSize = type.getColumnSize();
         switch (type.getJdbcType()) {
             case Types.BIT:
             case Types.BOOLEAN:
-                return Optional.of(booleanReadMapping());
+                return Optional.of(booleanColumnMapping());
 
             case Types.TINYINT:
-                return Optional.of(tinyintReadMapping());
+                return Optional.of(tinyintColumnMapping());
 
             case Types.SMALLINT:
-                return Optional.of(smallintReadMapping());
+                return Optional.of(smallintColumnMapping());
 
             case Types.INTEGER:
-                return Optional.of(integerReadMapping());
+                return Optional.of(integerColumnMapping());
 
             case Types.BIGINT:
-                return Optional.of(bigintReadMapping());
+                return Optional.of(bigintColumnMapping());
 
             case Types.REAL:
-                return Optional.of(realReadMapping());
+                return Optional.of(realColumnMapping());
 
             case Types.FLOAT:
             case Types.DOUBLE:
-                return Optional.of(doubleReadMapping());
+                return Optional.of(doubleColumnMapping());
 
             case Types.NUMERIC:
             case Types.DECIMAL:
@@ -201,36 +199,36 @@ public final class StandardReadMappings
                 if (precision > Decimals.MAX_PRECISION) {
                     return Optional.empty();
                 }
-                return Optional.of(decimalReadMapping(createDecimalType(precision, max(decimalDigits, 0))));
+                return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
 
             case Types.CHAR:
             case Types.NCHAR:
                 // TODO this is wrong, we're going to construct malformed Slice representation if source > charLength
                 int charLength = min(columnSize, CharType.MAX_LENGTH);
-                return Optional.of(charReadMapping(createCharType(charLength)));
+                return Optional.of(charColumnMapping(createCharType(charLength)));
 
             case Types.VARCHAR:
             case Types.NVARCHAR:
             case Types.LONGVARCHAR:
             case Types.LONGNVARCHAR:
                 if (columnSize > VarcharType.MAX_LENGTH) {
-                    return Optional.of(varcharReadMapping(createUnboundedVarcharType()));
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType()));
                 }
-                return Optional.of(varcharReadMapping(createVarcharType(columnSize)));
+                return Optional.of(varcharColumnMapping(createVarcharType(columnSize)));
 
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
-                return Optional.of(varbinaryReadMapping());
+                return Optional.of(varbinaryColumnMapping());
 
             case Types.DATE:
-                return Optional.of(dateReadMapping());
+                return Optional.of(dateColumnMapping());
 
             case Types.TIME:
-                return Optional.of(timeReadMapping());
+                return Optional.of(timeColumnMapping());
 
             case Types.TIMESTAMP:
-                return Optional.of(timestampReadMapping());
+                return Optional.of(timestampColumnMapping());
         }
         return Optional.empty();
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -150,14 +150,12 @@ public final class StandardColumnMappings
             return ColumnMapping.longMapping(
                     decimalType,
                     (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale),
-                    shortDecimalWriteFunction(decimalType),
-                    domain -> Domain.all(domain.getType())); // TODO enable
+                    shortDecimalWriteFunction(decimalType));
         }
         return ColumnMapping.sliceMapping(
                 decimalType,
                 (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale),
-                longDecimalWriteFunction(decimalType),
-                domain -> Domain.all(domain.getType())); // TODO enable
+                longDecimalWriteFunction(decimalType));
     }
 
     public static LongWriteFunction shortDecimalWriteFunction(DecimalType decimalType)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.jdbc;
 import com.google.common.base.CharMatcher;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
+import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
@@ -149,12 +150,14 @@ public final class StandardColumnMappings
             return ColumnMapping.longMapping(
                     decimalType,
                     (resultSet, columnIndex) -> encodeShortScaledValue(resultSet.getBigDecimal(columnIndex), scale),
-                    shortDecimalWriteFunction(decimalType));
+                    shortDecimalWriteFunction(decimalType),
+                    domain -> Domain.all(domain.getType())); // TODO enable
         }
         return ColumnMapping.sliceMapping(
                 decimalType,
                 (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex), scale),
-                longDecimalWriteFunction(decimalType));
+                longDecimalWriteFunction(decimalType),
+                domain -> Domain.all(domain.getType())); // TODO enable
     }
 
     public static LongWriteFunction shortDecimalWriteFunction(DecimalType decimalType)
@@ -211,7 +214,8 @@ public final class StandardColumnMappings
         return ColumnMapping.sliceMapping(
                 VARBINARY,
                 (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)),
-                varbinaryWriteFunction());
+                varbinaryWriteFunction(),
+                domain -> Domain.all(domain.getType()));
     }
 
     public static SliceWriteFunction varbinaryWriteFunction()

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteFunction.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+public interface WriteFunction
+{
+    Class<?> getJavaType();
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteMapping.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class WriteMapping
+{
+    public static WriteMapping booleanMapping(String dataType, BooleanWriteFunction writeFunction)
+    {
+        return new WriteMapping(dataType, writeFunction);
+    }
+
+    public static WriteMapping longMapping(String dataType, LongWriteFunction writeFunction)
+    {
+        return new WriteMapping(dataType, writeFunction);
+    }
+
+    public static WriteMapping doubleMapping(String dataType, DoubleWriteFunction writeFunction)
+    {
+        return new WriteMapping(dataType, writeFunction);
+    }
+
+    public static WriteMapping sliceMapping(String dataType, SliceWriteFunction writeFunction)
+    {
+        return new WriteMapping(dataType, writeFunction);
+    }
+
+    private final String dataType;
+    private final WriteFunction writeFunction;
+
+    private WriteMapping(String dataType, WriteFunction writeFunction)
+    {
+        this.dataType = requireNonNull(dataType, "dataType is null");
+        this.writeFunction = requireNonNull(writeFunction, "writeFunction is null");
+    }
+
+    /**
+     * Data type that should be used in the remote database when defining a column.
+     */
+    public String getDataType()
+    {
+        return dataType;
+    }
+
+    public WriteFunction getWriteFunction()
+    {
+        return writeFunction;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("dataType", dataType)
+                .toString();
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -64,6 +64,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -197,7 +198,7 @@ public class TestJdbcQueryBuilder
                 .build());
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -220,7 +221,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Long> longBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<Float> floatBuilder = ImmutableSet.builder();
@@ -246,7 +247,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<String> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -274,7 +275,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<String> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -307,7 +308,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Date> dateBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<Time> timeBuilder = ImmutableSet.builder();
@@ -340,7 +341,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Timestamp> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -367,7 +368,7 @@ public class TestJdbcQueryBuilder
                 columns.get(1), Domain.onlyNull(DOUBLE)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", columns, tupleDomain, Optional.empty());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             assertEquals(resultSet.next(), false);
         }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcConnectorId;
+import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.type.Type;
@@ -38,6 +39,10 @@ import java.util.Set;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.prestosql.plugin.jdbc.DriverConnectionFactory.basicConnectionProperties;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.realWriteFunction;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
@@ -143,37 +148,41 @@ public class MySqlClient
     }
 
     @Override
-    protected String toSqlType(Type type)
+    protected WriteMapping toWriteMapping(Type type)
     {
         if (REAL.equals(type)) {
-            return "float";
+            return WriteMapping.longMapping("float", realWriteFunction());
         }
         if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
         }
         if (TIMESTAMP.equals(type)) {
-            return "datetime";
+            return WriteMapping.longMapping("datetime", timestampWriteFunction());
         }
         if (VARBINARY.equals(type)) {
-            return "mediumblob";
+            return WriteMapping.sliceMapping("mediumblob", varbinaryWriteFunction());
         }
         if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
+            String dataType;
             if (varcharType.isUnbounded()) {
-                return "longtext";
+                dataType = "longtext";
             }
-            if (varcharType.getBoundedLength() <= 255) {
-                return "tinytext";
+            else if (varcharType.getBoundedLength() <= 255) {
+                dataType = "tinytext";
             }
-            if (varcharType.getBoundedLength() <= 65535) {
-                return "text";
+            else if (varcharType.getBoundedLength() <= 65535) {
+                dataType = "text";
             }
-            if (varcharType.getBoundedLength() <= 16777215) {
-                return "mediumtext";
+            else if (varcharType.getBoundedLength() <= 16777215) {
+                dataType = "mediumtext";
             }
-            return "longtext";
+            else {
+                dataType = "longtext";
+            }
+            return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
         }
 
-        return super.toSqlType(type);
+        return super.toWriteMapping(type);
     }
 }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -148,7 +148,7 @@ public class MySqlClient
     }
 
     @Override
-    protected WriteMapping toWriteMapping(Type type)
+    public WriteMapping toWriteMapping(Type type)
     {
         if (REAL.equals(type)) {
             return WriteMapping.longMapping("float", realWriteFunction());

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
@@ -251,14 +251,14 @@ public class TestMySqlTypeMapping
     @Test
     public void testDatetime()
     {
-        // TODO MySQL datetime is not correctly read (see comment in StandardReadMappings.timestampReadMapping)
+        // TODO MySQL datetime is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 
     @Test
     public void testTimestamp()
     {
-        // TODO MySQL timestamp is not correctly read (see comment in StandardReadMappings.timestampReadMapping)
+        // TODO MySQL timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -18,6 +18,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcConnectorId;
 import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
+import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.type.Type;
 import org.postgresql.Driver;
 
@@ -29,6 +30,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.String.format;
 
@@ -82,12 +84,12 @@ public class PostgreSqlClient
     }
 
     @Override
-    protected String toSqlType(Type type)
+    protected WriteMapping toWriteMapping(Type type)
     {
         if (VARBINARY.equals(type)) {
-            return "bytea";
+            return WriteMapping.sliceMapping("bytea", varbinaryWriteFunction());
         }
 
-        return super.toSqlType(type);
+        return super.toWriteMapping(type);
     }
 }

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -84,7 +84,7 @@ public class PostgreSqlClient
     }
 
     @Override
-    protected WriteMapping toWriteMapping(Type type)
+    public WriteMapping toWriteMapping(Type type)
     {
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("bytea", varbinaryWriteFunction());

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -15,10 +15,13 @@ package io.prestosql.plugin.postgresql;
 
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcConnectorId;
 import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
+import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.WriteMapping;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
 import org.postgresql.Driver;
 
@@ -29,6 +32,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -81,6 +85,13 @@ public class PostgreSqlClient
                 escapeNamePattern(schemaName, escape),
                 escapeNamePattern(tableName, escape),
                 new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
+    }
+
+    @Override
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
+    {
+        // TODO support PostgreSQL's TIMESTAMP WITH TIME ZONE and TIME WITH TIME ZONE explicitly, otherwise predicate pushdown for these types may be incorrect
+        return super.toPrestoType(session, typeHandle);
     }
 
     @Override

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -264,7 +264,7 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testTimestamp()
     {
-        // TODO timestamp is not correctly read (see comment in StandardReadMappings.timestampReadMapping)
+        // TODO timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 


### PR DESCRIPTION
Today, a jdbc-based connector controls how data should be read from a `ResultSet` via `ReadMapping` definitions. However, writing is hard-coded in `JdbcPageSink#appendColumn`.
This expands the `ReadMapping` concept into `ColumnMapping` which controls both reading and pushdown.
This also introduces separate `WriteMapping` concept which is used for writing (currently both CTAS and INSERT)

Ref https://github.com/prestodb/presto/pull/12151



