### PR TITLE
Create Block directly if the Data stream in ORC file is null

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/BooleanStreamReader.java
@@ -22,6 +22,7 @@ import io.prestosql.orc.stream.InputStreamSource;
 import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.prestosql.orc.metadata.Stream.StreamKind.DATA;
 import static io.prestosql.orc.metadata.Stream.StreamKind.PRESENT;
@@ -96,6 +96,16 @@ public class BooleanStreamReader
             }
         }
 
+        if (dataStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
@@ -106,7 +116,6 @@ public class BooleanStreamReader
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    verify(dataStream != null);
                     type.writeBoolean(builder, dataStream.nextBit());
                 }
                 else {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/ByteStreamReader.java
@@ -23,6 +23,7 @@ import io.prestosql.orc.stream.InputStreamSource;
 import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.prestosql.orc.metadata.Stream.StreamKind.DATA;
 import static io.prestosql.orc.metadata.Stream.StreamKind.PRESENT;
@@ -97,6 +97,16 @@ public class ByteStreamReader
             }
         }
 
+        if (dataStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
@@ -107,7 +117,6 @@ public class ByteStreamReader
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    verify(dataStream != null);
                     type.writeLong(builder, dataStream.next());
                 }
                 else {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/DecimalStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/DecimalStreamReader.java
@@ -25,6 +25,7 @@ import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.orc.stream.LongInputStream;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.Type;
@@ -101,6 +102,16 @@ public class DecimalStreamReader
 
         seekToOffset();
 
+        if (decimalStream == null && scaleStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = decimalType.createBlockBuilder(null, nextBatchSize);
 
         if (presentStream == null) {
@@ -128,11 +139,11 @@ public class DecimalStreamReader
             }
         }
         else {
+            verify(decimalStream != null);
+            verify(scaleStream != null);
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
                     // The current row is not null
-                    verify(decimalStream != null);
-                    verify(scaleStream != null);
                     long sourceScale = scaleStream.next();
                     if (decimalType.isShort()) {
                         long rescaledDecimal = Decimals.rescale(decimalStream.nextLong(), (int) sourceScale, decimalType.getScale());

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/FloatStreamReader.java
@@ -23,6 +23,7 @@ import io.prestosql.orc.stream.InputStreamSource;
 import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.prestosql.orc.metadata.Stream.StreamKind.DATA;
 import static io.prestosql.orc.metadata.Stream.StreamKind.PRESENT;
@@ -98,6 +98,16 @@ public class FloatStreamReader
             }
         }
 
+        if (dataStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
@@ -108,7 +118,6 @@ public class FloatStreamReader
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    verify(dataStream != null);
                     type.writeLong(builder, floatToRawIntBits(dataStream.next()));
                 }
                 else {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/LongDirectStreamReader.java
@@ -23,6 +23,7 @@ import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.orc.stream.LongInputStream;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.prestosql.orc.metadata.Stream.StreamKind.DATA;
 import static io.prestosql.orc.metadata.Stream.StreamKind.PRESENT;
@@ -97,6 +97,16 @@ public class LongDirectStreamReader
             }
         }
 
+        if (dataStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
@@ -107,7 +117,6 @@ public class LongDirectStreamReader
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    verify(dataStream != null);
                     type.writeLong(builder, dataStream.next());
                 }
                 else {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/TimestampStreamReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/TimestampStreamReader.java
@@ -23,6 +23,7 @@ import io.prestosql.orc.stream.InputStreamSources;
 import io.prestosql.orc.stream.LongInputStream;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -116,6 +117,16 @@ public class TimestampStreamReader
             }
         }
 
