### PR TITLE
Calculate query peak memory usage as memory cost (v2)

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
@@ -17,22 +17,8 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan customer_address
-                        final aggregation over (ca_county_345, d_qoy_320, d_year_316)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_345", "d_qoy_320", "d_year_316"])
-                                    partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan customer_address
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ca_county_173", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                            join (INNER, PARTITIONED):
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_173", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                                 final aggregation over (ca_county_173, d_qoy_148, d_year_144)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_173", "d_qoy_148", "d_year_144"])
@@ -46,6 +32,22 @@ remote exchange (GATHER, SINGLE, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan customer_address
+                    join (INNER, PARTITIONED):
+                        final aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_345", "d_qoy_320", "d_year_316"])
+                                    partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                                        join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan customer_address
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_448", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                                 final aggregation over (ca_county_448, d_qoy_423, d_year_419)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_448", "d_qoy_423", "d_year_419"])

--- a/presto-main/src/main/java/io/prestosql/cost/CachingCostProvider.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CachingCostProvider.java
@@ -106,13 +106,6 @@ public class CachingCostProvider
 
     private PlanCostEstimate calculateCumulativeCost(PlanNode node)
     {
-        PlanCostEstimate localCosts = costCalculator.calculateCost(node, statsProvider, session, types);
-
-        PlanCostEstimate sourcesCost = node.getSources().stream()
-                .map(this::getCumulativeCost)
-                .reduce(PlanCostEstimate.zero(), PlanCostEstimate::add);
-
-        PlanCostEstimate cumulativeCost = localCosts.add(sourcesCost);
-        return cumulativeCost;
+        return costCalculator.calculateCost(node, statsProvider, this, session, types);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculator.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculator.java
@@ -36,7 +36,7 @@ public interface CostCalculator
      * @param node The node to compute cost for.
      * @param stats The stats provider for node's stats and child nodes' stats, to be used if stats are needed to compute cost for the {@code node}
      */
-    PlanNodeCostEstimate calculateCost(
+    PlanCostEstimate calculateCost(
             PlanNode node,
             StatsProvider stats,
             Session session,

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculator.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculator.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public interface CostCalculator
 {
     /**
-     * Calculates non-cumulative cost of a node.
+     * Calculates cumulative cost of a node.
      *
      * @param node The node to compute cost for.
      * @param stats The stats provider for node's stats and child nodes' stats, to be used if stats are needed to compute cost for the {@code node}
@@ -39,6 +39,7 @@ public interface CostCalculator
     PlanCostEstimate calculateCost(
             PlanNode node,
             StatsProvider stats,
+            CostProvider sourcesCosts,
             Session session,
             TypeProvider types);
 

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
@@ -76,7 +76,7 @@ public class CostCalculatorUsingExchanges
         LocalCostEstimate localCost = node.accept(costEstimator, null);
 
         PlanCostEstimate sourcesCost = node.getSources().stream()
-                .map(sourcesCosts::getCumulativeCost)
+                .map(sourcesCosts::getCost)
                 .reduce(PlanCostEstimate.zero(), CostCalculatorUsingExchanges::add);
         return add(sourcesCost, localCost);
     }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
@@ -43,7 +43,10 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateJoinInputCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateLocalRepartitionCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteGatherCost;
@@ -52,6 +55,7 @@ import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRe
 import static io.prestosql.cost.LocalCostEstimate.addPartialComponents;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -72,57 +76,48 @@ public class CostCalculatorUsingExchanges
     @Override
     public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session, TypeProvider types)
     {
-        CostEstimator costEstimator = new CostEstimator(stats, types, taskCountEstimator);
-        LocalCostEstimate localCost = node.accept(costEstimator, null);
-
-        PlanCostEstimate sourcesCost = node.getSources().stream()
-                .map(sourcesCosts::getCost)
-                .reduce(PlanCostEstimate.zero(), CostCalculatorUsingExchanges::add);
-        return add(sourcesCost, localCost);
-    }
-
-    private static PlanCostEstimate add(PlanCostEstimate sourcesCost, LocalCostEstimate localCost)
-    {
-        return new PlanCostEstimate(
-                sourcesCost.getCpuCost() + localCost.getCpuCost(),
-                sourcesCost.getMemoryCost() + localCost.getMaxMemory(),
-                sourcesCost.getNetworkCost() + localCost.getNetworkCost());
+        CostEstimator costEstimator = new CostEstimator(stats, sourcesCosts, types, taskCountEstimator);
+        return node.accept(costEstimator, null);
     }
 
     private static class CostEstimator
-            extends PlanVisitor<LocalCostEstimate, Void>
+            extends PlanVisitor<PlanCostEstimate, Void>
     {
         private final StatsProvider stats;
+        private final CostProvider sourcesCosts;
         private final TypeProvider types;
         private final TaskCountEstimator taskCountEstimator;
 
-        CostEstimator(StatsProvider stats, TypeProvider types, TaskCountEstimator taskCountEstimator)
+        CostEstimator(StatsProvider stats, CostProvider sourcesCosts, TypeProvider types, TaskCountEstimator taskCountEstimator)
         {
             this.stats = requireNonNull(stats, "stats is null");
+            this.sourcesCosts = requireNonNull(sourcesCosts, "sourcesCosts is null");
             this.types = requireNonNull(types, "types is null");
             this.taskCountEstimator = requireNonNull(taskCountEstimator, "taskCountEstimator is null");
         }
 
         @Override
-        protected LocalCostEstimate visitPlan(PlanNode node, Void context)
+        protected PlanCostEstimate visitPlan(PlanNode node, Void context)
         {
-            return LocalCostEstimate.unknown();
+            // TODO implement cost estimates for all plan nodes
+            return PlanCostEstimate.unknown();
         }
 
         @Override
-        public LocalCostEstimate visitGroupReference(GroupReference node, Void context)
+        public PlanCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public LocalCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
+        public PlanCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
         {
-            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
+            return costForStreaming(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitRowNumber(RowNumberNode node, Void context)
+        public PlanCostEstimate visitRowNumber(RowNumberNode node, Void context)
         {
             List<Symbol> symbols = node.getOutputSymbols();
             // when maxRowCountPerPartition is set, the RowNumberOperator
@@ -136,55 +131,61 @@ public class CostCalculatorUsingExchanges
             PlanNodeStatsEstimate stats = getStats(node);
             double cpuCost = stats.getOutputSizeInBytes(symbols, types);
             double memoryCost = node.getPartitionBy().isEmpty() ? 0 : stats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
-            return LocalCostEstimate.of(cpuCost, memoryCost, 0);
+            LocalCostEstimate localCost = LocalCostEstimate.of(cpuCost, memoryCost, 0);
+            return costForStreaming(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitOutput(OutputNode node, Void context)
+        public PlanCostEstimate visitOutput(OutputNode node, Void context)
         {
-            return LocalCostEstimate.zero();
+            return costForStreaming(node, LocalCostEstimate.zero());
         }
 
         @Override
-        public LocalCostEstimate visitTableScan(TableScanNode node, Void context)
+        public PlanCostEstimate visitTableScan(TableScanNode node, Void context)
         {
             // TODO: add network cost, based on input size in bytes? Or let connector provide this cost?
-            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return costForSource(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitFilter(FilterNode node, Void context)
+        public PlanCostEstimate visitFilter(FilterNode node, Void context)
         {
-            return LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return costForStreaming(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitProject(ProjectNode node, Void context)
+        public PlanCostEstimate visitProject(ProjectNode node, Void context)
         {
-            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return costForStreaming(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitAggregation(AggregationNode node, Void context)
+        public PlanCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             if (node.getStep() != FINAL && node.getStep() != SINGLE) {
-                return LocalCostEstimate.unknown();
+                return PlanCostEstimate.unknown();
             }
             PlanNodeStatsEstimate aggregationStats = getStats(node);
             PlanNodeStatsEstimate sourceStats = getStats(node.getSource());
             double cpuCost = sourceStats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
             double memoryCost = aggregationStats.getOutputSizeInBytes(node.getOutputSymbols(), types);
-            return LocalCostEstimate.of(cpuCost, memoryCost, 0);
+            LocalCostEstimate localCost = LocalCostEstimate.of(cpuCost, memoryCost, 0);
+            return costForAccumulation(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitJoin(JoinNode node, Void context)
+        public PlanCostEstimate visitJoin(JoinNode node, Void context)
         {
-            return calculateJoinCost(
+            LocalCostEstimate localCost = calculateJoinCost(
                     node,
                     node.getLeft(),
                     node.getRight(),
                     Objects.equals(node.getDistributionType(), Optional.of(JoinNode.DistributionType.REPLICATED)));
+            return costForLookupJoin(node, localCost);
         }
 
         private LocalCostEstimate calculateJoinCost(PlanNode join, PlanNode probe, PlanNode build, boolean replicated)
@@ -208,7 +209,12 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public LocalCostEstimate visitExchange(ExchangeNode node, Void context)
+        public PlanCostEstimate visitExchange(ExchangeNode node, Void context)
+        {
+            return costForStreaming(node, calculateExchangeCost(node));
+        }
+
+        private LocalCostEstimate calculateExchangeCost(ExchangeNode node)
         {
             double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types);
             switch (node.getScope()) {
@@ -243,67 +249,126 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public LocalCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
+        public PlanCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
         {
-            return calculateJoinCost(
+            LocalCostEstimate localCost = calculateJoinCost(
                     node,
                     node.getSource(),
                     node.getFilteringSource(),
                     node.getDistributionType().orElse(SemiJoinNode.DistributionType.PARTITIONED).equals(SemiJoinNode.DistributionType.REPLICATED));
+            return costForLookupJoin(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
+        public PlanCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
         {
-            return calculateJoinCost(
+            LocalCostEstimate localCost = calculateJoinCost(
                     node,
                     node.getLeft(),
                     node.getRight(),
                     node.getDistributionType() == SpatialJoinNode.DistributionType.REPLICATED);
+            return costForLookupJoin(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitValues(ValuesNode node, Void context)
+        public PlanCostEstimate visitValues(ValuesNode node, Void context)
         {
-            return LocalCostEstimate.zero();
+            return costForSource(node, LocalCostEstimate.zero());
         }
 
         @Override
-        public LocalCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        public PlanCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
         {
-            return LocalCostEstimate.zero();
+            return costForAccumulation(node, LocalCostEstimate.zero());
         }
 
         @Override
-        public LocalCostEstimate visitLimit(LimitNode node, Void context)
+        public PlanCostEstimate visitLimit(LimitNode node, Void context)
         {
             // This is just a wild guess. First of all, LimitNode is rather rare except as a top node of a query plan,
             // so proper cost estimation is not that important. Second, since LimitNode can lead to incomplete evaluation
             // of the source, true cost estimation should be implemented as a "constraint" enforced on a sub-tree and
             // evaluated in context of actual source node type (and their sources).
-            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return costForStreaming(node, localCost);
         }
 
         @Override
-        public LocalCostEstimate visitUnion(UnionNode node, Void context)
+        public PlanCostEstimate visitUnion(UnionNode node, Void context)
         {
-            // Cost will be accounted either in CostCalculatorUsingExchanges#CostEstimator#visitExchanged
+            // Cost will be accounted either in CostCalculatorUsingExchanges#CostEstimator#visitExchange
             // or in CostCalculatorWithEstimatedExchanges#CostEstimator#visitUnion
             // This stub is needed just to avoid the cumulative cost being set to unknown
-            return LocalCostEstimate.zero();
+            return costForStreaming(node, LocalCostEstimate.zero());
+        }
+
+        private PlanCostEstimate costForSource(PlanNode node, LocalCostEstimate localCost)
+        {
+            verify(node.getSources().isEmpty(), "Unexpected sources for %s: %s", node, node.getSources());
+            return new PlanCostEstimate(localCost.getCpuCost(), localCost.getMaxMemory(), localCost.getMaxMemory(), localCost.getNetworkCost());
+        }
+
+        private PlanCostEstimate costForAccumulation(PlanNode node, LocalCostEstimate localCost)
+        {
+            PlanCostEstimate sourcesCost = getSourcesEstimations(node)
+                    .reduce(PlanCostEstimate.zero(), CostCalculatorUsingExchanges::addParallelSiblingsCost);
+            return new PlanCostEstimate(
+                    sourcesCost.getCpuCost() + localCost.getCpuCost(),
+                    max(
+                            sourcesCost.getMaxMemory(), // Accumulating operator allocates insignificant amount of memory (usually none) before first input page is received
+                            sourcesCost.getMaxMemoryWhenOutputting() + localCost.getMaxMemory()),
+                    localCost.getMaxMemory(), // Source freed its memory allocations when finished its output
+                    sourcesCost.getNetworkCost() + localCost.getNetworkCost());
+        }
+
+        private PlanCostEstimate costForStreaming(PlanNode node, LocalCostEstimate localCost)
+        {
+            PlanCostEstimate sourcesCost = getSourcesEstimations(node)
+                    .reduce(PlanCostEstimate.zero(), CostCalculatorUsingExchanges::addParallelSiblingsCost);
+            return new PlanCostEstimate(
+                    sourcesCost.getCpuCost() + localCost.getCpuCost(),
+                    max(
+                            sourcesCost.getMaxMemory(), // Streaming operator allocates insignificant amount of memory (usually none) before first input page is received
+                            sourcesCost.getMaxMemoryWhenOutputting() + localCost.getMaxMemory()),
+                    sourcesCost.getMaxMemoryWhenOutputting() + localCost.getMaxMemory(),
+                    sourcesCost.getNetworkCost() + localCost.getNetworkCost());
+        }
+
+        private PlanCostEstimate costForLookupJoin(PlanNode node, LocalCostEstimate localCost)
+        {
+            verify(node.getSources().size() == 2, "Unexpected number of sources for %s: %s", node, node.getSources());
+            List<PlanCostEstimate> sourcesCosts = getSourcesEstimations(node).collect(toImmutableList());
+            verify(sourcesCosts.size() == 2);
+            PlanCostEstimate probeCost = sourcesCosts.get(0);
+            PlanCostEstimate buildCost = sourcesCosts.get(1);
+
+            return new PlanCostEstimate(
+                    probeCost.getCpuCost() + buildCost.getCpuCost() + localCost.getCpuCost(),
+                    max(
+                            probeCost.getMaxMemory() + buildCost.getMaxMemory(), // Probe and build execute independently, so their max memory allocations can be realized at the same time
+                            probeCost.getMaxMemory() + buildCost.getMaxMemoryWhenOutputting() + localCost.getMaxMemory()),
+                    probeCost.getMaxMemoryWhenOutputting() + localCost.getMaxMemory(), // Build side finished and freed its memory allocations
+                    probeCost.getNetworkCost() + buildCost.getNetworkCost() + localCost.getNetworkCost());
         }
 
         private PlanNodeStatsEstimate getStats(PlanNode node)
         {
             return stats.getStats(node);
         }
+
+        private Stream<PlanCostEstimate> getSourcesEstimations(PlanNode node)
+        {
+            return node.getSources().stream()
+                    .map(sourcesCosts::getCost);
+        }
     }
 
-    private static PlanCostEstimate add(PlanCostEstimate a, PlanCostEstimate b)
+    private static PlanCostEstimate addParallelSiblingsCost(PlanCostEstimate a, PlanCostEstimate b)
     {
         return new PlanCostEstimate(
                 a.getCpuCost() + b.getCpuCost(),
-                a.getMemoryCost() + b.getMemoryCost(),
+                a.getMaxMemory() + b.getMaxMemory(),
+                a.getMaxMemoryWhenOutputting() + b.getMaxMemoryWhenOutputting(),
                 a.getNetworkCost() + b.getNetworkCost());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
@@ -49,7 +49,7 @@ import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateLo
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteGatherCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteRepartitionCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteReplicateCost;
-import static io.prestosql.cost.PlanCostEstimate.cpuCost;
+import static io.prestosql.cost.LocalCostEstimate.addPartialComponents;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static java.util.Objects.requireNonNull;
@@ -73,11 +73,11 @@ public class CostCalculatorUsingExchanges
     public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
     {
         CostEstimator costEstimator = new CostEstimator(stats, types, taskCountEstimator);
-        return node.accept(costEstimator, null);
+        return node.accept(costEstimator, null).toPlanCost();
     }
 
     private static class CostEstimator
-            extends PlanVisitor<PlanCostEstimate, Void>
+            extends PlanVisitor<LocalCostEstimate, Void>
     {
         private final StatsProvider stats;
         private final TypeProvider types;
@@ -91,25 +91,25 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        protected PlanCostEstimate visitPlan(PlanNode node, Void context)
+        protected LocalCostEstimate visitPlan(PlanNode node, Void context)
         {
-            return PlanCostEstimate.unknown();
+            return LocalCostEstimate.unknown();
         }
 
         @Override
-        public PlanCostEstimate visitGroupReference(GroupReference node, Void context)
+        public LocalCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public PlanCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
+        public LocalCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
         {
-            return cpuCost(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
+            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
         }
 
         @Override
-        public PlanCostEstimate visitRowNumber(RowNumberNode node, Void context)
+        public LocalCostEstimate visitRowNumber(RowNumberNode node, Void context)
         {
             List<Symbol> symbols = node.getOutputSymbols();
             // when maxRowCountPerPartition is set, the RowNumberOperator
@@ -123,49 +123,49 @@ public class CostCalculatorUsingExchanges
             PlanNodeStatsEstimate stats = getStats(node);
             double cpuCost = stats.getOutputSizeInBytes(symbols, types);
             double memoryCost = node.getPartitionBy().isEmpty() ? 0 : stats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
-            return new PlanCostEstimate(cpuCost, memoryCost, 0);
+            return LocalCostEstimate.of(cpuCost, memoryCost, 0);
         }
 
         @Override
-        public PlanCostEstimate visitOutput(OutputNode node, Void context)
+        public LocalCostEstimate visitOutput(OutputNode node, Void context)
         {
-            return PlanCostEstimate.zero();
+            return LocalCostEstimate.zero();
         }
 
         @Override
-        public PlanCostEstimate visitTableScan(TableScanNode node, Void context)
+        public LocalCostEstimate visitTableScan(TableScanNode node, Void context)
         {
             // TODO: add network cost, based on input size in bytes? Or let connector provide this cost?
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanCostEstimate visitFilter(FilterNode node, Void context)
+        public LocalCostEstimate visitFilter(FilterNode node, Void context)
         {
-            return cpuCost(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanCostEstimate visitProject(ProjectNode node, Void context)
+        public LocalCostEstimate visitProject(ProjectNode node, Void context)
         {
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanCostEstimate visitAggregation(AggregationNode node, Void context)
+        public LocalCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             if (node.getStep() != FINAL && node.getStep() != SINGLE) {
-                return PlanCostEstimate.unknown();
+                return LocalCostEstimate.unknown();
             }
             PlanNodeStatsEstimate aggregationStats = getStats(node);
             PlanNodeStatsEstimate sourceStats = getStats(node.getSource());
             double cpuCost = sourceStats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
             double memoryCost = aggregationStats.getOutputSizeInBytes(node.getOutputSymbols(), types);
-            return new PlanCostEstimate(cpuCost, memoryCost, 0);
+            return LocalCostEstimate.of(cpuCost, memoryCost, 0);
         }
 
         @Override
-        public PlanCostEstimate visitJoin(JoinNode node, Void context)
+        public LocalCostEstimate visitJoin(JoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -174,7 +174,7 @@ public class CostCalculatorUsingExchanges
                     Objects.equals(node.getDistributionType(), Optional.of(JoinNode.DistributionType.REPLICATED)));
         }
 
-        private PlanCostEstimate calculateJoinCost(PlanNode join, PlanNode probe, PlanNode build, boolean replicated)
+        private LocalCostEstimate calculateJoinCost(PlanNode join, PlanNode probe, PlanNode build, boolean replicated)
         {
             LocalCostEstimate joinInputCost = calculateJoinInputCost(
                     probe,
@@ -183,27 +183,19 @@ public class CostCalculatorUsingExchanges
                     types,
                     replicated,
                     taskCountEstimator.estimateSourceDistributedTaskCount());
-            PlanCostEstimate joinOutputCost = calculateJoinOutputCost(join);
-            return new PlanCostEstimate(
-                    joinOutputCost.getCpuCost() + joinInputCost.getCpuCost(),
-                    joinOutputCost.getMemoryCost() + joinInputCost.getMaxMemory(),
-                    joinOutputCost.getNetworkCost() + joinInputCost.getNetworkCost());
+            LocalCostEstimate joinOutputCost = calculateJoinOutputCost(join);
+            return addPartialComponents(joinInputCost, joinOutputCost);
         }
 
-        private PlanCostEstimate calculateJoinOutputCost(PlanNode join)
+        private LocalCostEstimate calculateJoinOutputCost(PlanNode join)
         {
             PlanNodeStatsEstimate outputStats = getStats(join);
             double joinOutputSize = outputStats.getOutputSizeInBytes(join.getOutputSymbols(), types);
-            return cpuCost(joinOutputSize);
+            return LocalCostEstimate.ofCpu(joinOutputSize);
         }
 
         @Override
-        public PlanCostEstimate visitExchange(ExchangeNode node, Void context)
-        {
-            return exchangeCost(node).toPlanCost();
-        }
-
-        private LocalCostEstimate exchangeCost(ExchangeNode node)
+        public LocalCostEstimate visitExchange(ExchangeNode node, Void context)
         {
             double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types);
             switch (node.getScope()) {
@@ -238,7 +230,7 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
+        public LocalCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -248,7 +240,7 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
+        public LocalCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -258,34 +250,34 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanCostEstimate visitValues(ValuesNode node, Void context)
+        public LocalCostEstimate visitValues(ValuesNode node, Void context)
         {
-            return PlanCostEstimate.zero();
+            return LocalCostEstimate.zero();
         }
 
         @Override
-        public PlanCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        public LocalCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
         {
-            return PlanCostEstimate.zero();
+            return LocalCostEstimate.zero();
         }
 
         @Override
-        public PlanCostEstimate visitLimit(LimitNode node, Void context)
+        public LocalCostEstimate visitLimit(LimitNode node, Void context)
         {
             // This is just a wild guess. First of all, LimitNode is rather rare except as a top node of a query plan,
             // so proper cost estimation is not that important. Second, since LimitNode can lead to incomplete evaluation
             // of the source, true cost estimation should be implemented as a "constraint" enforced on a sub-tree and
             // evaluated in context of actual source node type (and their sources).
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
+            return LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanCostEstimate visitUnion(UnionNode node, Void context)
+        public LocalCostEstimate visitUnion(UnionNode node, Void context)
         {
             // Cost will be accounted either in CostCalculatorUsingExchanges#CostEstimator#visitExchanged
             // or in CostCalculatorWithEstimatedExchanges#CostEstimator#visitUnion
             // This stub is needed just to avoid the cumulative cost being set to unknown
-            return PlanCostEstimate.zero();
+            return LocalCostEstimate.zero();
         }
 
         private PlanNodeStatsEstimate getStats(PlanNode node)

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
@@ -49,7 +49,7 @@ import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateLo
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteGatherCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteRepartitionCost;
 import static io.prestosql.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteReplicateCost;
-import static io.prestosql.cost.PlanNodeCostEstimate.cpuCost;
+import static io.prestosql.cost.PlanCostEstimate.cpuCost;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static java.util.Objects.requireNonNull;
@@ -70,14 +70,14 @@ public class CostCalculatorUsingExchanges
     }
 
     @Override
-    public PlanNodeCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
     {
         CostEstimator costEstimator = new CostEstimator(stats, types, taskCountEstimator);
         return node.accept(costEstimator, null);
     }
 
     private static class CostEstimator
-            extends PlanVisitor<PlanNodeCostEstimate, Void>
+            extends PlanVisitor<PlanCostEstimate, Void>
     {
         private final StatsProvider stats;
         private final TypeProvider types;
@@ -91,25 +91,25 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        protected PlanNodeCostEstimate visitPlan(PlanNode node, Void context)
+        protected PlanCostEstimate visitPlan(PlanNode node, Void context)
         {
-            return PlanNodeCostEstimate.unknown();
+            return PlanCostEstimate.unknown();
         }
 
         @Override
-        public PlanNodeCostEstimate visitGroupReference(GroupReference node, Void context)
+        public PlanCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public PlanNodeCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
+        public PlanCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
         {
             return cpuCost(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
         }
 
         @Override
-        public PlanNodeCostEstimate visitRowNumber(RowNumberNode node, Void context)
+        public PlanCostEstimate visitRowNumber(RowNumberNode node, Void context)
         {
             List<Symbol> symbols = node.getOutputSymbols();
             // when maxRowCountPerPartition is set, the RowNumberOperator
@@ -123,49 +123,49 @@ public class CostCalculatorUsingExchanges
             PlanNodeStatsEstimate stats = getStats(node);
             double cpuCost = stats.getOutputSizeInBytes(symbols, types);
             double memoryCost = node.getPartitionBy().isEmpty() ? 0 : stats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
-            return new PlanNodeCostEstimate(cpuCost, memoryCost, 0);
+            return new PlanCostEstimate(cpuCost, memoryCost, 0);
         }
 
         @Override
-        public PlanNodeCostEstimate visitOutput(OutputNode node, Void context)
+        public PlanCostEstimate visitOutput(OutputNode node, Void context)
         {
-            return PlanNodeCostEstimate.zero();
+            return PlanCostEstimate.zero();
         }
 
         @Override
-        public PlanNodeCostEstimate visitTableScan(TableScanNode node, Void context)
+        public PlanCostEstimate visitTableScan(TableScanNode node, Void context)
         {
             // TODO: add network cost, based on input size in bytes? Or let connector provide this cost?
             return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanNodeCostEstimate visitFilter(FilterNode node, Void context)
+        public PlanCostEstimate visitFilter(FilterNode node, Void context)
         {
             return cpuCost(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanNodeCostEstimate visitProject(ProjectNode node, Void context)
+        public PlanCostEstimate visitProject(ProjectNode node, Void context)
         {
             return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
-        public PlanNodeCostEstimate visitAggregation(AggregationNode node, Void context)
+        public PlanCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             if (node.getStep() != FINAL && node.getStep() != SINGLE) {
-                return PlanNodeCostEstimate.unknown();
+                return PlanCostEstimate.unknown();
             }
             PlanNodeStatsEstimate aggregationStats = getStats(node);
             PlanNodeStatsEstimate sourceStats = getStats(node.getSource());
             double cpuCost = sourceStats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
             double memoryCost = aggregationStats.getOutputSizeInBytes(node.getOutputSymbols(), types);
-            return new PlanNodeCostEstimate(cpuCost, memoryCost, 0);
+            return new PlanCostEstimate(cpuCost, memoryCost, 0);
         }
 
         @Override
-        public PlanNodeCostEstimate visitJoin(JoinNode node, Void context)
+        public PlanCostEstimate visitJoin(JoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -174,20 +174,20 @@ public class CostCalculatorUsingExchanges
                     Objects.equals(node.getDistributionType(), Optional.of(JoinNode.DistributionType.REPLICATED)));
         }
 
-        private PlanNodeCostEstimate calculateJoinCost(PlanNode join, PlanNode probe, PlanNode build, boolean replicated)
+        private PlanCostEstimate calculateJoinCost(PlanNode join, PlanNode probe, PlanNode build, boolean replicated)
         {
-            PlanNodeCostEstimate joinInputCost = calculateJoinInputCost(
+            PlanCostEstimate joinInputCost = calculateJoinInputCost(
                     probe,
                     build,
                     stats,
                     types,
                     replicated,
                     taskCountEstimator.estimateSourceDistributedTaskCount());
-            PlanNodeCostEstimate joinOutputCost = calculateJoinOutputCost(join);
+            PlanCostEstimate joinOutputCost = calculateJoinOutputCost(join);
             return joinInputCost.add(joinOutputCost);
         }
 
-        private PlanNodeCostEstimate calculateJoinOutputCost(PlanNode join)
+        private PlanCostEstimate calculateJoinOutputCost(PlanNode join)
         {
             PlanNodeStatsEstimate outputStats = getStats(join);
             double joinOutputSize = outputStats.getOutputSizeInBytes(join.getOutputSymbols(), types);
@@ -195,18 +195,18 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitExchange(ExchangeNode node, Void context)
+        public PlanCostEstimate visitExchange(ExchangeNode node, Void context)
         {
             double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types);
             switch (node.getScope()) {
                 case LOCAL:
                     switch (node.getType()) {
                         case GATHER:
-                            return PlanNodeCostEstimate.zero();
+                            return PlanCostEstimate.zero();
                         case REPARTITION:
                             return calculateLocalRepartitionCost(inputSizeInBytes);
                         case REPLICATE:
-                            return PlanNodeCostEstimate.zero();
+                            return PlanCostEstimate.zero();
                         default:
                             throw new IllegalArgumentException("Unexpected type: " + node.getType());
                     }
@@ -230,7 +230,7 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
+        public PlanCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -240,7 +240,7 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
+        public PlanCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
         {
             return calculateJoinCost(
                     node,
@@ -250,19 +250,19 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitValues(ValuesNode node, Void context)
+        public PlanCostEstimate visitValues(ValuesNode node, Void context)
         {
-            return PlanNodeCostEstimate.zero();
+            return PlanCostEstimate.zero();
         }
 
         @Override
-        public PlanNodeCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
+        public PlanCostEstimate visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
         {
-            return PlanNodeCostEstimate.zero();
+            return PlanCostEstimate.zero();
         }
 
         @Override
-        public PlanNodeCostEstimate visitLimit(LimitNode node, Void context)
+        public PlanCostEstimate visitLimit(LimitNode node, Void context)
         {
             // This is just a wild guess. First of all, LimitNode is rather rare except as a top node of a query plan,
             // so proper cost estimation is not that important. Second, since LimitNode can lead to incomplete evaluation
@@ -272,12 +272,12 @@ public class CostCalculatorUsingExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitUnion(UnionNode node, Void context)
+        public PlanCostEstimate visitUnion(UnionNode node, Void context)
         {
             // Cost will be accounted either in CostCalculatorUsingExchanges#CostEstimator#visitExchanged
             // or in CostCalculatorWithEstimatedExchanges#CostEstimator#visitUnion
             // This stub is needed just to avoid the cumulative cost being set to unknown
-            return PlanNodeCostEstimate.zero();
+            return PlanCostEstimate.zero();
         }
 
         private PlanNodeStatsEstimate getStats(PlanNode node)

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorUsingExchanges.java
@@ -70,10 +70,23 @@ public class CostCalculatorUsingExchanges
     }
 
     @Override
-    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session, TypeProvider types)
     {
         CostEstimator costEstimator = new CostEstimator(stats, types, taskCountEstimator);
-        return node.accept(costEstimator, null).toPlanCost();
+        LocalCostEstimate localCost = node.accept(costEstimator, null);
+
+        PlanCostEstimate sourcesCost = node.getSources().stream()
+                .map(sourcesCosts::getCumulativeCost)
+                .reduce(PlanCostEstimate.zero(), CostCalculatorUsingExchanges::add);
+        return add(sourcesCost, localCost);
+    }
+
+    private static PlanCostEstimate add(PlanCostEstimate sourcesCost, LocalCostEstimate localCost)
+    {
+        return new PlanCostEstimate(
+                sourcesCost.getCpuCost() + localCost.getCpuCost(),
+                sourcesCost.getMemoryCost() + localCost.getMaxMemory(),
+                sourcesCost.getNetworkCost() + localCost.getNetworkCost());
     }
 
     private static class CostEstimator
@@ -284,5 +297,13 @@ public class CostCalculatorUsingExchanges
         {
             return stats.getStats(node);
         }
+    }
+
+    private static PlanCostEstimate add(PlanCostEstimate a, PlanCostEstimate b)
+    {
+        return new PlanCostEstimate(
+                a.getCpuCost() + b.getCpuCost(),
+                a.getMemoryCost() + b.getMemoryCost(),
+                a.getNetworkCost() + b.getNetworkCost());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
@@ -33,8 +33,8 @@ import javax.inject.Inject;
 import java.util.Objects;
 import java.util.Optional;
 
-import static io.prestosql.cost.PlanNodeCostEstimate.cpuCost;
-import static io.prestosql.cost.PlanNodeCostEstimate.networkCost;
+import static io.prestosql.cost.PlanCostEstimate.cpuCost;
+import static io.prestosql.cost.PlanCostEstimate.networkCost;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -59,15 +59,15 @@ public class CostCalculatorWithEstimatedExchanges
     }
 
     @Override
-    public PlanNodeCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
     {
         ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(stats, types, taskCountEstimator);
-        PlanNodeCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
+        PlanCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
         return costCalculator.calculateCost(node, stats, session, types).add(estimatedExchangeCost);
     }
 
     private static class ExchangeCostEstimator
-            extends PlanVisitor<PlanNodeCostEstimate, Void>
+            extends PlanVisitor<PlanCostEstimate, Void>
     {
         private final StatsProvider stats;
         private final TypeProvider types;
@@ -81,33 +81,33 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        protected PlanNodeCostEstimate visitPlan(PlanNode node, Void context)
+        protected PlanCostEstimate visitPlan(PlanNode node, Void context)
         {
-            // TODO implement logic for other node types and return PlanNodeCostEstimate.unknown() here (or throw)
-            return PlanNodeCostEstimate.zero();
+            // TODO implement logic for other node types and return PlanCostEstimate.unknown() here (or throw)
+            return PlanCostEstimate.zero();
         }
 
         @Override
-        public PlanNodeCostEstimate visitGroupReference(GroupReference node, Void context)
+        public PlanCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public PlanNodeCostEstimate visitAggregation(AggregationNode node, Void context)
+        public PlanCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             PlanNode source = node.getSource();
             double inputSizeInBytes = getStats(source).getOutputSizeInBytes(source.getOutputSymbols(), types);
 
-            PlanNodeCostEstimate remoteRepartitionCost = calculateRemoteRepartitionCost(inputSizeInBytes);
-            PlanNodeCostEstimate localRepartitionCost = calculateLocalRepartitionCost(inputSizeInBytes);
+            PlanCostEstimate remoteRepartitionCost = calculateRemoteRepartitionCost(inputSizeInBytes);
+            PlanCostEstimate localRepartitionCost = calculateLocalRepartitionCost(inputSizeInBytes);
 
             // TODO consider cost of aggregation itself, not only exchanges, based on aggregation's properties
             return remoteRepartitionCost.add(localRepartitionCost);
         }
 
         @Override
-        public PlanNodeCostEstimate visitJoin(JoinNode node, Void context)
+        public PlanCostEstimate visitJoin(JoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getLeft(),
@@ -119,7 +119,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
+        public PlanCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getSource(),
@@ -131,7 +131,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
+        public PlanCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getLeft(),
@@ -143,7 +143,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanNodeCostEstimate visitUnion(UnionNode node, Void context)
+        public PlanCostEstimate visitUnion(UnionNode node, Void context)
         {
             // this assumes that all union inputs will be gathered over the network
             // that is not aways true
@@ -159,27 +159,27 @@ public class CostCalculatorWithEstimatedExchanges
         }
     }
 
-    public static PlanNodeCostEstimate calculateRemoteGatherCost(double inputSizeInBytes)
+    public static PlanCostEstimate calculateRemoteGatherCost(double inputSizeInBytes)
     {
         return networkCost(inputSizeInBytes);
     }
 
-    public static PlanNodeCostEstimate calculateRemoteRepartitionCost(double inputSizeInBytes)
+    public static PlanCostEstimate calculateRemoteRepartitionCost(double inputSizeInBytes)
     {
-        return new PlanNodeCostEstimate(inputSizeInBytes, 0, inputSizeInBytes);
+        return new PlanCostEstimate(inputSizeInBytes, 0, inputSizeInBytes);
     }
 
-    public static PlanNodeCostEstimate calculateLocalRepartitionCost(double inputSizeInBytes)
+    public static PlanCostEstimate calculateLocalRepartitionCost(double inputSizeInBytes)
     {
         return cpuCost(inputSizeInBytes);
     }
 
-    public static PlanNodeCostEstimate calculateRemoteReplicateCost(double inputSizeInBytes, int destinationTaskCount)
+    public static PlanCostEstimate calculateRemoteReplicateCost(double inputSizeInBytes, int destinationTaskCount)
     {
         return networkCost(inputSizeInBytes * destinationTaskCount);
     }
 
-    public static PlanNodeCostEstimate calculateJoinCostWithoutOutput(
+    public static PlanCostEstimate calculateJoinCostWithoutOutput(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -187,14 +187,14 @@ public class CostCalculatorWithEstimatedExchanges
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
-        PlanNodeCostEstimate exchangesCost = calculateJoinExchangeCost(
+        PlanCostEstimate exchangesCost = calculateJoinExchangeCost(
                 probe,
                 build,
                 stats,
                 types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
-        PlanNodeCostEstimate inputCost = calculateJoinInputCost(
+        PlanCostEstimate inputCost = calculateJoinInputCost(
                 probe,
                 build,
                 stats,
@@ -204,7 +204,7 @@ public class CostCalculatorWithEstimatedExchanges
         return exchangesCost.add(inputCost);
     }
 
-    private static PlanNodeCostEstimate calculateJoinExchangeCost(
+    private static PlanCostEstimate calculateJoinExchangeCost(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -216,22 +216,22 @@ public class CostCalculatorWithEstimatedExchanges
         double buildSizeInBytes = stats.getStats(build).getOutputSizeInBytes(build.getOutputSymbols(), types);
         if (replicated) {
             // assuming the probe side of a replicated join is always source distributed
-            PlanNodeCostEstimate replicateCost = calculateRemoteReplicateCost(buildSizeInBytes, estimatedSourceDistributedTaskCount);
+            PlanCostEstimate replicateCost = calculateRemoteReplicateCost(buildSizeInBytes, estimatedSourceDistributedTaskCount);
             // cost of the copies repartitioning is added in CostCalculatorUsingExchanges#calculateJoinCost
-            PlanNodeCostEstimate localRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
+            PlanCostEstimate localRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
             return replicateCost.add(localRepartitionCost);
         }
         else {
-            PlanNodeCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
-            PlanNodeCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
-            PlanNodeCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
+            PlanCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
+            PlanCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
+            PlanCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
             return probeCost
                     .add(buildRemoteRepartitionCost)
                     .add(buildLocalRepartitionCost);
         }
     }
 
-    public static PlanNodeCostEstimate calculateJoinInputCost(
+    public static PlanCostEstimate calculateJoinInputCost(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -267,6 +267,6 @@ public class CostCalculatorWithEstimatedExchanges
 
         double memoryCost = buildSideSize * buildSizeMultiplier;
 
-        return new PlanNodeCostEstimate(cpuCost, memoryCost, 0);
+        return new PlanCostEstimate(cpuCost, memoryCost, 0);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
@@ -17,6 +17,8 @@ package io.prestosql.cost;
 import io.prestosql.Session;
 import io.prestosql.sql.planner.TypeProvider;
 import io.prestosql.sql.planner.iterative.GroupReference;
+import io.prestosql.sql.planner.iterative.rule.DetermineJoinDistributionType;
+import io.prestosql.sql.planner.iterative.rule.ReorderJoins;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
@@ -36,18 +38,11 @@ import static io.prestosql.cost.PlanNodeCostEstimate.networkCost;
 import static java.util.Objects.requireNonNull;
 
 /**
- * HACK!
+ * A wrapper around CostCalculator that estimates ExchangeNodes cost.
  * <p>
- * This is a wrapper class around CostCalculator that estimates ExchangeNodes cost.
- * <p>
- * The ReorderJoins and DetermineJoinDistributionType rules are run before exchanges
- * are introduced. This cost calculator adds the implied costs for the exchanges that
- * will be added later. It is needed to account for the differences in exchange costs
- * for different types of joins.
- * <p>
- * Ideally the optimizer would produce different variations of a plan with all the
- * exchanges already introduced, so that the cost could be computed on the whole plan
- * and this class would not be needed.
+ * Certain rules (e.g. {@link ReorderJoins} and {@link DetermineJoinDistributionType}) are run before exchanges
+ * are added to a plan. This cost calculator adds the implied costs for the exchanges that will be added later.
+ * It is needed to account for the differences in exchange costs for different types of joins.
  */
 @ThreadSafe
 public class CostCalculatorWithEstimatedExchanges

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
@@ -33,8 +33,7 @@ import javax.inject.Inject;
 import java.util.Objects;
 import java.util.Optional;
 
-import static io.prestosql.cost.PlanCostEstimate.cpuCost;
-import static io.prestosql.cost.PlanCostEstimate.networkCost;
+import static io.prestosql.cost.LocalCostEstimate.addPartialComponents;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -62,12 +61,21 @@ public class CostCalculatorWithEstimatedExchanges
     public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
     {
         ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(stats, types, taskCountEstimator);
-        PlanCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
-        return costCalculator.calculateCost(node, stats, session, types).add(estimatedExchangeCost);
+        PlanCostEstimate costEstimate = costCalculator.calculateCost(node, stats, session, types);
+        LocalCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
+        return addExchangeCost(costEstimate, estimatedExchangeCost);
+    }
+
+    private static PlanCostEstimate addExchangeCost(PlanCostEstimate costEstimate, LocalCostEstimate estimatedExchangeCost)
+    {
+        return new PlanCostEstimate(
+                costEstimate.getCpuCost() + estimatedExchangeCost.getCpuCost(),
+                costEstimate.getMemoryCost() + estimatedExchangeCost.getMaxMemory(),
+                costEstimate.getNetworkCost() + estimatedExchangeCost.getNetworkCost());
     }
 
     private static class ExchangeCostEstimator
-            extends PlanVisitor<PlanCostEstimate, Void>
+            extends PlanVisitor<LocalCostEstimate, Void>
     {
         private final StatsProvider stats;
         private final TypeProvider types;
@@ -81,33 +89,33 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        protected PlanCostEstimate visitPlan(PlanNode node, Void context)
+        protected LocalCostEstimate visitPlan(PlanNode node, Void context)
         {
-            // TODO implement logic for other node types and return PlanCostEstimate.unknown() here (or throw)
-            return PlanCostEstimate.zero();
+            // TODO implement logic for other node types and return LocalCostEstimate.unknown() here (or throw)
+            return LocalCostEstimate.zero();
         }
 
         @Override
-        public PlanCostEstimate visitGroupReference(GroupReference node, Void context)
+        public LocalCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public PlanCostEstimate visitAggregation(AggregationNode node, Void context)
+        public LocalCostEstimate visitAggregation(AggregationNode node, Void context)
         {
             PlanNode source = node.getSource();
             double inputSizeInBytes = getStats(source).getOutputSizeInBytes(source.getOutputSymbols(), types);
 
-            PlanCostEstimate remoteRepartitionCost = calculateRemoteRepartitionCost(inputSizeInBytes);
-            PlanCostEstimate localRepartitionCost = calculateLocalRepartitionCost(inputSizeInBytes);
+            LocalCostEstimate remoteRepartitionCost = calculateRemoteRepartitionCost(inputSizeInBytes);
+            LocalCostEstimate localRepartitionCost = calculateLocalRepartitionCost(inputSizeInBytes);
 
             // TODO consider cost of aggregation itself, not only exchanges, based on aggregation's properties
-            return remoteRepartitionCost.add(localRepartitionCost);
+            return addPartialComponents(remoteRepartitionCost, localRepartitionCost);
         }
 
         @Override
-        public PlanCostEstimate visitJoin(JoinNode node, Void context)
+        public LocalCostEstimate visitJoin(JoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getLeft(),
@@ -119,7 +127,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
+        public LocalCostEstimate visitSemiJoin(SemiJoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getSource(),
@@ -131,7 +139,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
+        public LocalCostEstimate visitSpatialJoin(SpatialJoinNode node, Void context)
         {
             return calculateJoinExchangeCost(
                     node.getLeft(),
@@ -143,7 +151,7 @@ public class CostCalculatorWithEstimatedExchanges
         }
 
         @Override
-        public PlanCostEstimate visitUnion(UnionNode node, Void context)
+        public LocalCostEstimate visitUnion(UnionNode node, Void context)
         {
             // this assumes that all union inputs will be gathered over the network
             // that is not aways true
@@ -159,27 +167,27 @@ public class CostCalculatorWithEstimatedExchanges
         }
     }
 
-    public static PlanCostEstimate calculateRemoteGatherCost(double inputSizeInBytes)
+    public static LocalCostEstimate calculateRemoteGatherCost(double inputSizeInBytes)
     {
-        return networkCost(inputSizeInBytes);
+        return LocalCostEstimate.ofNetwork(inputSizeInBytes);
     }
 
-    public static PlanCostEstimate calculateRemoteRepartitionCost(double inputSizeInBytes)
+    public static LocalCostEstimate calculateRemoteRepartitionCost(double inputSizeInBytes)
     {
-        return new PlanCostEstimate(inputSizeInBytes, 0, inputSizeInBytes);
+        return LocalCostEstimate.of(inputSizeInBytes, 0, inputSizeInBytes);
     }
 
-    public static PlanCostEstimate calculateLocalRepartitionCost(double inputSizeInBytes)
+    public static LocalCostEstimate calculateLocalRepartitionCost(double inputSizeInBytes)
     {
-        return cpuCost(inputSizeInBytes);
+        return LocalCostEstimate.ofCpu(inputSizeInBytes);
     }
 
-    public static PlanCostEstimate calculateRemoteReplicateCost(double inputSizeInBytes, int destinationTaskCount)
+    public static LocalCostEstimate calculateRemoteReplicateCost(double inputSizeInBytes, int destinationTaskCount)
     {
-        return networkCost(inputSizeInBytes * destinationTaskCount);
+        return LocalCostEstimate.ofNetwork(inputSizeInBytes * destinationTaskCount);
     }
 
-    public static PlanCostEstimate calculateJoinCostWithoutOutput(
+    public static LocalCostEstimate calculateJoinCostWithoutOutput(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -187,24 +195,24 @@ public class CostCalculatorWithEstimatedExchanges
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
-        PlanCostEstimate exchangesCost = calculateJoinExchangeCost(
+        LocalCostEstimate exchangesCost = calculateJoinExchangeCost(
                 probe,
                 build,
                 stats,
                 types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
-        PlanCostEstimate inputCost = calculateJoinInputCost(
+        LocalCostEstimate inputCost = calculateJoinInputCost(
                 probe,
                 build,
                 stats,
                 types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
-        return exchangesCost.add(inputCost);
+        return addPartialComponents(exchangesCost, inputCost);
     }
 
-    private static PlanCostEstimate calculateJoinExchangeCost(
+    private static LocalCostEstimate calculateJoinExchangeCost(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -216,22 +224,20 @@ public class CostCalculatorWithEstimatedExchanges
         double buildSizeInBytes = stats.getStats(build).getOutputSizeInBytes(build.getOutputSymbols(), types);
         if (replicated) {
             // assuming the probe side of a replicated join is always source distributed
-            PlanCostEstimate replicateCost = calculateRemoteReplicateCost(buildSizeInBytes, estimatedSourceDistributedTaskCount);
+            LocalCostEstimate replicateCost = calculateRemoteReplicateCost(buildSizeInBytes, estimatedSourceDistributedTaskCount);
             // cost of the copies repartitioning is added in CostCalculatorUsingExchanges#calculateJoinCost
-            PlanCostEstimate localRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
-            return replicateCost.add(localRepartitionCost);
+            LocalCostEstimate localRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
+            return addPartialComponents(replicateCost, localRepartitionCost);
         }
         else {
-            PlanCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
-            PlanCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
-            PlanCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
-            return probeCost
-                    .add(buildRemoteRepartitionCost)
-                    .add(buildLocalRepartitionCost);
+            LocalCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
+            LocalCostEstimate buildRemoteRepartitionCost = calculateRemoteRepartitionCost(buildSizeInBytes);
+            LocalCostEstimate buildLocalRepartitionCost = calculateLocalRepartitionCost(buildSizeInBytes);
+            return addPartialComponents(probeCost, buildRemoteRepartitionCost, buildLocalRepartitionCost);
         }
     }
 
-    public static PlanCostEstimate calculateJoinInputCost(
+    public static LocalCostEstimate calculateJoinInputCost(
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
@@ -267,6 +273,6 @@ public class CostCalculatorWithEstimatedExchanges
 
         double memoryCost = buildSideSize * buildSizeMultiplier;
 
-        return new PlanCostEstimate(cpuCost, memoryCost, 0);
+        return LocalCostEstimate.of(cpuCost, memoryCost, 0);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostCalculatorWithEstimatedExchanges.java
@@ -58,10 +58,10 @@ public class CostCalculatorWithEstimatedExchanges
     }
 
     @Override
-    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session, TypeProvider types)
     {
         ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(stats, types, taskCountEstimator);
-        PlanCostEstimate costEstimate = costCalculator.calculateCost(node, stats, session, types);
+        PlanCostEstimate costEstimate = costCalculator.calculateCost(node, stats, sourcesCosts, session, types);
         LocalCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
         return addExchangeCost(costEstimate, estimatedExchangeCost);
     }

--- a/presto-main/src/main/java/io/prestosql/cost/CostComparator.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostComparator.java
@@ -46,13 +46,13 @@ public class CostComparator
         this.networkWeight = networkWeight;
     }
 
-    public Ordering<PlanNodeCostEstimate> forSession(Session session)
+    public Ordering<PlanCostEstimate> forSession(Session session)
     {
         requireNonNull(session, "session is null");
         return Ordering.from((left, right) -> this.compare(session, left, right));
     }
 
-    public int compare(Session session, PlanNodeCostEstimate left, PlanNodeCostEstimate right)
+    public int compare(Session session, PlanCostEstimate left, PlanCostEstimate right)
     {
         requireNonNull(session, "session is null");
         requireNonNull(left, "left is null");

--- a/presto-main/src/main/java/io/prestosql/cost/CostComparator.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostComparator.java
@@ -59,12 +59,14 @@ public class CostComparator
         requireNonNull(right, "right is null");
         checkArgument(!left.hasUnknownComponents() && !right.hasUnknownComponents(), "cannot compare unknown costs");
 
+        // TODO when one left.getMaxMemory() and right.getMaxMemory() exceeds query memory limit * configurable safety margin, choose the plan with lower memory usage
+
         double leftCost = left.getCpuCost() * cpuWeight
-                + left.getMemoryCost() * memoryWeight
+                + left.getMaxMemory() * memoryWeight
                 + left.getNetworkCost() * networkWeight;
 
         double rightCost = right.getCpuCost() * cpuWeight
-                + right.getMemoryCost() * memoryWeight
+                + right.getMaxMemory() * memoryWeight
                 + right.getNetworkCost() * networkWeight;
 
         return Double.compare(leftCost, rightCost);

--- a/presto-main/src/main/java/io/prestosql/cost/CostProvider.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostProvider.java
@@ -17,5 +17,5 @@ import io.prestosql.sql.planner.plan.PlanNode;
 
 public interface CostProvider
 {
-    PlanCostEstimate getCumulativeCost(PlanNode node);
+    PlanCostEstimate getCost(PlanNode node);
 }

--- a/presto-main/src/main/java/io/prestosql/cost/CostProvider.java
+++ b/presto-main/src/main/java/io/prestosql/cost/CostProvider.java
@@ -17,5 +17,5 @@ import io.prestosql.sql.planner.plan.PlanNode;
 
 public interface CostProvider
 {
-    PlanNodeCostEstimate getCumulativeCost(PlanNode node);
+    PlanCostEstimate getCumulativeCost(PlanNode node);
 }

--- a/presto-main/src/main/java/io/prestosql/cost/LocalCostEstimate.java
+++ b/presto-main/src/main/java/io/prestosql/cost/LocalCostEstimate.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cost;
+
+import io.prestosql.sql.planner.plan.PlanNode;
+
+import java.util.stream.Stream;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.Double.NaN;
+
+/**
+ * Represents inherent cost of some plan node, not including cost of its sources.
+ */
+public class LocalCostEstimate
+{
+    private final double cpuCost;
+    private final double maxMemory;
+    private final double networkCost;
+
+    public static LocalCostEstimate unknown()
+    {
+        return of(NaN, NaN, NaN);
+    }
+
+    public static LocalCostEstimate zero()
+    {
+        return of(0, 0, 0);
+    }
+
+    public static LocalCostEstimate ofCpu(double cpuCost)
+    {
+        return of(cpuCost, 0, 0);
+    }
+
+    public static LocalCostEstimate ofNetwork(double networkCost)
+    {
+        return of(0, 0, networkCost);
+    }
+
+    public static LocalCostEstimate of(double cpuCost, double maxMemory, double networkCost)
+    {
+        return new LocalCostEstimate(cpuCost, maxMemory, networkCost);
+    }
+
+    private LocalCostEstimate(double cpuCost, double maxMemory, double networkCost)
+    {
+        this.cpuCost = cpuCost;
+        this.maxMemory = maxMemory;
+        this.networkCost = networkCost;
+    }
+
+    public double getCpuCost()
+    {
+        return cpuCost;
+    }
+
+    public double getMaxMemory()
+    {
+        return maxMemory;
+    }
+
+    public double getNetworkCost()
+    {
+        return networkCost;
+    }
+
+    /**
+     * @deprecated This class represents individual cost of a part of a plan (usually of a single {@link PlanNode}). Use {@link CostProvider} instead.
+     */
+    @Deprecated
+    public PlanCostEstimate toPlanCost()
+    {
+        return new PlanCostEstimate(cpuCost, maxMemory, networkCost);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("cpuCost", cpuCost)
+                .add("maxMemory", maxMemory)
+                .add("networkCost", networkCost)
+                .toString();
+    }
+
+    /**
+     * Sums partial cost estimates of some (single) plan node.
+     */
+    public static LocalCostEstimate addPartialComponents(LocalCostEstimate one, LocalCostEstimate two, LocalCostEstimate... more)
+    {
+        return Stream.concat(Stream.of(one, two), Stream.of(more))
+                .reduce(zero(), (a, b) -> new LocalCostEstimate(
+                        a.cpuCost + b.cpuCost,
+                        a.maxMemory + b.maxMemory,
+                        a.networkCost + b.networkCost));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/cost/LocalCostEstimate.java
+++ b/presto-main/src/main/java/io/prestosql/cost/LocalCostEstimate.java
@@ -82,7 +82,7 @@ public class LocalCostEstimate
     @Deprecated
     public PlanCostEstimate toPlanCost()
     {
-        return new PlanCostEstimate(cpuCost, maxMemory, networkCost);
+        return new PlanCostEstimate(cpuCost, maxMemory, maxMemory, networkCost);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/cost/PlanCostEstimate.java
+++ b/presto-main/src/main/java/io/prestosql/cost/PlanCostEstimate.java
@@ -49,16 +49,6 @@ public final class PlanCostEstimate
         return ZERO;
     }
 
-    public static PlanCostEstimate cpuCost(double cpuCost)
-    {
-        return new PlanCostEstimate(cpuCost, 0, 0);
-    }
-
-    public static PlanCostEstimate networkCost(double networkCost)
-    {
-        return new PlanCostEstimate(0, 0, networkCost);
-    }
-
     @JsonCreator
     public PlanCostEstimate(
             @JsonProperty("cpuCost") double cpuCost,
@@ -137,13 +127,5 @@ public final class PlanCostEstimate
     public int hashCode()
     {
         return Objects.hash(cpuCost, memoryCost, networkCost);
-    }
-
-    public PlanCostEstimate add(PlanCostEstimate other)
-    {
-        return new PlanCostEstimate(
-                cpuCost + other.cpuCost,
-                memoryCost + other.memoryCost,
-                networkCost + other.networkCost);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/cost/PlanCostEstimate.java
+++ b/presto-main/src/main/java/io/prestosql/cost/PlanCostEstimate.java
@@ -24,43 +24,43 @@ import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isNaN;
 
-public final class PlanNodeCostEstimate
+public final class PlanCostEstimate
 {
-    private static final PlanNodeCostEstimate INFINITE = new PlanNodeCostEstimate(POSITIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY);
-    private static final PlanNodeCostEstimate UNKNOWN = new PlanNodeCostEstimate(NaN, NaN, NaN);
-    private static final PlanNodeCostEstimate ZERO = new PlanNodeCostEstimate(0, 0, 0);
+    private static final PlanCostEstimate INFINITE = new PlanCostEstimate(POSITIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY);
+    private static final PlanCostEstimate UNKNOWN = new PlanCostEstimate(NaN, NaN, NaN);
+    private static final PlanCostEstimate ZERO = new PlanCostEstimate(0, 0, 0);
 
     private final double cpuCost;
     private final double memoryCost;
     private final double networkCost;
 
-    public static PlanNodeCostEstimate infinite()
+    public static PlanCostEstimate infinite()
     {
         return INFINITE;
     }
 
-    public static PlanNodeCostEstimate unknown()
+    public static PlanCostEstimate unknown()
     {
         return UNKNOWN;
     }
 
-    public static PlanNodeCostEstimate zero()
+    public static PlanCostEstimate zero()
     {
         return ZERO;
     }
 
-    public static PlanNodeCostEstimate cpuCost(double cpuCost)
+    public static PlanCostEstimate cpuCost(double cpuCost)
     {
-        return new PlanNodeCostEstimate(cpuCost, 0, 0);
+        return new PlanCostEstimate(cpuCost, 0, 0);
     }
 
-    public static PlanNodeCostEstimate networkCost(double networkCost)
+    public static PlanCostEstimate networkCost(double networkCost)
     {
-        return new PlanNodeCostEstimate(0, 0, networkCost);
+        return new PlanCostEstimate(0, 0, networkCost);
     }
 
     @JsonCreator
-    public PlanNodeCostEstimate(
+    public PlanCostEstimate(
             @JsonProperty("cpuCost") double cpuCost,
             @JsonProperty("memoryCost") double memoryCost,
             @JsonProperty("networkCost") double networkCost)
@@ -127,7 +127,7 @@ public final class PlanNodeCostEstimate
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PlanNodeCostEstimate that = (PlanNodeCostEstimate) o;
+        PlanCostEstimate that = (PlanCostEstimate) o;
         return Double.compare(that.cpuCost, cpuCost) == 0 &&
                 Double.compare(that.memoryCost, memoryCost) == 0 &&
                 Double.compare(that.networkCost, networkCost) == 0;
@@ -139,9 +139,9 @@ public final class PlanNodeCostEstimate
         return Objects.hash(cpuCost, memoryCost, networkCost);
     }
 
-    public PlanNodeCostEstimate add(PlanNodeCostEstimate other)
+    public PlanCostEstimate add(PlanCostEstimate other)
     {
-        return new PlanNodeCostEstimate(
+        return new PlanCostEstimate(
                 cpuCost + other.cpuCost,
                 memoryCost + other.memoryCost,
                 networkCost + other.networkCost);

--- a/presto-main/src/main/java/io/prestosql/cost/PlanNodeCostEstimate.java
+++ b/presto-main/src/main/java/io/prestosql/cost/PlanNodeCostEstimate.java
@@ -54,11 +54,6 @@ public final class PlanNodeCostEstimate
         return new PlanNodeCostEstimate(cpuCost, 0, 0);
     }
 
-    public static PlanNodeCostEstimate memoryCost(double memoryCost)
-    {
-        return new PlanNodeCostEstimate(0, memoryCost, 0);
-    }
-
     public static PlanNodeCostEstimate networkCost(double networkCost)
     {
         return new PlanNodeCostEstimate(0, 0, networkCost);

--- a/presto-main/src/main/java/io/prestosql/cost/StatsAndCosts.java
+++ b/presto-main/src/main/java/io/prestosql/cost/StatsAndCosts.java
@@ -30,7 +30,7 @@ public class StatsAndCosts
     private static final StatsAndCosts EMPTY = new StatsAndCosts(ImmutableMap.of(), ImmutableMap.of());
 
     private final Map<PlanNodeId, PlanNodeStatsEstimate> stats;
-    private final Map<PlanNodeId, PlanNodeCostEstimate> costs;
+    private final Map<PlanNodeId, PlanCostEstimate> costs;
 
     public static StatsAndCosts empty()
     {
@@ -40,7 +40,7 @@ public class StatsAndCosts
     @JsonCreator
     public StatsAndCosts(
             @JsonProperty("stats") Map<PlanNodeId, PlanNodeStatsEstimate> stats,
-            @JsonProperty("costs") Map<PlanNodeId, PlanNodeCostEstimate> costs)
+            @JsonProperty("costs") Map<PlanNodeId, PlanCostEstimate> costs)
     {
         this.stats = ImmutableMap.copyOf(requireNonNull(stats, "stats is null"));
         this.costs = ImmutableMap.copyOf(requireNonNull(costs, "costs is null"));
@@ -53,7 +53,7 @@ public class StatsAndCosts
     }
 
     @JsonProperty
-    public Map<PlanNodeId, PlanNodeCostEstimate> getCosts()
+    public Map<PlanNodeId, PlanCostEstimate> getCosts()
     {
         return costs;
     }
@@ -63,7 +63,7 @@ public class StatsAndCosts
         Iterable<PlanNode> planIterator = Traverser.forTree(PlanNode::getSources)
                 .depthFirstPreOrder(root);
         ImmutableMap.Builder<PlanNodeId, PlanNodeStatsEstimate> filteredStats = ImmutableMap.builder();
-        ImmutableMap.Builder<PlanNodeId, PlanNodeCostEstimate> filteredCosts = ImmutableMap.builder();
+        ImmutableMap.Builder<PlanNodeId, PlanCostEstimate> filteredCosts = ImmutableMap.builder();
         for (PlanNode node : planIterator) {
             if (stats.containsKey(node.getId())) {
                 filteredStats.put(node.getId(), stats.get(node.getId()));
@@ -80,7 +80,7 @@ public class StatsAndCosts
         Iterable<PlanNode> planIterator = Traverser.forTree(PlanNode::getSources)
                 .depthFirstPreOrder(root);
         ImmutableMap.Builder<PlanNodeId, PlanNodeStatsEstimate> stats = ImmutableMap.builder();
-        ImmutableMap.Builder<PlanNodeId, PlanNodeCostEstimate> costs = ImmutableMap.builder();
+        ImmutableMap.Builder<PlanNodeId, PlanCostEstimate> costs = ImmutableMap.builder();
         for (PlanNode node : planIterator) {
             stats.put(node.getId(), statsProvider.getStats(node));
             costs.put(node.getId(), costProvider.getCumulativeCost(node));

--- a/presto-main/src/main/java/io/prestosql/cost/StatsAndCosts.java
+++ b/presto-main/src/main/java/io/prestosql/cost/StatsAndCosts.java
@@ -83,7 +83,7 @@ public class StatsAndCosts
         ImmutableMap.Builder<PlanNodeId, PlanCostEstimate> costs = ImmutableMap.builder();
         for (PlanNode node : planIterator) {
             stats.put(node.getId(), statsProvider.getStats(node));
-            costs.put(node.getId(), costProvider.getCumulativeCost(node));
+            costs.put(node.getId(), costProvider.getCost(node));
         }
         return new StatsAndCosts(stats.build(), costs.build());
     }

--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -23,7 +23,7 @@ import io.airlift.stats.Distribution.DistributionSnapshot;
 import io.prestosql.SessionRepresentation;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.connector.ConnectorId;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.eventlistener.EventListenerManager;
@@ -255,7 +255,7 @@ public class QueryMonitor
     private static StatsAndCosts reconstructStatsAndCosts(StageInfo stageInfo)
     {
         ImmutableMap.Builder<PlanNodeId, PlanNodeStatsEstimate> planNodeStats = ImmutableMap.builder();
-        ImmutableMap.Builder<PlanNodeId, PlanNodeCostEstimate> planNodeCosts = ImmutableMap.builder();
+        ImmutableMap.Builder<PlanNodeId, PlanCostEstimate> planNodeCosts = ImmutableMap.builder();
         reconstructStatsAndCosts(stageInfo, planNodeStats, planNodeCosts);
         return new StatsAndCosts(planNodeStats.build(), planNodeCosts.build());
     }
@@ -263,7 +263,7 @@ public class QueryMonitor
     private static void reconstructStatsAndCosts(
             StageInfo stage,
             ImmutableMap.Builder<PlanNodeId, PlanNodeStatsEstimate> planNodeStats,
-            ImmutableMap.Builder<PlanNodeId, PlanNodeCostEstimate> planNodeCosts)
+            ImmutableMap.Builder<PlanNodeId, PlanCostEstimate> planNodeCosts)
     {
         PlanFragment planFragment = stage.getPlan();
         if (planFragment != null) {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/Memo.java
@@ -138,7 +138,7 @@ public class Memo
     private void evictStatisticsAndCost(int group)
     {
         getGroup(group).stats = null;
-        getGroup(group).cumulativeCost = null;
+        getGroup(group).cost = null;
         for (int parentGroup : getGroup(group).incomingReferences.elementSet()) {
             if (parentGroup != ROOT_GROUP_REF) {
                 evictStatisticsAndCost(parentGroup);
@@ -160,14 +160,14 @@ public class Memo
         group.stats = requireNonNull(stats, "stats is null");
     }
 
-    public Optional<PlanCostEstimate> getCumulativeCost(int group)
+    public Optional<PlanCostEstimate> getCost(int group)
     {
-        return Optional.ofNullable(getGroup(group).cumulativeCost);
+        return Optional.ofNullable(getGroup(group).cost);
     }
 
-    public void storeCumulativeCost(int group, PlanCostEstimate cost)
+    public void storeCost(int group, PlanCostEstimate cost)
     {
-        getGroup(group).cumulativeCost = requireNonNull(cost, "cost is null");
+        getGroup(group).cost = requireNonNull(cost, "cost is null");
     }
 
     private void incrementReferenceCounts(PlanNode fromNode, int fromGroup)
@@ -256,7 +256,7 @@ public class Memo
         @Nullable
         private PlanNodeStatsEstimate stats;
         @Nullable
-        private PlanCostEstimate cumulativeCost;
+        private PlanCostEstimate cost;
 
         private Group(PlanNode member)
         {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/Memo.java
@@ -15,7 +15,7 @@ package io.prestosql.sql.planner.iterative;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
 import io.prestosql.sql.planner.plan.PlanNode;
@@ -160,12 +160,12 @@ public class Memo
         group.stats = requireNonNull(stats, "stats is null");
     }
 
-    public Optional<PlanNodeCostEstimate> getCumulativeCost(int group)
+    public Optional<PlanCostEstimate> getCumulativeCost(int group)
     {
         return Optional.ofNullable(getGroup(group).cumulativeCost);
     }
 
-    public void storeCumulativeCost(int group, PlanNodeCostEstimate cost)
+    public void storeCumulativeCost(int group, PlanCostEstimate cost)
     {
         getGroup(group).cumulativeCost = requireNonNull(cost, "cost is null");
     }
@@ -256,7 +256,7 @@ public class Memo
         @Nullable
         private PlanNodeStatsEstimate stats;
         @Nullable
-        private PlanNodeCostEstimate cumulativeCost;
+        private PlanCostEstimate cumulativeCost;
 
         private Group(PlanNode member)
         {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -177,6 +177,8 @@ public class DetermineJoinDistributionType
          *   always goes to the right), determining JOIN type is not that simple. As when
          *   choosing REPLICATED over REPARTITIONED join the cost of exchanging and building
          *   the hash table scales with the number of nodes where the build side is replicated.
+         *
+         *   TODO Decision about the distribution should be based on LocalCostEstimate only when PlanCostEstimate cannot be calculated. Otherwise cost comparator cannot take query.max-memory into account.
          */
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();
         LocalCostEstimate cost = calculateJoinCostWithoutOutput(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -17,7 +17,7 @@ package io.prestosql.sql.planner.iterative.rule;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.prestosql.cost.CostComparator;
-import io.prestosql.cost.PlanCostEstimate;
+import io.prestosql.cost.LocalCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.cost.TaskCountEstimator;
@@ -179,13 +179,13 @@ public class DetermineJoinDistributionType
          *   the hash table scales with the number of nodes where the build side is replicated.
          */
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();
-        PlanCostEstimate cost = calculateJoinCostWithoutOutput(
+        LocalCostEstimate cost = calculateJoinCostWithoutOutput(
                 possibleJoinNode.getLeft(),
                 possibleJoinNode.getRight(),
                 stats,
                 types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
-        return new PlanNodeWithCost(cost, possibleJoinNode);
+        return new PlanNodeWithCost(cost.toPlanCost(), possibleJoinNode);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -17,7 +17,7 @@ package io.prestosql.sql.planner.iterative.rule;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.prestosql.cost.CostComparator;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.cost.TaskCountEstimator;
@@ -179,7 +179,7 @@ public class DetermineJoinDistributionType
          *   the hash table scales with the number of nodes where the build side is replicated.
          */
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();
-        PlanNodeCostEstimate cost = calculateJoinCostWithoutOutput(
+        PlanCostEstimate cost = calculateJoinCostWithoutOutput(
                 possibleJoinNode.getLeft(),
                 possibleJoinNode.getRight(),
                 stats,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -147,6 +147,8 @@ public class DetermineSemiJoinDistributionType
          *
          *   However assuming the cost of SEMI-JOIN output is always the same, we can still make
          *   cost based decisions based on the input cost for different types of SEMI-JOINs.
+         *
+         *   TODO Decision about the distribution should be based on LocalCostEstimate only when PlanCostEstimate cannot be calculated. Otherwise cost comparator cannot take query.max-memory into account.
          */
 
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -30,7 +30,7 @@ package io.prestosql.sql.planner.iterative.rule;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.prestosql.cost.CostComparator;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.cost.TaskCountEstimator;
@@ -150,7 +150,7 @@ public class DetermineSemiJoinDistributionType
          */
 
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();
-        PlanNodeCostEstimate cost = calculateJoinCostWithoutOutput(
+        PlanCostEstimate cost = calculateJoinCostWithoutOutput(
                 possibleJoinNode.getSource(),
                 possibleJoinNode.getFilteringSource(),
                 stats,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -30,7 +30,7 @@ package io.prestosql.sql.planner.iterative.rule;
 import com.google.common.collect.Ordering;
 import io.airlift.units.DataSize;
 import io.prestosql.cost.CostComparator;
-import io.prestosql.cost.PlanCostEstimate;
+import io.prestosql.cost.LocalCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.cost.TaskCountEstimator;
@@ -150,13 +150,13 @@ public class DetermineSemiJoinDistributionType
          */
 
         int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount();
-        PlanCostEstimate cost = calculateJoinCostWithoutOutput(
+        LocalCostEstimate cost = calculateJoinCostWithoutOutput(
                 possibleJoinNode.getSource(),
                 possibleJoinNode.getFilteringSource(),
                 stats,
                 types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
-        return new PlanNodeWithCost(cost, possibleJoinNode);
+        return new PlanNodeWithCost(cost.toPlanCost(), possibleJoinNode);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PlanNodeWithCost.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PlanNodeWithCost.java
@@ -14,7 +14,7 @@
 
 package io.prestosql.sql.planner.iterative.rule;
 
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.sql.planner.plan.PlanNode;
 
 import static java.util.Objects.requireNonNull;
@@ -22,9 +22,9 @@ import static java.util.Objects.requireNonNull;
 public class PlanNodeWithCost
 {
     private final PlanNode planNode;
-    private final PlanNodeCostEstimate cost;
+    private final PlanCostEstimate cost;
 
-    public PlanNodeWithCost(PlanNodeCostEstimate cost, PlanNode planNode)
+    public PlanNodeWithCost(PlanCostEstimate cost, PlanNode planNode)
     {
         this.cost = requireNonNull(cost, "cost is null");
         this.planNode = requireNonNull(planNode, "planNode is null");
@@ -35,7 +35,7 @@ public class PlanNodeWithCost
         return planNode;
     }
 
-    public PlanNodeCostEstimate getCost()
+    public PlanCostEstimate getCost()
     {
         return cost;
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
@@ -23,7 +23,7 @@ import io.airlift.log.Logger;
 import io.prestosql.Session;
 import io.prestosql.cost.CostComparator;
 import io.prestosql.cost.CostProvider;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.matching.Captures;
 import io.prestosql.matching.Pattern;
 import io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType;
@@ -567,18 +567,18 @@ public class ReorderJoins
     @VisibleForTesting
     static class JoinEnumerationResult
     {
-        public static final JoinEnumerationResult UNKNOWN_COST_RESULT = new JoinEnumerationResult(Optional.empty(), PlanNodeCostEstimate.unknown());
-        public static final JoinEnumerationResult INFINITE_COST_RESULT = new JoinEnumerationResult(Optional.empty(), PlanNodeCostEstimate.infinite());
+        public static final JoinEnumerationResult UNKNOWN_COST_RESULT = new JoinEnumerationResult(Optional.empty(), PlanCostEstimate.unknown());
+        public static final JoinEnumerationResult INFINITE_COST_RESULT = new JoinEnumerationResult(Optional.empty(), PlanCostEstimate.infinite());
 
         private final Optional<PlanNode> planNode;
-        private final PlanNodeCostEstimate cost;
+        private final PlanCostEstimate cost;
 
-        private JoinEnumerationResult(Optional<PlanNode> planNode, PlanNodeCostEstimate cost)
+        private JoinEnumerationResult(Optional<PlanNode> planNode, PlanCostEstimate cost)
         {
             this.planNode = requireNonNull(planNode, "planNode is null");
             this.cost = requireNonNull(cost, "cost is null");
-            checkArgument((cost.hasUnknownComponents() || cost.equals(PlanNodeCostEstimate.infinite())) && !planNode.isPresent()
-                            || (!cost.hasUnknownComponents() || !cost.equals(PlanNodeCostEstimate.infinite())) && planNode.isPresent(),
+            checkArgument((cost.hasUnknownComponents() || cost.equals(PlanCostEstimate.infinite())) && !planNode.isPresent()
+                            || (!cost.hasUnknownComponents() || !cost.equals(PlanCostEstimate.infinite())) && planNode.isPresent(),
                     "planNode should be present if and only if cost is known");
         }
 
@@ -587,17 +587,17 @@ public class ReorderJoins
             return planNode;
         }
 
-        public PlanNodeCostEstimate getCost()
+        public PlanCostEstimate getCost()
         {
             return cost;
         }
 
-        static JoinEnumerationResult createJoinEnumerationResult(Optional<PlanNode> planNode, PlanNodeCostEstimate cost)
+        static JoinEnumerationResult createJoinEnumerationResult(Optional<PlanNode> planNode, PlanCostEstimate cost)
         {
             if (cost.hasUnknownComponents()) {
                 return UNKNOWN_COST_RESULT;
             }
-            if (cost.equals(PlanNodeCostEstimate.infinite())) {
+            if (cost.equals(PlanCostEstimate.infinite())) {
                 return INFINITE_COST_RESULT;
             }
             return new JoinEnumerationResult(planNode, cost);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
@@ -411,7 +411,7 @@ public class ReorderJoins
 
         private JoinEnumerationResult createJoinEnumerationResult(PlanNode planNode)
         {
-            return JoinEnumerationResult.createJoinEnumerationResult(Optional.of(planNode), costProvider.getCumulativeCost(planNode));
+            return JoinEnumerationResult.createJoinEnumerationResult(Optional.of(planNode), costProvider.getCost(planNode));
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/NodeRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/NodeRepresentation.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.sql.planner.planPrinter;
 
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.PlanFragmentId;
@@ -37,7 +37,7 @@ public class NodeRepresentation
     private final List<PlanFragmentId> remoteSources;
     private final Optional<PlanNodeStats> stats;
     private final List<PlanNodeStatsEstimate> estimatedStats;
-    private final List<PlanNodeCostEstimate> estimatedCost;
+    private final List<PlanCostEstimate> estimatedCost;
 
     private final StringBuilder details = new StringBuilder();
 
@@ -49,7 +49,7 @@ public class NodeRepresentation
             List<Symbol> outputs,
             Optional<PlanNodeStats> stats,
             List<PlanNodeStatsEstimate> estimatedStats,
-            List<PlanNodeCostEstimate> estimatedCost,
+            List<PlanCostEstimate> estimatedCost,
             List<PlanNodeId> children,
             List<PlanFragmentId> remoteSources)
     {
@@ -133,7 +133,7 @@ public class NodeRepresentation
         return estimatedStats;
     }
 
-    public List<PlanNodeCostEstimate> getEstimatedCost()
+    public List<PlanCostEstimate> getEstimatedCost()
     {
         return estimatedCost;
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/PlanPrinter.java
@@ -25,7 +25,7 @@ import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
 import io.prestosql.Session;
 import io.prestosql.SystemSessionProperties;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.execution.StageInfo;
@@ -1169,8 +1169,8 @@ public class PlanPrinter
             List<PlanNodeStatsEstimate> estimatedStats = allNodes.stream()
                     .map(nodeId -> estimatedStatsAndCosts.getStats().getOrDefault(nodeId, PlanNodeStatsEstimate.unknown()))
                     .collect(toList());
-            List<PlanNodeCostEstimate> estimatedCosts = allNodes.stream()
-                    .map(nodeId -> estimatedStatsAndCosts.getCosts().getOrDefault(nodeId, PlanNodeCostEstimate.unknown()))
+            List<PlanCostEstimate> estimatedCosts = allNodes.stream()
+                    .map(nodeId -> estimatedStatsAndCosts.getCosts().getOrDefault(nodeId, PlanCostEstimate.unknown()))
                     .collect(toList());
 
             NodeRepresentation nodeOutput = new NodeRepresentation(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
@@ -219,7 +219,7 @@ public class TextRenderer
                     formatAsLong(stats.getOutputRowCount()),
                     formatEstimateAsDataSize(stats.getOutputSizeInBytes(node.getOutputs(), plan.getTypes())),
                     formatDouble(cost.getCpuCost()),
-                    formatDouble(cost.getMemoryCost()),
+                    formatDouble(cost.getMaxMemory()),
                     formatDouble(cost.getNetworkCost())));
 
             if (i < estimateCount - 1) {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
@@ -15,7 +15,7 @@ package io.prestosql.sql.planner.planPrinter;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 
 import java.util.List;
@@ -203,7 +203,7 @@ public class TextRenderer
     private String printEstimates(PlanRepresentation plan, NodeRepresentation node)
     {
         if (node.getEstimatedStats().stream().allMatch(PlanNodeStatsEstimate::isOutputRowCountUnknown) &&
-                node.getEstimatedCost().stream().allMatch(c -> c.equals(PlanNodeCostEstimate.unknown()))) {
+                node.getEstimatedCost().stream().allMatch(c -> c.equals(PlanCostEstimate.unknown()))) {
             return "";
         }
 
@@ -213,7 +213,7 @@ public class TextRenderer
         output.append("Estimates: ");
         for (int i = 0; i < estimateCount; i++) {
             PlanNodeStatsEstimate stats = node.getEstimatedStats().get(i);
-            PlanNodeCostEstimate cost = node.getEstimatedCost().get(i);
+            PlanCostEstimate cost = node.getEstimatedCost().get(i);
 
             output.append(format("{rows: %s (%s), cpu: %s, memory: %s, network: %s}",
                     formatAsLong(stats.getOutputRowCount()),

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -319,9 +319,9 @@ public class TestCostCalculator
                 "key2");
 
         Map<String, PlanCostEstimate> costs = ImmutableMap.of(
-                "ts1", new PlanCostEstimate(0, 128, 0),
-                "ts2", new PlanCostEstimate(0, 64, 0),
-                "ts3", new PlanCostEstimate(0, 32, 0));
+                "ts1", new PlanCostEstimate(0, 128, 128, 0),
+                "ts2", new PlanCostEstimate(0, 64, 64, 0),
+                "ts3", new PlanCostEstimate(0, 32, 32, 0));
 
         Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
                 "join", statsEstimate(join, 10_000),
@@ -332,29 +332,56 @@ public class TestCostCalculator
 
         Map<String, Type> types = ImmutableMap.of("key1", BIGINT, "key2", BIGINT, "key3", BIGINT);
 
-        assertCost(join23, costs, stats, types).memory(
-                100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 64 + 32); // ts2, ts3 memory footprint
-        assertCost(join, costs, stats, types).memory(
-                2000 * IS_NULL_OVERHEAD // join memory footprint
-                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+        assertCost(join23, costs, stats, types)
+                .memory(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64 + 32) // ts2, ts3 memory footprint
+                .memoryWhenOutputting(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64); // ts2 memory footprint
 
-        assertCostEstimatedExchanges(join23, costs, stats, types).memory(
-                100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 64 + 32); // ts2, ts3 memory footprint
-        assertCostEstimatedExchanges(join, costs, stats, types).memory(
-                2000 * IS_NULL_OVERHEAD // join memory footprint
-                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+        assertCost(join, costs, stats, types)
+                .memory(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
+                                + 128) // ts1 memory footprint
+                .memoryWhenOutputting(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 128); // ts1 memory footprint
 
-        assertCostFragmentedPlan(join23, costs, stats, types).memory(
-                100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 64 + 32); // ts2, ts3 memory footprint
-        assertCostFragmentedPlan(join, costs, stats, types).memory(
-                2000 * IS_NULL_OVERHEAD // join memory footprint
-                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
-                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+        assertCostEstimatedExchanges(join23, costs, stats, types)
+                .memory(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64 + 32) // ts2, ts3 memory footprint
+                .memoryWhenOutputting(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64); // ts2 memory footprint
+
+        assertCostEstimatedExchanges(join, costs, stats, types)
+                .memory(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
+                                + 128) // ts1 memory footprint
+                .memoryWhenOutputting(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 128); // ts1 memory footprint
+
+        assertCostFragmentedPlan(join23, costs, stats, types)
+                .memory(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64 + 32) // ts2, ts3 memory footprint
+                .memoryWhenOutputting(
+                        100 * IS_NULL_OVERHEAD // join23 memory footprint
+                                + 64); // ts2 memory footprint
+
+        assertCostFragmentedPlan(join, costs, stats, types)
+                .memory(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
+                                + 128) // ts1 memory footprint
+                .memoryWhenOutputting(
+                        2000 * IS_NULL_OVERHEAD // join memory footprint
+                                + 128); // ts1 memory footprint
     }
 
     @Test
@@ -660,7 +687,13 @@ public class TestCostCalculator
 
         CostAssertionBuilder memory(double value)
         {
-            assertEquals(actual.getMemoryCost(), value, 0.000001);
+            assertEquals(actual.getMaxMemory(), value, 0.000001);
+            return this;
+        }
+
+        CostAssertionBuilder memoryWhenOutputting(double value)
+        {
+            assertEquals(actual.getMaxMemoryWhenOutputting(), value, 0.000001);
             return this;
         }
 
@@ -795,6 +828,6 @@ public class TestCostCalculator
 
     private static PlanCostEstimate cpuCost(double cpuCost)
     {
-        return new PlanCostEstimate(cpuCost, 0, 0);
+        return new PlanCostEstimate(cpuCost, 0, 0, 0);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -490,13 +490,34 @@ public class TestCostCalculator
             Map<String, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
+        Function<PlanNode, PlanNodeStatsEstimate> statsProvider = planNode -> stats.get(planNode.getId().toString());
         PlanNodeCostEstimate cumulativeCost = calculateCumulativeCost(
                 costCalculator,
                 node,
-                planNode -> costs.get(planNode.getId().toString()),
-                planNode -> stats.get(planNode.getId().toString()),
+                sourceCostProvider(costCalculator, costs, statsProvider, types),
+                statsProvider,
                 types);
         return new CostAssertionBuilder(cumulativeCost);
+    }
+
+    private Function<PlanNode, PlanNodeCostEstimate> sourceCostProvider(
+            CostCalculator costCalculator,
+            Map<String, PlanNodeCostEstimate> costs,
+            Function<PlanNode, PlanNodeStatsEstimate> statsProvider,
+            Map<String, Type> types)
+    {
+        return node -> {
+            PlanNodeCostEstimate providedCost = costs.get(node.getId().toString());
+            if (providedCost != null) {
+                return providedCost;
+            }
+            return calculateCumulativeCost(
+                    costCalculator,
+                    node,
+                    sourceCostProvider(costCalculator, costs, statsProvider, types),
+                    statsProvider,
+                    types);
+        };
     }
 
     private void assertCostHasUnknownComponentsForUnknownStats(PlanNode node, Map<String, Type> types)

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -293,6 +293,72 @@ public class TestCostCalculator
     }
 
     @Test
+    public void testMemoryCostJoinAboveJoin()
+    {
+        //      join
+        //     /   \
+        //   ts1    join23
+        //          /    \
+        //        ts2     ts3
+
+        TableScanNode ts1 = tableScan("ts1", "key1");
+        TableScanNode ts2 = tableScan("ts2", "key2");
+        TableScanNode ts3 = tableScan("ts3", "key3");
+        JoinNode join23 = join(
+                "join23",
+                ts2,
+                ts3,
+                JoinNode.DistributionType.PARTITIONED,
+                "key2",
+                "key3");
+        JoinNode join = join(
+                "join",
+                ts1,
+                join23,
+                JoinNode.DistributionType.PARTITIONED,
+                "key1",
+                "key2");
+
+        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of(
+                "ts1", new PlanNodeCostEstimate(0, 128, 0),
+                "ts2", new PlanNodeCostEstimate(0, 64, 0),
+                "ts3", new PlanNodeCostEstimate(0, 32, 0));
+
+        Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
+                "join", statsEstimate(join, 10_000),
+                "join23", statsEstimate(join23, 2_000),
+                "ts1", statsEstimate(ts1, 10_000),
+                "ts2", statsEstimate(ts2, 1_000),
+                "ts3", statsEstimate(ts3, 100));
+
+        Map<String, Type> types = ImmutableMap.of("key1", BIGINT, "key2", BIGINT, "key3", BIGINT);
+
+        assertCost(join23, costs, stats, types).memory(
+                100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 64 + 32); // ts2, ts3 memory footprint
+        assertCost(join, costs, stats, types).memory(
+                2000 * IS_NULL_OVERHEAD // join memory footprint
+                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+
+        assertCostEstimatedExchanges(join23, costs, stats, types).memory(
+                100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 64 + 32); // ts2, ts3 memory footprint
+        assertCostEstimatedExchanges(join, costs, stats, types).memory(
+                2000 * IS_NULL_OVERHEAD // join memory footprint
+                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+
+        assertCostFragmentedPlan(join23, costs, stats, types).memory(
+                100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 64 + 32); // ts2, ts3 memory footprint
+        assertCostFragmentedPlan(join, costs, stats, types).memory(
+                2000 * IS_NULL_OVERHEAD // join memory footprint
+                        + 100 * IS_NULL_OVERHEAD // join23 memory footprint
+                        + 128 + 64 + 32); // ts1, ts2, ts3 memory footprint
+    }
+
+    @Test
     public void testAggregation()
     {
         TableScanNode tableScan = tableScan("ts", "orderkey");

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -530,7 +530,7 @@ public class TestCostCalculator
         }
 
         @Override
-        public PlanCostEstimate getCumulativeCost(PlanNode node)
+        public PlanCostEstimate getCost(PlanNode node)
         {
             if (costs.containsKey(node.getId().toString())) {
                 return costs.get(node.getId().toString());
@@ -547,13 +547,13 @@ public class TestCostCalculator
             Map<String, Type> types)
     {
         Function<PlanNode, PlanNodeStatsEstimate> statsProvider = planNode -> stats.get(planNode.getId().toString());
-        PlanCostEstimate cumulativeCost = calculateCumulativeCost(
+        PlanCostEstimate cost = calculateCost(
                 costCalculator,
                 node,
                 sourceCostProvider(costCalculator, costs, statsProvider, types),
                 statsProvider,
                 types);
-        return new CostAssertionBuilder(cumulativeCost);
+        return new CostAssertionBuilder(cost);
     }
 
     private Function<PlanNode, PlanCostEstimate> sourceCostProvider(
@@ -567,7 +567,7 @@ public class TestCostCalculator
             if (providedCost != null) {
                 return providedCost;
             }
-            return calculateCumulativeCost(
+            return calculateCost(
                     costCalculator,
                     node,
                     sourceCostProvider(costCalculator, costs, statsProvider, types),
@@ -578,14 +578,14 @@ public class TestCostCalculator
 
     private void assertCostHasUnknownComponentsForUnknownStats(PlanNode node, Map<String, Type> types)
     {
-        new CostAssertionBuilder(calculateCumulativeCost(
+        new CostAssertionBuilder(calculateCost(
                 costCalculatorUsingExchanges,
                 node,
                 planNode -> PlanCostEstimate.unknown(),
                 planNode -> PlanNodeStatsEstimate.unknown(),
                 types))
                 .hasUnknownComponents();
-        new CostAssertionBuilder(calculateCumulativeCost(
+        new CostAssertionBuilder(calculateCost(
                 costCalculatorWithEstimatedExchanges,
                 node,
                 planNode -> PlanCostEstimate.unknown(),
@@ -597,8 +597,8 @@ public class TestCostCalculator
     private void assertFragmentedEqualsUnfragmented(PlanNode node, Map<String, PlanNodeStatsEstimate> stats, Map<String, Type> types)
     {
         StatsCalculator statsCalculator = statsCalculator(stats);
-        PlanCostEstimate costWithExchanges = calculateCumulativeCost(node, costCalculatorUsingExchanges, statsCalculator, types);
-        PlanCostEstimate costWithFragments = calculateCumulativeCostFragmentedPlan(node, statsCalculator, types);
+        PlanCostEstimate costWithExchanges = calculateCost(node, costCalculatorUsingExchanges, statsCalculator, types);
+        PlanCostEstimate costWithFragments = calculateCostFragmentedPlan(node, statsCalculator, types);
         assertEquals(costWithExchanges, costWithFragments);
     }
 
@@ -608,7 +608,7 @@ public class TestCostCalculator
                 requireNonNull(stats.get(node.getId().toString()), "no stats for node");
     }
 
-    private PlanCostEstimate calculateCumulativeCost(
+    private PlanCostEstimate calculateCost(
             CostCalculator costCalculator,
             PlanNode node,
             Function<PlanNode, PlanCostEstimate> costs,
@@ -624,16 +624,16 @@ public class TestCostCalculator
                         .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))));
     }
 
-    private PlanCostEstimate calculateCumulativeCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
+    private PlanCostEstimate calculateCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider);
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session, typeProvider);
-        return costProvider.getCumulativeCost(node);
+        return costProvider.getCost(node);
     }
 
-    private PlanCostEstimate calculateCumulativeCostFragmentedPlan(PlanNode node, StatsCalculator statsCalculator, Map<String, Type> types)
+    private PlanCostEstimate calculateCostFragmentedPlan(PlanNode node, StatsCalculator statsCalculator, Map<String, Type> types)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -74,7 +74,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.cost.PlanNodeCostEstimate.cpuCost;
+import static io.prestosql.cost.PlanCostEstimate.cpuCost;
 import static io.prestosql.metadata.FunctionKind.AGGREGATE;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.plugin.tpch.TpchTransactionHandle.INSTANCE;
@@ -181,7 +181,7 @@ public class TestCostCalculator
     {
         TableScanNode tableScan = tableScan("ts", "orderkey");
         PlanNode project = project("project", tableScan, "string", new Cast(new SymbolReference("orderkey"), "STRING"));
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of("ts", cpuCost(1000));
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of("ts", cpuCost(1000));
         Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
                 "project", statsEstimate(project, 4000),
                 "ts", statsEstimate(tableScan, 1000));
@@ -219,7 +219,7 @@ public class TestCostCalculator
                 "orderkey",
                 "orderkey_0");
 
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of(
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of(
                 "ts1", cpuCost(6000),
                 "ts2", cpuCost(1000));
 
@@ -261,7 +261,7 @@ public class TestCostCalculator
                 "orderkey",
                 "orderkey_0");
 
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of(
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of(
                 "ts1", cpuCost(6000),
                 "ts2", cpuCost(1000));
 
@@ -319,10 +319,10 @@ public class TestCostCalculator
                 "key1",
                 "key2");
 
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of(
-                "ts1", new PlanNodeCostEstimate(0, 128, 0),
-                "ts2", new PlanNodeCostEstimate(0, 64, 0),
-                "ts3", new PlanNodeCostEstimate(0, 32, 0));
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of(
+                "ts1", new PlanCostEstimate(0, 128, 0),
+                "ts2", new PlanCostEstimate(0, 64, 0),
+                "ts3", new PlanCostEstimate(0, 32, 0));
 
         Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
                 "join", statsEstimate(join, 10_000),
@@ -364,7 +364,7 @@ public class TestCostCalculator
         TableScanNode tableScan = tableScan("ts", "orderkey");
         AggregationNode aggregation = aggregation("agg", tableScan);
 
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of("ts", cpuCost(6000));
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of("ts", cpuCost(6000));
         Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
                 "ts", statsEstimate(tableScan, 6000),
                 "agg", statsEstimate(aggregation, 13));
@@ -463,7 +463,7 @@ public class TestCostCalculator
                 "ts1", statsEstimate(ts1, 4000),
                 "ts2", statsEstimate(ts2, 1000),
                 "union", statsEstimate(ts1, 5000));
-        Map<String, PlanNodeCostEstimate> costs = ImmutableMap.of(
+        Map<String, PlanCostEstimate> costs = ImmutableMap.of(
                 "ts1", cpuCost(1000),
                 "ts2", cpuCost(1000));
         Map<String, Type> types = ImmutableMap.of(
@@ -482,7 +482,7 @@ public class TestCostCalculator
 
     private CostAssertionBuilder assertCost(
             PlanNode node,
-            Map<String, PlanNodeCostEstimate> costs,
+            Map<String, PlanCostEstimate> costs,
             Map<String, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
@@ -491,7 +491,7 @@ public class TestCostCalculator
 
     private CostAssertionBuilder assertCostEstimatedExchanges(
             PlanNode node,
-            Map<String, PlanNodeCostEstimate> costs,
+            Map<String, PlanCostEstimate> costs,
             Map<String, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
@@ -500,7 +500,7 @@ public class TestCostCalculator
 
     private CostAssertionBuilder assertCostFragmentedPlan(
             PlanNode node,
-            Map<String, PlanNodeCostEstimate> costs,
+            Map<String, PlanCostEstimate> costs,
             Map<String, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
@@ -509,19 +509,19 @@ public class TestCostCalculator
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator(stats), session, typeProvider);
         CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session, typeProvider);
         SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
-        return new CostAssertionBuilder(subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanNodeCostEstimate.unknown()));
+        return new CostAssertionBuilder(subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
     }
 
     private static class TestingCostProvider
             implements CostProvider
     {
-        private final Map<String, PlanNodeCostEstimate> costs;
+        private final Map<String, PlanCostEstimate> costs;
         private final CostCalculator costCalculator;
         private final StatsProvider statsProvider;
         private final Session session;
         private final TypeProvider types;
 
-        private TestingCostProvider(Map<String, PlanNodeCostEstimate> costs, CostCalculator costCalculator, StatsProvider statsProvider, Session session, TypeProvider types)
+        private TestingCostProvider(Map<String, PlanCostEstimate> costs, CostCalculator costCalculator, StatsProvider statsProvider, Session session, TypeProvider types)
         {
             this.costs = ImmutableMap.copyOf(requireNonNull(costs, "costs is null"));
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
@@ -531,7 +531,7 @@ public class TestCostCalculator
         }
 
         @Override
-        public PlanNodeCostEstimate getCumulativeCost(PlanNode node)
+        public PlanCostEstimate getCumulativeCost(PlanNode node)
         {
             if (costs.containsKey(node.getId().toString())) {
                 return costs.get(node.getId().toString());
@@ -539,11 +539,11 @@ public class TestCostCalculator
             return calculateCumulativeCost(node);
         }
 
-        private PlanNodeCostEstimate calculateCumulativeCost(PlanNode node)
+        private PlanCostEstimate calculateCumulativeCost(PlanNode node)
         {
-            PlanNodeCostEstimate sourcesCost = node.getSources().stream()
+            PlanCostEstimate sourcesCost = node.getSources().stream()
                     .map(this::getCumulativeCost)
-                    .reduce(PlanNodeCostEstimate.zero(), PlanNodeCostEstimate::add);
+                    .reduce(PlanCostEstimate.zero(), PlanCostEstimate::add);
 
             return costCalculator.calculateCost(node, statsProvider, session, types).add(sourcesCost);
         }
@@ -552,12 +552,12 @@ public class TestCostCalculator
     private CostAssertionBuilder assertCost(
             CostCalculator costCalculator,
             PlanNode node,
-            Map<String, PlanNodeCostEstimate> costs,
+            Map<String, PlanCostEstimate> costs,
             Map<String, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
         Function<PlanNode, PlanNodeStatsEstimate> statsProvider = planNode -> stats.get(planNode.getId().toString());
-        PlanNodeCostEstimate cumulativeCost = calculateCumulativeCost(
+        PlanCostEstimate cumulativeCost = calculateCumulativeCost(
                 costCalculator,
                 node,
                 sourceCostProvider(costCalculator, costs, statsProvider, types),
@@ -566,14 +566,14 @@ public class TestCostCalculator
         return new CostAssertionBuilder(cumulativeCost);
     }
 
-    private Function<PlanNode, PlanNodeCostEstimate> sourceCostProvider(
+    private Function<PlanNode, PlanCostEstimate> sourceCostProvider(
             CostCalculator costCalculator,
-            Map<String, PlanNodeCostEstimate> costs,
+            Map<String, PlanCostEstimate> costs,
             Function<PlanNode, PlanNodeStatsEstimate> statsProvider,
             Map<String, Type> types)
     {
         return node -> {
-            PlanNodeCostEstimate providedCost = costs.get(node.getId().toString());
+            PlanCostEstimate providedCost = costs.get(node.getId().toString());
             if (providedCost != null) {
                 return providedCost;
             }
@@ -591,14 +591,14 @@ public class TestCostCalculator
         new CostAssertionBuilder(calculateCumulativeCost(
                 costCalculatorUsingExchanges,
                 node,
-                planNode -> PlanNodeCostEstimate.unknown(),
+                planNode -> PlanCostEstimate.unknown(),
                 planNode -> PlanNodeStatsEstimate.unknown(),
                 types))
                 .hasUnknownComponents();
         new CostAssertionBuilder(calculateCumulativeCost(
                 costCalculatorWithEstimatedExchanges,
                 node,
-                planNode -> PlanNodeCostEstimate.unknown(),
+                planNode -> PlanCostEstimate.unknown(),
                 planNode -> PlanNodeStatsEstimate.unknown(),
                 types))
                 .hasUnknownComponents();
@@ -607,8 +607,8 @@ public class TestCostCalculator
     private void assertFragmentedEqualsUnfragmented(PlanNode node, Map<String, PlanNodeStatsEstimate> stats, Map<String, Type> types)
     {
         StatsCalculator statsCalculator = statsCalculator(stats);
-        PlanNodeCostEstimate costWithExchanges = calculateCumulativeCost(node, costCalculatorUsingExchanges, statsCalculator, types);
-        PlanNodeCostEstimate costWithFragments = calculateCumulativeCostFragmentedPlan(node, statsCalculator, types);
+        PlanCostEstimate costWithExchanges = calculateCumulativeCost(node, costCalculatorUsingExchanges, statsCalculator, types);
+        PlanCostEstimate costWithFragments = calculateCumulativeCostFragmentedPlan(node, statsCalculator, types);
         assertEquals(costWithExchanges, costWithFragments);
     }
 
@@ -618,27 +618,27 @@ public class TestCostCalculator
                 requireNonNull(stats.get(node.getId().toString()), "no stats for node");
     }
 
-    private PlanNodeCostEstimate calculateCumulativeCost(
+    private PlanCostEstimate calculateCumulativeCost(
             CostCalculator costCalculator,
             PlanNode node,
-            Function<PlanNode, PlanNodeCostEstimate> costs,
+            Function<PlanNode, PlanCostEstimate> costs,
             Function<PlanNode, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
-        PlanNodeCostEstimate localCost = costCalculator.calculateCost(
+        PlanCostEstimate localCost = costCalculator.calculateCost(
                 node,
                 planNode -> requireNonNull(stats.apply(planNode), "no stats for node"),
                 session,
                 TypeProvider.copyOf(types.entrySet().stream()
                         .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))));
 
-        PlanNodeCostEstimate sourcesCost = node.getSources().stream()
+        PlanCostEstimate sourcesCost = node.getSources().stream()
                 .map(source -> requireNonNull(costs.apply(source), format("no cost for source: %s", source.getId())))
-                .reduce(PlanNodeCostEstimate.zero(), PlanNodeCostEstimate::add);
+                .reduce(PlanCostEstimate.zero(), PlanCostEstimate::add);
         return sourcesCost.add(localCost);
     }
 
-    private PlanNodeCostEstimate calculateCumulativeCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
+    private PlanCostEstimate calculateCumulativeCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
@@ -647,21 +647,21 @@ public class TestCostCalculator
         return costProvider.getCumulativeCost(node);
     }
 
-    private PlanNodeCostEstimate calculateCumulativeCostFragmentedPlan(PlanNode node, StatsCalculator statsCalculator, Map<String, Type> types)
+    private PlanCostEstimate calculateCumulativeCostFragmentedPlan(PlanNode node, StatsCalculator statsCalculator, Map<String, Type> types)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types.entrySet().stream()
                 .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue)));
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider);
         CostProvider costProvider = new CachingCostProvider(costCalculatorUsingExchanges, statsProvider, Optional.empty(), session, typeProvider);
         SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
-        return subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanNodeCostEstimate.unknown());
+        return subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown());
     }
 
     private static class CostAssertionBuilder
     {
-        private final PlanNodeCostEstimate actual;
+        private final PlanCostEstimate actual;
 
-        CostAssertionBuilder(PlanNodeCostEstimate actual)
+        CostAssertionBuilder(PlanCostEstimate actual)
         {
             this.actual = requireNonNull(actual, "actual is null");
         }

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -74,7 +74,6 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.cost.PlanCostEstimate.cpuCost;
 import static io.prestosql.metadata.FunctionKind.AGGREGATE;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.plugin.tpch.TpchTransactionHandle.INSTANCE;
@@ -536,16 +535,7 @@ public class TestCostCalculator
             if (costs.containsKey(node.getId().toString())) {
                 return costs.get(node.getId().toString());
             }
-            return calculateCumulativeCost(node);
-        }
-
-        private PlanCostEstimate calculateCumulativeCost(PlanNode node)
-        {
-            PlanCostEstimate sourcesCost = node.getSources().stream()
-                    .map(this::getCumulativeCost)
-                    .reduce(PlanCostEstimate.zero(), PlanCostEstimate::add);
-
-            return costCalculator.calculateCost(node, statsProvider, session, types).add(sourcesCost);
+            return costCalculator.calculateCost(node, statsProvider, this, session, types);
         }
     }
 
@@ -625,17 +615,13 @@ public class TestCostCalculator
             Function<PlanNode, PlanNodeStatsEstimate> stats,
             Map<String, Type> types)
     {
-        PlanCostEstimate localCost = costCalculator.calculateCost(
+        return costCalculator.calculateCost(
                 node,
                 planNode -> requireNonNull(stats.apply(planNode), "no stats for node"),
+                source -> requireNonNull(costs.apply(source), format("no cost for source: %s", source.getId())),
                 session,
                 TypeProvider.copyOf(types.entrySet().stream()
                         .collect(ImmutableMap.toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))));
-
-        PlanCostEstimate sourcesCost = node.getSources().stream()
-                .map(source -> requireNonNull(costs.apply(source), format("no cost for source: %s", source.getId())))
-                .reduce(PlanCostEstimate.zero(), PlanCostEstimate::add);
-        return sourcesCost.add(localCost);
     }
 
     private PlanCostEstimate calculateCumulativeCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
@@ -805,5 +791,10 @@ public class TestCostCalculator
                     session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
                     return transactionSessionConsumer.apply(session);
                 });
+    }
+
+    private static PlanCostEstimate cpuCost(double cpuCost)
+    {
+        return new PlanCostEstimate(cpuCost, 0, 0);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostComparator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostComparator.java
@@ -69,9 +69,9 @@ public class TestCostComparator
     {
         CostComparator costComparator = new CostComparator(1.0, 1.0, 1.0);
         Session session = testSessionBuilder().build();
-        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanNodeCostEstimate.zero(), PlanNodeCostEstimate.unknown()));
-        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanNodeCostEstimate.unknown(), PlanNodeCostEstimate.zero()));
-        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanNodeCostEstimate.unknown(), PlanNodeCostEstimate.unknown()));
+        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanCostEstimate.zero(), PlanCostEstimate.unknown()));
+        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanCostEstimate.unknown(), PlanCostEstimate.zero()));
+        assertThrows(IllegalArgumentException.class, () -> costComparator.compare(session, PlanCostEstimate.unknown(), PlanCostEstimate.unknown()));
     }
 
     private static class CostComparisonAssertion
@@ -79,8 +79,8 @@ public class TestCostComparator
         private final CostComparator costComparator;
         private final Session session = testSessionBuilder().build();
 
-        private PlanNodeCostEstimate smaller;
-        private PlanNodeCostEstimate larger;
+        private PlanCostEstimate smaller;
+        private PlanCostEstimate larger;
 
         public CostComparisonAssertion(double cpuWeight, double memoryWeight, double networkWeight)
         {
@@ -98,14 +98,14 @@ public class TestCostComparator
         public CostComparisonAssertion smaller(double cpu, double memory, double network)
         {
             checkState(smaller == null, "already set");
-            smaller = new PlanNodeCostEstimate(cpu, memory, network);
+            smaller = new PlanCostEstimate(cpu, memory, network);
             return this;
         }
 
         public CostComparisonAssertion larger(double cpu, double memory, double network)
         {
             checkState(larger == null, "already set");
-            larger = new PlanNodeCostEstimate(cpu, memory, network);
+            larger = new PlanCostEstimate(cpu, memory, network);
             return this;
         }
     }

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostComparator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostComparator.java
@@ -98,14 +98,14 @@ public class TestCostComparator
         public CostComparisonAssertion smaller(double cpu, double memory, double network)
         {
             checkState(smaller == null, "already set");
-            smaller = new PlanCostEstimate(cpu, memory, network);
+            smaller = new PlanCostEstimate(cpu, memory, 0, network);
             return this;
         }
 
         public CostComparisonAssertion larger(double cpu, double memory, double network)
         {
             checkState(larger == null, "already set");
-            larger = new PlanCostEstimate(cpu, memory, network);
+            larger = new PlanCostEstimate(cpu, memory, 0, network);
             return this;
         }
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
@@ -14,7 +14,7 @@
 package io.prestosql.sql.planner.iterative;
 
 import com.google.common.collect.ImmutableList;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsEstimate;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
 import io.prestosql.sql.planner.Symbol;
@@ -238,8 +238,8 @@ public class TestMemo
         Memo memo = new Memo(idAllocator, x);
         int xGroup = memo.getRootGroup();
         int yGroup = getChildGroup(memo, memo.getRootGroup());
-        PlanNodeCostEstimate yCost = PlanNodeCostEstimate.cpuCost(42);
-        PlanNodeCostEstimate xCost = yCost.add(PlanNodeCostEstimate.networkCost(37));
+        PlanCostEstimate yCost = PlanCostEstimate.cpuCost(42);
+        PlanCostEstimate xCost = yCost.add(PlanCostEstimate.networkCost(37));
 
         memo.storeCumulativeCost(yGroup, yCost);
         memo.storeCumulativeCost(xGroup, xCost);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
@@ -238,8 +238,8 @@ public class TestMemo
         Memo memo = new Memo(idAllocator, x);
         int xGroup = memo.getRootGroup();
         int yGroup = getChildGroup(memo, memo.getRootGroup());
-        PlanCostEstimate yCost = PlanCostEstimate.cpuCost(42);
-        PlanCostEstimate xCost = yCost.add(PlanCostEstimate.networkCost(37));
+        PlanCostEstimate yCost = new PlanCostEstimate(42, 0, 0);
+        PlanCostEstimate xCost = new PlanCostEstimate(42, 0, 37);
 
         memo.storeCumulativeCost(yGroup, yCost);
         memo.storeCumulativeCost(xGroup, xCost);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
@@ -238,8 +238,8 @@ public class TestMemo
         Memo memo = new Memo(idAllocator, x);
         int xGroup = memo.getRootGroup();
         int yGroup = getChildGroup(memo, memo.getRootGroup());
-        PlanCostEstimate yCost = new PlanCostEstimate(42, 0, 0);
-        PlanCostEstimate xCost = new PlanCostEstimate(42, 0, 37);
+        PlanCostEstimate yCost = new PlanCostEstimate(42, 0, 0, 0);
+        PlanCostEstimate xCost = new PlanCostEstimate(42, 0, 0, 37);
 
         memo.storeCost(yGroup, yCost);
         memo.storeCost(xGroup, xCost);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/TestMemo.java
@@ -241,16 +241,16 @@ public class TestMemo
         PlanCostEstimate yCost = new PlanCostEstimate(42, 0, 0);
         PlanCostEstimate xCost = new PlanCostEstimate(42, 0, 37);
 
-        memo.storeCumulativeCost(yGroup, yCost);
-        memo.storeCumulativeCost(xGroup, xCost);
+        memo.storeCost(yGroup, yCost);
+        memo.storeCost(xGroup, xCost);
 
-        assertEquals(memo.getCumulativeCost(yGroup), Optional.of(yCost));
-        assertEquals(memo.getCumulativeCost(xGroup), Optional.of(xCost));
+        assertEquals(memo.getCost(yGroup), Optional.of(yCost));
+        assertEquals(memo.getCost(xGroup), Optional.of(xCost));
 
         memo.replace(yGroup, node(), "rule");
 
-        assertEquals(memo.getCumulativeCost(yGroup), Optional.empty());
-        assertEquals(memo.getCumulativeCost(xGroup), Optional.empty());
+        assertEquals(memo.getCost(yGroup), Optional.empty());
+        assertEquals(memo.getCost(xGroup), Optional.empty());
     }
 
     private static void assertMatchesStructure(PlanNode actual, PlanNode expected)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -21,7 +21,7 @@ import io.prestosql.cost.CachingCostProvider;
 import io.prestosql.cost.CachingStatsProvider;
 import io.prestosql.cost.CostComparator;
 import io.prestosql.cost.CostProvider;
-import io.prestosql.cost.PlanNodeCostEstimate;
+import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
@@ -103,7 +103,7 @@ public class TestJoinEnumerator
                 createContext());
         JoinEnumerationResult actual = joinEnumerator.createJoinAccordingToPartitioning(multiJoinNode.getSources(), multiJoinNode.getOutputSymbols(), ImmutableSet.of(0));
         assertFalse(actual.getPlanNode().isPresent());
-        assertEquals(actual.getCost(), PlanNodeCostEstimate.infinite());
+        assertEquals(actual.getCost(), PlanCostEstimate.infinite());
     }
 
     private Rule.Context createContext()


### PR DESCRIPTION
A different approach to https://github.com/prestosql/presto/pull/108, building upon https://github.com/prestosql/presto/pull/210

