### PR TITLE
Improve performance for positioned reads on S3

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -73,6 +73,7 @@ import org.apache.hadoop.util.Progressable;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -88,12 +89,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.amazonaws.regions.Regions.US_EAST_1;
 import static com.amazonaws.services.s3.Headers.SERVER_SIDE_ENCRYPTION;
 import static com.amazonaws.services.s3.Headers.UNENCRYPTED_CONTENT_LENGTH;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkPositionIndexes;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -139,6 +141,9 @@ import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.createTempFile;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hadoop.fs.FSExceptionMessages.CANNOT_SEEK_PAST_EOF;
+import static org.apache.hadoop.fs.FSExceptionMessages.NEGATIVE_SEEK;
+import static org.apache.hadoop.fs.FSExceptionMessages.STREAM_IS_CLOSED;
 
 public class PrestoS3FileSystem
         extends FileSystem
@@ -789,7 +794,8 @@ public class PrestoS3FileSystem
         private final Duration maxBackoffTime;
         private final Duration maxRetryTime;
 
-        private boolean closed;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
         private InputStream in;
         private long streamPosition;
         private long nextReadPosition;
@@ -809,15 +815,87 @@ public class PrestoS3FileSystem
         @Override
         public void close()
         {
-            closed = true;
+            closed.set(true);
             closeStream();
         }
 
         @Override
-        public void seek(long pos)
+        public int read(long position, byte[] buffer, int offset, int length)
+                throws IOException
         {
-            checkState(!closed, "already closed");
-            checkArgument(pos >= 0, "position is negative: %s", pos);
+            checkClosed();
+            if (position < 0) {
+                throw new EOFException(NEGATIVE_SEEK);
+            }
+            checkPositionIndexes(offset, offset + length, buffer.length);
+            if (length == 0) {
+                return 0;
+            }
+
+            try {
+                return retry()
+                        .maxAttempts(maxAttempts)
+                        .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
+                        .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class, EOFException.class)
+                        .onRetry(STATS::newGetObjectRetry)
+                        .run("getS3Object", () -> {
+                            InputStream stream;
+                            try {
+                                GetObjectRequest request = new GetObjectRequest(host, keyFromPath(path))
+                                        .withRange(position, (position + length) - 1);
+                                stream = s3.getObject(request).getObjectContent();
+                            }
+                            catch (RuntimeException e) {
+                                STATS.newGetObjectError();
+                                if (e instanceof AmazonS3Exception) {
+                                    switch (((AmazonS3Exception) e).getStatusCode()) {
+                                        case HTTP_RANGE_NOT_SATISFIABLE:
+                                            throw new EOFException(CANNOT_SEEK_PAST_EOF);
+                                        case HTTP_FORBIDDEN:
+                                        case HTTP_NOT_FOUND:
+                                        case HTTP_BAD_REQUEST:
+                                            throw new UnrecoverableS3OperationException(path, e);
+                                    }
+                                }
+                                throw e;
+                            }
+
+                            STATS.connectionOpened();
+                            try {
+                                int read = 0;
+                                while (read < length) {
+                                    int n = stream.read(buffer, offset + read, length - read);
+                                    if (n <= 0) {
+                                        break;
+                                    }
+                                    read += n;
+                                }
+                                return read;
+                            }
+                            catch (Throwable t) {
+                                STATS.newReadError(t);
+                                abortStream(stream);
+                                throw t;
+                            }
+                            finally {
+                                STATS.connectionReleased();
+                                stream.close();
+                            }
+                        });
+            }
+            catch (Exception e) {
+                throw propagate(e);
+            }
+        }
+
+        @Override
+        public void seek(long pos)
+                throws IOException
+        {
+            checkClosed();
+            if (pos < 0) {
+                throw new EOFException(NEGATIVE_SEEK);
+            }
 
             // this allows a seek beyond the end of the stream but the next read will fail
             nextReadPosition = pos;
@@ -840,6 +918,7 @@ public class PrestoS3FileSystem
         public int read(byte[] buffer, int offset, int length)
                 throws IOException
         {
+            checkClosed();
             try {
                 int bytesRead = retry()
                         .maxAttempts(maxAttempts)
@@ -864,14 +943,8 @@ public class PrestoS3FileSystem
                 }
                 return bytesRead;
             }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
             catch (Exception e) {
-                throwIfInstanceOf(e, IOException.class);
-                throwIfUnchecked(e);
-                throw new RuntimeException(e);
+                throw propagate(e);
             }
         }
 
