### PR TITLE
add worklist web ui

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ClusterStatsResource.java
@@ -20,7 +20,6 @@ import io.prestosql.execution.QueryState;
 import io.prestosql.execution.scheduler.NodeSchedulerConfig;
 import io.prestosql.memory.ClusterMemoryManager;
 import io.prestosql.metadata.InternalNodeManager;
-import io.prestosql.spi.Node;
 import io.prestosql.spi.NodeState;
 
 import javax.inject.Inject;
@@ -29,9 +28,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import java.util.HashSet;
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -115,45 +111,6 @@ public class ClusterStatsResource
         return Response.ok()
                 .entity(clusterMemoryManager.getWorkerMemoryInfo())
                 .build();
-    }
-
-    @GET
-    @Path("workerList")
-    public Response getWorkerList()
-    {
-        Set<Node> nodes = nodeManager.getAllNodes().getActiveNodes();
-        Set<JsonNodeInfo> jsonNodes = new HashSet<>();
-        for (Node node : nodes) {
-            JsonNodeInfo jsonNode = new JsonNodeInfo(node.getNodeIdentifier(), node.getHostAndPort().getHostText());
-            jsonNodes.add(jsonNode);
-        }
-        return Response.ok().entity(jsonNodes).build();
-    }
-
-    public static class JsonNodeInfo
-    {
-        private final String nodeId;
-        private final String nodeIp;
-
-        @JsonCreator
-        public JsonNodeInfo(@JsonProperty("nodeId") String nodeId,
-                @JsonProperty("nodeIp") String nodeIp)
-        {
-            this.nodeId = nodeId;
-            this.nodeIp = nodeIp;
-        }
-
-        @JsonProperty
-        public String getNodeId()
-        {
-            return nodeId;
-        }
-
-        @JsonProperty
-        public String getNodeIp()
-        {
-            return nodeIp;
-        }
     }
 
     public static class ClusterStats

