### PR TITLE
GCS OAuth token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
         <dep.jmxutils.version>1.20</dep.jmxutils.version>
+        <dep.gcs.version>1.9.10</dep.gcs.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -884,6 +885,40 @@
                 <groupId>io.airlift</groupId>
                 <artifactId>testing-mysql-server</artifactId>
                 <version>5.7.22-1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>util</artifactId>
+                <version>${dep.gcs.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>gcsio</artifactId>
+                <version>${dep.gcs.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>util-hadoop</artifactId>
+                <version>hadoop2-${dep.gcs.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>gcs-connector</artifactId>
+                <version>hadoop2-${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
@@ -103,6 +103,7 @@ public class BenchmarkDriverOptions
                 toProperties(this.sessionProperties),
                 ImmutableMap.of(),
                 ImmutableMap.of(),
+                ImmutableMap.of(),
                 null,
                 clientRequestTimeout);
     }

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -125,6 +125,9 @@ public class ClientOptions
     @Option(name = "--session", title = "session", description = "Session property (property can be used multiple times; format is key=value; use 'SHOW SESSION' to see available properties)")
     public final List<ClientSessionProperty> sessionProperties = new ArrayList<>();
 
+    @Option(name = "--extra-credential", title = "extra-credential", description = "Extra credentials (property can be used multiple times; format is key=value)")
+    public final List<ClientExtraCredential> extraCredentials = new ArrayList<>();
+
     @Option(name = "--socks-proxy", title = "socks-proxy", description = "SOCKS proxy to use for server connections")
     public HostAndPort socksProxy;
 
@@ -166,6 +169,7 @@ public class ClientOptions
                 toProperties(sessionProperties),
                 emptyMap(),
                 emptyMap(),
+                toExtraCredentials(extraCredentials),
                 null,
                 clientRequestTimeout);
     }
@@ -210,6 +214,15 @@ public class ClientOptions
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         for (ClientResourceEstimate estimate : estimates) {
             builder.put(estimate.getResource(), estimate.getEstimate());
+        }
+        return builder.build();
+    }
+
+    public static Map<String, String> toExtraCredentials(List<ClientExtraCredential> extraCredentials)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (ClientExtraCredential credential : extraCredentials) {
+            builder.put(credential.getName(), credential.getValue());
         }
         return builder.build();
     }
@@ -364,6 +377,67 @@ public class ClientOptions
             return Objects.equals(this.catalog, other.catalog) &&
                     Objects.equals(this.name, other.name) &&
                     Objects.equals(this.value, other.value);
+        }
+    }
+
+    public static final class ClientExtraCredential
+    {
+        private final String name;
+        private final String value;
+
+        public ClientExtraCredential(String extraCredential)
+        {
+            List<String> nameValue = NAME_VALUE_SPLITTER.splitToList(extraCredential);
+            checkArgument(nameValue.size() == 2, "Extra credential: %s", extraCredential);
+
+            this.name = nameValue.get(0);
+            this.value = nameValue.get(1);
+            checkArgument(!name.isEmpty(), "Credential name is empty");
+            checkArgument(!value.isEmpty(), "Credential value is empty");
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(name), "Credential name contains spaces or is not US_ASCII: %s", name);
+            checkArgument(name.indexOf('=') < 0, "Credential name must not contain '=': %s", name);
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "Credential value contains space or is not US_ASCII: %s", name);
+        }
+
+        public ClientExtraCredential(String name, String value)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.value = value;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name + '=' + value;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ClientExtraCredential other = (ClientExtraCredential) o;
+            return Objects.equals(name, other.name) && Objects.equals(value, other.value);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, value);
         }
     }
 }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
@@ -99,6 +99,16 @@ public class TestClientOptions
     }
 
     @Test
+    public void testExtraCredentials()
+    {
+        Console console = singleCommand(Console.class).parse("--extra-credential", "test.token.foo=foo", "--extra-credential", "test.token.bar=bar");
+        ClientOptions options = console.clientOptions;
+        assertEquals(options.extraCredentials, ImmutableList.of(
+                new ClientOptions.ClientExtraCredential("test.token.foo", "foo"),
+                new ClientOptions.ClientExtraCredential("test.token.bar", "bar")));
+    }
+
+    @Test
     public void testSessionProperties()
     {
         Console console = singleCommand(Console.class).parse("--session", "system=system-value", "--session", "catalog.name=catalog-property");
@@ -143,5 +153,13 @@ public class TestClientOptions
     public void testEqualSignNoAllowedInPropertyCatalog()
     {
         new ClientSessionProperty(Optional.of("cat=alog"), "name", "value");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Multiple entries with same key: test.token.foo=bar and test.token.foo=foo")
+    public void testDuplicateExtraCredentialKey()
+    {
+        Console console = singleCommand(Console.class).parse("--extra-credential", "test.token.foo=foo", "--extra-credential", "test.token.foo=bar");
+        ClientOptions options = console.clientOptions;
+        options.toClientSession();
     }
 }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -100,6 +100,7 @@ public class TestQueryRunner
                         ImmutableMap.of(),
                         ImmutableMap.of(),
                         ImmutableMap.of(),
+                        ImmutableMap.of(),
                         null,
                         new Duration(2, MINUTES)));
         try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {

--- a/presto-client/src/main/java/io/prestosql/client/ClientSession.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientSession.java
@@ -48,6 +48,7 @@ public class ClientSession
     private final Map<String, String> properties;
     private final Map<String, String> preparedStatements;
     private final Map<String, ClientSelectedRole> roles;
+    private final Map<String, String> extraCredentials;
     private final String transactionId;
     private final Duration clientRequestTimeout;
 
@@ -79,6 +80,7 @@ public class ClientSession
             Map<String, String> properties,
             Map<String, String> preparedStatements,
             Map<String, ClientSelectedRole> roles,
+            Map<String, String> extraCredentials,
             String transactionId,
             Duration clientRequestTimeout)
     {
@@ -98,6 +100,7 @@ public class ClientSession
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
         this.preparedStatements = ImmutableMap.copyOf(requireNonNull(preparedStatements, "preparedStatements is null"));
         this.roles = ImmutableMap.copyOf(requireNonNull(roles, "roles is null"));
+        this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
         this.clientRequestTimeout = clientRequestTimeout;
 
         for (String clientTag : clientTags) {
@@ -118,6 +121,14 @@ public class ClientSession
             checkArgument(entry.getKey().indexOf('=') < 0, "Session property name must not contain '=': %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getKey()), "Session property name is not US_ASCII: %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getValue()), "Session property value is not US_ASCII: %s", entry.getValue());
+        }
+
+        // verify the extra credentials are valid
+        for (Entry<String, String> entry : extraCredentials.entrySet()) {
+            checkArgument(!entry.getKey().isEmpty(), "Credential name is empty");
+            checkArgument(entry.getKey().indexOf('=') < 0, "Credential name must not contain '=': %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getKey()), "Credential name is not US_ASCII: %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getValue()), "Credential value is not US_ASCII: %s", entry.getValue());
         }
     }
 
