### PR TITLE
Fix issues with extra credentials

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GoogleGcsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GoogleGcsConfigurationInitializer.java
@@ -42,6 +42,7 @@ public class GoogleGcsConfigurationInitializer
 
         if (useGcsAccessToken) {
             // use oauth token to authenticate with Google Cloud Storage
+            config.set(AUTH_SERVICE_ACCOUNT_ENABLE.getKey(), "false");
             config.set(AUTHENTICATION_PREFIX + ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX, GcsAccessTokenProvider.class.getName());
         }
         else if (jsonKeyFilePath != null) {

--- a/presto-main/src/main/java/io/prestosql/Session.java
+++ b/presto-main/src/main/java/io/prestosql/Session.java
@@ -350,7 +350,7 @@ public final class Session
                 queryId,
                 Optional.of(transactionId),
                 clientTransactionSupport,
-                new Identity(identity.getUser(), identity.getPrincipal(), roles.build()),
+                new Identity(identity.getUser(), identity.getPrincipal(), roles.build(), identity.getExtraCredentials()),
                 source,
                 catalog,
                 schema,


### PR DESCRIPTION
Fix two issues during the revising of previous PR.

- Fix lost credentials in `beginTransactionId`.
- Explicitly set `fs.gs.enable.service.account.auth` to `false` in GCS module.