### PR TITLE
Make thrift metastore client retry configurable

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RetryDriver.java
@@ -27,14 +27,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class RetryDriver
 {
     private static final Logger log = Logger.get(RetryDriver.class);
-    private static final int DEFAULT_RETRY_ATTEMPTS = 10;
-    private static final Duration DEFAULT_SLEEP_TIME = Duration.valueOf("1s");
-    private static final Duration DEFAULT_MAX_RETRY_TIME = Duration.valueOf("30s");
-    private static final double DEFAULT_SCALE_FACTOR = 2.0;
+    public static final int DEFAULT_MAX_ATTEMPTS = 10;
+    public static final Duration DEFAULT_SLEEP_TIME = new Duration(1, SECONDS);
+    public static final Duration DEFAULT_MAX_RETRY_TIME = new Duration(30, SECONDS);
+    public static final double DEFAULT_SCALE_FACTOR = 2.0;
 
     private final int maxAttempts;
     private final Duration minSleepTime;
@@ -67,7 +68,7 @@ public class RetryDriver
 
     private RetryDriver()
     {
-        this(DEFAULT_RETRY_ATTEMPTS,
+        this(DEFAULT_MAX_ATTEMPTS,
                 DEFAULT_SLEEP_TIME,
                 DEFAULT_SLEEP_TIME,
                 DEFAULT_SCALE_FACTOR,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.HiveBasicStatistics;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.HiveViewNotSupportedException;
@@ -112,18 +113,28 @@ public class ThriftHiveMetastore
     private final ThriftHiveMetastoreStats stats;
     private final HiveCluster clientProvider;
     private final Function<Exception, Exception> exceptionMapper;
+    private final double backoffScaleFactor;
+    private final Duration minBackoffDelay;
+    private final Duration maxBackoffDelay;
+    private final Duration maxRetryTime;
+    private final int maxRetries;
 
     @Inject
-    public ThriftHiveMetastore(HiveCluster hiveCluster)
+    public ThriftHiveMetastore(HiveCluster hiveCluster, ThriftHiveMetastoreConfig thriftConfig)
     {
-        this(hiveCluster, new ThriftHiveMetastoreStats(), identity());
+        this(hiveCluster, new ThriftHiveMetastoreStats(), identity(), thriftConfig);
     }
 
-    public ThriftHiveMetastore(HiveCluster hiveCluster, ThriftHiveMetastoreStats stats, Function<Exception, Exception> exceptionMapper)
+    public ThriftHiveMetastore(HiveCluster hiveCluster, ThriftHiveMetastoreStats stats, Function<Exception, Exception> exceptionMapper, ThriftHiveMetastoreConfig thriftConfig)
     {
         this.clientProvider = requireNonNull(hiveCluster, "hiveCluster is null");
         this.stats = requireNonNull(stats, "stats is null");
         this.exceptionMapper = requireNonNull(exceptionMapper, "exceptionMapper is null");
+        this.backoffScaleFactor = thriftConfig.getBackoffScaleFactor();
+        this.minBackoffDelay = thriftConfig.getMinBackoffDelay();
+        this.maxBackoffDelay = thriftConfig.getMaxBackoffDelay();
+        this.maxRetryTime = thriftConfig.getMaxRetryTime();
+        this.maxRetries = thriftConfig.getMaxRetries();
     }
 
     @Managed
@@ -1310,6 +1321,8 @@ public class ThriftHiveMetastore
     private RetryDriver retry()
     {
         return RetryDriver.retry()
+                .exponentialBackoff(minBackoffDelay, maxBackoffDelay, maxRetryTime, backoffScaleFactor)
+                .maxAttempts(maxRetries + 1)
                 .exceptionMapper(exceptionMapper)
                 .stopOn(PrestoException.class);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreConfig.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.prestosql.plugin.hive.RetryDriver;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class ThriftHiveMetastoreConfig
+{
+    private int maxRetries = RetryDriver.DEFAULT_MAX_ATTEMPTS - 1;
+    private double backoffScaleFactor = RetryDriver.DEFAULT_SCALE_FACTOR;
+    private Duration minBackoffDelay = RetryDriver.DEFAULT_SLEEP_TIME;
+    private Duration maxBackoffDelay = RetryDriver.DEFAULT_SLEEP_TIME;
+    private Duration maxRetryTime = RetryDriver.DEFAULT_MAX_RETRY_TIME;
+
+    @Min(0)
+    public int getMaxRetries()
+    {
+        return maxRetries;
+    }
+
+    @Config("hive.metastore.thrift.client.max-retries")
+    @ConfigDescription("Maximum number of retry attempts for metastore requests")
+    public ThriftHiveMetastoreConfig setMaxRetries(int maxRetries)
+    {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    public double getBackoffScaleFactor()
+    {
+        return backoffScaleFactor;
+    }
+
+    @Config("hive.metastore.thrift.client.backoff-scale-factor")
+    @ConfigDescription("Scale factor for metastore request retry delay")
+    public ThriftHiveMetastoreConfig setBackoffScaleFactor(double backoffScaleFactor)
+    {
+        this.backoffScaleFactor = backoffScaleFactor;
+        return this;
+    }
+
+    @NotNull
+    public Duration getMaxRetryTime()
+    {
+        return maxRetryTime;
+    }
+
+    @Config("hive.metastore.thrift.client.max-retry-time")
+    @ConfigDescription("Total time limit for a metastore request to be retried")
+    public ThriftHiveMetastoreConfig setMaxRetryTime(Duration maxRetryTime)
+    {
+        this.maxRetryTime = maxRetryTime;
+        return this;
+    }
+
+    public Duration getMinBackoffDelay()
+    {
+        return minBackoffDelay;
+    }
+
+    @Config("hive.metastore.thrift.client.min-backoff-delay")
+    @ConfigDescription("Minimum delay between metastore request retries")
+    public ThriftHiveMetastoreConfig setMinBackoffDelay(Duration minBackoffDelay)
+    {
+        this.minBackoffDelay = minBackoffDelay;
+        return this;
+    }
+
+    public Duration getMaxBackoffDelay()
+    {
+        return maxBackoffDelay;
+    }
+
+    @Config("hive.metastore.thrift.client.max-backoff-delay")
+    @ConfigDescription("Maximum delay between metastore request retries")
+    public ThriftHiveMetastoreConfig setMaxBackoffDelay(Duration maxBackoffDelay)
+    {
+        this.maxBackoffDelay = maxBackoffDelay;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -39,6 +39,7 @@ public class ThriftMetastoreModule
         binder.bind(HiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(HiveCluster.class).to(StaticHiveCluster.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
+        configBinder(binder).bindConfig(ThriftHiveMetastoreConfig.class);
 
         binder.bind(HiveMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveClient.java
@@ -46,6 +46,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.HiveCluster;
 import io.prestosql.plugin.hive.metastore.thrift.TestingHiveCluster;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
 import io.prestosql.plugin.hive.orc.OrcPageSource;
 import io.prestosql.plugin.hive.parquet.ParquetPageSource;
 import io.prestosql.plugin.hive.rcfile.RcFilePageSource;
@@ -711,7 +712,7 @@ public abstract class AbstractTestHiveClient
 
         HiveCluster hiveCluster = new TestingHiveCluster(hiveClientConfig, host, port);
         ExtendedHiveMetastore metastore = new CachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, new ThriftHiveMetastoreConfig())),
                 executor,
                 Duration.valueOf("1m"),
                 Duration.valueOf("15s"),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -37,6 +37,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.HiveCluster;
 import io.prestosql.plugin.hive.metastore.thrift.TestingHiveCluster;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorMetadata;
@@ -163,7 +164,7 @@ public abstract class AbstractTestHiveFileSystem
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, config, new NoHdfsAuthentication());
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, new ThriftHiveMetastoreConfig())),
                 executor,
                 config,
                 getBasePath(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.hive.metastore.thrift.HiveCluster;
 import io.prestosql.plugin.hive.metastore.thrift.HiveMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreStats;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -56,7 +57,7 @@ public class TestCachingHiveMetastore
         mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
-        ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster);
+        ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster, new ThriftHiveMetastoreConfig());
         metastore = new CachingHiveMetastore(
                 new BridgingHiveMetastore(thriftHiveMetastore),
                 executor,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftHiveMetastoreConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestThriftHiveMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ThriftHiveMetastoreConfig.class)
+                .setMaxRetries(9)
+                .setBackoffScaleFactor(2.0)
+                .setMinBackoffDelay(new Duration(1, SECONDS))
+                .setMaxBackoffDelay(new Duration(1, SECONDS))
+                .setMaxRetryTime(new Duration(30, SECONDS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.metastore.thrift.client.max-retries", "15")
+                .put("hive.metastore.thrift.client.backoff-scale-factor", "3.0")
+                .put("hive.metastore.thrift.client.min-backoff-delay", "2s")
+                .put("hive.metastore.thrift.client.max-backoff-delay", "4s")
+                .put("hive.metastore.thrift.client.max-retry-time", "60s")
+                .build();
+
+        ThriftHiveMetastoreConfig expected = new ThriftHiveMetastoreConfig()
+                .setMaxRetries(15)
+                .setBackoffScaleFactor(3.0)
+                .setMinBackoffDelay(new Duration(2, SECONDS))
+                .setMaxBackoffDelay(new Duration(4, SECONDS))
+                .setMaxRetryTime(new Duration(60, SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
@findepi @electrum 
I have migrated previous https://github.com/prestodb/presto/pull/12123 from facebook presto which is used to **make thrift metastore client retry configurable** to current PrestoSQL. Nothing changed during the migration except for necessary import path change from `com.facebook.presto` to `io.prestosql` and change path for some added files; The original PR is in the state of **ready-to-merge** and the merge is blocked for **release code freeze**
Please help to re-review this PR;
Many thanks.