@@ -199,6 +210,11 @@ public class ClientSession
         return roles;
     }
 
+    public Map<String, String> getExtraCredentials()
+    {
+        return extraCredentials;
+    }
+
     public String getTransactionId()
     {
         return transactionId;
@@ -251,6 +267,7 @@ public class ClientSession
         private Map<String, String> properties;
         private Map<String, String> preparedStatements;
         private Map<String, ClientSelectedRole> roles;
+        private Map<String, String> credentials;
         private String transactionId;
         private Duration clientRequestTimeout;
 
@@ -272,6 +289,7 @@ public class ClientSession
             properties = clientSession.getProperties();
             preparedStatements = clientSession.getPreparedStatements();
             roles = clientSession.getRoles();
+            credentials = clientSession.getExtraCredentials();
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
         }
@@ -303,6 +321,12 @@ public class ClientSession
         public Builder withRoles(Map<String, ClientSelectedRole> roles)
         {
             this.roles = roles;
+            return this;
+        }
+
+        public Builder withCredentials(Map<String, String> credentials)
+        {
+            this.credentials = requireNonNull(credentials, "extraCredentials is null");
             return this;
         }
 
@@ -342,6 +366,7 @@ public class ClientSession
                     properties,
                     preparedStatements,
                     roles,
+                    credentials,
                     transactionId,
                     clientRequestTimeout);
         }

--- a/presto-client/src/main/java/io/prestosql/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/io/prestosql/client/PrestoHeaders.java
@@ -41,6 +41,7 @@ public final class PrestoHeaders
     public static final String PRESTO_CLIENT_TAGS = "X-Presto-Client-Tags";
     public static final String PRESTO_CLIENT_CAPABILITIES = "X-Presto-Client-Capabilities";
     public static final String PRESTO_RESOURCE_ESTIMATE = "X-Presto-Resource-Estimate";
+    public static final String PRESTO_EXTRA_CREDENTIAL = "X-Presto-Extra-Credential";
 
     public static final String PRESTO_CURRENT_STATE = "X-Presto-Current-State";
     public static final String PRESTO_MAX_WAIT = "X-Presto-Max-Wait";

--- a/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
@@ -57,6 +57,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_CAPABILITIES;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_TAGS;
 import static io.prestosql.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static io.prestosql.client.PrestoHeaders.PRESTO_EXTRA_CREDENTIAL;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -187,6 +188,11 @@ class StatementClientV1
         Map<String, ClientSelectedRole> roles = session.getRoles();
         for (Entry<String, ClientSelectedRole> entry : roles.entrySet()) {
             builder.addHeader(PrestoHeaders.PRESTO_ROLE, entry.getKey() + '=' + urlEncode(entry.getValue().toString()));
+        }
+
+        Map<String, String> extraCredentials = session.getExtraCredentials();
+        for (Entry<String, String> entry : extraCredentials.entrySet()) {
+            builder.addHeader(PRESTO_EXTRA_CREDENTIAL, entry.getKey() + "=" + entry.getValue());
         }
 
         Map<String, String> statements = session.getPreparedStatements();

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -104,4 +104,7 @@ Name                              Description
 ``KerberosConfigPath``            Kerberos configuration file.
 ``KerberosKeytabPath``            Kerberos keytab file.
 ``KerberosCredentialCachePath``   Kerberos credential cache.
+``extraCredentials``              Extra credentials for connecting to external services. The
+                                  extraCredentials is a list of key-value pairs. Example:
+                                  ``foo:bar;abc:xyz`` will create credentials ``abc=xyz`` and ``foo=bar``
 ================================= =======================================================================

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.geospatial;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.Session;
 import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
@@ -77,7 +78,7 @@ public class TestSpatialJoins
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
 
         FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -16,7 +16,7 @@ package io.prestosql.plugin.geospatial;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.Session;
 import io.prestosql.plugin.hive.HdfsConfiguration;
-import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveClientConfig;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
@@ -78,7 +78,7 @@ public class TestSpatialJoins
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
 
         FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -49,7 +49,7 @@ public abstract class AbstractTestHiveFileSystemS3
         S3ConfigurationUpdater s3Config = new PrestoS3ConfigurationUpdater(new HiveS3Config()
                 .setS3AwsAccessKey(awsAccessKey)
                 .setS3AwsSecretKey(awsSecretKey));
-        return new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, s3Config), ImmutableSet.of());
+        return new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, s3Config, ignored -> {}), ImmutableSet.of());
     }
 
     @Override

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -49,7 +49,7 @@ public abstract class AbstractTestHiveFileSystemS3
         S3ConfigurationUpdater s3Config = new PrestoS3ConfigurationUpdater(new HiveS3Config()
                 .setS3AwsAccessKey(awsAccessKey)
                 .setS3AwsSecretKey(awsSecretKey));
-        return new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, s3Config), ImmutableSet.of());
+        return new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, s3Config), ImmutableSet.of());
     }
 
     @Override

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.plugin.hive.s3.PrestoS3ConfigurationUpdater;
 import io.prestosql.plugin.hive.s3.S3ConfigurationUpdater;
@@ -48,7 +49,7 @@ public abstract class AbstractTestHiveFileSystemS3
         S3ConfigurationUpdater s3Config = new PrestoS3ConfigurationUpdater(new HiveS3Config()
                 .setS3AwsAccessKey(awsAccessKey)
                 .setS3AwsSecretKey(awsSecretKey));
