### PR TITLE
Report offending table name when metadata invalid

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -422,6 +422,21 @@ public class HiveMetadata
 
     private ConnectorTableMetadata getTableMetadata(SchemaTableName tableName)
     {
+        try {
+            return doGetTableMetadata(tableName);
+        }
+        catch (PrestoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            // Errors related to invalid or unsupported information in the Metastore should be handled explicitly (eg. as PrestoException(HIVE_INVALID_METADATA)).
+            // This is just a catch-all solution so that we have any actionable information when eg. SELECT * FROM information_schema.columns fails.
+            throw new RuntimeException("Failed to construct table metadata for table " + tableName, e);
+        }
+    }
+
+    private ConnectorTableMetadata doGetTableMetadata(SchemaTableName tableName)
+    {
         Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName());
         if (!table.isPresent() || table.get().getTableType().equals(TableType.VIRTUAL_VIEW.name())) {
             throw new TableNotFoundException(tableName);
@@ -474,7 +489,7 @@ public class HiveMetadata
             properties.put(ORC_BLOOM_FILTER_FPP, Double.parseDouble(orcBloomFilterFfp));
         }
 
-        // Avro specfic property
+        // Avro specific property
         String avroSchemaUrl = table.get().getParameters().get(AVRO_SCHEMA_URL_KEY);
         if (avroSchemaUrl != null) {
             properties.put(AVRO_SCHEMA_URL, avroSchemaUrl);


### PR DESCRIPTION
A query like

    SELECT table_schema, table_name, column_name
    FROM information_schema.columns

may fail with something like the following:

    java.lang.IllegalArgumentException: Row type must have at least one parameter
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:135)
        at com.facebook.presto.type.RowParametricType.createType(RowParametricType.java:51)
        at com.facebook.presto.type.TypeRegistry.instantiateParametricType(TypeRegistry.java:207)
        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:165)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3524)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2273)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2156)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2046)
        at com.google.common.cache.LocalCache.get(LocalCache.java:3943)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3967)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4952)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4958)
        at com.facebook.presto.type.TypeRegistry.getType(TypeRegistry.java:177)
        at com.facebook.presto.hive.HiveMetadata.lambda$columnMetadataGetter$47(HiveMetadata.java:2137)
        at com.facebook.presto.hive.HiveMetadata.getTableMetadata(HiveMetadata.java:447)
        at com.facebook.presto.hive.HiveMetadata.listTableColumns(HiveMetadata.java:595)

here, there is no clue which table caused the problem.

This commit includes table name to the exception message when there is
an exception in `getTableMetadata` call.