### PR TITLE
Fix creating empty non-bucketed Hive partition

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1331,13 +1331,6 @@ public class HiveMetadata
         Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, partitionedBy, columnTypes);
 
         for (PartitionUpdate partitionUpdate : partitionUpdates) {
-            if (partitionUpdate.getFileNames().size() == 0) {
-                HiveWriteUtils.createDirectory(
-                        new HdfsContext(session, table.get().getDatabaseName(), table.get().getTableName()),
-                        hdfsEnvironment,
-                        partitionUpdate.getWritePath());
-            }
-
             if (partitionUpdate.getName().isEmpty()) {
                 // insert into unpartitioned table
                 PartitionStatistics partitionStatistics = createPartitionStatistics(

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1246,13 +1246,19 @@ public class SemiTransactionalHiveMetastore
                     schemaTableName,
                     ignored -> new PartitionAdder(partition.getDatabaseName(), partition.getTableName(), delegate, PARTITION_COMMIT_BATCH_SIZE));
 
-            if (!targetPath.equals(currentPath)) {
-                renameDirectory(
-                        context,
-                        hdfsEnvironment,
-                        currentPath,
-                        targetPath,
-                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
+            if (pathExists(context, hdfsEnvironment, currentPath)) {
+                if (!targetPath.equals(currentPath)) {
+                    renameDirectory(
+                            context,
+                            hdfsEnvironment,
+                            currentPath,
+                            targetPath,
+                            () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
+                }
+            }
+            else {
+                cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true));
+                createDirectory(context, hdfsEnvironment, targetPath);
             }
             String partitionName = getPartitionName(partition.getDatabaseName(), partition.getTableName(), partition.getValues());
             partitionAdder.addPartition(new PartitionWithStatistics(partition, partitionName, partitionAndMore.getStatisticsUpdate()));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -947,26 +947,22 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testCreateEmptyPartition()
+    public void testCreateEmptyNonBucketedPartition()
     {
-        String tableName = "empty_partition_table";
-        assertUpdate(format("" +
-                "CREATE TABLE %s " +
-                "WITH ( " +
-                " FORMAT = 'ORC', " +
-                "   partitioned_by = ARRAY['p_varchar'] " +
-                ") " +
-                "AS " +
-                "SELECT c_bigint, p_varchar " +
-                "FROM ( " +
-                "  VALUES " +
-                "    (BIGINT '7', 'longlonglong')" +
-                ") AS x (c_bigint, p_varchar)", tableName), 1);
-        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 1");
+        String tableName = "test_insert_empty_partitioned_unbucketed_table";
+        assertUpdate("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  dummy_col bigint," +
+                "  part varchar)" +
+                "WITH (" +
+                "  format = 'ORC', " +
+                "  partitioned_by = ARRAY[ 'part' ] " +
+                ")");
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 0");
 
         // create an empty partition
-        assertUpdate(format("CALL system.create_empty_partition('%s', '%s', ARRAY['p_varchar'], ARRAY['%s'])", TPCH_SCHEMA, tableName, "empty"));
-        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 2");
+        assertUpdate(format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'])", TPCH_SCHEMA, tableName, "empty"));
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 1");
         assertUpdate("DROP TABLE " + tableName);
     }
 


### PR DESCRIPTION
Previously, creating empty non-bucketed Hive partition procedure call
does not work when the WriteMode is STAGE_AND_MOVE_TO_TARGET_DIRECTORY,
since no file is created and the stage directory will not exist.

Extracted-From: https://github.com/prestodb/presto/pull/12204

Fixes: https://github.com/prestosql/presto/issues/104