### PR TITLE
Updated RPM installation & removal behavior

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -168,6 +168,10 @@
                                     <includes>
                                         <include>*</include>
                                     </includes>
+                                    <directives>
+                                        <directive>config</directive>
+                                        <directive>noreplace</directive>
+                                    </directives>
                                 </rule>
 
                                 <rule>

--- a/presto-server-rpm/src/main/rpm/postremove
+++ b/presto-server-rpm/src/main/rpm/postremove
@@ -3,11 +3,16 @@
 # if this is the last version of presto-server-rpm being removed (i.e. not on upgrade)
 if [ "$1" -eq 0 ]
 then
-    # Delete the conf directory manually during uninstall.
-    # rpm -e wont remove it, because this directory was manually updated in postinstall
-    rm -rf /etc/presto
+    # Delete /etc/presto/env.sh manually during uninstall.
+    # rpm -e wont remove it, because this file is created during preinstall
+    rm -f /etc/presto/env.sh
     # Delete the data directory manually during uninstall.
     # rpm -e wont remove it, because this directory may later contain files not
     # deployed by the rpm
     rm -rf /var/lib/presto
+    # Remove /etc/presto directory if no other files present
+    if [ -z "$(ls -A /etc/presto)" ]
+    then
+        rm -rf /etc/presto
+    fi
 fi


### PR DESCRIPTION
If you only have one RPM installed or you need to downgrade (and don’t know about oldpackage or noscripts), you can end up removing a good configuration directory by accident. Some configuration management systems handle RPM installations differently or don't have any context about downgrading. 

Removing the /etc/presto cleanup removes the risk for operations accidents and places the responsibility on the operator to cleanup the directory. This is fairly normal with removal of other RPM packages where operators may have created custom configuration files. 