### PR TITLE
Expose plan node stats and cost in event listener

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -29,6 +29,7 @@ import io.prestosql.cost.CostCalculator.EstimatedExchanges;
 import io.prestosql.cost.CostCalculatorUsingExchanges;
 import io.prestosql.cost.CostCalculatorWithEstimatedExchanges;
 import io.prestosql.cost.CostComparator;
+import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.cost.StatsCalculatorModule;
 import io.prestosql.cost.TaskCountEstimator;
 import io.prestosql.event.QueryMonitor;
@@ -199,6 +200,7 @@ public class CoordinatorModule
         httpClientBinder(binder).bindHttpClient("workerInfo", ForWorkerInfo.class);
 
         // query monitor
+        jsonCodecBinder(binder).bindJsonCodec(StatsAndCosts.class);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
 

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryStatistics.java
@@ -51,8 +51,15 @@ public class QueryStatistics
 
     private final List<StageCpuDistribution> cpuTimeDistribution;
 
+    /**
+     * Operator summaries serialized to JSON. Serialization format and structure
+     * can change without preserving backward compatibility.
+     */
     private final List<String> operatorSummaries;
-
+    /**
+     * Plan node stats and costs summaries serialized to JSON. Serialization format and structure
+     * can change without preserving backward compatibility.
+     */
     private final Optional<String> planNodeStatsAndCosts;
 
     public QueryStatistics(

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryStatistics.java
@@ -53,6 +53,8 @@ public class QueryStatistics
 
     private final List<String> operatorSummaries;
 
+    private final Optional<String> planNodeStatsAndCosts;
+
     public QueryStatistics(
             Duration cpuTime,
             Duration wallTime,
@@ -77,7 +79,8 @@ public class QueryStatistics
             int completedSplits,
             boolean complete,
             List<StageCpuDistribution> cpuTimeDistribution,
-            List<String> operatorSummaries)
+            List<String> operatorSummaries,
+            Optional<String> planNodeStatsAndCosts)
     {
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.wallTime = requireNonNull(wallTime, "wallTime is null");
@@ -103,6 +106,7 @@ public class QueryStatistics
         this.complete = complete;
         this.cpuTimeDistribution = requireNonNull(cpuTimeDistribution, "cpuTimeDistribution is null");
         this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
+        this.planNodeStatsAndCosts = requireNonNull(planNodeStatsAndCosts, "planNodeStatsAndCosts is null");
     }
 
     public Duration getCpuTime()
@@ -223,5 +227,10 @@ public class QueryStatistics
     public List<String> getOperatorSummaries()
     {
         return operatorSummaries;
+    }
+
+    public Optional<String> getPlanNodeStatsAndCosts()
+    {
+        return planNodeStatsAndCosts;
     }
 }


### PR DESCRIPTION
This allows to gather information about computed
stats and costs and compare them to real operator
performance.

This enables: https://github.com/prestosql/presto/issues/51