### PR TITLE
Fix information_schema.columns queries for Kafka

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -82,6 +82,7 @@ import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static io.prestosql.tests.StructuralTestUtil.mapType;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -105,8 +106,8 @@ import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestParquetReader
 {
-    private static final int MAX_PRECISION_INT32 = (int) maxPrecision(4);
-    private static final int MAX_PRECISION_INT64 = (int) maxPrecision(8);
+    private static final int MAX_PRECISION_INT32 = toIntExact(maxPrecision(4));
+    private static final int MAX_PRECISION_INT64 = toIntExact(maxPrecision(8));
 
     private Logger parquetLogger;
 
@@ -191,10 +192,10 @@ public abstract class AbstractTestParquetReader
     }
 
     @Test
-    public void testCustomSchemaArrayOfStucts()
+    public void testCustomSchemaArrayOfStructs()
             throws Exception
     {
-        MessageType customSchemaArrayOfStucts = parseMessageType("message ParquetSchema { " +
+        MessageType customSchemaArrayOfStructs = parseMessageType("message ParquetSchema { " +
                 "  optional group self (LIST) { " +
                 "    repeated group self_tuple { " +
                 "      optional int64 a; " +
@@ -213,11 +214,11 @@ public abstract class AbstractTestParquetReader
         Type structType = RowType.from(asList(field("a", BIGINT), field("b", BOOLEAN), field("c", VARCHAR)));
         tester.testSingleLevelArrayRoundTrip(
                 getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector))),
-                values, values, "self", new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
+                values, values, "self", new ArrayType(structType), Optional.of(customSchemaArrayOfStructs));
     }
 
     @Test
-    public void testSingleLevelSchemaArrayOfStucts()
+    public void testSingleLevelSchemaArrayOfStructs()
             throws Exception
     {
         Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
@@ -42,7 +42,6 @@ import java.util.function.Supplier;
 
 import static io.prestosql.plugin.kafka.KafkaHandleResolver.convertColumnHandle;
 import static io.prestosql.plugin.kafka.KafkaHandleResolver.convertTableHandle;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -186,8 +185,7 @@ public class KafkaMetadata
                 columns.put(tableName, getTableMetadata(tableName).getColumns());
             }
             catch (TableNotFoundException e) {
-                // Normally it would mean the table disappeared during listing operation
-                throw new IllegalStateException(format("Table %s cannot be gone because tables are statically defined", tableName), e);
+                // information_schema table or a system table
             }
         }
         return columns.build();

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestIntegrationSmokeTest.java
@@ -173,6 +173,13 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "SELECT table_name, column_name FROM information_schema.columns " +
                         "WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '%orders%'",
                 ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
         assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
     }
 

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueryFramework.java
@@ -203,6 +203,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertUpdate(queryRunner, session, sql, OptionalLong.of(count), Optional.of(planAssertion));
     }
 
+    protected void assertQuerySucceeds(@Language("SQL") String sql)
+    {
+        assertQuerySucceeds(getSession(), sql);
+    }
+
     protected void assertQuerySucceeds(Session session, @Language("SQL") String sql)
     {
         QueryAssertions.assertQuerySucceeds(queryRunner, session, sql);

--- a/presto-tpcds/src/test/java/io/prestosql/plugin/tpcds/TestTpcds.java
+++ b/presto-tpcds/src/test/java/io/prestosql/plugin/tpcds/TestTpcds.java
@@ -71,9 +71,4 @@ public class TestTpcds
         assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price IN (i_wholesale_cost, " + longValues + ")");
         assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price NOT IN (i_wholesale_cost, " + longValues + ")");
     }
-
-    private void assertQuerySucceeds(String sql)
-    {
-        computeActual(sql);
-    }
 }


### PR DESCRIPTION
Before the change, the queries would sometimes (depending on
filter conditions) fail with:
```
Caused by: java.lang.IllegalStateException: Table information_schema.enabled_roles cannot be gone because tables are statically defined
	at io.prestosql.plugin.kafka.KafkaMetadata.listTableColumns(KafkaMetadata.java:190)
	at io.prestosql.metadata.MetadataManager.listTableColumns(MetadataManager.java:529)
	at io.prestosql.metadata.MetadataListing.listTableColumns(MetadataListing.java:93)
	at io.prestosql.connector.informationSchema.InformationSchemaPageSourceProvider.buildColumns(InformationSchemaPageSourceProvider.java:147)
	at io.prestosql.connector.informationSchema.InformationSchemaPageSourceProvider.getInformationSchemaTable(InformationSchemaPageSourceProvider.java:116)
	at io.prestosql.connector.informationSchema.InformationSchemaPageSourceProvider.getInternalTable(InformationSchemaPageSourceProvider.java:110)
	at io.prestosql.connector.informationSchema.InformationSchemaPageSourceProvider.createPageSource(InformationSchemaPageSourceProvider.java:80)
```

Note: this is not related to roles. Any information_schema table would
cause this.