-        return new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, s3Config));
+        return new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, s3Config), ImmutableSet.of());
     }
 
     @Override

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -166,6 +166,26 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcsio</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>util-hadoop</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <scope>runtime</scope>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/DynamicConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/DynamicConfigurationProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+
+import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+
+public interface DynamicConfigurationProvider
+{
+    void updateConfiguration(Configuration configuration, HdfsContext context, URI uri);
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfigurationInitializer.java
@@ -50,7 +50,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DOMAIN_SOCKET_PATH_KEY;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.COMPRESSRESULT;
 import static org.apache.hadoop.io.SequenceFile.CompressionType.BLOCK;
 
-public class HdfsConfigurationUpdater
+public class HdfsConfigurationInitializer
 {
     private final HostAndPort socksProxy;
     private final Duration ipcPingInterval;
@@ -66,13 +66,13 @@ public class HdfsConfigurationUpdater
     private int textMaxLineLength;
 
     @VisibleForTesting
-    public HdfsConfigurationUpdater(HiveClientConfig config)
+    public HdfsConfigurationInitializer(HiveClientConfig config)
     {
         this(config, ignored -> {});
     }
 
     @Inject
-    public HdfsConfigurationUpdater(HiveClientConfig config, S3ConfigurationUpdater s3ConfigurationUpdater)
+    public HdfsConfigurationInitializer(HiveClientConfig config, S3ConfigurationUpdater s3ConfigurationUpdater)
     {
         requireNonNull(config, "config is null");
         checkArgument(config.getDfsTimeout().toMillis() >= 1, "dfsTimeout must be at least 1 ms");
@@ -106,7 +106,7 @@ public class HdfsConfigurationUpdater
         return result;
     }
 
-    public void updateConfiguration(Configuration config)
+    public void initializeConfiguration(Configuration config)
     {
         copy(resourcesConfiguration, config);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
@@ -63,6 +63,7 @@ public class HiveClientModule
         binder.bind(CoercionPolicy.class).to(HiveCoercionPolicy.class).in(Scopes.SINGLETON);
 
         binder.bind(HdfsConfigurationUpdater.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, DynamicConfigurationProvider.class);
         binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsEnvironment.class).in(Scopes.SINGLETON);
         binder.bind(DirectoryLister.class).to(HadoopDirectoryLister.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveClientModule.java
@@ -62,7 +62,7 @@ public class HiveClientModule
         binder.bind(TypeTranslator.class).toInstance(new HiveTypeTranslator());
         binder.bind(CoercionPolicy.class).to(HiveCoercionPolicy.class).in(Scopes.SINGLETON);
 
-        binder.bind(HdfsConfigurationUpdater.class).in(Scopes.SINGLETON);
+        binder.bind(HdfsConfigurationInitializer.class).in(Scopes.SINGLETON);
         newSetBinder(binder, DynamicConfigurationProvider.class);
         binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsEnvironment.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
@@ -22,6 +22,7 @@ import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationModule;
+import io.prestosql.plugin.hive.gcs.HiveGcsModule;
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
 import io.prestosql.plugin.hive.s3.HiveS3Module;
@@ -100,6 +101,7 @@ public class HiveConnectorFactory
                     new JsonModule(),
                     new HiveClientModule(catalogName),
                     new HiveS3Module(),
+                    new HiveGcsModule(),
                     new HiveMetastoreModule(metastore),
                     new HiveSecurityModule(),
                     new HiveAuthenticationModule(),

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveHdfsConfiguration.java
@@ -13,12 +13,14 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.conf.Configuration;
 
 import javax.inject.Inject;
 
 import java.net.URI;
+import java.util.Set;
 
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.copy;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.getInitialConfiguration;
@@ -37,23 +39,31 @@ public class HiveHdfsConfiguration
         {
             Configuration configuration = new Configuration(false);
             copy(INITIAL_CONFIGURATION, configuration);
-            updater.updateConfiguration(configuration);
+            initializer.updateConfiguration(configuration);
             return configuration;
         }
     };
 
-    private final HdfsConfigurationUpdater updater;
+    private final HdfsConfigurationUpdater initializer;
+    private final Set<DynamicConfigurationProvider> dynamicProviders;
 
     @Inject
-    public HiveHdfsConfiguration(HdfsConfigurationUpdater updater)
+    public HiveHdfsConfiguration(HdfsConfigurationUpdater initializer, Set<DynamicConfigurationProvider> dynamicProviders)
     {
-        this.updater = requireNonNull(updater, "updater is null");
+        this.initializer = requireNonNull(initializer, "initializer is null");
+        this.dynamicProviders = ImmutableSet.copyOf(requireNonNull(dynamicProviders, "dynamicProviders is null"));
     }
 
     @Override
     public Configuration getConfiguration(HdfsContext context, URI uri)
     {
-        // use the same configuration for everything
-        return hadoopConfiguration.get();
+        if (dynamicProviders.isEmpty()) {
+            return hadoopConfiguration.get();
+        }
+        Configuration config = copy(hadoopConfiguration.get());
+        for (DynamicConfigurationProvider provider : dynamicProviders) {
+            provider.updateConfiguration(config, context, uri);
+        }
+        return config;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveHdfsConfiguration.java
@@ -39,16 +39,16 @@ public class HiveHdfsConfiguration
         {
             Configuration configuration = new Configuration(false);
             copy(INITIAL_CONFIGURATION, configuration);
-            initializer.updateConfiguration(configuration);
+            initializer.initializeConfiguration(configuration);
             return configuration;
         }
     };
 
-    private final HdfsConfigurationUpdater initializer;
+    private final HdfsConfigurationInitializer initializer;
     private final Set<DynamicConfigurationProvider> dynamicProviders;
 
     @Inject
-    public HiveHdfsConfiguration(HdfsConfigurationUpdater initializer, Set<DynamicConfigurationProvider> dynamicProviders)
+    public HiveHdfsConfiguration(HdfsConfigurationInitializer initializer, Set<DynamicConfigurationProvider> dynamicProviders)
     {
         this.initializer = requireNonNull(initializer, "initializer is null");
         this.dynamicProviders = ImmutableSet.copyOf(requireNonNull(dynamicProviders, "dynamicProviders is null"));
@@ -58,6 +58,7 @@ public class HiveHdfsConfiguration
     public Configuration getConfiguration(HdfsContext context, URI uri)
     {
         if (dynamicProviders.isEmpty()) {
+            // use the same configuration for everything
             return hadoopConfiguration.get();
         }
         Configuration config = copy(hadoopConfiguration.get());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/AuthenticationModules.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/AuthenticationModules.java
@@ -20,7 +20,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.prestosql.plugin.hive.ForHdfs;
 import io.prestosql.plugin.hive.ForHiveMetastore;
-import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 
 import javax.inject.Inject;
 
@@ -57,7 +57,7 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHiveMetastore
-            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config, HdfsConfigurationUpdater updater)
+            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config, HdfsConfigurationInitializer updater)
             {
                 String principal = config.getHiveMetastoreClientPrincipal();
                 String keytabLocation = config.getHiveMetastoreClientKeytab();
@@ -102,7 +102,7 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HdfsConfigurationUpdater updater)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HdfsConfigurationInitializer updater)
             {
                 String principal = config.getHdfsPrestoPrincipal();
                 String keytabLocation = config.getHdfsPrestoKeytab();
@@ -128,7 +128,7 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HdfsConfigurationUpdater updater)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HdfsConfigurationInitializer updater)
             {
                 String principal = config.getHdfsPrestoPrincipal();
                 String keytabLocation = config.getHdfsPrestoKeytab();
@@ -137,7 +137,7 @@ public final class AuthenticationModules
         };
     }
 