--- a/presto-main/src/main/resources/webapp/src/components/ClusterHUD.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/ClusterHUD.jsx
@@ -181,10 +181,12 @@ export class ClusterHUD extends React.Component {
                     </div>
                     <div className="col-xs-4">
                         <div className="stat stat-large">
-                            <span className="stat-text">
-                                {this.state.activeWorkers[this.state.activeWorkers.length - 1]}
-                            </span>
-                            <span className="sparkline" id="active-workers-sparkline"><div className="loader">Loading ...</div></span>
+                            <a target="_blank" href="workers.html">
+                                <span className="stat-text">
+                                    {this.state.activeWorkers[this.state.activeWorkers.length - 1]}
+                                </span>
+                                <span className="sparkline" id="active-workers-sparkline"><div className="loader">Loading ...</div></span>
+                            </a>
                         </div>
                     </div>
                     <div className="col-xs-4">

--- a/presto-main/src/main/resources/webapp/src/components/WorkerList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/WorkerList.jsx
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import {
+    addToHistory,
+} from "../utils";
+
+const SMALL_SPARKLINE_PROPERTIES = {
+    width: '100%',
+    height: '57px',
+    fillColor: '#3F4552',
+    lineColor: '#747F96',
+    spotColor: '#1EDCFF',
+    tooltipClassname: 'sparkline-tooltip',
+    disableHiddenCheck: true,
+};
+
+export class WorkerList extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            workerInfo: null,
+            initialized: false,
+            ended: false,
+
+            workerid: [],
+            workerip: [],
+        };
+        this.refreshLoop = this.refreshLoop.bind(this);
+    }
+
+    refreshLoop() {
+        clearTimeout(this.timeoutId); // to stop multiple series of refreshLoop from going on simultaneously
+        // const nodeId = getFirstParameter(window.location.search);
+        $.get('/v1/cluster/workerList', function (workerInfo) {
+            this.setState({
+                initialized: true,
+                workerInfo: workerInfo
+            })
+            for (var index in workerInfo) {
+                this.setState({
+                    workerid: addToHistory(workerInfo[index].nodeId, this.state.workerid),
+                    workerip: addToHistory(workerInfo[index].nodeIp, this.state.workerip)
+                });
+            }
+        }.bind(this))
+            .error(function () {
+                this.setState({
+                    initialized: true,
+                });
+            }.bind(this));
+
+    }
+
+    componentDidMount() {
+        this.refreshLoop();
+    }
+
+    render() {
+        const workerInfo = this.state.workerInfo;
+        const workerid = this.state.workerid;
+        const workerip = this.state.workerip;
+
+        if (workerInfo === null) {
+            if (this.state.initialized === false) {
+                return (
+                    <div className="loader">Loading...</div>
+                );
+            }
+            else {
+                return (
+                    <div className="row error-message">
+                        <div className="col-xs-12"><h4>Worker list information could not be loaded</h4></div>
+                    </div>
+                );
+            }
+        }
+
+        var list = function () {
+            var trs = [];
+            for (var i  in workerid) {
+                trs.push(
+                    <tr>
+                        <td className="info-text wrap-text">{i}</td>
+                        <td className="info-text wrap-text"><a href={"worker.html?" + workerid[i]} className="font-light" target="_blank">{workerid[i]}</a></td>
+                        <td className="info-text wrap-text"><a href={"worker.html?" + workerid[i]} className="font-light" target="_blank">{workerip[i]}</a></td>
+                    </tr>
+                );
+            }
+            return trs;
+        };
+
+        return (
+            <div>
+                <div className="row">
+                    <div className="col-xs-12">
+                        <h3>Overview</h3>
+                        <hr className="h3-hr"/>
+                        <table className="table">
+                            <tbody>
+                            <tr>
+                                <td className="info-title stage-table-stat-text">ID</td>
+                                <td className="info-title stage-table-stat-text">Node ID</td>
+                                <td className="info-title stage-table-stat-text">Node IP</td>
+                            </tr>
+                            {list()}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/presto-main/src/main/resources/webapp/src/components/WorkerList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/WorkerList.jsx
@@ -45,7 +45,7 @@ export class WorkerList extends React.Component {
     refreshLoop() {
         clearTimeout(this.timeoutId); // to stop multiple series of refreshLoop from going on simultaneously
         // const nodeId = getFirstParameter(window.location.search);
-        $.get('/v1/cluster/workerList', function (workerInfo) {
+        $.get('/v1/worker', function (workerInfo) {
             this.setState({
                 initialized: true,
                 workerInfo: workerInfo
@@ -94,7 +94,6 @@ export class WorkerList extends React.Component {
             for (var i  in workerid) {
                 trs.push(
                     <tr>
-                        <td className="info-text wrap-text">{i}</td>
                         <td className="info-text wrap-text"><a href={"worker.html?" + workerid[i]} className="font-light" target="_blank">{workerid[i]}</a></td>
                         <td className="info-text wrap-text"><a href={"worker.html?" + workerid[i]} className="font-light" target="_blank">{workerip[i]}</a></td>
                     </tr>
@@ -112,7 +111,6 @@ export class WorkerList extends React.Component {
                         <table className="table">
                             <tbody>
                             <tr>
-                                <td className="info-title stage-table-stat-text">ID</td>
                                 <td className="info-title stage-table-stat-text">Node ID</td>
                                 <td className="info-title stage-table-stat-text">Node IP</td>
                             </tr>

--- a/presto-main/src/main/resources/webapp/src/webpack.config.js
+++ b/presto-main/src/main/resources/webapp/src/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
         'embedded_plan': __dirname +'/embedded_plan.jsx',
         'stage': __dirname +'/stage.jsx',
         'worker': __dirname +'/worker.jsx',
+        'workers': __dirname +'/workers.jsx',
     },
     mode: "development",
     module: {

--- a/presto-main/src/main/resources/webapp/src/workers.jsx
+++ b/presto-main/src/main/resources/webapp/src/workers.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {WorkerList} from "./components/WorkerList";
+import {PageTitle} from "./components/PageTitle";
+
+ReactDOM.render(
+    <PageTitle title="Worker List" />,
+    document.getElementById('title')
+);
+
+ReactDOM.render(
+    <WorkerList />,
+    document.getElementById('worker-list')
+);

--- a/presto-main/src/main/resources/webapp/workers.html
+++ b/presto-main/src/main/resources/webapp/workers.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Query Details - Presto">
+    <title>Worker List - Presto</title>
+
+    <link rel="icon" href="assets/favicon.ico">
+
+    <!-- Bootstrap core -->
+    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- jQuery -->
+    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+
+    <!-- Bootstrap JS -->
+    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+
+    <!-- Sparkline -->
+    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+
+    <!-- CSS loader -->
+    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+
+    <!-- Clipboard -->
+    <script src="vendor/clipboardjs/clipboard.min.js"></script>
+
+    <!-- Custom CSS -->
+    <link href="assets/presto.css" rel="stylesheet">
+</head>
+
+<body>
+
+<div class="container">
+    <div id="title"></div>
+
+    <div id="worker-list">
+        <div class="loader">Loading...</div>
+    </div>
+    <!--<div id="worker-threads">
+        <div class="loader">Loading...</div>
+    </div>-->
+</div> <!-- /container -->
+
+<script type="text/javascript" src="dist/workers.js"></script>
+
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+</body>
+</html>


### PR DESCRIPTION
This commit add list of workers' infomation in the web UI.
This implementation add an GET http interface that is list the workers.
I hava  included the React-generated JavaScript.
The visualized cluster worker list is necessary for monitoring and operation and maintenance,so I thought we should add this page.

The effect is as follows:
1.The web UI index add a link for workers
![web_ui_index](https://raw.githubusercontent.com/zm12397/zm12397.github.io/master/styles/images/otherpic/web_ui_index.jpg)
2.Click the Active Workers region,then open the workers page
![web_ui_list](https://raw.githubusercontent.com/zm12397/zm12397.github.io/master/styles/images/otherpic/web_ui_list.jpg)
This page shows the worker list,contains NodeID and NodeIP per worker node;
3.Click one worker item,then open the worker's details
![web_ui_worker](https://raw.githubusercontent.com/zm12397/zm12397.github.io/master/styles/images/otherpic/web_ui_worker.jpg)