### PR TITLE
Add Failure Aware Hive MetaStore Client

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -1,0 +1,433 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
+import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
+import org.apache.hadoop.hive.metastore.api.Role;
+import org.apache.hadoop.hive.metastore.api.RolePrincipalGrant;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class FailureAwareThriftMetastoreClient
+        implements ThriftMetastoreClient
+{
+    public interface Callback
+    {
+        void success();
+
+        void failed(TException e);
+    }
+
+    private final ThriftMetastoreClient delegate;
+    private final Callback callback;
+
+    public FailureAwareThriftMetastoreClient(ThriftMetastoreClient client, Callback callback)
+    {
+        this.delegate = requireNonNull(client, "client is null");
+        this.callback = requireNonNull(callback, "callback is null");
+    }
+
+    @VisibleForTesting
+    public ThriftMetastoreClient getDelegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+
+    @Override
+    public List<String> getAllDatabases()
+            throws TException
+    {
+        return runWithHandle(delegate::getAllDatabases);
+    }
+
+    @Override
+    public Database getDatabase(String databaseName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getDatabase(databaseName));
+    }
+
+    @Override
+    public List<String> getAllTables(String databaseName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getAllTables(databaseName));
+    }
+
+    @Override
+    public List<String> getTableNamesByFilter(String databaseName, String filter)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getTableNamesByFilter(databaseName, filter));
+    }
+
+    @Override
+    public void createDatabase(Database database)
+            throws TException
+    {
+        runWithHandle(() -> delegate.createDatabase(database));
+    }
+
+    @Override
+    public void dropDatabase(String databaseName, boolean deleteData, boolean cascade)
+            throws TException
+    {
+        runWithHandle(() -> delegate.dropDatabase(databaseName, deleteData, cascade));
+    }
+
+    @Override
+    public void alterDatabase(String databaseName, Database database)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterDatabase(databaseName, database));
+    }
+
+    @Override
+    public void createTable(Table table)
+            throws TException
+    {
+        runWithHandle(() -> delegate.createTable(table));
+    }
+
+    @Override
+    public void dropTable(String databaseName, String name, boolean deleteData)
+            throws TException
+    {
+        runWithHandle(() -> delegate.dropTable(databaseName, name, deleteData));
+    }
+
+    @Override
+    public void alterTable(String databaseName, String tableName, Table newTable)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterTable(databaseName, tableName, newTable));
+    }
+
+    @Override
+    public Table getTable(String databaseName, String tableName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getTable(databaseName, tableName));
+    }
+
+    @Override
+    public Table getTableWithCapabilities(String databaseName, String tableName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getTableWithCapabilities(databaseName, tableName));
+    }
+
+    @Override
+    public List<FieldSchema> getFields(String databaseName, String tableName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getFields(databaseName, tableName));
+    }
+
+    @Override
+    public List<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, List<String> columnNames)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getTableColumnStatistics(databaseName, tableName, columnNames));
+    }
+
+    @Override
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setTableColumnStatistics(databaseName, tableName, statistics));
+    }
+
+    @Override
+    public void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
+            throws TException
+    {
+        runWithHandle(() -> delegate.deleteTableColumnStatistics(databaseName, tableName, columnName));
+    }
+
+    @Override
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> partitionNames, List<String> columnNames)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNames, columnNames));
+    }
+
+    @Override
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics));
+    }
+
+    @Override
+    public void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)
+            throws TException
+    {
+        runWithHandle(() -> delegate.deletePartitionColumnStatistics(databaseName, tableName, partitionName, columnName));
+    }
+
+    @Override
+    public List<String> getPartitionNames(String databaseName, String tableName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getPartitionNames(databaseName, tableName));
+    }
+
+    @Override
+    public List<String> getPartitionNamesFiltered(String databaseName, String tableName, List<String> partitionValues)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getPartitionNamesFiltered(databaseName, tableName, partitionValues));
+    }
+
+    @Override
+    public int addPartitions(List<Partition> newPartitions)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.addPartitions(newPartitions));
+    }
+
+    @Override
+    public boolean dropPartition(String databaseName, String tableName, List<String> partitionValues, boolean deleteData)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.dropPartition(databaseName, tableName, partitionValues, deleteData));
+    }
+
+    @Override
+    public void alterPartition(String databaseName, String tableName, Partition partition)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterPartition(databaseName, tableName, partition));
+    }
+
+    @Override
+    public Partition getPartition(String databaseName, String tableName, List<String> partitionValues)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getPartition(databaseName, tableName, partitionValues));
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getPartitionsByNames(databaseName, tableName, partitionNames));
+    }
+
+    @Override
+    public List<Role> listRoles(String principalName, PrincipalType principalType)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.listRoles(principalName, principalType));
+    }
+
+    @Override
+    public List<HiveObjectPrivilege> listPrivileges(String principalName, PrincipalType principalType, HiveObjectRef hiveObjectRef)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.listPrivileges(principalName, principalType, hiveObjectRef));
+    }
+
+    @Override
+    public List<String> getRoleNames()
+            throws TException
+    {
+        return runWithHandle(delegate::getRoleNames);
+    }
+
+    @Override
+    public void createRole(String role, String grantor)
+            throws TException
+    {
+        runWithHandle(() -> delegate.createRole(role, grantor));
+    }
+
+    @Override
+    public void dropRole(String role)
+            throws TException
+    {
+        runWithHandle(() -> delegate.dropRole(role));
+    }
+
+    @Override
+    public boolean grantPrivileges(PrivilegeBag privilegeBag)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.grantPrivileges(privilegeBag));
+    }
+
+    @Override
+    public boolean revokePrivileges(PrivilegeBag privilegeBag)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.revokePrivileges(privilegeBag));
+    }
+
+    @Override
+    public void grantRole(String role, String granteeName, PrincipalType granteeType, String grantorName, PrincipalType grantorType, boolean grantOption)
+            throws TException
+    {
+        runWithHandle(() -> delegate.grantRole(role, granteeName, granteeType, grantorName, grantorType, grantOption));
+    }
+
+    @Override
+    public void revokeRole(String role, String granteeName, PrincipalType granteeType, boolean grantOption)
+            throws TException
+    {
+        runWithHandle(() -> delegate.revokeRole(role, granteeName, granteeType, grantOption));
+    }
+
+    @Override
+    public List<RolePrincipalGrant> listRoleGrants(String name, PrincipalType principalType)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.listRoleGrants(name, principalType));
+    }
+
+    @Override
+    public void setUGI(String userName)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setUGI(userName));
+    }
+
+    @Override
+    public long openTransaction(String user)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.openTransaction(user));
+    }
+
+    @Override
+    public void commitTransaction(long transactionId)
+            throws TException
+    {
+        runWithHandle(() -> delegate.commitTransaction(transactionId));
+    }
+
+    @Override
+    public void sendTransactionHeartbeat(long transactionId)
+            throws TException
+    {
+        runWithHandle(() -> delegate.sendTransactionHeartbeat(transactionId));
+    }
+
+    @Override
+    public LockResponse acquireLock(LockRequest lockRequest)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.acquireLock(lockRequest));
+    }
+
+    @Override
+    public LockResponse checkLock(long lockId)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.checkLock(lockId));
+    }
+
+    @Override
+    public String getValidWriteIds(List<String> tableList, long currentTransactionId)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getValidWriteIds(tableList, currentTransactionId));
+    }
+
+    @Override
+    public String get_config_value(String name, String defaultValue)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.get_config_value(name, defaultValue));
+    }
+
+    @Override
+    public String getDelegationToken(String userName)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.getDelegationToken(userName));
+    }
+
+    private <T> T runWithHandle(ThrowingSupplier<T> supplier)
+            throws TException
+    {
+        try {
+            T result = supplier.get();
+            callback.success();
+            return result;
+        }
+        catch (TException thriftException) {
+            try {
+                callback.failed(thriftException);
+            }
+            catch (RuntimeException callbackException) {
+                callbackException.addSuppressed(thriftException);
+                throw callbackException;
+            }
+            throw thriftException;
+        }
+    }
+
+    private void runWithHandle(ThrowingRunnable runnable)
+            throws TException
+    {
+        try {
+            runnable.run();
+            callback.success();
+        }
+        catch (TException thriftException) {
+            try {
+                callback.failed(thriftException);
+            }
+            catch (RuntimeException callbackException) {
+                callbackException.addSuppressed(thriftException);
+                throw callbackException;
+            }
+            throw thriftException;
+        }
+    }
+
+    private interface ThrowingSupplier<T>
+    {
+        T get()
+                throws TException;
+    }
+
+    private interface ThrowingRunnable
+    {
+        void run()
+                throws TException;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -13,30 +13,41 @@
  */
 package io.prestosql.plugin.hive.metastore.thrift;
 
+import com.google.common.base.Ticker;
 import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
+import io.prestosql.plugin.hive.metastore.thrift.FailureAwareThriftMetastoreClient.Callback;
 import org.apache.thrift.TException;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.hive.metastore.thrift.StaticMetastoreConfig.HIVE_METASTORE_USERNAME;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 
 public class StaticMetastoreLocator
         implements MetastoreLocator
 {
     private final List<HostAndPort> addresses;
+    private final List<Backoff> backoffs;
     private final ThriftMetastoreClientFactory clientFactory;
     private final String metastoreUsername;
 
@@ -60,6 +71,7 @@ public class StaticMetastoreLocator
                 .map(StaticMetastoreLocator::checkMetastoreUri)
                 .map(uri -> HostAndPort.fromParts(uri.getHost(), uri.getPort()))
                 .collect(toList());
+        this.backoffs = IntStream.range(0, addresses.size()).mapToObj(ignore -> new Backoff()).collect(toImmutableList());
         this.metastoreUsername = metastoreUsername;
         this.clientFactory = requireNonNull(clientFactory, "clientFactory is null");
     }
@@ -76,23 +88,44 @@ public class StaticMetastoreLocator
     public ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken)
             throws TException
     {
-        List<HostAndPort> metastores = new ArrayList<>(addresses);
-        Collections.shuffle(metastores.subList(1, metastores.size()));
+        List<Integer> indices = backoffs.stream()
+                .sorted(Comparator.comparingLong(backoff -> backoff.getBackoffDuration()))
+                .map(backoffs::indexOf)
+                .collect(toImmutableList());
 
         TException lastException = null;
-        for (HostAndPort metastore : metastores) {
+        for (int index : indices) {
             try {
-                ThriftMetastoreClient client = clientFactory.create(metastore, delegationToken);
-                if (!isNullOrEmpty(metastoreUsername)) {
-                    client.setUGI(metastoreUsername);
-                }
-                return client;
+                return getClient(addresses.get(index), backoffs.get(index), delegationToken);
             }
             catch (TException e) {
                 lastException = e;
             }
         }
         throw new TException("Failed connecting to Hive metastore: " + addresses, lastException);
+    }
+
+    private ThriftMetastoreClient getClient(HostAndPort address, Backoff backoff, Optional<String> delegationToken)
+            throws TException
+    {
+        ThriftMetastoreClient client = new FailureAwareThriftMetastoreClient(clientFactory.create(address, delegationToken), new Callback()
+        {
+            @Override
+            public void success()
+            {
+                backoff.success();
+            }
+
+            @Override
+            public void failed(TException e)
+            {
+                backoff.fail();
+            }
+        });
+        if (!isNullOrEmpty(metastoreUsername)) {
+            client.setUGI(metastoreUsername);
+        }
+        return client;
     }
 
     private static URI checkMetastoreUri(URI uri)
@@ -104,5 +137,36 @@ public class StaticMetastoreLocator
         checkArgument(uri.getHost() != null, "metastoreUri host is missing: %s", uri);
         checkArgument(uri.getPort() != -1, "metastoreUri port is missing: %s", uri);
         return uri;
+    }
+
+    private static class Backoff
+    {
+        private static final long MIN_BACKOFF = new Duration(50, MILLISECONDS).roundTo(NANOSECONDS);
+        private static final long MAX_BACKOFF = new Duration(60, SECONDS).roundTo(NANOSECONDS);
+
+        private final Ticker ticker = Ticker.systemTicker();
+        private long backoffDuration = MIN_BACKOFF;
+        private OptionalLong lastFailureTimestamps = OptionalLong.empty();
+
+        synchronized void fail()
+        {
+            lastFailureTimestamps = OptionalLong.of(ticker.read());
+            backoffDuration = min(backoffDuration * 2, MAX_BACKOFF);
+        }
+
+        synchronized void success()
+        {
+            lastFailureTimestamps = OptionalLong.empty();
+            backoffDuration = MIN_BACKOFF;
+        }
+
+        synchronized long getBackoffDuration()
+        {
+            if (lastFailureTimestamps.isPresent()) {
+                long timeSinceLastFail = ticker.read() - lastFailureTimestamps.getAsLong();
+                return max(backoffDuration - timeSinceLastFail, 0);
+            }
+            return 0;
+        }
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
@@ -18,23 +18,22 @@ import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.authentication.NoHiveMetastoreAuthentication;
 import org.apache.thrift.transport.TTransportException;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.requireNonNull;
 
 public class MockThriftMetastoreClientFactory
         extends ThriftMetastoreClientFactory
 {
-    private final List<ThriftMetastoreClient> clients;
+    private Map<HostAndPort, Optional<ThriftMetastoreClient>> clients;
 
-    public MockThriftMetastoreClientFactory(Optional<HostAndPort> socksProxy, Duration timeout, List<ThriftMetastoreClient> clients)
+    public MockThriftMetastoreClientFactory(Optional<HostAndPort> socksProxy, Duration timeout, Map<String, Optional<ThriftMetastoreClient>> clients)
     {
         super(Optional.empty(), socksProxy, timeout, new NoHiveMetastoreAuthentication(), "localhost");
-        this.clients = new ArrayList<>(requireNonNull(clients, "clients is null"));
+        this.clients = clients.entrySet().stream().collect(Collectors.toMap(entry -> createHostAndPort(entry.getKey()), Map.Entry::getValue));
     }
 
     @Override
@@ -42,11 +41,16 @@ public class MockThriftMetastoreClientFactory
             throws TTransportException
     {
         checkArgument(!delegationToken.isPresent(), "delegation token is not supported");
-        checkState(!clients.isEmpty(), "mock not given enough clients");
-        ThriftMetastoreClient client = clients.remove(0);
-        if (client == null) {
+        Optional<ThriftMetastoreClient> client = clients.getOrDefault(address, Optional.empty());
+        if (!client.isPresent()) {
             throw new TTransportException(TTransportException.TIMED_OUT);
         }
-        return client;
+        return client.get();
+    }
+
+    private static HostAndPort createHostAndPort(String str)
+    {
+        URI uri = URI.create(str);
+        return HostAndPort.fromParts(uri.getHost(), uri.getPort());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestFailureAwareThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestFailureAwareThriftMetastoreClient.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import org.apache.thrift.TException;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+import static io.prestosql.spi.testing.InterfaceTestUtils.assertProperForwardingMethodsAreCalled;
+
+public class TestFailureAwareThriftMetastoreClient
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(ThriftMetastoreClient.class, FailureAwareThriftMetastoreClient.class);
+    }
+
+    @Test
+    public void testProperForwardingMethodsAreCalled()
+    {
+        FailureAwareThriftMetastoreClient.Callback dummyCallback = new FailureAwareThriftMetastoreClient.Callback()
+        {
+            @Override
+            public void success() {}
+
+            @Override
+            public void failed(TException e) {}
+        };
+        assertProperForwardingMethodsAreCalled(ThriftMetastoreClient.class, client -> new FailureAwareThriftMetastoreClient(client, dummyCallback));
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -13,66 +13,76 @@
  */
 package io.prestosql.plugin.hive.metastore.thrift;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
-import java.util.List;
+import java.net.SocketTimeoutException;
+import java.util.Map;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static io.airlift.testing.Assertions.assertContains;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class TestStaticMetastoreLocator
 {
     private static final ThriftMetastoreClient DEFAULT_CLIENT = createFakeMetastoreClient();
     private static final ThriftMetastoreClient FALLBACK_CLIENT = createFakeMetastoreClient();
 
+    private static final String DEFAULT_URI = "thrift://default:8080";
+    private static final String FALLBACK_URI = "thrift://fallback:8090";
+    private static final String FALLBACK2_URI = "thrift://fallback2:8090";
+
     private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK = new StaticMetastoreConfig()
-            .setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090");
+            .setMetastoreUris(Joiner.on(',').join(DEFAULT_URI, FALLBACK_URI, FALLBACK2_URI));
 
     private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK = new StaticMetastoreConfig()
-            .setMetastoreUris("thrift://default:8080");
+            .setMetastoreUris(DEFAULT_URI);
 
     private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK_WITH_USER = new StaticMetastoreConfig()
-            .setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090")
+            .setMetastoreUris(Joiner.on(',').join(DEFAULT_URI, FALLBACK_URI, FALLBACK2_URI))
             .setMetastoreUsername("presto");
 
     private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK_WITH_USER = new StaticMetastoreConfig()
-            .setMetastoreUris("thrift://default:8080")
+            .setMetastoreUris(DEFAULT_URI)
             .setMetastoreUsername("presto");
+
+    private static final Map<String, Optional<ThriftMetastoreClient>> CLIENTS = ImmutableMap.of(DEFAULT_URI, Optional.of(DEFAULT_CLIENT), FALLBACK_URI, Optional.of(FALLBACK_CLIENT));
 
     @Test
     public void testDefaultHiveMetastore()
             throws TException
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, singletonList(DEFAULT_CLIENT));
-        assertEquals(locator.createMetastoreClient(Optional.empty()), DEFAULT_CLIENT);
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, ImmutableMap.of(DEFAULT_URI, Optional.of(DEFAULT_CLIENT)));
+        assertEqualHiveClient(locator.createMetastoreClient(Optional.empty()), DEFAULT_CLIENT);
     }
 
     @Test
     public void testFallbackHiveMetastore()
             throws TException
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, asList(null, null, FALLBACK_CLIENT));
-        assertEquals(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, ImmutableMap.of(DEFAULT_URI, Optional.empty(), FALLBACK_URI, Optional.of(FALLBACK_CLIENT)));
+        assertEqualHiveClient(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
     }
 
     @Test
     public void testFallbackHiveMetastoreFails()
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, asList(null, null, null));
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, ImmutableMap.of());
         assertCreateClientFails(locator, "Failed connecting to Hive metastore: [default:8080, fallback:8090, fallback2:8090]");
     }
 
     @Test
     public void testMetastoreFailedWithoutFallback()
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITHOUT_FALLBACK, singletonList(null));
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITHOUT_FALLBACK, ImmutableMap.of(DEFAULT_URI, Optional.empty()));
         assertCreateClientFails(locator, "Failed connecting to Hive metastore: [default:8080]");
     }
 
