### PR TITLE
Make Git quite when running tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ cache:
   directories:
     - $HOME/.m2/repository
 
+git:
+  quiet: true
+
 install:
   - ./mvnw -v
   - |


### PR DESCRIPTION
Make Git quite when running tests in Travis

Without this change, test automation logs are polluted
with about 430 lines like:
Unpacking objects:  91% (51/56)

See:
https://docs.travis-ci.com/user/customizing-the-build/#git-clone-quiet
