### PR TITLE
Use and record writer time zone in ORC files

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
@@ -101,6 +101,8 @@ public class OrcReader
 
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
 
+        validateWrite(validation -> validation.getOrcEncoding() == orcEncoding, "Unexpected ORC encoding");
+
         //
         // Read the file tail:
         //

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
@@ -131,7 +131,7 @@ public final class OrcWriter
             OrcWriteValidationMode validationMode,
             OrcWriterStats stats)
     {
-        this.validationBuilder = validate ? new OrcWriteValidationBuilder(validationMode, types)
+        this.validationBuilder = validate ? new OrcWriteValidationBuilder(validationMode, orcEncoding, types)
                 .setStringStatisticsLimitInBytes(toIntExact(options.getMaxStringStatisticsLimit().toBytes())) : null;
 
         this.orcDataSink = requireNonNull(orcDataSink, "orcDataSink is null");

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
@@ -46,12 +46,14 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -139,6 +141,7 @@ public final class OrcWriter
         this.orcEncoding = requireNonNull(orcEncoding, "orcEncoding is null");
         this.compression = requireNonNull(compression, "compression is null");
         recordValidation(validation -> validation.setCompression(compression));
+        recordValidation(validation -> validation.setTimeZone(hiveStorageTimeZone.toTimeZone().toZoneId()));
 
         requireNonNull(options, "options is null");
         checkArgument(options.getStripeMaxSize().compareTo(options.getStripeMinSize()) >= 0, "stripeMaxSize must be greater than stripeMinSize");
@@ -411,7 +414,8 @@ public final class OrcWriter
         columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null));
 
         // add footer
-        StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()));
+        Optional<ZoneId> timeZone = Optional.of(hiveStorageTimeZone.toTimeZone().toZoneId());
+        StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()), timeZone);
         Slice footer = metadataWriter.writeStripeFooter(stripeFooter);
         outputData.add(createDataOutput(footer));
 

--- a/presto-orc/src/main/java/io/prestosql/orc/Stripe.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/Stripe.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.orc.metadata.ColumnEncoding;
 import io.prestosql.orc.stream.InputStreamSources;
 
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -25,13 +26,15 @@ import static java.util.Objects.requireNonNull;
 public class Stripe
 {
     private final long rowCount;
+    private final ZoneId timeZone;
     private final List<ColumnEncoding> columnEncodings;
     private final List<RowGroup> rowGroups;
     private final InputStreamSources dictionaryStreamSources;
 
-    public Stripe(long rowCount, List<ColumnEncoding> columnEncodings, List<RowGroup> rowGroups, InputStreamSources dictionaryStreamSources)
+    public Stripe(long rowCount, ZoneId timeZone, List<ColumnEncoding> columnEncodings, List<RowGroup> rowGroups, InputStreamSources dictionaryStreamSources)
     {
         this.rowCount = rowCount;
+        this.timeZone = requireNonNull(timeZone, "timeZone is null");
         this.columnEncodings = requireNonNull(columnEncodings, "columnEncodings is null");
         this.rowGroups = ImmutableList.copyOf(requireNonNull(rowGroups, "rowGroups is null"));
         this.dictionaryStreamSources = requireNonNull(dictionaryStreamSources, "dictionaryStreamSources is null");
@@ -40,6 +43,11 @@ public class Stripe
     public long getRowCount()
     {
         return rowCount;
+    }
+
+    public ZoneId getTimeZone()
+    {
+        return timeZone;
     }
 
     public List<ColumnEncoding> getColumnEncodings()
@@ -62,6 +70,7 @@ public class Stripe
     {
         return toStringHelper(this)
                 .add("rowCount", rowCount)
+                .add("timeZone", timeZone)
                 .add("columnEncodings", columnEncodings)
                 .add("rowGroups", rowGroups)
                 .add("dictionaryStreams", dictionaryStreamSources)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/DwrfMetadataReader.java
@@ -129,7 +129,7 @@ public class DwrfMetadataReader
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         DwrfProto.StripeFooter stripeFooter = DwrfProto.StripeFooter.parseFrom(input);
-        return new StripeFooter(toStream(stripeFooter.getStreamsList()), toColumnEncoding(types, stripeFooter.getColumnsList()));
+        return new StripeFooter(toStream(stripeFooter.getStreamsList()), toColumnEncoding(types, stripeFooter.getColumnsList()), Optional.empty());
     }
 
     private static Stream toStream(DwrfProto.Stream stream)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -83,7 +83,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readStripeFooter(types, inputStream);
         }
-        catch (IOException e) {
+        catch (IOException | RuntimeException e) {
             throw propagate(e, "Invalid stripe footer");
         }
     }

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
@@ -44,8 +44,10 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
 import static io.airlift.slice.SliceUtf8.tryGetCodePointAt;
@@ -159,7 +161,11 @@ public class OrcMetadataReader
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         OrcProto.StripeFooter stripeFooter = OrcProto.StripeFooter.parseFrom(input);
-        return new StripeFooter(toStream(stripeFooter.getStreamsList()), toColumnEncoding(stripeFooter.getColumnsList()));
+        return new StripeFooter(
+                toStream(stripeFooter.getStreamsList()),
+                toColumnEncoding(stripeFooter.getColumnsList()),
+                Optional.ofNullable(emptyToNull(stripeFooter.getWriterTimezone()))
+                        .map(zone -> TimeZone.getTimeZone(zone).toZoneId()));
     }
 
     private static Stream toStream(OrcProto.Stream stream)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