@@ -80,15 +90,66 @@ public class TestStaticMetastoreLocator
     public void testFallbackHiveMetastoreWithHiveUser()
             throws TException
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK_WITH_USER, asList(null, null, FALLBACK_CLIENT));
-        assertEquals(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK_WITH_USER, ImmutableMap.of(DEFAULT_URI, Optional.empty(), FALLBACK_URI, Optional.empty(), FALLBACK2_URI, Optional.of(FALLBACK_CLIENT)));
+        assertEqualHiveClient(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
     }
 
     @Test
     public void testMetastoreFailedWithoutFallbackWithHiveUser()
     {
-        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITHOUT_FALLBACK_WITH_USER, singletonList(null));
+        MetastoreLocator locator = createMetastoreLocator(CONFIG_WITHOUT_FALLBACK_WITH_USER, ImmutableMap.of(DEFAULT_URI, Optional.empty()));
         assertCreateClientFails(locator, "Failed connecting to Hive metastore: [default:8080]");
+    }
+
+    @Test
+    public void testFallbackHiveMetastoreOnTimeOut()
+            throws TException
+    {
+        MetastoreLocator cluster = createMetastoreLocator(CONFIG_WITH_FALLBACK, CLIENTS);
+
+        ThriftMetastoreClient metastoreClient1 = cluster.createMetastoreClient(Optional.empty());
+        assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
+
+        assertGetTableException(metastoreClient1);
+
+        ThriftMetastoreClient metastoreClient2 = cluster.createMetastoreClient(Optional.empty());
+        assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
+
+        assertGetTableException(metastoreClient2);
+    }
+
+    @Test
+    public void testFallbackHiveMetastoreOnAllTimeOut()
+            throws TException
+    {
+        MetastoreLocator cluster = createMetastoreLocator(CONFIG_WITH_FALLBACK, CLIENTS);
+
+        ThriftMetastoreClient metastoreClient1 = cluster.createMetastoreClient(Optional.empty());
+        assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
+
+        for (int i = 0; i < 20; ++i) {
+            assertGetTableException(metastoreClient1);
+        }
+
+        ThriftMetastoreClient metastoreClient2 = cluster.createMetastoreClient(Optional.empty());
+        assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
+
+        assertGetTableException(metastoreClient2);
+
+        // Still get FALLBACK_CLIENT because DEFAULT_CLIENT failed more times before and therefore longer backoff
+        ThriftMetastoreClient metastoreClient3 = cluster.createMetastoreClient(Optional.empty());
+        assertEqualHiveClient(metastoreClient3, FALLBACK_CLIENT);
+    }
+
+    private static void assertGetTableException(ThriftMetastoreClient client)
+    {
+        try {
+            client.getTable("foo", "bar");
+            fail("Expected getTable to throw an exception");
+        }
+        catch (TException e) {
+            assertContains(e.getMessage(), "Read timeout");
+        }
     }
 
     private static void assertCreateClientFails(MetastoreLocator locator, String message)
