### PR TITLE
Add spilled data to query stats, CLI, and Web UI

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
@@ -79,6 +79,7 @@ CPU Time: 33.7s total,  191K rows/s, 16.6MB/s, 22% active
 Per Node: 2.5 parallelism,  473K rows/s, 41.1MB/s
 Parallelism: 2.5
 Peak Memory: 1.97GB
+Spilled: 20GB
 0:13 [6.45M rows,  560MB] [ 473K rows/s, 41.1MB/s] [=========>>           ] 20%
 
      STAGES   ROWS  ROWS/s  BYTES  BYTES/s   PEND    RUN   DONE
@@ -203,8 +204,13 @@ Peak Memory: 1.97GB
             // Parallelism: 5.3
             out.println(format("Parallelism: %.1f", parallelism));
 
-            //Peak Memory: 1.97GB
+            // Peak Memory: 1.97GB
             reprintLine("Peak Memory: " + formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
+
+            // Spilled Data: 20GB
+            if (stats.getSpilledBytes() > 0) {
+                reprintLine("Spilled: " + formatDataSize(bytes(stats.getSpilledBytes()), true));
+            }
         }
 
         // 0:32 [2.12GB, 15M rows] [67MB/s, 463K rows/s]
@@ -294,8 +300,13 @@ Peak Memory: 1.97GB
                 // Parallelism: 5.3
                 reprintLine(format("Parallelism: %.1f", parallelism));
 
-                //Peak Memory: 1.97GB
+                // Peak Memory: 1.97GB
                 reprintLine("Peak Memory: " + formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
+
+                // Spilled Data: 20GB
+                if (stats.getSpilledBytes() > 0) {
+                    reprintLine("Spilled: " + formatDataSize(bytes(stats.getSpilledBytes()), true));
+                }
             }
 
             verify(terminalWidth >= 75); // otherwise handled above

--- a/presto-client/src/main/java/io/prestosql/client/StatementStats.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementStats.java
@@ -43,6 +43,7 @@ public class StatementStats
     private final long processedRows;
     private final long processedBytes;
     private final long peakMemoryBytes;
+    private final long spilledBytes;
     private final StageStats rootStage;
 
     @JsonCreator
@@ -62,6 +63,7 @@ public class StatementStats
             @JsonProperty("processedRows") long processedRows,
             @JsonProperty("processedBytes") long processedBytes,
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
+            @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("rootStage") StageStats rootStage)
     {
         this.state = requireNonNull(state, "state is null");
@@ -79,6 +81,7 @@ public class StatementStats
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
         this.peakMemoryBytes = peakMemoryBytes;
+        this.spilledBytes = spilledBytes;
         this.rootStage = rootStage;
     }
 
@@ -188,6 +191,12 @@ public class StatementStats
         return OptionalDouble.of(min(100, (completedSplits * 100.0) / totalSplits));
     }
 
+    @JsonProperty
+    public long getSpilledBytes()
+    {
+        return spilledBytes;
+    }
+
     @Override
     public String toString()
     {
@@ -207,6 +216,7 @@ public class StatementStats
                 .add("processedRows", processedRows)
                 .add("processedBytes", processedBytes)
                 .add("peakMemoryBytes", peakMemoryBytes)
+                .add("spilledBytes", spilledBytes)
                 .add("rootStage", rootStage)
                 .toString();
     }
@@ -233,6 +243,7 @@ public class StatementStats
         private long processedRows;
         private long processedBytes;
         private long peakMemoryBytes;
+        private long spilledBytes;
         private StageStats rootStage;
 
         private Builder() {}
@@ -327,6 +338,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setSpilledBytes(long spilledBytes)
+        {
+            this.spilledBytes = spilledBytes;
+            return this;
+        }
+
         public Builder setRootStage(StageStats rootStage)
         {
             this.rootStage = rootStage;
@@ -351,6 +368,7 @@ public class StatementStats
                     processedRows,
                     processedBytes,
                     peakMemoryBytes,
+                    spilledBytes,
                     rootStage);
         }
     }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
@@ -90,7 +90,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -582,4 +582,12 @@ public class QueryStats
         }
         return OptionalDouble.of(min(100, (completedDrivers * 100.0) / totalDrivers));
     }
