### PR TITLE
Update to Hive 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
             <dependency>
                 <groupId>io.prestosql.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>2.3.4-1</version>
+                <version>3.0.0-1</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore;
 
+import com.google.common.base.Joiner;
 import io.prestosql.plugin.hive.PartitionOfflineException;
 import io.prestosql.plugin.hive.TableOfflineException;
 import io.prestosql.spi.PrestoException;
@@ -32,7 +33,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.prestosql.plugin.hive.HiveSplitManager.PRESTO_OFFLINE;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.stream.Collectors.toList;
-import static org.apache.hadoop.hive.metastore.MetaStoreUtils.typeToThriftType;
+import static org.apache.hadoop.hive.metastore.ColumnType.typeToThriftType;
 import static org.apache.hadoop.hive.metastore.ProtectMode.getProtectModeFromString;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.BUCKET_COUNT;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.BUCKET_FIELD_NAME;
@@ -100,7 +101,7 @@ public class MetastoreUtil
         schema.setProperty(META_TABLE_LOCATION, sd.getLocation());
 
         if (sd.getBucketProperty().isPresent()) {
-            schema.setProperty(BUCKET_FIELD_NAME, sd.getBucketProperty().get().getBucketedBy().get(0));
+            schema.setProperty(BUCKET_FIELD_NAME, Joiner.on(",").join(sd.getBucketProperty().get().getBucketedBy()));
             schema.setProperty(BUCKET_COUNT, Integer.toString(sd.getBucketProperty().get().getBucketCount()));
         }
         else {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import io.prestosql.plugin.hive.HiveBasicStatistics;
 import io.prestosql.plugin.hive.HiveBucketProperty;
 import io.prestosql.plugin.hive.HiveType;
@@ -896,7 +897,7 @@ public final class ThriftMetastoreUtil
 
     public static Decimal toMetastoreDecimal(BigDecimal decimal)
     {
-        return new Decimal(ByteBuffer.wrap(decimal.unscaledValue().toByteArray()), (short) decimal.scale());
+        return new Decimal(Shorts.checkedCast(decimal.scale()), ByteBuffer.wrap(decimal.unscaledValue().toByteArray()));
     }
 
     private static OptionalLong toMetastoreDistinctValuesCount(OptionalLong distinctValuesCount, OptionalLong nullsCount)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSource.java
@@ -29,7 +29,6 @@ import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.List;
@@ -59,15 +58,10 @@ public class RcFilePageSource
 
     private boolean closed;
 
-    public RcFilePageSource(
-            RcFileReader rcFileReader,
-            List<HiveColumnHandle> columns,
-            DateTimeZone hiveStorageTimeZone,
-            TypeManager typeManager)
+    public RcFilePageSource(RcFileReader rcFileReader, List<HiveColumnHandle> columns, TypeManager typeManager)
     {
         requireNonNull(rcFileReader, "rcReader is null");
         requireNonNull(columns, "columns is null");
-        requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         requireNonNull(typeManager, "typeManager is null");
 
         this.rcFileReader = rcFileReader;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -147,11 +147,7 @@ public class RcFilePageSourceFactory
                     length,
                     new DataSize(8, Unit.MEGABYTE));
 
-            return Optional.of(new RcFilePageSource(
-                    rcFileReader,
-                    columns,
-                    hiveStorageTimeZone,
-                    typeManager));
+            return Optional.of(new RcFilePageSource(rcFileReader, columns, typeManager));
         }
         catch (Throwable e) {
             try {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -235,6 +235,22 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testReadNoColumns()
+    {
+        testWithAllStorageFormats(this::testReadNoColumns);
+    }
+
+    private void testReadNoColumns(Session session, HiveStorageFormat storageFormat)
+    {
+        if (!insertOperationsSupported(storageFormat)) {
+            return;
+        }
+        assertUpdate(session, format("CREATE TABLE test_read_no_columns WITH (format = '%s') AS SELECT 0 x", storageFormat), 1);
+        assertQuery(session, "SELECT count(*) FROM test_read_no_columns", "SELECT 1");
+        assertUpdate(session, "DROP TABLE test_read_no_columns");
+    }
+
+    @Test
     public void createTableWithEveryType()
     {
         @Language("SQL") String query = "" +

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreUtil.java
@@ -17,13 +17,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.SkewedInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.testng.annotations.Test;
 
 import java.util.List;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Date;
 import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
-import org.apache.hadoop.hive.metastore.api.Decimal;
 import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
@@ -34,7 +33,6 @@ import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -42,6 +40,7 @@ import java.util.OptionalLong;
 
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getHiveBasicStatistics;
+import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.toMetastoreDecimal;
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateStatisticsParameters;
 import static org.apache.hadoop.hive.metastore.api.ColumnStatisticsData.binaryStats;
 import static org.apache.hadoop.hive.metastore.api.ColumnStatisticsData.booleanStats;
@@ -146,9 +145,9 @@ public class TestThriftMetastoreUtil
     {
         DecimalColumnStatsData decimalColumnStatsData = new DecimalColumnStatsData();
         BigDecimal low = new BigDecimal("0");
-        decimalColumnStatsData.setLowValue(new Decimal(ByteBuffer.wrap(low.unscaledValue().toByteArray()), (short) low.scale()));
+        decimalColumnStatsData.setLowValue(toMetastoreDecimal(low));
         BigDecimal high = new BigDecimal("100");
-        decimalColumnStatsData.setHighValue(new Decimal(ByteBuffer.wrap(high.unscaledValue().toByteArray()), (short) high.scale()));
+        decimalColumnStatsData.setHighValue(toMetastoreDecimal(high));
         decimalColumnStatsData.setNumNulls(1);
         decimalColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DECIMAL_TYPE_NAME, decimalStats(decimalColumnStatsData));

--- a/presto-parquet/src/main/java/io/prestosql/parquet/ParquetEncoding.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/ParquetEncoding.java
@@ -24,7 +24,6 @@ import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.bitpacking.ByteBitPackingValuesReader;
-import org.apache.parquet.column.values.boundedint.ZeroIntegerValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
@@ -36,6 +35,7 @@ import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValues
 import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
+import org.apache.parquet.column.values.rle.ZeroIntegerValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 
 import java.io.IOException;

--- a/presto-parquet/src/main/java/io/prestosql/parquet/dictionary/DictionaryReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/dictionary/DictionaryReader.java
@@ -13,16 +13,16 @@
  */
 package io.prestosql.parquet.dictionary;
 
+import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 public class DictionaryReader
         extends ValuesReader
@@ -36,11 +36,10 @@ public class DictionaryReader
     }
 
     @Override
-    public void initFromPage(int valueCount, byte[] page, int offset)
+    public void initFromPage(int valueCount, ByteBuffer page, int offset)
             throws IOException
     {
-        checkArgument(page.length > offset, "Attempt to read offset not in the  page");
-        ByteArrayInputStream in = new ByteArrayInputStream(page, offset, page.length - offset);
+        InputStream in = new ByteBufferInputStream(page, offset, page.limit() - offset);
         int bitWidth = BytesUtils.readIntLittleEndianOnOneByte(in);
         decoder = new RunLengthBitPackingHybridDecoder(bitWidth, in);
     }


### PR DESCRIPTION
This fixes reading from Parquet when no columns are selected.

Fixes #201

Depends on https://github.com/prestosql/presto-hive-apache/pull/2