### PR TITLE
Add an optional JDBC connector type mapping to varchar

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
@@ -21,6 +23,9 @@ import io.prestosql.plugin.jdbc.credential.CredentialProviderType;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
+import java.util.Set;
+
+import static com.google.common.base.Strings.nullToEmpty;
 import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -33,6 +38,7 @@ public class BaseJdbcConfig
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private CredentialProviderType credentialProviderType = INLINE;
+    private Set<String> jdbcTypesMappedToVarchar = ImmutableSet.of();
 
     @NotNull
     public String getConnectionUrl()
@@ -109,6 +115,18 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setCredentialProviderType(CredentialProviderType credentialProviderType)
     {
         this.credentialProviderType = requireNonNull(credentialProviderType, "credentialProviderType is null");
+        return this;
+    }
+
+    public Set<String> getJdbcTypesMappedToVarchar()
+    {
+        return jdbcTypesMappedToVarchar;
+    }
+
+    @Config("jdbc-types-mapped-to-varchar")
+    public BaseJdbcConfig setJdbcTypesMappedToVarchar(String jdbcTypesMappedToVarchar)
+    {
+        this.jdbcTypesMappedToVarchar = ImmutableSet.copyOf(Splitter.on(",").omitEmptyStrings().trimResults().split(nullToEmpty(jdbcTypesMappedToVarchar)));
         return this;
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
@@ -26,6 +27,7 @@ import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.FILE;
 import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
 
 public class TestBaseJdbcConfig
 {
@@ -38,7 +40,8 @@ public class TestBaseJdbcConfig
                 .setPasswordCredentialName(null)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
-                .setCredentialProviderType(INLINE));
+                .setCredentialProviderType(INLINE)
+                .setJdbcTypesMappedToVarchar(null));
     }
 
     @Test
@@ -51,6 +54,7 @@ public class TestBaseJdbcConfig
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .put("credential-provider.type", "FILE")
+                .put("jdbc-types-mapped-to-varchar", "mytype,struct_type1")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
@@ -59,8 +63,11 @@ public class TestBaseJdbcConfig
                 .setPasswordCredentialName("bar")
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
-                .setCredentialProviderType(FILE);
+                .setCredentialProviderType(FILE)
+                .setJdbcTypesMappedToVarchar("mytype, struct_type1");
 
         assertFullMapping(properties, expected);
+
+        assertEquals(expected.getJdbcTypesMappedToVarchar(), ImmutableSet.of("mytype", "struct_type1"));
     }
 }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -162,6 +162,10 @@ public class MySqlClient
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new PrestoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
 
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
         if (jdbcTypeName.equalsIgnoreCase("json")) {
             return Optional.of(jsonColumnMapping());
         }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
@@ -67,6 +67,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -121,6 +122,7 @@ public class PhoenixClient
         super(
                 ESCAPE_CHARACTER,
                 connectionFactory,
+                ImmutableSet.of(),
                 config.isCaseInsensitiveNameMatching(),
                 config.getCaseInsensitiveNameMatchingCacheTtl());
         this.configuration = new Configuration(false);

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -271,6 +271,10 @@ public class PostgreSqlClient
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new PrestoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
 
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
         switch (jdbcTypeName) {
             case "uuid":
                 return Optional.of(uuidColumnMapping());

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -102,10 +102,14 @@ public class SqlServerClient
     }
 
     @Override
-    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle type)
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
         // TODO implement proper type mapping
-        return super.toPrestoType(session, connection, type)
+        return super.toPrestoType(session, connection, typeHandle)
                 .map(columnMapping -> new ColumnMapping(
                         columnMapping.getType(),
                         columnMapping.getReadFunction(),


### PR DESCRIPTION
Add optional catalog parameters that map Jdbc types to varchar:

```jdbc-types-mapped-to-varchar = jdbcTypeName[,jdbcTypeName[,...]]```

Now catalogs can control whether or not to fetch unsupported Presto types and to stay compatible when future support will be implemented.

For example:
PostgreSQL catalog with the following configuration will map `tsrange` and `inet` to Presto  VARCHAR:

```jdbc-types-mapped-to-varchar = tsrange,inet```

Ref https://github.com/prestodb/presto/pull/11833