### PR TITLE
Rename GCS_ACCESS_KEY_CONF

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsAccessTokenProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsAccessTokenProvider.java
@@ -22,14 +22,14 @@ import static java.util.concurrent.TimeUnit.HOURS;
 public class GcsAccessTokenProvider
         implements AccessTokenProvider
 {
-    public static final String GCS_ACCESS_KEY_CONF = "presto.gcs.oauth-access-token";
+    public static final String GCS_ACCESS_TOKEN_CONF = "presto.gcs.oauth-access-token";
     public static final Long EXPIRATION_TIME_MILLISECONDS = HOURS.toMillis(1);
     private Configuration config;
 
     @Override
     public AccessToken getAccessToken()
     {
-        return new AccessToken(nullToEmpty(config.get(GCS_ACCESS_KEY_CONF)), EXPIRATION_TIME_MILLISECONDS);
+        return new AccessToken(nullToEmpty(config.get(GCS_ACCESS_TOKEN_CONF)), EXPIRATION_TIME_MILLISECONDS);
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
@@ -20,11 +20,13 @@ import org.apache.hadoop.conf.Configuration;
 import java.net.URI;
 
 import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import static io.prestosql.plugin.hive.gcs.GcsAccessTokenProvider.GCS_ACCESS_KEY_CONF;
+import static io.prestosql.plugin.hive.gcs.GcsAccessTokenProvider.GCS_ACCESS_TOKEN_CONF;
 
 public class GcsConfigurationProvider
         implements DynamicConfigurationProvider
 {
+    private static final String GCS_OAUTH_KEY = "hive.gcs.oauth";
+
     @Override
     public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
     {
@@ -32,9 +34,9 @@ public class GcsConfigurationProvider
             return;
         }
 
-        String accessToken = context.getIdentity().getExtraCredentials().get(GCS_ACCESS_KEY_CONF);
+        String accessToken = context.getIdentity().getExtraCredentials().get(GCS_OAUTH_KEY);
         if (accessToken != null) {
-            configuration.set(GCS_ACCESS_KEY_CONF, accessToken);
+            configuration.set(GCS_ACCESS_TOKEN_CONF, accessToken);
         }
     }
 }


### PR DESCRIPTION
@electrum 

Rename the config for GCS Oauth token in extra credentials to `hive.gcs.oauth`.