### PR TITLE
Add hostname parameter for SPN construction in Kerberos auth

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
@@ -64,7 +64,12 @@ public class KerberosAuthenticator
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
 
         try {
-            String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            String hostname = config.getHostName();
+
+            if (hostname == null || hostname.isEmpty()) {
+                hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            }
+
             String servicePrincipal = config.getServiceName() + "/" + hostname;
             loginContext = new LoginContext("", null, null, new Configuration()
             {
@@ -90,8 +95,9 @@ public class KerberosAuthenticator
             });
             loginContext.login();
 
+            String finalHostname = hostname;
             serverCredential = doAs(loginContext.getSubject(), () -> gssManager.createCredential(
-                    gssManager.createName(config.getServiceName() + "@" + hostname, GSSName.NT_HOSTBASED_SERVICE),
+                    gssManager.createName(config.getServiceName() + "@" + finalHostname, GSSName.NT_HOSTBASED_SERVICE),
                     INDEFINITE_LIFETIME,
                     new Oid[] {
                             new Oid("1.2.840.113554.1.2.2"), // kerberos 5

--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
@@ -26,6 +26,7 @@ public class KerberosConfig
     private File kerberosConfig;
     private String serviceName;
     private File keytab;
+    private String hostName;
 
     @NotNull
     public File getKerberosConfig()
@@ -62,6 +63,18 @@ public class KerberosConfig
     public KerberosConfig setKeytab(File keytab)
     {
         this.keytab = keytab;
+        return this;
+    }
+
+    public String getHostName()
+    {
+        return hostName;
+    }
+
+    @Config("http.authentication.krb5.host-name")
+    public KerberosConfig setHostName(String hostName)
+    {
+        this.hostName = hostName;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
@@ -28,7 +28,8 @@ public class TestKerberosConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KerberosConfig.class)
                 .setKerberosConfig(null)
                 .setServiceName(null)
-                .setKeytab(null));
+                .setKeytab(null)
+                .setHostName(null));
     }
 
     @Test
@@ -38,12 +39,14 @@ public class TestKerberosConfig
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.server.authentication.krb5.service-name", "airlift")
                 .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
+                .put("http.authentication.krb5.host-name", "prestodb.io")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()
                 .setKerberosConfig(new File("/etc/krb5.conf"))
                 .setServiceName("airlift")
-                .setKeytab(new File("/tmp/presto.keytab"));
+                .setKeytab(new File("/tmp/presto.keytab"))
+                .setHostName("prestodb.io");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This PR adds a configuration option to override the hostname in the SPN for Kerberos authentication to the coordinator.

This feature is very helpful in container environments where containers have arbitrary hostnames (i.e. Kubernetes).

(also submitted to prestodb as #12047)