@@ -32,8 +32,10 @@ import io.prestosql.orc.protobuf.MessageLite;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
@@ -268,6 +270,8 @@ public class OrcMetadataWriter
     public int writeStripeFooter(SliceOutput output, StripeFooter footer)
             throws IOException
     {
+        ZoneId zone = footer.getTimeZone().orElseThrow(() -> new IllegalArgumentException("Time zone not set"));
+
         OrcProto.StripeFooter footerProtobuf = OrcProto.StripeFooter.newBuilder()
                 .addAllStreams(footer.getStreams().stream()
                         .map(OrcMetadataWriter::toStream)
@@ -275,6 +279,7 @@ public class OrcMetadataWriter
                 .addAllColumns(footer.getColumnEncodings().stream()
                         .map(OrcMetadataWriter::toColumnEncoding)
                         .collect(toList()))
+                .setWriterTimezone(TimeZone.getTimeZone(zone).getID())
                 .build();
 
         return writeProtobufObject(output, footerProtobuf);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/StripeFooter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/StripeFooter.java
@@ -15,7 +15,9 @@ package io.prestosql.orc.metadata;
 
 import com.google.common.collect.ImmutableList;
 
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -23,11 +25,13 @@ public class StripeFooter
 {
     private final List<Stream> streams;
     private final List<ColumnEncoding> columnEncodings;
+    private final Optional<ZoneId> timeZone;
 
-    public StripeFooter(List<Stream> streams, List<ColumnEncoding> columnEncodings)
+    public StripeFooter(List<Stream> streams, List<ColumnEncoding> columnEncodings, Optional<ZoneId> timeZone)
     {
         this.streams = ImmutableList.copyOf(requireNonNull(streams, "streams is null"));
         this.columnEncodings = ImmutableList.copyOf(requireNonNull(columnEncodings, "columnEncodings is null"));
+        this.timeZone = requireNonNull(timeZone, "timeZone is null");
     }
 
     public List<ColumnEncoding> getColumnEncodings()
@@ -38,5 +42,10 @@ public class StripeFooter
     public List<Stream> getStreams()
     {
         return streams;
+    }
+
+    public Optional<ZoneId> getTimeZone()
+    {
+        return timeZone;
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/BooleanStreamReader.java
@@ -28,6 +28,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -130,7 +131,7 @@ public class BooleanStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         dataStreamSource = missingStreamSource(BooleanInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/ByteStreamReader.java
@@ -29,6 +29,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -132,7 +133,7 @@ public class ByteStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         dataStreamSource = missingStreamSource(ByteInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/DecimalStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/DecimalStreamReader.java
@@ -34,6 +34,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -192,7 +193,7 @@ public class DecimalStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         decimalStreamSource = missingStreamSource(DecimalInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/DoubleStreamReader.java
@@ -29,6 +29,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -132,7 +133,7 @@ public class DoubleStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         dataStreamSource = missingStreamSource(DoubleInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/FloatStreamReader.java
@@ -29,6 +29,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -133,7 +134,7 @@ public class FloatStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         dataStreamSource = missingStreamSource(FloatInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/ListStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/ListStreamReader.java
@@ -25,13 +25,13 @@ import io.prestosql.orc.stream.LongInputStream;
 import io.prestosql.spi.block.ArrayBlock;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
-import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,10 +65,10 @@ public class ListStreamReader
 
     private boolean rowGroupOpen;
 
-    public ListStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
+    public ListStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.elementStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone, systemMemoryContext);
+        this.elementStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), systemMemoryContext);
     }
 
     @Override
@@ -160,7 +160,7 @@ public class ListStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
@@ -174,7 +174,7 @@ public class ListStreamReader
 
         rowGroupOpen = false;
 
-        elementStreamReader.startStripe(dictionaryStreamSources, encoding);
+        elementStreamReader.startStripe(timeZone, dictionaryStreamSources, encoding);
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/LongDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/LongDictionaryStreamReader.java
@@ -29,6 +29,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -197,7 +198,7 @@ public class LongDictionaryStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         dictionaryDataStreamSource = dictionaryStreamSources.getInputStreamSource(streamDescriptor, DICTIONARY_DATA, LongInputStream.class);
         dictionarySize = encoding.get(streamDescriptor.getStreamId())

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/LongDirectStreamReader.java
@@ -29,6 +29,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -132,7 +133,7 @@ public class LongDirectStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         dataStreamSource = missingStreamSource(LongInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/LongStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/LongStreamReader.java
@@ -25,6 +25,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -65,7 +66,7 @@ public class LongStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException
     {
         ColumnEncodingKind kind = encoding.get(streamDescriptor.getStreamId())
@@ -81,7 +82,7 @@ public class LongStreamReader
             throw new IllegalArgumentException("Unsupported encoding " + kind);
         }
 
-        currentReader.startStripe(dictionaryStreamSources, encoding);
+        currentReader.startStripe(timeZone, dictionaryStreamSources, encoding);
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/MapDirectStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/MapDirectStreamReader.java
@@ -26,13 +26,13 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,11 +67,11 @@ public class MapDirectStreamReader
 
     private boolean rowGroupOpen;
 
-    public MapDirectStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
+    public MapDirectStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.keyStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone, systemMemoryContext);
-        this.valueStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(1), hiveStorageTimeZone, systemMemoryContext);
+        this.keyStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), systemMemoryContext);
+        this.valueStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(1), systemMemoryContext);
     }
 
     @Override