@@ -98,13 +159,32 @@ public class TestStaticMetastoreLocator
                 .hasMessage(message);
     }
 
-    private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, List<ThriftMetastoreClient> clients)
+    private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, Map<String, Optional<ThriftMetastoreClient>> clients)
     {
         return new StaticMetastoreLocator(config, new HiveAuthenticationConfig(), new MockThriftMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
     }
 
     private static ThriftMetastoreClient createFakeMetastoreClient()
     {
-        return new MockThriftMetastoreClient();
+        return new MockThriftMetastoreClient()
+        {
+            @Override
+            public Table getTable(String dbName, String tableName)
+                    throws TException
+            {
+                throw new TException(new SocketTimeoutException("Read timeout"));
+            }
+        };
+    }
+
+    private void assertEqualHiveClient(ThriftMetastoreClient actual, ThriftMetastoreClient expected)
+    {
+        if (actual instanceof FailureAwareThriftMetastoreClient) {
+            actual = ((FailureAwareThriftMetastoreClient) actual).getDelegate();
+        }
+        if (expected instanceof FailureAwareThriftMetastoreClient) {
+            expected = ((FailureAwareThriftMetastoreClient) expected).getDelegate();
+        }
+        assertEquals(actual, expected);
     }
 }

--- a/presto-spi/src/test/java/io/prestosql/spi/testing/InterfaceTestUtils.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/testing/InterfaceTestUtils.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Method;
 import java.util.function.Function;
 
