### PR TITLE
Support Parquet v2 dictionary filtering

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.hive.parquet.predicate;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.prestosql.parquet.RichColumnDescriptor;
 import io.prestosql.plugin.hive.HiveColumnHandle;
@@ -27,7 +26,6 @@ import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.StandardTypes;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.Encoding;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -36,11 +34,8 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import static com.google.common.collect.Sets.union;
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
-import static io.prestosql.parquet.predicate.PredicateUtils.isOnlyDictionaryEncodingPages;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory.getParquetTupleDomain;
 import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
@@ -48,44 +43,16 @@ import static io.prestosql.spi.predicate.TupleDomain.withColumnDomains;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TypeSignature.parseTypeSignature;
-import static org.apache.parquet.column.Encoding.BIT_PACKED;
-import static org.apache.parquet.column.Encoding.PLAIN;
-import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
-import static org.apache.parquet.column.Encoding.RLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestParquetPredicateUtils
 {
-    @Test
-    @SuppressWarnings("deprecation")
-    public void testDictionaryEncodingCasesV1()
-    {
-        Set<Encoding> required = ImmutableSet.of(BIT_PACKED);
-        Set<Encoding> optional = ImmutableSet.of(BIT_PACKED, RLE);
-        Set<Encoding> repeated = ImmutableSet.of(RLE);
-
-        Set<Encoding> notDictionary = ImmutableSet.of(PLAIN);
-        Set<Encoding> mixedDictionary = ImmutableSet.of(PLAIN_DICTIONARY, PLAIN);
-        Set<Encoding> dictionary = ImmutableSet.of(PLAIN_DICTIONARY);
-
-        assertFalse(isOnlyDictionaryEncodingPages(union(required, notDictionary)), "required notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(optional, notDictionary)), "optional notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, notDictionary)), "repeated notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(required, mixedDictionary)), "required mixedDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(optional, mixedDictionary)), "optional mixedDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, mixedDictionary)), "repeated mixedDictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(required, dictionary)), "required dictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(optional, dictionary)), "optional dictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(repeated, dictionary)), "repeated dictionary");
-    }
-
     @Test
     public void testParquetTupleDomainPrimitiveArray()
     {

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
@@ -28,6 +28,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.format.DictionaryPageHeader;
 import org.apache.parquet.format.PageHeader;
@@ -118,7 +119,7 @@ public final class PredicateUtils
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
             RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
             if (descriptor != null) {
-                if (isOnlyDictionaryEncodingPages(columnMetaData.getEncodings()) && isColumnPredicate(descriptor, parquetTupleDomain)) {
+                if (isOnlyDictionaryEncodingPages(columnMetaData) && isColumnPredicate(descriptor, parquetTupleDomain)) {
                     int totalSize = toIntExact(columnMetaData.getTotalSize());
                     byte[] buffer = new byte[totalSize];
                     dataSource.readFully(columnMetaData.getStartingPos(), buffer);
@@ -161,9 +162,16 @@ public final class PredicateUtils
 
     @VisibleForTesting
     @SuppressWarnings("deprecation")
-    static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
+    static boolean isOnlyDictionaryEncodingPages(ColumnChunkMetaData columnMetaData)
     {
-        // TODO: update to use EncodingStats in ColumnChunkMetaData when available
+        // Files written with newer versions of Parquet libraries (e.g. parquet-mr 1.9.0) will have EncodingStats available
+        // Otherwise, fallback to v1 logic
+        EncodingStats stats = columnMetaData.getEncodingStats();
+        if (stats != null) {
+            return stats.hasDictionaryPages() && !stats.hasNonDictionaryEncodedPages();
+        }
+
+        Set<Encoding> encodings = columnMetaData.getEncodings();
         if (encodings.contains(PLAIN_DICTIONARY)) {
             // PLAIN_DICTIONARY was present, which means at least one page was
             // dictionary-encoded and 1.0 encodings are used
@@ -171,10 +179,6 @@ public final class PredicateUtils
             return Sets.difference(encodings, ImmutableSet.of(PLAIN_DICTIONARY, RLE, BIT_PACKED)).isEmpty();
         }
 
-        // if PLAIN_DICTIONARY wasn't present, then either the column is not
-        // dictionary-encoded, or the 2.0 encoding, RLE_DICTIONARY, was used.
-        // for 2.0, this cannot determine whether a page fell back without
-        // page encoding stats
         return false;
     }
 }

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
@@ -161,7 +161,7 @@ public final class PredicateUtils
 
     @VisibleForTesting
     @SuppressWarnings("deprecation")
-    public static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
+    static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
     {
         // TODO: update to use EncodingStats in ColumnChunkMetaData when available
         if (encodings.contains(PLAIN_DICTIONARY)) {

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/MetadataReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/MetadataReader.java
@@ -26,6 +26,7 @@ import org.apache.parquet.format.RowGroup;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.format.Statistics;
 import org.apache.parquet.format.Type;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
@@ -59,6 +60,7 @@ public final class MetadataReader
 {
     private static final int PARQUET_METADATA_LENGTH = 4;
     private static final byte[] MAGIC = "PAR1".getBytes(US_ASCII);
+    private static final ParquetMetadataConverter PARQUET_METADATA_CONVERTER = new ParquetMetadataConverter();
 
     private MetadataReader() {}
 
@@ -129,6 +131,7 @@ public final class MetadataReader
                             columnPath,
                             primitiveTypeName,
                             CompressionCodecName.fromParquet(metaData.codec),
+                            PARQUET_METADATA_CONVERTER.convertEncodingStats(metaData.encoding_stats),
                             readEncodings(metaData.encodings),
                             readStats(metaData.statistics, primitiveTypeName),
                             metaData.data_page_offset,

--- a/presto-parquet/src/test/java/io/prestosql/parquet/predicate/TestPredicateUtils.java
+++ b/presto-parquet/src/test/java/io/prestosql/parquet/predicate/TestPredicateUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.parquet.predicate;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.parquet.column.Encoding;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.google.common.collect.Sets.union;
+import static io.prestosql.parquet.predicate.PredicateUtils.isOnlyDictionaryEncodingPages;
+import static org.apache.parquet.column.Encoding.BIT_PACKED;
+import static org.apache.parquet.column.Encoding.PLAIN;
+import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
+import static org.apache.parquet.column.Encoding.RLE;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestPredicateUtils
+{
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDictionaryEncodingCasesV1()
+    {
+        Set<Encoding> required = ImmutableSet.of(BIT_PACKED);
+        Set<Encoding> optional = ImmutableSet.of(BIT_PACKED, RLE);
+        Set<Encoding> repeated = ImmutableSet.of(RLE);
+
+        Set<Encoding> notDictionary = ImmutableSet.of(PLAIN);
+        Set<Encoding> mixedDictionary = ImmutableSet.of(PLAIN_DICTIONARY, PLAIN);
+        Set<Encoding> dictionary = ImmutableSet.of(PLAIN_DICTIONARY);
+
+        assertFalse(isOnlyDictionaryEncodingPages(union(required, notDictionary)), "required notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(union(optional, notDictionary)), "optional notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, notDictionary)), "repeated notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(union(required, mixedDictionary)), "required mixedDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(union(optional, mixedDictionary)), "optional mixedDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, mixedDictionary)), "repeated mixedDictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(union(required, dictionary)), "required dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(union(optional, dictionary)), "optional dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(union(repeated, dictionary)), "repeated dictionary");
+    }
+}

--- a/presto-parquet/src/test/java/io/prestosql/parquet/predicate/TestPredicateUtils.java
+++ b/presto-parquet/src/test/java/io/prestosql/parquet/predicate/TestPredicateUtils.java
@@ -15,6 +15,9 @@ package io.prestosql.parquet.predicate;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.testng.annotations.Test;
 
 import java.util.Set;
@@ -25,6 +28,10 @@ import static org.apache.parquet.column.Encoding.BIT_PACKED;
 import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
 import static org.apache.parquet.column.Encoding.RLE;
+import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
+import static org.apache.parquet.hadoop.metadata.ColumnPath.fromDotString;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -32,7 +39,7 @@ public class TestPredicateUtils
 {
     @Test
     @SuppressWarnings("deprecation")
-    public void testDictionaryEncodingCasesV1()
+    public void testDictionaryEncodingV1()
     {
         Set<Encoding> required = ImmutableSet.of(BIT_PACKED);
         Set<Encoding> optional = ImmutableSet.of(BIT_PACKED, RLE);
@@ -42,14 +49,42 @@ public class TestPredicateUtils
         Set<Encoding> mixedDictionary = ImmutableSet.of(PLAIN_DICTIONARY, PLAIN);
         Set<Encoding> dictionary = ImmutableSet.of(PLAIN_DICTIONARY);
 
-        assertFalse(isOnlyDictionaryEncodingPages(union(required, notDictionary)), "required notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(optional, notDictionary)), "optional notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, notDictionary)), "repeated notDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(required, mixedDictionary)), "required mixedDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(optional, mixedDictionary)), "optional mixedDictionary");
-        assertFalse(isOnlyDictionaryEncodingPages(union(repeated, mixedDictionary)), "repeated mixedDictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(required, dictionary)), "required dictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(optional, dictionary)), "optional dictionary");
-        assertTrue(isOnlyDictionaryEncodingPages(union(repeated, dictionary)), "repeated dictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(required, notDictionary))), "required notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(optional, notDictionary))), "optional notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(repeated, notDictionary))), "repeated notDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(required, mixedDictionary))), "required mixedDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(optional, mixedDictionary))), "optional mixedDictionary");
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(repeated, mixedDictionary))), "repeated mixedDictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(required, dictionary))), "required dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(optional, dictionary))), "optional dictionary");
+        assertTrue(isOnlyDictionaryEncodingPages(createColumnMetaDataV1(union(repeated, dictionary))), "repeated dictionary");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDictionaryEncodingV2()
+    {
+        assertTrue(isOnlyDictionaryEncodingPages(createColumnMetaDataV2(RLE_DICTIONARY)));
+        assertTrue(isOnlyDictionaryEncodingPages(createColumnMetaDataV2(PLAIN_DICTIONARY)));
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV2(PLAIN)));
+
+        // Simulate fallback to plain encoding e.g. too many unique entries
+        assertFalse(isOnlyDictionaryEncodingPages(createColumnMetaDataV2(RLE_DICTIONARY, PLAIN)));
+    }
+
+    private ColumnChunkMetaData createColumnMetaDataV2(Encoding... dataEncodings)
+    {
+        EncodingStats encodingStats = new EncodingStats.Builder()
+                .withV2Pages()
+                .addDictEncoding(PLAIN)
+                .addDataEncodings(ImmutableSet.copyOf(dataEncodings)).build();
+
+        return ColumnChunkMetaData.get(fromDotString("column"), BINARY, UNCOMPRESSED, encodingStats, encodingStats.getDataEncodings(), new BinaryStatistics(), 0, 0, 1, 1, 1);
+    }
+
+    @SuppressWarnings("deprecation")
+    private ColumnChunkMetaData createColumnMetaDataV1(Set<Encoding> encodings)
+    {
+        return ColumnChunkMetaData.get(fromDotString("column"), BINARY, UNCOMPRESSED, encodings, new BinaryStatistics(), 0, 0, 1, 1, 1);
     }
 }


### PR DESCRIPTION
Use page encoding stats if they're available to determine if all pages
are dictionary encoded enabling the use of dictionary filtering.