-    private static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation, HdfsConfigurationUpdater updater)
+    private static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation, HdfsConfigurationInitializer updater)
     {
         KerberosAuthentication kerberosAuthentication = new KerberosAuthentication(principal, keytabLocation);
         KerberosHadoopAuthentication kerberosHadoopAuthentication = createKerberosHadoopAuthentication(kerberosAuthentication, updater);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/KerberosHadoopAuthentication.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/KerberosHadoopAuthentication.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.plugin.hive.authentication;
 
-import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 
@@ -28,10 +28,10 @@ public class KerberosHadoopAuthentication
 {
     private final KerberosAuthentication kerberosAuthentication;
 
-    public static KerberosHadoopAuthentication createKerberosHadoopAuthentication(KerberosAuthentication kerberosAuthentication, HdfsConfigurationUpdater updater)
+    public static KerberosHadoopAuthentication createKerberosHadoopAuthentication(KerberosAuthentication kerberosAuthentication, HdfsConfigurationInitializer initializer)
     {
         Configuration configuration = getInitialConfiguration();
-        updater.updateConfiguration(configuration);
+        initializer.initializeConfiguration(configuration);
 
         // In order to enable KERBEROS authentication method for HDFS
         // UserGroupInformation.authenticationMethod static field must be set to KERBEROS

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsAccessTokenProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsAccessTokenProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.concurrent.TimeUnit.HOURS;
+
+public class GcsAccessTokenProvider
+        implements AccessTokenProvider
+{
+    public static final String GCS_ACCESS_KEY_CONF = "presto.gcs.oauth-access-token";
+    public static final Long EXPIRATION_TIME_MILLISECONDS = HOURS.toMillis(1);
+    private Configuration config;
+
+    @Override
+    public AccessToken getAccessToken()
+    {
+        return new AccessToken(nullToEmpty(config.get(GCS_ACCESS_KEY_CONF)), EXPIRATION_TIME_MILLISECONDS);
+    }
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public void setConf(Configuration configuration)
+    {
+        this.config = configuration;
+    }
+
+    @Override
+    public Configuration getConf()
+    {
+        return config;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationInitializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import org.apache.hadoop.conf.Configuration;
+
+public interface GcsConfigurationInitializer
+{
+    void updateConfiguration(Configuration config);
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
+import io.prestosql.plugin.hive.DynamicConfigurationProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+
+import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import static io.prestosql.plugin.hive.gcs.GcsAccessTokenProvider.GCS_ACCESS_KEY_CONF;
+
+public class GcsConfigurationProvider
+        implements DynamicConfigurationProvider
+{
+    @Override
+    public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
+    {
+        if (!uri.getScheme().equals(GoogleCloudStorageFileSystem.SCHEME)) {
+            return;
+        }
+
+        String accessToken = context.getIdentity().getExtraCredentials().get(GCS_ACCESS_KEY_CONF);
+        if (accessToken != null) {
+            configuration.set(GCS_ACCESS_KEY_CONF, accessToken);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GoogleGcsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GoogleGcsConfigurationInitializer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import org.apache.hadoop.conf.Configuration;
+
+import javax.inject.Inject;
+
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.AUTHENTICATION_PREFIX;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.AUTH_SERVICE_ACCOUNT_ENABLE;
+import static com.google.cloud.hadoop.util.AccessTokenProviderClassFromConfigFactory.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX;
+import static com.google.cloud.hadoop.util.EntriesCredentialConfiguration.JSON_KEYFILE_SUFFIX;
+
+public class GoogleGcsConfigurationInitializer
+        implements GcsConfigurationInitializer
+{
+    private final boolean useGcsAccessToken;
+    private final String jsonKeyFilePath;
+
+    @Inject
+    public GoogleGcsConfigurationInitializer(HiveGcsConfig config)
+    {
+        this.useGcsAccessToken = config.isUseGcsAccessToken();
+        this.jsonKeyFilePath = config.getJsonKeyFilePath();
+    }
+
+    public void updateConfiguration(Configuration config)
+    {
+        config.set("fs.gs.impl", GoogleHadoopFileSystem.class.getName());
+
+        if (useGcsAccessToken) {
+            // use oauth token to authenticate with Google Cloud Storage
+            config.set(AUTHENTICATION_PREFIX + ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX, GcsAccessTokenProvider.class.getName());
+        }
+        else if (jsonKeyFilePath != null) {
+            // use service account key file
+            config.set(AUTH_SERVICE_ACCOUNT_ENABLE.getKey(), "true");
+            config.set(AUTHENTICATION_PREFIX + JSON_KEYFILE_SUFFIX, jsonKeyFilePath);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/HiveGcsConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/HiveGcsConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class HiveGcsConfig
+{
+    private boolean useGcsAccessToken;
+    private String jsonKeyFilePath;
+
+    public String getJsonKeyFilePath()
+    {
+        return jsonKeyFilePath;
+    }
+
+    @Config("hive.gcs.json-key-file-path")
+    @ConfigDescription("JSON key file used to access Google Cloud Storage")
+    public HiveGcsConfig setJsonKeyFilePath(String jsonKeyFilePath)
+    {
+        this.jsonKeyFilePath = jsonKeyFilePath;
+        return this;
+    }
+
+    public boolean isUseGcsAccessToken()
+    {
+        return useGcsAccessToken;
+    }
+
+    @Config("hive.gcs.use-access-token")
+    @ConfigDescription("Use client-provided OAuth token to access Google Cloud Storage")
+    public HiveGcsConfig setUseGcsAccessToken(boolean useGcsAccessToken)
+    {
+        this.useGcsAccessToken = useGcsAccessToken;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/HiveGcsModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/HiveGcsModule.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.prestosql.plugin.hive.DynamicConfigurationProvider;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class HiveGcsModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(HiveGcsConfig.class);
+        binder.bind(GcsConfigurationInitializer.class).to(GoogleGcsConfigurationInitializer.class).in(Scopes.SINGLETON);
+
+        if (buildConfigObject(HiveGcsConfig.class).isUseGcsAccessToken()) {
+            newSetBinder(binder, DynamicConfigurationProvider.class).addBinding().to(GcsConfigurationProvider.class).in(Scopes.SINGLETON);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -129,7 +129,7 @@ public class FileHiveMetastore
     public static FileHiveMetastore createTestingFileHiveMetastore(File catalogDirectory)
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, catalogDirectory.toURI().toString(), "test");
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import io.airlift.json.JsonCodec;
 import io.prestosql.plugin.hive.HdfsConfiguration;
-import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.HiveBasicStatistics;
@@ -129,7 +129,7 @@ public class FileHiveMetastore
     public static FileHiveMetastore createTestingFileHiveMetastore(File catalogDirectory)
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, catalogDirectory.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
@@ -727,7 +727,7 @@ public abstract class AbstractTestHiveClient
         setupHive(connectorId.toString(), databaseName, hiveClientConfig.getTimeZone());
 
         metastoreClient = hiveMetastore;
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         locationService = new HiveLocationService(hdfsEnvironment);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
@@ -727,7 +727,7 @@ public abstract class AbstractTestHiveClient
         setupHive(connectorId.toString(), databaseName, hiveClientConfig.getTimeZone());
 
         metastoreClient = hiveMetastore;
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig), ImmutableSet.of());
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         locationService = new HiveLocationService(hdfsEnvironment);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -88,7 +88,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
-import static io.prestosql.plugin.hive.HdfsConfigurationUpdater.configureCompression;
+import static io.prestosql.plugin.hive.HdfsConfigurationInitializer.configureCompression;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.airlift.tpch.TpchTable;
@@ -94,7 +95,7 @@ public final class HiveQueryRunner
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
             HiveClientConfig hiveClientConfig = new HiveClientConfig();
-            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
             HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
 
             FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
@@ -95,7 +95,7 @@ public final class HiveQueryRunner
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
             HiveClientConfig hiveClientConfig = new HiveClientConfig();
-            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
+            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig), ImmutableSet.of());
             HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
 
             FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -22,6 +22,8 @@ import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.Signature;
 import io.prestosql.operator.PagesIndex;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.gcs.GoogleGcsConfigurationInitializer;
+import io.prestosql.plugin.hive.gcs.HiveGcsConfig;
 import io.prestosql.plugin.hive.orc.DwrfPageSourceFactory;
 import io.prestosql.plugin.hive.orc.OrcPageSourceFactory;
 import io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory;
@@ -121,7 +123,12 @@ public final class HiveTestUtils
 
     public static HdfsEnvironment createTestHdfsEnvironment(HiveClientConfig config)
     {
-        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, new PrestoS3ConfigurationUpdater(new HiveS3Config())), ImmutableSet.of());
+        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(
+                new HdfsConfigurationInitializer(
+                        config,
+                        new PrestoS3ConfigurationUpdater(new HiveS3Config()),
+                        new GoogleGcsConfigurationInitializer(new HiveGcsConfig())),
+                ImmutableSet.of());
         return new HdfsEnvironment(hdfsConfig, config, new NoHdfsAuthentication());
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -121,7 +121,7 @@ public final class HiveTestUtils
 
     public static HdfsEnvironment createTestHdfsEnvironment(HiveClientConfig config)
     {
-        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, new PrestoS3ConfigurationUpdater(new HiveS3Config())));
+        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, new PrestoS3ConfigurationUpdater(new HiveS3Config())), ImmutableSet.of());
         return new HdfsEnvironment(hdfsConfig, config, new NoHdfsAuthentication());
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -121,7 +121,7 @@ public final class HiveTestUtils
 
     public static HdfsEnvironment createTestHdfsEnvironment(HiveClientConfig config)
     {
-        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(config, new PrestoS3ConfigurationUpdater(new HiveS3Config())), ImmutableSet.of());
+        HdfsConfiguration hdfsConfig = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, new PrestoS3ConfigurationUpdater(new HiveS3Config())), ImmutableSet.of());
         return new HdfsEnvironment(hdfsConfig, config, new NoHdfsAuthentication());
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -426,7 +426,7 @@ public class TestBackgroundHiveSplitLoader
         public TestingHdfsEnvironment()
         {
             super(
-                    new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig())),
+                    new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig()), ImmutableSet.of()),
                     new HiveClientConfig(),
                     new NoHdfsAuthentication());
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -426,7 +426,7 @@ public class TestBackgroundHiveSplitLoader
         public TestingHdfsEnvironment()
         {
             super(
-                    new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig()), ImmutableSet.of()),
+                    new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig()), ImmutableSet.of()),
                     new HiveClientConfig(),
                     new NoHdfsAuthentication());
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestFileSystemCache.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestFileSystemCache.java
@@ -35,7 +35,7 @@ public class TestFileSystemCache
         ImpersonatingHdfsAuthentication auth = new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication());
         HdfsEnvironment environment =
                 new HdfsEnvironment(
-                        new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig()), ImmutableSet.of()),
+                        new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig()), ImmutableSet.of()),
                         new HiveClientConfig(),
                         auth);
         FileSystem fs1 = getFileSystem(environment, "user");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestFileSystemCache.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestFileSystemCache.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.authentication.ImpersonatingHdfsAuthentication;
 import io.prestosql.plugin.hive.authentication.SimpleHadoopAuthentication;
 import org.apache.hadoop.conf.Configuration;
