### PR TITLE
Fix char value padding with respect to UTF-16 surrogate pairs

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
@@ -71,7 +71,7 @@ public class TestStringFunctions
 
     public static String padRight(String s, int n)
     {
-        return String.format("%1$-" + n + "s", s);
+        return s + repeat(" ", n - s.codePointCount(0, s.length()));
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/type/TestCharType.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestCharType.java
@@ -13,13 +13,23 @@
  */
 package io.prestosql.type;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.CharType;
+import org.testng.annotations.Test;
 
+import static io.airlift.slice.SliceUtf8.codePointToUtf8;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.prestosql.spi.type.CharType.createCharType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.isSupplementaryCodePoint;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class TestCharType
         extends AbstractTestType
@@ -52,5 +62,28 @@ public class TestCharType
     protected Object getGreaterValue(Object value)
     {
         return Slices.utf8Slice(((Slice) value).toStringUtf8() + "_");
+    }
+
+    @Test
+    public void testGetObjectValue()
+    {
+        CharType charType = createCharType(3);
+
+        for (int codePoint : ImmutableList.of(0, 1, 10, 17, (int) ' ', 127, 1011, 11_000, 65_891, MIN_SUPPLEMENTARY_CODE_POINT, MAX_CODE_POINT)) {
+            BlockBuilder blockBuilder = charType.createBlockBuilder(null, 1);
+            Slice slice = (codePoint != ' ') ? codePointToUtf8(codePoint) : EMPTY_SLICE;
+            blockBuilder.writeBytes(slice, 0, slice.length());
+            blockBuilder.closeEntry();
+            Block block = blockBuilder.build();
+            int codePointLengthInUtf16 = isSupplementaryCodePoint(codePoint) ? 2 : 1;
+
+            String objectValue = (String) charType.getObjectValue(SESSION, block, 0);
+            assertNotNull(objectValue);
+            assertEquals(objectValue.codePointAt(0), codePoint, "first code point");
+            assertEquals(objectValue.length(), codePointLengthInUtf16 + 2, "size");
+            for (int i = codePointLengthInUtf16; i < objectValue.length(); i++) {
+                assertEquals(objectValue.codePointAt(i), ' ');
+            }
+        }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/CharType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/CharType.java
@@ -22,6 +22,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Objects;
 
+import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.type.Chars.compareChars;
 import static java.lang.String.format;
@@ -78,9 +79,9 @@ public final class CharType
         }
 
         StringBuilder builder = new StringBuilder(length);
-        String value = block.getSlice(position, 0, block.getSliceLength(position)).toStringUtf8();
-        builder.append(value);
-        for (int i = value.length(); i < length; i++) {
+        Slice slice = block.getSlice(position, 0, block.getSliceLength(position));
+        builder.append(slice.toStringUtf8());
+        for (int i = countCodePoints(slice); i < length; i++) {
             builder.append(' ');
         }
 


### PR DESCRIPTION
Previously, the code was using `String#length` to determine how many
space characters needs to be added at the end of the returned value.
However, this method calculates text length incorrectly when text
contains one or more supplementary characters, i.e. characters encoded
as surrogate pairs in UTF-16.