### PR TITLE
Fix session property dynamic_schedule_for_grouped_execution

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -187,8 +187,8 @@ public final class SystemSessionProperties
                 booleanProperty(
                         DYNAMIC_SCHEDULE_FOR_GROUPED_EXECUTION,
                         "Experimental: Use dynamic schedule for grouped execution when possible",
-                        false,
-                        featuresConfig.isDynamicScheduleForGroupedExecutionEnabled()),
+                        featuresConfig.isDynamicScheduleForGroupedExecutionEnabled(),
+                        false),
                 booleanProperty(
                         PREFER_STREAMING_OPERATORS,
                         "Prefer source table layouts that produce streaming operators",


### PR DESCRIPTION
Previously the parameter `default` and `hidden` are in wrong order.

Ref https://github.com/prestodb/presto/pull/12321