@@ -219,7 +219,7 @@ public class MapDirectStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
@@ -233,8 +233,8 @@ public class MapDirectStreamReader
 
         rowGroupOpen = false;
 
-        keyStreamReader.startStripe(dictionaryStreamSources, encoding);
-        valueStreamReader.startStripe(dictionaryStreamSources, encoding);
+        keyStreamReader.startStripe(timeZone, dictionaryStreamSources, encoding);
+        valueStreamReader.startStripe(timeZone, dictionaryStreamSources, encoding);
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/MapStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/MapStreamReader.java
@@ -21,11 +21,11 @@ import io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
-import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -45,11 +45,11 @@ public class MapStreamReader
     private final MapFlatStreamReader flatReader;
     private StreamReader currentReader;
 
-    public MapStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
+    public MapStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new MapDirectStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
-        flatReader = new MapFlatStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
+        directReader = new MapDirectStreamReader(streamDescriptor, systemMemoryContext);
+        flatReader = new MapFlatStreamReader(streamDescriptor, systemMemoryContext);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class MapStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException
     {
         ColumnEncodingKind kind = encoding.get(streamDescriptor.getStreamId())
@@ -82,7 +82,7 @@ public class MapStreamReader
             throw new IllegalArgumentException("Unsupported encoding " + kind);
         }
 
