### PR TITLE
Correct roles documentation for catalog support

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-role.rst
+++ b/presto-docs/src/main/sphinx/sql/create-role.rst
@@ -9,13 +9,11 @@ Synopsis
 
     CREATE ROLE role_name
     [ WITH ADMIN ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
-    [ IN catalog ]
 
 Description
 -----------
 
-``CREATE ROLE`` creates the specified role in ``catalog`` or in the
-current catalog if ``catalog`` is not specified.
+``CREATE ROLE`` creates the specified role in the current catalog.
 
 The optional ``WITH ADMIN`` clause causes the role to be created with
 the specified user as a role admin. A role admin has permission to drop
@@ -32,10 +30,6 @@ Create role ``admin`` ::
 Create role ``moderator`` with admin ``bob``::
 
     CREATE ROLE moderator WITH ADMIN USER bob;
-
-Create role ``foo`` in catalog ``bar``::
-
-    CREATE ROLE foo IN bar;
 
 Limitations
 -----------

--- a/presto-docs/src/main/sphinx/sql/drop-role.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-role.rst
@@ -7,13 +7,12 @@ Synopsis
 
 .. code-block:: none
 
-    DROP ROLE role_name [ IN catalog ]
+    DROP ROLE role_name
 
 Description
 -----------
 
-``DROP ROLE`` drops the specified role in ``catalog`` or in the
-current catalog if ``catalog`` is not specified.
+``DROP ROLE`` drops the specified role in the current catalog.
 
 For ``DROP ROLE`` statement to succeed, the user executing it should possess
 admin privileges for the given role.
@@ -24,10 +23,6 @@ Examples
 Drop role ``admin`` ::
 
     DROP ROLE admin;
-
-Drop role ``foo`` in catalog ``bar``::
-
-    DROP ROLE foo IN bar;
 
 Limitations
 -----------

--- a/presto-docs/src/main/sphinx/sql/grant-roles.rst
+++ b/presto-docs/src/main/sphinx/sql/grant-roles.rst
@@ -11,13 +11,11 @@ Synopsis
     TO ( user | USER user | ROLE role) [, ...]
     [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
     [ WITH ADMIN OPTION ]
-    [ IN catalog ]
 
 Description
 -----------
 
-Grants the specified role(s) to the specified principal(s) in ``catalog`` or
-in the current catalog if ``catalog`` is not specified.
+Grants the specified role(s) to the specified principal(s) in the current catalog.
 
 If the ``WITH ADMIN OPTION`` clause is specified, the role(s) are granted
 to the users with ``GRANT`` option.
@@ -39,10 +37,6 @@ Grant role ``bar`` to user ``foo`` ::
 Grant roles ``bar`` and ``foo`` to user ``baz`` and role ``qux`` with admin option ::
 
     GRANT bar, foo TO USER baz, ROLE qux WITH ADMIN OPTION;
-
-Grant role ``bar`` to user ``foo`` in catalog ``baz`` ::
-
-    GRANT bar TO USER foo IN baz;
 
 Limitations
 -----------

--- a/presto-docs/src/main/sphinx/sql/revoke-roles.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke-roles.rst
@@ -12,13 +12,11 @@ Synopsis
     role [, ...]
     FROM ( user | USER user | ROLE role) [, ...]
     [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
-    [ IN catalog ]
 
 Description
 -----------
 
-Revokes the specified role(s) from the specified principal(s) in ``catalog`` or
-in the current catalog if ``catalog`` is not specified.
+Revokes the specified role(s) from the specified principal(s) in the current catalog.
 
 If the ``ADMIN OPTION FOR`` clause is specified, the ``GRANT`` permission is
 revoked instead of the role.
@@ -40,10 +38,6 @@ Revoke role ``bar`` from user ``foo`` ::
 Revoke admin option for roles ``bar`` and ``foo`` from user ``baz`` and role ``qux`` ::
 
     REVOKE ADMIN OPTION FOR bar, foo FROM USER baz, ROLE qux;
-
-Revoke role ``bar`` from user ``foo`` in catalog ``baz`` ::
-
-    REVOKE bar FROM USER foo IN baz;
 
 Limitations
 -----------

--- a/presto-docs/src/main/sphinx/sql/set-role.rst
+++ b/presto-docs/src/main/sphinx/sql/set-role.rst
@@ -7,13 +7,12 @@ Synopsis
 
 .. code-block:: none
 
-    SET ROLE ( role | ALL | NONE ) [ IN catalog ]
+    SET ROLE ( role | ALL | NONE )
 
 Description
 -----------
 
-``SET ROLE`` sets the enabled role for the current session in ``catalog``
-or in the current catalog if ``catalog`` is not specified.
+``SET ROLE`` sets the enabled role for the current session in the current catalog.
 
 ``SET ROLE role`` enables a single specified role for the current session.
 For the ``SET ROLE role`` statement to succeed, the user executing it should


### PR DESCRIPTION
Reopened after mistakenly closing 