+
+    @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return succinctBytes(operatorSummaries.stream()
+                .mapToLong(stats -> stats.getSpilledDataSize().toBytes())
+                .sum());
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
@@ -81,7 +81,7 @@ public class OperatorContext
 
     private final OperationTiming finishTiming = new OperationTiming();
 
-    private final SpillContext spillContext;
+    private final OperatorSpillContext spillContext;
     private final AtomicReference<Supplier<OperatorInfo>> infoSupplier = new AtomicReference<>();
 
     private final AtomicLong peakUserMemoryReservation = new AtomicLong();
@@ -480,6 +480,8 @@ public class OperatorContext
                 succinctBytes(peakSystemMemoryReservation.get()),
                 succinctBytes(peakTotalMemoryReservation.get()),
 
+                succinctBytes(spillContext.getSpilledBytes()),
+
                 memoryFuture.get().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                 info);
     }
@@ -523,6 +525,7 @@ public class OperatorContext
     {
         private final DriverContext driverContext;
         private final AtomicLong reservedBytes = new AtomicLong();
+        private final AtomicLong spilledBytes = new AtomicLong();
 
         public OperatorSpillContext(DriverContext driverContext)
         {
@@ -535,11 +538,17 @@ public class OperatorContext
             if (bytes >= 0) {
                 reservedBytes.addAndGet(bytes);
                 driverContext.reserveSpill(bytes);
+                spilledBytes.addAndGet(bytes);
             }
             else {
                 reservedBytes.accumulateAndGet(-bytes, this::decrementSpilledReservation);
                 driverContext.freeSpill(-bytes);
             }
+        }
+
+        public long getSpilledBytes()
+        {
+            return spilledBytes.longValue();
         }
 
         private long decrementSpilledReservation(long reservedBytes, long bytesBeingFreed)

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
@@ -74,6 +74,8 @@ public class OperatorStats
     private final DataSize peakSystemMemoryReservation;
     private final DataSize peakTotalMemoryReservation;
 
+    private final DataSize spilledDataSize;
+
     private final Optional<BlockedReason> blockedReason;
 
     private final OperatorInfo info;
@@ -118,6 +120,8 @@ public class OperatorStats
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("peakSystemMemoryReservation") DataSize peakSystemMemoryReservation,
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
+
+            @JsonProperty("spilledDataSize") DataSize spilledDataSize,
 
             @JsonProperty("blockedReason") Optional<BlockedReason> blockedReason,
 
@@ -166,6 +170,8 @@ public class OperatorStats
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakSystemMemoryReservation = requireNonNull(peakSystemMemoryReservation, "peakSystemMemoryReservation is null");
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.blockedReason = blockedReason;
 
@@ -359,6 +365,12 @@ public class OperatorStats
     }
 
     @JsonProperty
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
+    @JsonProperty
     public Optional<BlockedReason> getBlockedReason()
     {
         return blockedReason;
@@ -411,6 +423,8 @@ public class OperatorStats
         long peakSystemMemory = this.peakSystemMemoryReservation.toBytes();
         long peakTotalMemory = this.peakTotalMemoryReservation.toBytes();
 
+        long spilledDataSize = this.spilledDataSize.toBytes();
+
         Optional<BlockedReason> blockedReason = this.blockedReason;
 
         Mergeable<OperatorInfo> base = getMergeableInfoOrNull(info);
@@ -450,6 +464,8 @@ public class OperatorStats
             peakUserMemory = max(peakUserMemory, operator.getPeakUserMemoryReservation().toBytes());
             peakSystemMemory = max(peakSystemMemory, operator.getPeakSystemMemoryReservation().toBytes());
             peakTotalMemory = max(peakTotalMemory, operator.getPeakTotalMemoryReservation().toBytes());
+
+            spilledDataSize += operator.getSpilledDataSize().toBytes();
 
             if (operator.getBlockedReason().isPresent()) {
                 blockedReason = operator.getBlockedReason();
@@ -500,6 +516,8 @@ public class OperatorStats
                 succinctBytes(peakUserMemory),
                 succinctBytes(peakSystemMemory),
                 succinctBytes(peakTotalMemory),
+
+                succinctBytes(spilledDataSize),
 
                 blockedReason,
 
@@ -556,6 +574,7 @@ public class OperatorStats
                 peakUserMemoryReservation,
                 peakSystemMemoryReservation,
                 peakTotalMemoryReservation,
+                spilledDataSize,
                 blockedReason,
                 (info != null && info.isFinal()) ? info : null);
     }