@@ -34,7 +35,7 @@ public class TestFileSystemCache
         ImpersonatingHdfsAuthentication auth = new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication());
         HdfsEnvironment environment =
                 new HdfsEnvironment(
-                        new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig())),
+                        new HiveHdfsConfiguration(new HdfsConfigurationUpdater(new HiveClientConfig()), ImmutableSet.of()),
                         new HiveClientConfig(),
                         auth);
         FileSystem fs1 = getFileSystem(environment, "user");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientFileMetastore.java
@@ -29,7 +29,7 @@ public class TestHiveClientFileMetastore
     {
         File baseDir = new File(tempDir, "metastore");
         HiveClientConfig hiveConfig = new HiveClientConfig();
-        HdfsConfigurationUpdater updator = new HdfsConfigurationUpdater(hiveConfig);
+        HdfsConfigurationInitializer updator = new HdfsConfigurationInitializer(hiveConfig);
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updator, ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveClientFileMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
@@ -29,7 +30,7 @@ public class TestHiveClientFileMetastore
         File baseDir = new File(tempDir, "metastore");
         HiveClientConfig hiveConfig = new HiveClientConfig();
         HdfsConfigurationUpdater updator = new HdfsConfigurationUpdater(hiveConfig);
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updator);
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updator, ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -66,7 +66,7 @@ import java.util.Properties;
 import static io.prestosql.orc.OrcEncoding.DWRF;
 import static io.prestosql.orc.OrcEncoding.ORC;
 import static io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
