### PR TITLE
Remove exists check when creating a file in S3

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -360,9 +360,8 @@ public class PrestoS3FileSystem
     public FSDataOutputStream create(Path path, FsPermission permission, boolean overwrite, int bufferSize, short replication, long blockSize, Progressable progress)
             throws IOException
     {
-        if ((!overwrite) && exists(path)) {
-            throw new IOException("File already exists:" + path);
-        }
+        // Ignore the overwrite flag, since Presto always writes to unique file names.
+        // Checking for file existence can break read-after-write consistency.
 
         if (!stagingDirectory.exists()) {
             createDirectories(stagingDirectory.toPath());


### PR DESCRIPTION
Fixes #103. We remove exists check in PrestoS3FileSystem when we try to create a file in non-overwrite mode as adding the exists check breaks the S3 read-after-write consistency.