+import static com.google.common.base.Defaults.defaultValue;
 import static com.google.common.reflect.Reflection.newProxy;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -48,8 +49,8 @@ public final class InterfaceTestUtils
         for (Method actualMethod : iface.getDeclaredMethods()) {
             Object[] actualArguments = new Object[actualMethod.getParameterCount()];
             for (int i = 0; i < actualArguments.length; i++) {
-                if (actualMethod.getParameterTypes()[i] == boolean.class) {
-                    actualArguments[i] = false;
+                if (actualMethod.getParameterTypes()[i].isPrimitive()) {
+                    actualArguments[i] = defaultValue(actualMethod.getParameterTypes()[i]);
                 }
             }
             C forwardingInstance = forwardingInstanceFactory.apply(
@@ -57,8 +58,8 @@ public final class InterfaceTestUtils
                         assertEquals(actualMethod.getName(), expectedMethod.getName());
                         // TODO assert arguments
 
-                        if (actualMethod.getReturnType() == boolean.class) {
-                            return false;
+                        if (actualMethod.getReturnType().isPrimitive()) {
+                            return defaultValue(actualMethod.getReturnType());
                         }
                         return null;
                     }));


### PR DESCRIPTION
Current hive metastore client only failover when connection fails. This patch add failure aware hive metastore client so that it could capture exceptions during communication and failover to backup client.

Ref https://github.com/prestodb/presto/pull/11513

