### PR TITLE
Remove equals and hashCode methods from Identity

### DIFF
--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
@@ -480,7 +480,7 @@ public class TestQueryStateMachine
     private static void assertEqualSessionsWithoutTransactionId(Session actual, Session expected)
     {
         assertEquals(actual.getQueryId(), expected.getQueryId());
-        assertEquals(actual.getIdentity(), expected.getIdentity());
+        assertEquals(actual.getIdentity().getUser(), expected.getIdentity().getUser());
         assertEquals(actual.getSource(), expected.getSource());
         assertEquals(actual.getCatalog(), expected.getCatalog());
         assertEquals(actual.getSchema(), expected.getSchema());

--- a/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
@@ -15,7 +15,6 @@ package io.prestosql.spi.security;
 
 import java.security.Principal;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
@@ -69,20 +68,15 @@ public class Identity
     @Override
     public boolean equals(Object o)
     {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Identity identity = (Identity) o;
-        return Objects.equals(user, identity.user);
+        // TODO: remove equals completely after a few months
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(user);
+        // TODO remove hashCode completely after a few months
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Remove equals and hashCode methods from Identity

equals and hashCode methods from Identity were based only on one field
out of three. It is questionable if Identities with different principals and
same user are still same objects. Such case should be solved in place of
usage, not in the entity. So far these methods were not used (Identity
or any object that wraps it was not stored in any collection).
