### PR TITLE
Change Server stating state at the end of startup.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/StaticCatalogStore.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/StaticCatalogStore.java
@@ -40,7 +40,6 @@ public class StaticCatalogStore
     private final File catalogConfigurationDir;
     private final Set<String> disabledCatalogs;
     private final AtomicBoolean catalogsLoading = new AtomicBoolean();
-    private final AtomicBoolean catalogsLoaded = new AtomicBoolean();
 
     @Inject
     public StaticCatalogStore(ConnectorManager connectorManager, StaticCatalogStoreConfig config)
@@ -57,11 +56,6 @@ public class StaticCatalogStore
         this.disabledCatalogs = ImmutableSet.copyOf(disabledCatalogs);
     }
 
-    public boolean areCatalogsLoaded()
-    {
-        return catalogsLoaded.get();
-    }
-
     public void loadCatalogs()
             throws Exception
     {
@@ -74,8 +68,6 @@ public class StaticCatalogStore
                 loadCatalog(file);
             }
         }
-
-        catalogsLoaded.set(true);
     }
 
     private void loadCatalog(File file)

--- a/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
@@ -136,6 +136,8 @@ public class PrestoServer
 
             injector.getInstance(Announcer.class).start();
 
+            injector.getInstance(ServerInfoResource.class).startupComplete();
+
             log.info("======== SERVER STARTED ========");
         }
         catch (Throwable e) {

--- a/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
@@ -16,7 +16,6 @@ package io.prestosql.server;
 import io.airlift.node.NodeInfo;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.client.ServerInfo;
-import io.prestosql.metadata.StaticCatalogStore;
 import io.prestosql.spi.NodeState;
 
 import javax.inject.Inject;
@@ -30,7 +29,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.Duration.nanosSince;
 import static io.prestosql.spi.NodeState.ACTIVE;
 import static io.prestosql.spi.NodeState.SHUTTING_DOWN;
@@ -46,17 +47,16 @@ public class ServerInfoResource
     private final NodeVersion version;
     private final String environment;
     private final boolean coordinator;
-    private final StaticCatalogStore catalogStore;
     private final GracefulShutdownHandler shutdownHandler;
     private final long startTime = System.nanoTime();
+    private final AtomicBoolean startupComplete = new AtomicBoolean();
 
     @Inject
-    public ServerInfoResource(NodeVersion nodeVersion, NodeInfo nodeInfo, ServerConfig serverConfig, StaticCatalogStore catalogStore, GracefulShutdownHandler shutdownHandler)
+    public ServerInfoResource(NodeVersion nodeVersion, NodeInfo nodeInfo, ServerConfig serverConfig, GracefulShutdownHandler shutdownHandler)
     {
         this.version = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = requireNonNull(nodeInfo, "nodeInfo is null").getEnvironment();
         this.coordinator = requireNonNull(serverConfig, "serverConfig is null").isCoordinator();
-        this.catalogStore = requireNonNull(catalogStore, "catalogStore is null");
         this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
     }
 
@@ -64,7 +64,7 @@ public class ServerInfoResource
     @Produces(APPLICATION_JSON)
     public ServerInfo getInfo()
     {
-        boolean starting = !catalogStore.areCatalogsLoaded();
+        boolean starting = !startupComplete.get();
         return new ServerInfo(version, environment, coordinator, starting, Optional.of(nanosSince(startTime)));
     }
 
@@ -118,5 +118,10 @@ public class ServerInfoResource
         }
         // return 404 to allow load balancers to only send traffic to the coordinator
         return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    public void startupComplete()
+    {
+        checkState(startupComplete.compareAndSet(false, true), "Server startup already marked as complete");
     }
 }


### PR DESCRIPTION
The /v1/info#starting state is switched to false after catalogs have been loaded. Moving this to after password authenticators, event listeners, etc have been executed. Just before the "SERVER STARTED"
log message.