### PR TITLE
Fix exception message in TupleDomain#toLinkedMap

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/TupleDomain.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/TupleDomain.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -374,7 +375,7 @@ public final class TupleDomain<T>
             Domain previous = result.put(key, entry.getValue());
 
             if (previous != null) {
-                throw new IllegalArgumentException(String.format("Every argument must have a unique mapping. %s maps to %s and %s", entry.getKey(), entry.getValue(), previous));
+                throw new IllegalArgumentException(format("Every argument must have a unique mapping. %s maps to %s and %s", entry.getKey(), entry.getValue(), previous));
             }
         }
 
@@ -426,7 +427,7 @@ public final class TupleDomain<T>
         return toMap(
                 keyMapper,
                 valueMapper,
-                (u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
+                (u, v) -> { throw new IllegalStateException(format("Duplicate values for a key: %s and %s", u, v)); },
                 LinkedHashMap::new);
     }
 }


### PR DESCRIPTION
The message assumed lambda's `u` parameter is a map key, whereas it's a
value.