-        currentReader.startStripe(dictionaryStreamSources, encoding);
+        currentReader.startStripe(timeZone, dictionaryStreamSources, encoding);
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/SliceDictionaryStreamReader.java
@@ -33,6 +33,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -331,7 +332,7 @@ public class SliceDictionaryStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         stripeDictionaryDataStreamSource = dictionaryStreamSources.getInputStreamSource(streamDescriptor, DICTIONARY_DATA, ByteArrayInputStream.class);
         stripeDictionaryLengthStreamSource = dictionaryStreamSources.getInputStreamSource(streamDescriptor, LENGTH, LongInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/SliceDirectStreamReader.java
@@ -33,6 +33,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -218,7 +219,7 @@ public class SliceDirectStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
     {
         presentStreamSource = missingStreamSource(BooleanInputStream.class);
         lengthStreamSource = missingStreamSource(LongInputStream.class);

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/SliceStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/SliceStreamReader.java
@@ -28,6 +28,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -74,7 +75,7 @@ public class SliceStreamReader
     }
 
     @Override
-    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    public void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException
     {
         ColumnEncodingKind columnEncodingKind = encoding.get(streamDescriptor.getStreamId())
@@ -90,7 +91,7 @@ public class SliceStreamReader
             throw new IllegalArgumentException("Unsupported encoding " + columnEncodingKind);
         }
 
-        currentReader.startStripe(dictionaryStreamSources, encoding);
+        currentReader.startStripe(timeZone, dictionaryStreamSources, encoding);
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/StreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/StreamReader.java
@@ -19,6 +19,7 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 
 public interface StreamReader
@@ -28,7 +29,7 @@ public interface StreamReader
 
     void prepareNextRead(int batchSize);
 
-    void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    void startStripe(ZoneId timeZone, InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
             throws IOException;
 
     void startRowGroup(InputStreamSources dataStreamSources)

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/StreamReaders.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/StreamReaders.java
@@ -15,7 +15,6 @@ package io.prestosql.orc.reader;
 
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.orc.StreamDescriptor;
-import org.joda.time.DateTimeZone;
 
 public final class StreamReaders
 {
@@ -23,10 +22,7 @@ public final class StreamReaders
     {
     }
 
-    public static StreamReader createStreamReader(
-            StreamDescriptor streamDescriptor,
-            DateTimeZone hiveStorageTimeZone,
-            AggregatedMemoryContext systemMemoryContext)
+    public static StreamReader createStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         switch (streamDescriptor.getStreamType()) {
             case BOOLEAN:
@@ -48,13 +44,13 @@ public final class StreamReaders
             case CHAR:
                 return new SliceStreamReader(streamDescriptor, systemMemoryContext);
             case TIMESTAMP:
-                return new TimestampStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
+                return new TimestampStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case LIST:
-                return new ListStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
+                return new ListStreamReader(streamDescriptor, systemMemoryContext);
             case STRUCT:
-                return new StructStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
+                return new StructStreamReader(streamDescriptor, systemMemoryContext);
             case MAP:
-                return new MapStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
+                return new MapStreamReader(streamDescriptor, systemMemoryContext);
             case DECIMAL:
                 return new DecimalStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case UNION:


### PR DESCRIPTION
Early versions of the Apache ORC writer made the mistake of recording
timestamps from an epoch that was relative to the time zone of the
writer. This was fixed in later versions by recording the writer time
zone in the stripe footer. Hive 3.1 always writes using UTC.

Presto used a global configuration for the writer time zone, which
was needed to handle old files, but was never updated to use the time
zone from the stripe footer.

On read, Presto now uses the stripe value if present, otherwise it
uses the configured value. On write, Presto continues to write
timestamps using the configured time zone, but now records this value
when writing files.