### PR TITLE
[hotfix] numFalse in columnStatistic should marked as not present when…

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -518,9 +518,16 @@ public final class ThriftMetastoreUtil
         }
         if (columnStatistics.getStatsData().isSetBooleanStats()) {
             BooleanColumnStatsData booleanStatsData = columnStatistics.getStatsData().getBooleanStats();
+            OptionalLong falseCount = OptionalLong.empty();
+            OptionalLong trueCount = OptionalLong.empty();
+            if (booleanStatsData.isSetNumFalses() && booleanStatsData.isSetNumTrues() && booleanStatsData.getNumFalses() != -1) {
+                // Impala 'COMPUTE STATS' write 1 as the numTrue and -1 as the numFalse
+                falseCount = OptionalLong.of(booleanStatsData.getNumFalses());
+                trueCount = OptionalLong.of(booleanStatsData.getNumTrues());
+            }
             return createBooleanColumnStatistics(
-                    booleanStatsData.isSetNumTrues() ? OptionalLong.of(booleanStatsData.getNumTrues()) : OptionalLong.empty(),
-                    booleanStatsData.isSetNumFalses() ? OptionalLong.of(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
+                    trueCount,
+                    falseCount,
                     booleanStatsData.isSetNumNulls() ? fromMetastoreNullsCount(booleanStatsData.getNumNulls()) : OptionalLong.empty());
         }
         if (columnStatistics.getStatsData().isSetStringStats()) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -204,6 +204,24 @@ public class TestThriftMetastoreUtil
     }
 
     @Test
+    public void testImpalaGeneratedBooleanStatistics()
+    {
+        BooleanColumnStatsData impalaGeneratedBooleanColumnStatsData = new BooleanColumnStatsData(1L, -1L, 2L);
+        ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BOOLEAN_TYPE_NAME, booleanStats(impalaGeneratedBooleanColumnStatsData));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+
+        assertEquals(actual.getIntegerStatistics(), Optional.empty());
+        assertEquals(actual.getDoubleStatistics(), Optional.empty());
+        assertEquals(actual.getDecimalStatistics(), Optional.empty());
+        assertEquals(actual.getDateStatistics(), Optional.empty());
+        assertEquals(actual.getMaxValueSizeInBytes(), OptionalLong.empty());
+        assertEquals(actual.getTotalSizeInBytes(), OptionalLong.empty());
+        assertEquals(actual.getNullsCount(), OptionalLong.of(2));
+        assertEquals(actual.getDistinctValuesCount(), OptionalLong.empty());
+        assertEquals(actual.getBooleanStatistics(), Optional.of(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())));
+    }
+
+    @Test
     public void testEmptyBooleanStatsToColumnStatistics()
     {
         BooleanColumnStatsData emptyBooleanColumnStatsData = new BooleanColumnStatsData();


### PR DESCRIPTION
@electrum  @rschlussel 
I have migrated the original PR (https://github.com/prestodb/presto/pull/11859/files) from facebook presto repo. Nothing else changed during the migration, no conflict happened.
Please help to review it.
Let's work together to make a better presto;