@@ -953,34 +1026,53 @@ public class PrestoS3FileSystem
                             }
                         });
             }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
             catch (Exception e) {
-                throwIfInstanceOf(e, IOException.class);
-                throwIfUnchecked(e);
-                throw new RuntimeException(e);
+                throw propagate(e);
             }
         }
 
         private void closeStream()
         {
             if (in != null) {
-                try {
-                    if (in instanceof S3ObjectInputStream) {
-                        ((S3ObjectInputStream) in).abort();
-                    }
-                    else {
-                        in.close();
-                    }
-                }
-                catch (IOException | AbortedException ignored) {
-                    // thrown if the current thread is in the interrupted state
-                }
+                abortStream(in);
                 in = null;
                 STATS.connectionReleased();
             }
+        }
+
+        private void checkClosed()
+                throws IOException
+        {
+            if (closed.get()) {
+                throw new IOException(STREAM_IS_CLOSED);
+            }
+        }
+
+        private static void abortStream(InputStream in)
+        {
+            try {
+                if (in instanceof S3ObjectInputStream) {
+                    ((S3ObjectInputStream) in).abort();
+                }
+                else {
+                    in.close();
+                }
+            }
+            catch (IOException | AbortedException ignored) {
+                // thrown if the current thread is in the interrupted state
+            }
+        }
+
+        private static RuntimeException propagate(Exception e)
+                throws IOException
+        {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new InterruptedIOException();
+            }
+            throwIfInstanceOf(e, IOException.class);
+            throwIfUnchecked(e);
+            throw new IOException(e);
         }
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -540,7 +540,7 @@ public class PrestoS3FileSystem
      */
     @VisibleForTesting
     static class UnrecoverableS3OperationException
-            extends RuntimeException
+            extends IOException
     {
         public UnrecoverableS3OperationException(Path path, Throwable cause)
         {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystemStats.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystemStats.java
@@ -251,15 +251,15 @@ public class PrestoS3FileSystemStats
         listObjectsCalls.update(1);
     }
 
-    public void newReadError(Exception e)
+    public void newReadError(Throwable t)
     {
-        if (e instanceof SocketException) {
+        if (t instanceof SocketException) {
             socketExceptions.update(1);
         }
-        else if (e instanceof SocketTimeoutException) {
+        else if (t instanceof SocketTimeoutException) {
             socketTimeoutExceptions.update(1);
         }
-        else if (e instanceof AbortedException) {
+        else if (t instanceof AbortedException) {
             awsAbortedExceptions.update(1);
         }
         else {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
@@ -232,7 +232,7 @@ public class TestPrestoS3FileSystem
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Failing getObject call with " + HTTP_NOT_FOUND + ".*")
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = ".*Failing getObject call with " + HTTP_NOT_FOUND + ".*")
     public void testReadNotFound()
             throws Exception
     {
@@ -248,7 +248,7 @@ public class TestPrestoS3FileSystem
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Failing getObject call with " + HTTP_FORBIDDEN + ".*")
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = ".*Failing getObject call with " + HTTP_FORBIDDEN + ".*")
     public void testReadForbidden()
             throws Exception
     {
@@ -356,7 +356,7 @@ public class TestPrestoS3FileSystem
         }
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Failing getObjectMetadata call with " + HTTP_FORBIDDEN + ".*")
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = ".*Failing getObjectMetadata call with " + HTTP_FORBIDDEN + ".*")
     public void testGetMetadataForbidden()
             throws Exception
     {
@@ -410,6 +410,7 @@ public class TestPrestoS3FileSystem
 
     @Test(expectedExceptions = UnrecoverableS3OperationException.class, expectedExceptionsMessageRegExp = ".*\\Q (Path: /tmp/test/path)\\E")
     public void testUnrecoverableS3ExceptionMessage()
+            throws Exception
     {
         throw new UnrecoverableS3OperationException(new Path("/tmp/test/path"), new IOException("test io exception"));
     }


### PR DESCRIPTION
This eliminates reading extra data from S3 by always requesting the exact
range needed (rather than performing streaming reads). Also, because all
data is always read from connections, this allows connection reuse via the
HTTP client connection pool.