### PR TITLE
Make service principal hostname configurable in Kerberos auth

### DIFF
--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -87,6 +87,7 @@ Kerberos authentication is configured in the coordinator node's
     http-server.authentication.type=KERBEROS
 
     http.server.authentication.krb5.service-name=presto
+    http.server.authentication.krb5.host-name=presto.prestosql.io
     http.server.authentication.krb5.keytab=/etc/presto/presto.keytab
     http.authentication.krb5.config=/etc/krb5.conf
 
@@ -101,11 +102,15 @@ Property                                                Description
 ======================================================= ======================================================
 ``http-server.authentication.type``                     Authentication type for the Presto
                                                         coordinator. Must be set to ``KERBEROS``.
-``http.server.authentication.krb5.service-name``        The Kerberos server name for the Presto coordinator.
+``http.server.authentication.krb5.service-name``        The Kerberos service name for the Presto coordinator.
                                                         Must match the Kerberos principal.
+``http.server.authentication.krb5.principal-hostname``  The Kerberos hostname for the Presto coordinator.
+                                                        Must match the Kerberos principal. This parameter is
+                                                        optional. If included, Presto will use this value
+                                                        in the host part of the Kerberos principal instead
+                                                        of the machine's hostname.
 ``http.server.authentication.krb5.keytab``              The location of the keytab that can be used to
-                                                        authenticate the Kerberos principal specified in
-                                                        ``http.server.authentication.krb5.service-name``.
+                                                        authenticate the Kerberos principal.
 ``http.authentication.krb5.config``                     The location of the Kerberos configuration file.
 ``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
                                                         Should be set to ``true``.

--- a/presto-main/src/main/java/io/prestosql/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/KerberosAuthenticator.java
@@ -64,7 +64,10 @@ public class KerberosAuthenticator
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
 
         try {
-            String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            String hostname = Optional.ofNullable(config.getPrincipalHostname())
+                    .orElseGet(() -> getLocalHost().getCanonicalHostName())
+                    .toLowerCase(Locale.US);
+
             String servicePrincipal = config.getServiceName() + "/" + hostname;
             loginContext = new LoginContext("", null, null, new Configuration()
             {
@@ -99,7 +102,7 @@ public class KerberosAuthenticator
                     },
                     ACCEPT_ONLY));
         }
-        catch (LoginException | UnknownHostException e) {
+        catch (LoginException e) {
             throw new RuntimeException(e);
         }
     }
@@ -193,5 +196,15 @@ public class KerberosAuthenticator
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    private static InetAddress getLocalHost()
+    {
+        try {
+            return InetAddress.getLocalHost();
+        }
+        catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/KerberosConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/KerberosConfig.java
@@ -26,6 +26,7 @@ public class KerberosConfig
     private File kerberosConfig;
     private String serviceName;
     private File keytab;
+    private String principalHostname;
 
     @NotNull
     public File getKerberosConfig()
@@ -62,6 +63,18 @@ public class KerberosConfig
     public KerberosConfig setKeytab(File keytab)
     {
         this.keytab = keytab;
+        return this;
+    }
+
+    public String getPrincipalHostname()
+    {
+        return principalHostname;
+    }
+
+    @Config("http.authentication.krb5.principal-hostname")
+    public KerberosConfig setPrincipalHostname(String principalHostname)
+    {
+        this.principalHostname = principalHostname;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/server/security/TestKerberosConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestKerberosConfig.java
@@ -28,7 +28,8 @@ public class TestKerberosConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KerberosConfig.class)
                 .setKerberosConfig(null)
                 .setServiceName(null)
-                .setKeytab(null));
+                .setKeytab(null)
+                .setPrincipalHostname(null));
     }
 
     @Test
@@ -38,12 +39,14 @@ public class TestKerberosConfig
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.server.authentication.krb5.service-name", "airlift")
                 .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
+                .put("http.authentication.krb5.principal-hostname", "presto.prestosql.io")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()
                 .setKerberosConfig(new File("/etc/krb5.conf"))
                 .setServiceName("airlift")
-                .setKeytab(new File("/tmp/presto.keytab"));
+                .setKeytab(new File("/tmp/presto.keytab"))
+                .setPrincipalHostname("presto.prestosql.io");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This PR adds a configuration option to override the hostname in the SPN for Kerberos authentication to the coordinator.

This feature is very helpful in container environments where containers have arbitrary hostnames (i.e. Kubernetes).

supersedes #144, see also: prestodb/presto#12047