-import static io.prestosql.plugin.hive.HdfsConfigurationUpdater.configureCompression;
+import static io.prestosql.plugin.hive.HdfsConfigurationInitializer.configureCompression;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveType.toHiveType;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/gcs/TestHiveGcsConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/gcs/TestHiveGcsConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.gcs;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestHiveGcsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(HiveGcsConfig.class)
+                .setJsonKeyFilePath(null)
+                .setUseGcsAccessToken(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.gcs.json-key-file-path", "/tmp/key.json")
+                .put("hive.gcs.use-access-token", "true")
+                .build();
+
+        HiveGcsConfig expected = new HiveGcsConfig()
+                .setJsonKeyFilePath("/tmp/key.json")
+                .setUseGcsAccessToken(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore.glue;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.AbstractTestHiveClientLocal;
 import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
@@ -44,7 +45,7 @@ public class TestHiveClientGlueMetastore
     protected ExtendedHiveMetastore createMetastore(File tempDir)
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
         glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -16,7 +16,7 @@ package io.prestosql.plugin.hive.metastore.glue;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.AbstractTestHiveClientLocal;
 import io.prestosql.plugin.hive.HdfsConfiguration;
-import io.prestosql.plugin.hive.HdfsConfigurationUpdater;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveClientConfig;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
@@ -45,7 +45,7 @@ public class TestHiveClientGlueMetastore
     protected ExtendedHiveMetastore createMetastore(File tempDir)
     {
         HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig), ImmutableSet.of());
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
         glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
@@ -13,17 +13,22 @@
  */
 package io.prestosql.jdbc;
 
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.jdbc.AbstractConnectionProperty.checkedPredicate;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.function.Function.identity;
@@ -48,6 +53,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
+    public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -67,6 +73,7 @@ final class ConnectionProperties
             .add(KERBEROS_KEYTAB_PATH)
             .add(KERBEROS_CREDENTIAL_CACHE_PATH)
             .add(ACCESS_TOKEN)
+            .add(EXTRA_CREDENTIALS)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -272,6 +279,40 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class ExtraCredentials
+            extends AbstractConnectionProperty<Map<String, String>>
+    {
+        private static final CharMatcher PRINTABLE_ASCII = CharMatcher.inRange((char) 0x21, (char) 0x7E);
+
+        public ExtraCredentials()
+        {
+            super("extraCredentials", NOT_REQUIRED, ALLOWED, ExtraCredentials::parseExtraCredentials);
+        }
+
+        // Extra credentials consists of a list of credential name value pairs.
+        // E.g., `jdbc:presto://example.net:8080/?extraCredentials=abc:xyz;foo:bar` will create credentials `abc=xyz` and `foo=bar`
+        public static Map<String, String> parseExtraCredentials(String extraCredentialString)
+        {
+            return Splitter.on(';').splitToList(extraCredentialString).stream()
+                    .map(ExtraCredentials::parseSingleCredential)
+                    .collect(toImmutableMap(entry -> entry.get(0), entry -> entry.get(1)));
+        }
+
+        public static List<String> parseSingleCredential(String credential)
+        {
+            List<String> nameValue = Splitter.on(':').splitToList(credential);
+            checkArgument(nameValue.size() == 2, "Malformed credential: %s", credential);
+            String name = nameValue.get(0);
+            String value = nameValue.get(1);
+            checkArgument(!name.isEmpty(), "Credential name is empty");
+            checkArgument(!value.isEmpty(), "Credential value is empty");
+
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(name), "Credential name contains spaces or is not printable ASCII: %s", name);
+            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "Credential value contains spaces or is not printable ASCII: %s", name);
+            return nameValue;
         }
     }
 }

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -87,6 +87,7 @@ public class PrestoConnection
     private final URI jdbcUri;
     private final URI httpUri;
     private final String user;
+    private final Map<String, String> extraCredentials;
     private final Optional<String> applicationNamePrefix;
     private final Map<String, String> clientInfo = new ConcurrentHashMap<>();
     private final Map<String, String> sessionProperties = new ConcurrentHashMap<>();
@@ -106,7 +107,7 @@ public class PrestoConnection
         this.catalog.set(uri.getCatalog());
         this.user = uri.getUser();
         this.applicationNamePrefix = uri.getApplicationNamePrefix();
-
+        this.extraCredentials = uri.getExtraCredentials();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
 
         timeZoneId.set(ZoneId.systemDefault());
@@ -627,6 +628,12 @@ public class PrestoConnection
         return user;
     }
 
+    @VisibleForTesting
+    Map<String, String> getExtraCredentials()
+    {
+        return ImmutableMap.copyOf(extraCredentials);
+    }
+
     ServerInfo getServerInfo()
             throws SQLException
     {
@@ -700,7 +707,7 @@ public class PrestoConnection
                                 new ClientSelectedRole(
                                         ClientSelectedRole.Type.valueOf(entry.getValue().getType().toString()),
                                         entry.getValue().getRole()))),
-                ImmutableMap.of(),
+                extraCredentials,
                 transactionId.get(),
                 timeout);
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -700,6 +700,7 @@ public class PrestoConnection
                                 new ClientSelectedRole(
                                         ClientSelectedRole.Type.valueOf(entry.getValue().getType().toString()),
                                         entry.getValue().getRole()))),
+                ImmutableMap.of(),
                 transactionId.get(),
                 timeout);
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -14,6 +14,7 @@
 package io.prestosql.jdbc;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import io.prestosql.client.ClientException;
@@ -41,6 +42,7 @@ import static io.prestosql.client.OkHttpUtil.setupSsl;
 import static io.prestosql.client.OkHttpUtil.tokenAuth;
 import static io.prestosql.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static io.prestosql.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
+import static io.prestosql.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.prestosql.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_CREDENTIAL_CACHE_PATH;
@@ -135,6 +137,12 @@ final class PrestoDriverUri
     public Properties getProperties()
     {
         return properties;
+    }
+
+    public Map<String, String> getExtraCredentials()
+            throws SQLException
+    {
+        return EXTRA_CREDENTIALS.getValue(properties).orElse(ImmutableMap.of());
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcConnection.java
@@ -29,11 +29,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 import java.util.Set;
 
 import static io.prestosql.jdbc.TestPrestoDriver.closeQuietly;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -192,6 +194,18 @@ public class TestJdbcConnection
             connection.setClientInfo("ApplicationName", "testing");
             assertConnectionSource(connection, "fruit:testing");
         }
+    }
+
+    @Test
+    public void testExtraCredentials()
+            throws SQLException
+    {
+        Map<String, String> credentials = ImmutableMap.of("test.token.foo", "bar", "test.token.abc", "xyz");
+        Connection connection = DriverManager.getConnection("jdbc:presto://localhost:8080?extraCredentials=test.token.foo:bar;test.token.abc:xyz", "admin", null);
+
+        assertTrue(connection instanceof PrestoConnection);
+        PrestoConnection prestoConnection = (PrestoConnection) connection;
+        assertEquals(prestoConnection.getExtraCredentials(), credentials);
     }
 
     private Connection createConnection()

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static io.prestosql.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.prestosql.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.prestosql.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static io.prestosql.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
@@ -91,6 +92,17 @@ public class TestPrestoDriverUri
 
         // kerberos config without service name
         assertInvalid("jdbc:presto://localhost:8080?KerberosCredentialCachePath=/test", "Connection property 'KerberosCredentialCachePath' is not allowed");