+        if (secondsStream == null && nanosStream == null && presentStream != null) {
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = new RunLengthEncodedBlock(
+                    type.createBlockBuilder(null, 1).appendNull().build(),
+                    nextBatchSize);
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
 
         if (presentStream == null) {
@@ -131,10 +142,10 @@ public class TimestampStreamReader
             }
         }
         else {
+            verify(secondsStream != null, "Value is not null but seconds stream is not present");
+            verify(nanosStream != null, "Value is not null but nanos stream is not present");
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    verify(secondsStream != null, "Value is not null but seconds stream is not present");
-                    verify(nanosStream != null, "Value is not null but nanos stream is not present");
                     type.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
                 }
                 else {

--- a/presto-orc/src/test/java/io/prestosql/orc/BenchmarkStreamReaders.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/BenchmarkStreamReaders.java
@@ -20,12 +20,16 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.SqlDecimal;
 import io.prestosql.spi.type.SqlTimestamp;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.TypeSignature;
+import io.prestosql.type.TypeRegistry;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -40,6 +44,9 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +85,7 @@ public class BenchmarkStreamReaders
 {
     public static final DecimalType DECIMAL_TYPE = createDecimalType(10, 5);
     public static final int ROWS = 10_000_000;
+    public static final Collection<?> NULL_VALUES = Collections.nCopies(ROWS, null);
 
     @Benchmark
     public Object readBooleanNoNull(BooleanNoNullBenchmarkData data)
@@ -100,6 +108,19 @@ public class BenchmarkStreamReaders
         List<Block> blocks = new ArrayList<>();
         while (recordReader.nextBatch() > 0) {
             Block block = recordReader.readBlock(BOOLEAN, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readAllNull(AllNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(data.getType(), 0);
             blocks.add(block);
         }
         return blocks;
@@ -287,22 +308,20 @@ public class BenchmarkStreamReaders
         return blocks;
     }
 
-    @SuppressWarnings("FieldMayBeFinal")
-    @State(Scope.Thread)
-    public static class BooleanNoNullBenchmarkData
+    private abstract static class BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File booleanNoNullFile;
-        private Random random;
+        protected final Random random = new Random(0);
+        private Type type;
+        private File temporaryDirectory;
+        private File orcFile;
 
-        @Setup
-        public void setup()
+        public void setup(Type type)
                 throws Exception
         {
-            random = new Random(0);
+            this.type = type;
             temporaryDirectory = createTempDir();
-            booleanNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(booleanNoNullFile, ORC_12, NONE, BOOLEAN, createBooleanValuesNoNull().iterator());
+            orcFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(orcFile, ORC_12, NONE, type, createValues());
         }
 
         @TearDown
@@ -312,164 +331,148 @@ public class BenchmarkStreamReaders
             deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
         }
 
-        private OrcRecordReader createRecordReader()
+        public Type getType()
+        {
+            return type;
+        }
+
+        protected abstract Iterator<?> createValues();
+
+        OrcRecordReader createRecordReader()
                 throws IOException
         {
-            OrcDataSource dataSource = new FileOrcDataSource(booleanNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcDataSource dataSource = new FileOrcDataSource(orcFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
             OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
             return orcReader.createRecordReader(
-                    ImmutableMap.of(0, BOOLEAN),
+                    ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,
                     UTC, // arbitrary
                     newSimpleAggregatedMemoryContext(),
                     INITIAL_BATCH_SIZE);
         }
+    }
 
-        private List<Boolean> createBooleanValuesNoNull()
+    @State(Scope.Thread)
+    public static class AllNullBenchmarkData
+            extends BenchmarkData
+    {
+        @SuppressWarnings("unused")
+        @Param({
+                "boolean",
+
+                "tinyint",
+                "integer",
+                "bigint",
+                "decimal(10,5)",
+
+                "timestamp",
+
+                "real",
+                "double",
+
+                "varchar",
+                "varbinary",
+        })
+        private String typeSignature;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            Type type = new TypeRegistry().getType(TypeSignature.parseTypeSignature(typeSignature));
+            setup(type);
+        }
+
+        @Override
+        protected final Iterator<?> createValues()
+        {
+            return NULL_VALUES.iterator();
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BooleanNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(BOOLEAN);
+        }
+
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Boolean> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(random.nextBoolean());
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class BooleanWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File booleanWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            booleanWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(booleanWithNullFile, ORC_12, NONE, BOOLEAN, createBooleanValuesWithNull().iterator());
+            setup(BOOLEAN);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(booleanWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, BOOLEAN),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Boolean> createBooleanValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Boolean> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(random.nextBoolean() ? random.nextBoolean() : null);
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class TinyIntNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File tinyIntNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            tinyIntNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(tinyIntNoNullFile, ORC_12, NONE, TINYINT, createTinyIntValuesNoNull().iterator());
+            setup(TINYINT);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(tinyIntNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, TINYINT),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Byte> createTinyIntValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Byte> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(Long.valueOf(random.nextLong()).byteValue());
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class TinyIntWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File tinyIntWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            tinyIntWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(tinyIntWithNullFile, ORC_12, NONE, TINYINT, createTinyIntValuesWithNull().iterator());
+            setup(TINYINT);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(tinyIntWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, TINYINT),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Byte> createTinyIntValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Byte> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
@@ -480,100 +483,48 @@ public class BenchmarkStreamReaders
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class DecimalNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File decimalNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            decimalNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(decimalNoNullFile, ORC_12, NONE, DECIMAL_TYPE, createDecimalValuesNoNull().iterator());
+            setup(DECIMAL_TYPE);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
+        @Override
+        protected Iterator<?> createValues()
         {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(decimalNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, DECIMAL_TYPE),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<SqlDecimal> createDecimalValuesNoNull()
-        {
-            Random random = new Random();
             List<SqlDecimal> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10000000000L), 10, 5));
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class DecimalWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File decimalWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            decimalWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(decimalWithNullFile, ORC_12, NONE, DECIMAL_TYPE, createDecimalValuesWithNull().iterator());
+            setup(DECIMAL_TYPE);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
+        @Override
+        protected Iterator<?> createValues()
         {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(decimalWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, DECIMAL_TYPE),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<SqlDecimal> createDecimalValuesWithNull()
-        {
-            Random random = new Random();
             List<SqlDecimal> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 if (random.nextBoolean()) {
@@ -583,300 +534,149 @@ public class BenchmarkStreamReaders
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class DoubleNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File doubleNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            doubleNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(doubleNoNullFile, ORC_12, NONE, DOUBLE, createDoubleValuesNoNull().iterator());
+            setup(DOUBLE);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(doubleNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, DOUBLE),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Double> createDoubleValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Double> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
-                values.add(Double.valueOf(random.nextDouble()));
+                values.add(random.nextDouble());
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class DoubleWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File doubleWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            doubleWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(doubleWithNullFile, ORC_12, NONE, DOUBLE, createDoubleValuesWithNull().iterator());
+            setup(DOUBLE);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(doubleWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, DOUBLE),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Double> createDoubleValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Double> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 if (random.nextBoolean()) {
-                    values.add(Double.valueOf(random.nextDouble()));
+                    values.add(random.nextDouble());
                 }
                 else {
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class FloatNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File floatNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            floatNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(floatNoNullFile, ORC_12, NONE, REAL, createFloatValuesNoNull().iterator());
+            setup(REAL);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(floatNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, REAL),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Float> createFloatValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Float> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
-                values.add(Float.valueOf(random.nextFloat()));
+                values.add(random.nextFloat());
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class FloatWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File floatWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            floatWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(floatWithNullFile, ORC_12, NONE, REAL, createFloatValuesWithNull().iterator());
+            setup(REAL);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(floatWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, REAL),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Float> createFloatValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Float> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 if (random.nextBoolean()) {
-                    values.add(Float.valueOf(random.nextFloat()));
+                    values.add(random.nextFloat());
                 }
                 else {
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class BigintNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File bigintNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-
-            bigintNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(bigintNoNullFile, ORC_12, NONE, BIGINT, createBigintValuesNoNull().iterator());
+            setup(BIGINT);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(bigintNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, BIGINT),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Long> createBigintValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Long> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
-                values.add(Long.valueOf(random.nextLong()));
+                values.add(random.nextLong());
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class BigintWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File bigintWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            bigintWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(bigintWithNullFile, ORC_12, NONE, BIGINT, createBigintValuesWithNull().iterator());
+            setup(BIGINT);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(bigintWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, BIGINT),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<Long> createBigintValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<Long> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
@@ -887,99 +687,48 @@ public class BenchmarkStreamReaders
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class VarcharNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File varcharNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            varcharNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(varcharNoNullFile, ORC_12, NONE, VARCHAR, createVarcharValuesNoNull().iterator());
+            setup(VARCHAR);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(varcharNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, VARCHAR),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<String> createVarcharValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<String> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(Strings.repeat("0", 4));
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class VarcharWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File varcharWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-            varcharWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(varcharWithNullFile, ORC_12, NONE, VARCHAR, createVarcharValuesWithNulls().iterator());
+            setup(VARCHAR);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
+        @Override
+        protected Iterator<?> createValues()
         {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(varcharWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, VARCHAR),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<String> createVarcharValuesWithNulls()
-        {
-            Random random = new Random();
             List<String> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 if (random.nextBoolean()) {
@@ -989,99 +738,47 @@ public class BenchmarkStreamReaders
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class TimestampNoNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File timestampNoNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-
-            timestampNoNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(timestampNoNullFile, ORC_12, NONE, TIMESTAMP, createSqlTimeStampValuesNoNull().iterator());
+            setup(TIMESTAMP);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(timestampNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, TIMESTAMP),
-                    OrcPredicate.TRUE,
-                    UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<SqlTimestamp> createSqlTimeStampValuesNoNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<SqlTimestamp> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
                 values.add(new SqlTimestamp((random.nextLong()), UTC_KEY));
             }
-            return values;
+            return values.iterator();
         }
     }
 
     @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class TimestampWithNullBenchmarkData
+            extends BenchmarkData
     {
-        protected File temporaryDirectory;
-        protected File timestampWithNullFile;
-        private Random random;
-
         @Setup
         public void setup()
                 throws Exception
         {
-            random = new Random(0);
-            temporaryDirectory = createTempDir();
-
-            timestampWithNullFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(timestampWithNullFile, ORC_12, NONE, TIMESTAMP, createSqlTimestampValuesWithNull().iterator());
+            setup(TIMESTAMP);
         }
 
-        @TearDown
-        public void tearDown()
-                throws IOException
-        {
-            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
-        }
-
-        private OrcRecordReader createRecordReader()
-                throws IOException
-        {
-            OrcDataSource dataSource = new FileOrcDataSource(timestampWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
-            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-            return orcReader.createRecordReader(
-                    ImmutableMap.of(0, TIMESTAMP),
-                    OrcPredicate.TRUE,
-                    UTC,
-                    newSimpleAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE);
-        }
-
-        private List<SqlTimestamp> createSqlTimestampValuesWithNull()
+        @Override
+        protected Iterator<?> createValues()
         {
             List<SqlTimestamp> values = new ArrayList<>();
             for (int i = 0; i < ROWS; ++i) {
@@ -1092,7 +789,7 @@ public class BenchmarkStreamReaders
                     values.add(null);
                 }
             }
-            return values;
+            return values.iterator();
         }
     }
 


### PR DESCRIPTION
In this patch we directly create a block if its data stream is null. These were the benchmark numbers that we got for the above change

Current Presto
```
Benchmark
BenchmarkStreamReaders.readBooleanWithAllNull          avgt   60  0.028 ±  0.001   s/op
BenchmarkStreamReaders.readByteWithAllNull             avgt   60  0.028 ±  0.001   s/op
BenchmarkStreamReaders.readDecimalWithAllNull          avgt   60  0.031 ±  0.001   s/op
BenchmarkStreamReaders.readDoubleWithAllNull           avgt   60  0.031 ±  0.001   s/op
BenchmarkStreamReaders.readFloatWithAllNull            avgt   60  0.029 ±  0.001   s/op
BenchmarkStreamReaders.readLongDirectWithAllNull       avgt   60  0.031 ±  0.001   s/op
BenchmarkStreamReaders.readSliceDictionaryWithAllNull  avgt   60  0.022 ±  0.001   s/op
BenchmarkStreamReaders.readTimestampWithAllNull        avgt   60  0.031 ±  0.001   s/op
```

After short circuiting the block creation
```
Benchmark                                              Mode  Cnt  Score    Error  Units
BenchmarkStreamReaders.readBooleanWithAllNull          avgt   60  0.004 ±  0.001   s/op
BenchmarkStreamReaders.readByteWithAllNull             avgt   60  0.004 ±  0.001   s/op
BenchmarkStreamReaders.readDecimalWithAllNull          avgt   60  0.006 ±  0.001   s/op
BenchmarkStreamReaders.readDoubleWithAllNull           avgt   60  0.004 ±  0.001   s/op
BenchmarkStreamReaders.readFloatWithAllNull            avgt   60  0.004 ±  0.001   s/op
BenchmarkStreamReaders.readLongDirectWithAllNull       avgt   60  0.005 ±  0.001   s/op
BenchmarkStreamReaders.readTimestampWithAllNull        avgt   60  0.005 ±  0.001   s/op
```