--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -639,6 +639,7 @@ class Query
                 .setProcessedRows(queryStats.getRawInputPositions())
                 .setProcessedBytes(queryStats.getRawInputDataSize().toBytes())
                 .setPeakMemoryBytes(queryStats.getPeakUserMemoryReservation().toBytes())
+                .setSpilledBytes(queryStats.getSpilledDataSize().toBytes())
                 .setRootStage(toStageStats(outputStage))
                 .build();
     }

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1388,6 +1388,16 @@ export class QueryDetail extends React.Component {
                                             {query.queryStats.physicalWrittenDataSize}
                                         </td>
                                     </tr>
+                                    {parseDataSize(query.queryStats.spilledDataSize) > 0 &&
+                                    <tr>
+                                        <td className="info-title">
+                                            Spilled Data
+                                        </td>
+                                        <td className="info-text">
+                                            {query.queryStats.spilledDataSize}
+                                        </td>
+                                    </tr>
+                                    }
                                     </tbody>
                                 </table>
                             </div>

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
@@ -70,6 +70,7 @@ public class TestQueryStats
                     succinctBytes(127L),
                     succinctBytes(128L),
                     succinctBytes(129L),
+                    succinctBytes(130L),
                     Optional.empty(),
                     null),
             new OperatorStats(
@@ -104,6 +105,7 @@ public class TestQueryStats
                     succinctBytes(227L),
                     succinctBytes(228L),
                     succinctBytes(229L),
+                    succinctBytes(230L),
                     Optional.empty(),
                     null),
             new OperatorStats(
@@ -138,6 +140,7 @@ public class TestQueryStats
                     succinctBytes(327L),
                     succinctBytes(328L),
                     succinctBytes(329L),
+                    succinctBytes(330L),
                     Optional.empty(),
                     null));
 
@@ -250,6 +253,7 @@ public class TestQueryStats
         assertEquals(actual.getTotalMemoryReservation(), new DataSize(19, BYTE));
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(20, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(21, BYTE));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(690, BYTE));
 
         assertEquals(actual.getTotalScheduledTime(), new Duration(20, NANOSECONDS));
         assertEquals(actual.getTotalCpuTime(), new Duration(21, NANOSECONDS));

--- a/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
@@ -71,6 +71,7 @@ public class TestOperatorStats
             new DataSize(22, BYTE),
             new DataSize(23, BYTE),
             new DataSize(24, BYTE),
+            new DataSize(25, BYTE),
             Optional.empty(),
             NON_MERGEABLE_INFO);
 
@@ -113,6 +114,7 @@ public class TestOperatorStats
             new DataSize(22, BYTE),
             new DataSize(23, BYTE),
             new DataSize(24, BYTE),
+            new DataSize(25, BYTE),
             Optional.empty(),
             MERGEABLE_INFO);
 
@@ -164,6 +166,7 @@ public class TestOperatorStats
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(22, BYTE));
         assertEquals(actual.getPeakSystemMemoryReservation(), new DataSize(23, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(24, BYTE));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(25, BYTE));
         assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
         assertEquals(((SplitOperatorInfo) actual.getInfo()).getSplitInfo(), NON_MERGEABLE_INFO.getSplitInfo());
     }
@@ -207,6 +210,7 @@ public class TestOperatorStats
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(22, BYTE));
         assertEquals(actual.getPeakSystemMemoryReservation(), new DataSize(23, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(24, BYTE));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 25, BYTE));
         assertNull(actual.getInfo());
     }
 
@@ -249,6 +253,7 @@ public class TestOperatorStats
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(22, BYTE));
         assertEquals(actual.getPeakSystemMemoryReservation(), new DataSize(23, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(24, BYTE));
+        assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 25, BYTE));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);
         assertEquals(((PartitionedOutputInfo) actual.getInfo()).getPagesAdded(), 3 * MERGEABLE_INFO.getPagesAdded());
     }


### PR DESCRIPTION
> This commit adds instrumentation about the spilled data size in the
> query summary and the web UI.
> 
> This implementation adds an operator stat that is rolled up
> to the query level. I followed the approach in the comment:
> https://github.com/prestodb/presto/pull/8010#issuecomment-31484408

Approved by @raghavsethi at https://github.com/prestodb/presto/pull/11910