+
+        // invalid extra credentials
+        assertInvalid("presto://localhost:8080?extraCredentials=:invalid", "Connection property 'extraCredentials' value is invalid:");
+        assertInvalid("presto://localhost:8080?extraCredentials=invalid:", "Connection property 'extraCredentials' value is invalid:");
+        assertInvalid("presto://localhost:8080?extraCredentials=:invalid", "Connection property 'extraCredentials' value is invalid:");
+
+        // duplicate credential keys
+        assertInvalid("presto://localhost:8080?extraCredentials=test.token.foo:bar;test.token.foo:xyz", "Connection property 'extraCredentials' value is invalid");
+
+        // empty extra credentials
+        assertInvalid("presto://localhost:8080?extraCredentials=", "Connection property 'extraCredentials' value is empty");
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' is required")
@@ -211,6 +223,16 @@ public class TestPrestoDriverUri
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(SSL_TRUST_STORE_PATH.getKey()), "truststore.jks");
         assertEquals(properties.getProperty(SSL_TRUST_STORE_PASSWORD.getKey()), "password");
+    }
+
+    @Test
+    public void testUriWithExtraCredentials()
+            throws SQLException
+    {
+        String extraCredentials = "test.token.foo:bar;test.token.abc:xyz";
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?extraCredentials=" + extraCredentials);
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(EXTRA_CREDENTIALS.getKey()), extraCredentials);
     }
 
     private static void assertUriPortScheme(PrestoDriverUri parameters, int port, String scheme)

--- a/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 public final class SessionRepresentation
@@ -271,11 +272,16 @@ public final class SessionRepresentation
 
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
+        return toSession(sessionPropertyManager, emptyMap());
+    }
+
+    public Session toSession(SessionPropertyManager sessionPropertyManager, Map<String, String> extraCredentials)
+    {
         return new Session(
                 new QueryId(queryId),
                 transactionId,
                 clientTransactionSupport,
-                new Identity(user, principal.map(BasicPrincipal::new), roles),
+                new Identity(user, principal.map(BasicPrincipal::new), roles, extraCredentials),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/io/prestosql/server/HttpRequestSessionContext.java
@@ -54,6 +54,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_CATALOG;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_CAPABILITIES;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_TAGS;
+import static io.prestosql.client.PrestoHeaders.PRESTO_EXTRA_CREDENTIAL;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -109,7 +110,11 @@ public final class HttpRequestSessionContext
 
         String user = trimEmptyToNull(servletRequest.getHeader(PRESTO_USER));
         assertRequest(user != null, "User must be set");
-        identity = new Identity(user, Optional.ofNullable(servletRequest.getUserPrincipal()), parseRoleHeaders(servletRequest));
+        identity = new Identity(
+                user,
+                Optional.ofNullable(servletRequest.getUserPrincipal()),
+                parseRoleHeaders(servletRequest),
+                parseExtraCredentials(servletRequest));
 
         source = servletRequest.getHeader(PRESTO_SOURCE);
         traceToken = Optional.ofNullable(trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN)));
@@ -287,13 +292,7 @@ public final class HttpRequestSessionContext
 
     private static Map<String, String> parseSessionHeaders(HttpServletRequest servletRequest)
     {
-        Map<String, String> sessionProperties = new HashMap<>();
-        for (String header : splitSessionHeader(servletRequest.getHeaders(PRESTO_SESSION))) {
-            List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
-            assertRequest(nameValue.size() == 2, "Invalid %s header", PRESTO_SESSION);
-            sessionProperties.put(nameValue.get(0), nameValue.get(1));
-        }
-        return sessionProperties;
+        return parseProperty(servletRequest, PRESTO_SESSION);
     }
 
     private static Map<String, SelectedRole> parseRoleHeaders(HttpServletRequest servletRequest)
@@ -305,6 +304,22 @@ public final class HttpRequestSessionContext
             roles.put(nameValue.get(0), SelectedRole.valueOf(urlDecode(nameValue.get(1))));
         }
         return roles.build();
+    }
+
+    private static Map<String, String> parseExtraCredentials(HttpServletRequest servletRequest)
+    {
+        return parseProperty(servletRequest, PRESTO_EXTRA_CREDENTIAL);
+    }
+
+    private static Map<String, String> parseProperty(HttpServletRequest servletRequest, String headerName)
+    {
+        Map<String, String> properties = new HashMap<>();
+        for (String header : splitSessionHeader(servletRequest.getHeaders(headerName))) {
+            List<String> nameValue = Splitter.on('=').trimResults().splitToList(header);
+            assertRequest(nameValue.size() == 2, "Invalid %s header", headerName);
+            properties.put(nameValue.get(0), nameValue.get(1));
+        }
+        return properties;
     }
 
     private Set<String> parseClientTags(HttpServletRequest servletRequest)

--- a/presto-main/src/main/java/io/prestosql/server/TaskResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskResource.java
@@ -125,7 +125,7 @@ public class TaskResource
     {
         requireNonNull(taskUpdateRequest, "taskUpdateRequest is null");
 
-        Session session = taskUpdateRequest.getSession().toSession(sessionPropertyManager);
+        Session session = taskUpdateRequest.getSession().toSession(sessionPropertyManager, taskUpdateRequest.getExtraCredentials());
         TaskInfo taskInfo = taskManager.updateTask(session,
                 taskId,
                 taskUpdateRequest.getFragment(),

--- a/presto-main/src/main/java/io/prestosql/server/TaskUpdateRequest.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskUpdateRequest.java
@@ -22,6 +22,7 @@ import io.prestosql.execution.buffer.OutputBuffers;
 import io.prestosql.sql.planner.PlanFragment;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -31,6 +32,8 @@ import static java.util.Objects.requireNonNull;
 public class TaskUpdateRequest
 {
     private final SessionRepresentation session;
+    // extraCredentials is stored separately from SessionRepresentation to avoid being leaked
+    private final Map<String, String> extraCredentials;
     private final Optional<PlanFragment> fragment;
     private final List<TaskSource> sources;
     private final OutputBuffers outputIds;
@@ -39,18 +42,21 @@ public class TaskUpdateRequest
     @JsonCreator
     public TaskUpdateRequest(
             @JsonProperty("session") SessionRepresentation session,
+            @JsonProperty("extraCredentials") Map<String, String> extraCredentials,
             @JsonProperty("fragment") Optional<PlanFragment> fragment,
             @JsonProperty("sources") List<TaskSource> sources,
             @JsonProperty("outputIds") OutputBuffers outputIds,
             @JsonProperty("totalPartitions") OptionalInt totalPartitions)
     {
         requireNonNull(session, "session is null");
+        requireNonNull(extraCredentials, "credentials is null");
         requireNonNull(fragment, "fragment is null");
         requireNonNull(sources, "sources is null");
         requireNonNull(outputIds, "outputIds is null");
         requireNonNull(totalPartitions, "totalPartitions is null");
 
         this.session = session;
+        this.extraCredentials = extraCredentials;
         this.fragment = fragment;
         this.sources = ImmutableList.copyOf(sources);
         this.outputIds = outputIds;
@@ -61,6 +67,12 @@ public class TaskUpdateRequest
     public SessionRepresentation getSession()
     {
         return session;
+    }
+
+    @JsonProperty
+    public Map<String, String> getExtraCredentials()
+    {
+        return extraCredentials;
     }
 
     @JsonProperty
@@ -92,6 +104,7 @@ public class TaskUpdateRequest
     {
         return toStringHelper(this)
                 .add("session", session)
+                .add("extraCredentials", extraCredentials.keySet())
                 .add("fragment", fragment)
                 .add("sources", sources)
                 .add("outputIds", outputIds)

--- a/presto-main/src/main/java/io/prestosql/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/io/prestosql/server/remotetask/HttpRemoteTask.java
@@ -504,6 +504,7 @@ public final class HttpRemoteTask
         Optional<PlanFragment> fragment = sendPlan.get() ? Optional.of(planFragment) : Optional.empty();
         TaskUpdateRequest updateRequest = new TaskUpdateRequest(
                 session.toSessionRepresentation(),
+                session.getIdentity().getExtraCredentials(),
                 fragment,
                 sources,
                 outputBuffers.get(),

--- a/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
@@ -29,6 +29,7 @@ import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.prestosql.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CATALOG;
 import static io.prestosql.client.PrestoHeaders.PRESTO_CLIENT_INFO;
+import static io.prestosql.client.PrestoHeaders.PRESTO_EXTRA_CREDENTIAL;
 import static io.prestosql.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PATH;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -61,6 +62,8 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_ROLE, "foo_connector=ALL")
                         .put(PRESTO_ROLE, "bar_connector=NONE")
                         .put(PRESTO_ROLE, "foobar_connector=ROLE{role}")
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.token.foo=bar")
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.token.abc=xyz")
                         .build(),
                 "testRemote");
 
@@ -79,6 +82,7 @@ public class TestHttpRequestSessionContext
                 "foo_connector", new SelectedRole(SelectedRole.Type.ALL, Optional.empty()),
                 "bar_connector", new SelectedRole(SelectedRole.Type.NONE, Optional.empty()),
                 "foobar_connector", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("role"))));
+        assertEquals(context.getIdentity().getExtraCredentials(), ImmutableMap.of("test.token.foo", "bar", "test.token.abc", "xyz"));
     }
 
     @Test(expectedExceptions = WebApplicationException.class)

