### PR TITLE
Fix starvation while waiting for minimum number of workers

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/ClusterSizeMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/execution/ClusterSizeMonitor.java
@@ -124,6 +124,11 @@ public class ClusterSizeMonitor
         minimumWorkerRequirementMet = true;
     }
 
+    /**
+     * Returns a listener that completes when the minimum number of workers for the cluster has been met.
+     * Note: caller should not add a listener using the direct executor, as this can delay the
+     * notifications for other listeners.
+     */
     public synchronized ListenableFuture<?> waitForMinimumWorkers()
     {
         if (currentCount >= executionMinCount) {

--- a/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
@@ -329,8 +329,8 @@ public class SqlQueryExecution
     private void waitForMinimumWorkers()
     {
         ListenableFuture<?> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers();
-        addSuccessCallback(minimumWorkerFuture, this::startExecution);
-        addExceptionCallback(minimumWorkerFuture, stateMachine::transitionToFailed);
+        addSuccessCallback(minimumWorkerFuture, () -> queryExecutor.submit(this::startExecution));
+        addExceptionCallback(minimumWorkerFuture, throwable -> queryExecutor.submit(() -> stateMachine.transitionToFailed(throwable)));
     }
 
     private void startExecution()


### PR DESCRIPTION
Callers of waitForMinimumWorkers should not use a direct executor in listeners, as this can delay notifications to other listeners.