### PR TITLE
Skip unsupported types when pushing down in Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartitionManager.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartitionManager.java
@@ -152,7 +152,9 @@ public class CassandraPartitionManager
                             Object value = range.getSingleValue();
 
                             CassandraType valueType = columnHandle.getCassandraType();
-                            columnValues.add(valueType.validatePartitionKey(value));
+                            if (valueType.isSupportedPartitionKey()) {
+                                columnValues.add(value);
+                            }
                         }
                         return columnValues.build();
                     },

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
@@ -427,7 +427,7 @@ public enum CassandraType
         }
     }
 
-    public Object validatePartitionKey(Object value)
+    public boolean isSupportedPartitionKey()
     {
         switch (this) {
             case ASCII:
@@ -443,7 +443,7 @@ public enum CassandraType
             case TIMESTAMP:
             case UUID:
             case TIMEUUID:
-                return value;
+                return true;
             case COUNTER:
             case BLOB:
             case CUSTOM:
@@ -452,8 +452,7 @@ public enum CassandraType
             case LIST:
             case MAP:
             default:
-                // todo should we just skip partition pruning instead of throwing an exception?
-                throw new PrestoException(NOT_SUPPORTED, "Unsupport partition key type: " + this);
+                return false;
         }
     }
 

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraTestingUtils.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraTestingUtils.java
@@ -197,23 +197,23 @@ public class CassandraTestingUtils
                 "   typeinteger, " +
                 "   typelong, " +
                 // TODO: NOT YET SUPPORTED AS A PARTITION KEY
-                // "   typebytes, " +
+                "   typebytes, " +
                 "   typetimestamp, " +
                 "   typeansi, " +
                 "   typeboolean, " +
                 // TODO: PRECISION LOST. IMPLEMENT IT AS STRING
-                //  "   typedecimal, " +
+                "   typedecimal, " +
                 "   typedouble, " +
                 "   typefloat, " +
                 "   typeinet, " +
                 "   typevarchar, " +
                 // TODO: NOT YET SUPPORTED AS A PARTITION KEY
-                // "   typevarint, " +
-                "   typetimeuuid " +
+                "   typevarint, " +
+                "   typetimeuuid, " +
                 // TODO: NOT YET SUPPORTED AS A PARTITION KEY
-                // "   typelist, " +
-                // "   typemap, " +
-                // "   typeset" +
+                "   typelist, " +
+                "   typemap, " +
+                "   typeset" +
                 " ))" +
                 ")");
 


### PR DESCRIPTION
Before this change, we couldn't use some cassandra column types (blob, decimal, varint, timeuuid, list, map, set) in WHERE clause. 