--- a/presto-spi/src/main/java/io/prestosql/spi/security/ConnectorIdentity.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/ConnectorIdentity.java
@@ -14,8 +14,12 @@
 package io.prestosql.spi.security;
 
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorIdentity
@@ -23,12 +27,19 @@ public class ConnectorIdentity
     private final String user;
     private final Optional<Principal> principal;
     private final Optional<SelectedRole> role;
+    private final Map<String, String> extraCredentials;
 
     public ConnectorIdentity(String user, Optional<Principal> principal, Optional<SelectedRole> role)
+    {
+        this(user, principal, role, emptyMap());
+    }
+
+    public ConnectorIdentity(String user, Optional<Principal> principal, Optional<SelectedRole> role, Map<String, String> extraCredentials)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
         this.role = requireNonNull(role, "role is null");
+        this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
     }
 
     public String getUser()
@@ -44,6 +55,11 @@ public class ConnectorIdentity
     public Optional<SelectedRole> getRole()
     {
         return role;
+    }
+
+    public Map<String, String> getExtraCredentials()
+    {
+        return extraCredentials;
     }
 
     @Override
@@ -67,6 +83,7 @@ public class ConnectorIdentity
         sb.append("user='").append(user).append('\'');
         principal.ifPresent(principal -> sb.append(", principal=").append(principal));
         role.ifPresent(role -> sb.append(", role=").append(role));
+        sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append('}');
         return sb.toString();
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/Identity.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.security;
 
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,6 +28,7 @@ public class Identity
     private final String user;
     private final Optional<Principal> principal;
     private final Map<String, SelectedRole> roles;
+    private final Map<String, String> extraCredentials;
 
     public Identity(String user, Optional<Principal> principal)
     {
@@ -35,9 +37,15 @@ public class Identity
 
     public Identity(String user, Optional<Principal> principal, Map<String, SelectedRole> roles)
     {
+        this(user, principal, roles, emptyMap());
+    }
+
+    public Identity(String user, Optional<Principal> principal, Map<String, SelectedRole> roles, Map<String, String> extraCredentials)
+    {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
         this.roles = unmodifiableMap(requireNonNull(roles, "roles is null"));
+        this.extraCredentials = unmodifiableMap(new HashMap<>(requireNonNull(extraCredentials, "extraCredentials is null")));
     }
 
     public String getUser()
@@ -55,15 +63,20 @@ public class Identity
         return roles;
     }
 
+    public Map<String, String> getExtraCredentials()
+    {
+        return extraCredentials;
+    }
+
     public ConnectorIdentity toConnectorIdentity()
     {
-        return new ConnectorIdentity(user, principal, Optional.empty());
+        return new ConnectorIdentity(user, principal, Optional.empty(), extraCredentials);
     }
 
     public ConnectorIdentity toConnectorIdentity(String catalog)
     {
         requireNonNull(catalog, "catalog is null");
-        return new ConnectorIdentity(user, principal, Optional.ofNullable(roles.get(catalog)));
+        return new ConnectorIdentity(user, principal, Optional.ofNullable(roles.get(catalog)), extraCredentials);
     }
 
     @Override
@@ -92,6 +105,7 @@ public class Identity
         sb.append("user='").append(user).append('\'');
         principal.ifPresent(principal -> sb.append(", principal=").append(principal));
         sb.append(", roles=").append(roles);
+        sb.append(", extraCredentials=").append(extraCredentials.keySet());
         sb.append('}');
         return sb.toString();
     }

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestingPrestoClient.java
@@ -159,6 +159,7 @@ public abstract class AbstractTestingPrestoClient<T>
                                 new ClientSelectedRole(
                                         ClientSelectedRole.Type.valueOf(entry.getValue().getType().toString()),
                                         entry.getValue().getRole()))),
+                session.getIdentity().getExtraCredentials(),
                 session.getTransactionId().map(Object::toString).orElse(null),
                 clientRequestTimeout);
     }

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
@@ -79,6 +79,7 @@ public class TestFinalQueryInfo
                     ImmutableMap.of(),
                     ImmutableMap.of(),
                     ImmutableMap.of(),
+                    ImmutableMap.of(),
                     null,
                     new Duration(2, MINUTES));
 


### PR DESCRIPTION
This PR adds connector token support in Presto. and GCS module in Hive Connectors.

- ea2df20..1b7d68c: allow client to pass connector tokens to connector
- fedc801: add dynamic configuration provider
- c661834: add HiveGcsModule to support OAuth token authentication with Google Cloud Storage

supersedes #94 

@dain @electrum 