### PR TITLE
Pass session to JdbcClient#toWriteMapping

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -281,18 +281,18 @@ public class BaseJdbcClient
     }
 
     @Override
-    public JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata)
+    public JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
-        return beginWriteTable(tableMetadata);
+        return beginWriteTable(session, tableMetadata);
     }
 
     @Override
-    public JdbcOutputTableHandle beginInsertTable(ConnectorTableMetadata tableMetadata)
+    public JdbcOutputTableHandle beginInsertTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
-        return beginWriteTable(tableMetadata);
+        return beginWriteTable(session, tableMetadata);
     }
 
-    private JdbcOutputTableHandle beginWriteTable(ConnectorTableMetadata tableMetadata)
+    private JdbcOutputTableHandle beginWriteTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
         SchemaTableName schemaTableName = tableMetadata.getTable();
         String schema = schemaTableName.getSchemaName();
@@ -323,7 +323,7 @@ public class BaseJdbcClient
                 columnNames.add(columnName);
                 columnTypes.add(column.getType());
                 // TODO in INSERT case, we should reuse original column type and, ideally, constraints (then JdbcPageSink must get writer from toPrestoType())
-                columnList.add(format("%s %s", quoted(columnName), toWriteMapping(column.getType()).getDataType()));
+                columnList.add(format("%s %s", quoted(columnName), toWriteMapping(session, column.getType()).getDataType()));
             }
 
             String sql = format(
@@ -473,7 +473,7 @@ public class BaseJdbcClient
     }
 
     @Override
-    public WriteMapping toWriteMapping(Type type)
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
         if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -49,7 +49,7 @@ public interface JdbcClient
 
     Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle);
 
-    WriteMapping toWriteMapping(Type type);
+    WriteMapping toWriteMapping(ConnectorSession session, Type type);
 
     ConnectorSplitSource getSplits(JdbcTableLayoutHandle layoutHandle);
 
@@ -65,11 +65,11 @@ public interface JdbcClient
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
 
-    JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);
+    JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
     void commitCreateTable(JdbcOutputTableHandle handle);
 
-    JdbcOutputTableHandle beginInsertTable(ConnectorTableMetadata tableMetadata);
+    JdbcOutputTableHandle beginInsertTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
     void finishInsertTable(JdbcOutputTableHandle handle);
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -165,7 +165,7 @@ public class JdbcMetadata
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
-        JdbcOutputTableHandle handle = jdbcClient.beginCreateTable(tableMetadata);
+        JdbcOutputTableHandle handle = jdbcClient.beginCreateTable(session, tableMetadata);
         setRollback(() -> jdbcClient.rollbackCreateTable(handle));
         return handle;
     }
@@ -197,7 +197,7 @@ public class JdbcMetadata
     @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        JdbcOutputTableHandle handle = jdbcClient.beginInsertTable(getTableMetadata(session, tableHandle));
+        JdbcOutputTableHandle handle = jdbcClient.beginInsertTable(session, getTableMetadata(session, tableHandle));
         setRollback(() -> jdbcClient.rollbackCreateTable(handle));
         return handle;
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSink;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
 
 import java.sql.Connection;
@@ -47,7 +48,7 @@ public class JdbcPageSink
     private final List<WriteFunction> columnWriters;
     private int batchSize;
 
-    public JdbcPageSink(JdbcOutputTableHandle handle, JdbcClient jdbcClient)
+    public JdbcPageSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient)
     {
         try {
             connection = jdbcClient.getConnection(handle);
@@ -69,7 +70,7 @@ public class JdbcPageSink
 
         columnWriters = columnTypes.stream()
                 .map(type -> {
-                    WriteFunction writeFunction = jdbcClient.toWriteMapping(type).getWriteFunction();
+                    WriteFunction writeFunction = jdbcClient.toWriteMapping(session, type).getWriteFunction();
                     verify(
                             type.getJavaType() == writeFunction.getJavaType(),
                             "Presto type %s is not compatible with write function %s accepting %s",

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSinkProvider.java
@@ -38,12 +38,12 @@ public class JdbcPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
     {
-        return new JdbcPageSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
     {
-        return new JdbcPageSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return new JdbcPageSink(session, (JdbcOutputTableHandle) tableHandle, jdbcClient);
     }
 }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcConnectorId;
 import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
@@ -148,7 +149,7 @@ public class MySqlClient
     }
 
     @Override
-    public WriteMapping toWriteMapping(Type type)
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
         if (REAL.equals(type)) {
             return WriteMapping.longMapping("float", realWriteFunction());
@@ -183,6 +184,6 @@ public class MySqlClient
             return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
         }
 
-        return super.toWriteMapping(type);
+        return super.toWriteMapping(session, type);
     }
 }

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -95,12 +95,12 @@ public class PostgreSqlClient
     }
 
     @Override
-    public WriteMapping toWriteMapping(Type type)
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("bytea", varbinaryWriteFunction());
         }
 
-        return super.toWriteMapping(type);
+        return super.toWriteMapping(session, type);
     }
 }


### PR DESCRIPTION
Write function may be session-dependent. In particular, write function
for timestamp should depend on
`io.prestosql.spi.connector.ConnectorSession#isLegacyTimestamp` value.