### PR TITLE
Add support for PostgreSQL arrays

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -775,7 +775,7 @@ public class BaseJdbcClient
         return name;
     }
 
-    private static ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
+    protected static ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
             throws SQLException
     {
         Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -231,7 +231,8 @@ public class BaseJdbcClient
                             resultSet.getInt("DATA_TYPE"),
                             resultSet.getString("TYPE_NAME"),
                             resultSet.getInt("COLUMN_SIZE"),
-                            resultSet.getInt("DECIMAL_DIGITS"));
+                            resultSet.getInt("DECIMAL_DIGITS"),
+                            Optional.empty());
                     Optional<ColumnMapping> columnMapping = toPrestoType(session, typeHandle);
                     // skip unsupported column types
                     if (columnMapping.isPresent()) {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcTypeHandle.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcTypeHandle.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -27,18 +28,21 @@ public final class JdbcTypeHandle
     private final String jdbcTypeName;
     private final int columnSize;
     private final int decimalDigits;
+    private final Optional<Integer> arrayDimensions;
 
     @JsonCreator
     public JdbcTypeHandle(
             @JsonProperty("jdbcType") int jdbcType,
             @JsonProperty("jdbcTypeName") String jdbcTypeName,
             @JsonProperty("columnSize") int columnSize,
-            @JsonProperty("decimalDigits") int decimalDigits)
+            @JsonProperty("decimalDigits") int decimalDigits,
+            @JsonProperty("arrayDimensions") Optional<Integer> arrayDimensions)
     {
         this.jdbcType = jdbcType;
         this.jdbcTypeName = requireNonNull(jdbcTypeName, "jdbcTypeName is null");
         this.columnSize = columnSize;
         this.decimalDigits = decimalDigits;
+        this.arrayDimensions = requireNonNull(arrayDimensions, "arrayDimensions is null");
     }
 
     @JsonProperty
@@ -65,10 +69,16 @@ public final class JdbcTypeHandle
         return decimalDigits;
     }
 
+    @JsonProperty
+    public Optional<Integer> getArrayDimensions()
+    {
+        return arrayDimensions;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(jdbcType, jdbcTypeName, columnSize, decimalDigits);
+        return Objects.hash(jdbcType, jdbcTypeName, columnSize, decimalDigits, arrayDimensions);
     }
 
     @Override
@@ -84,17 +94,20 @@ public final class JdbcTypeHandle
         return jdbcType == that.jdbcType &&
                 columnSize == that.columnSize &&
                 decimalDigits == that.decimalDigits &&
-                Objects.equals(jdbcTypeName, that.jdbcTypeName);
+                Objects.equals(jdbcTypeName, that.jdbcTypeName) &&
+                Objects.equals(arrayDimensions, that.arrayDimensions);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
+                .omitNullValues()
                 .add("jdbcType", jdbcType)
                 .add("jdbcTypeName", jdbcTypeName)
                 .add("columnSize", columnSize)
                 .add("decimalDigits", decimalDigits)
+                .add("arrayDimensions", arrayDimensions.orElse(null))
                 .toString();
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -14,25 +14,26 @@
 package io.prestosql.plugin.jdbc;
 
 import java.sql.Types;
+import java.util.Optional;
 
 public final class TestingJdbcTypeHandle
 {
     private TestingJdbcTypeHandle() {}
 
-    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, "boolean", 1, 0);
+    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, "boolean", 1, 0, Optional.empty());
 
-    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, "smallint", 1, 0);
-    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, "tinyint", 2, 0);
-    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, "integer", 4, 0);
-    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, "bigint", 8, 0);
+    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, "smallint", 1, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, "tinyint", 2, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, "integer", 4, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, "bigint", 8, 0, Optional.empty());
 
-    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, "real", 8, 0);
-    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, "double precision", 8, 0);
+    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, "real", 8, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, "double precision", 8, 0, Optional.empty());
 
-    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, "char", 10, 0);
-    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, "varchar", 10, 0);
+    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, "char", 10, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, "varchar", 10, 0, Optional.empty());
 
-    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, "date", 8, 0);
-    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, "time", 4, 0);
-    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, "timestamp", 8, 0);
+    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, "date", 8, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, "time", 4, 0, Optional.empty());
+    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, "timestamp", 8, 0, Optional.empty());
 }

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>json</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -40,6 +40,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.StandardTypes;
+import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSignature;
@@ -74,6 +75,7 @@ import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.prestosql.plugin.postgresql.TypeUtils.getArrayElementPgTypeName;
 import static io.prestosql.plugin.postgresql.TypeUtils.getJdbcObjectArray;
@@ -261,6 +263,9 @@ public class PostgreSqlClient
         }
         if (TIMESTAMP.equals(type)) {
             return WriteMapping.longMapping("timestamp", timestampWriteFunction(session));
+        }
+        if (TinyintType.TINYINT.equals(type)) {
+            return WriteMapping.longMapping("smallint", tinyintWriteFunction());
         }
         if (type.getTypeSignature().getBase().equals(StandardTypes.JSON)) {
             return WriteMapping.sliceMapping("jsonb", typedVarcharWriteFunction("json"));

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/TypeUtils.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/TypeUtils.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.postgresql;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.CharType;
+import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
+import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.ISOChronology;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.sql.Date;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DateType.DATE;
+import static io.prestosql.spi.type.Decimals.decodeUnscaledValue;
+import static io.prestosql.spi.type.Decimals.encodeScaledValue;
+import static io.prestosql.spi.type.Decimals.encodeShortScaledValue;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static io.prestosql.spi.type.TypeUtils.readNativeValue;
+import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.joda.time.DateTimeZone.UTC;
+
+public final class TypeUtils
+{
+    private TypeUtils() {}
+
+    // PostgreSQL jdbc array element names understood by org.postgresql.jdbc2.TypeInfoCache#getPGArrayType
+    // for multidimensional arrays, this should return the base type (e.g. array(array(integer)) returns 'integer')
+    public static String getArrayElementPgTypeName(ConnectorSession session, PostgreSqlClient client, Type elementType)
+    {
+        if (DOUBLE.equals(elementType)) {
+            return "float";
+        }
+
+        if (REAL.equals(elementType)) {
+            return "float4";
+        }
+
+        // TypeInfoCache#getPGArrayType apparently doesn't allow for specifying variable-length limits.
+        // Since PostgreSQL char[] can only hold single byte elements, map all CharType to varchar
+        if (elementType instanceof VarcharType || elementType instanceof CharType) {
+            return "varchar";
+        }
+
+        if (elementType instanceof DecimalType) {
+            return "decimal";
+        }
+
+        if (elementType instanceof ArrayType) {
+            return getArrayElementPgTypeName(session, client, ((ArrayType) elementType).getElementType());
+        }
+
+        return client.toWriteMapping(session, elementType).getDataType();
+    }
+
+    public static Block jdbcObjectArrayToBlock(ConnectorSession session, Type type, Object[] elements)
+    {
+        BlockBuilder builder = type.createBlockBuilder(null, elements.length);
+        for (Object element : elements) {
+            writeNativeValue(type, builder, jdbcObjectToPrestoNative(session, element, type));
+        }
+        return builder.build();
+    }
+
+    public static Object[] getJdbcObjectArray(ConnectorSession session, Type elementType, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        Object[] valuesArray = new Object[positionCount];
+        int subArrayLength = 1;
+        for (int i = 0; i < positionCount; i++) {
+            Object objectValue = prestoNativeToJdbcObject(session, elementType, readNativeValue(elementType, block, i));
+            valuesArray[i] = objectValue;
+            if (objectValue != null && objectValue.getClass().isArray()) {
+                subArrayLength = Math.max(subArrayLength, Array.getLength(objectValue));
+            }
+        }
+        // PostgreSql requires subarrays with matching dimensions, including arrays of null
+        if (elementType instanceof ArrayType) {
+            handleArrayNulls(valuesArray, subArrayLength);
+        }
+        return valuesArray;
+    }
+
+    public static Object[] toBoxedArray(Object jdbcArray)
+    {
+        if (!jdbcArray.getClass().isArray()) {
+            return null;
+        }
+        if (!jdbcArray.getClass().getComponentType().isPrimitive()) {
+            return (Object[]) jdbcArray;
+        }
+
+        int elementCount = Array.getLength(jdbcArray);
+        Object[] elements = new Object[elementCount];
+        for (int i = 0; i < elementCount; i++) {
+            elements[i] = Array.get(jdbcArray, i);
+        }
+        return elements;
+    }
+
+    private static void handleArrayNulls(Object[] valuesArray, int length)
+    {
+        for (int i = 0; i < valuesArray.length; i++) {
+            if (valuesArray[i] == null) {
+                valuesArray[i] = new Object[length];
+            }
+        }
+    }
+
+    private static Object jdbcObjectToPrestoNative(ConnectorSession session, Object jdbcObject, Type prestoType)
+    {
+        if (jdbcObject == null) {
+            return null;
+        }
+
+        if (BOOLEAN.equals(prestoType)
+                || TINYINT.equals(prestoType)
+                || SMALLINT.equals(prestoType)
+                || INTEGER.equals(prestoType)
+                || BIGINT.equals(prestoType)
+                || DOUBLE.equals(prestoType)) {
+            return jdbcObject;
+        }
+
+        if (prestoType instanceof ArrayType) {
+            return jdbcObjectArrayToBlock(session, ((ArrayType) prestoType).getElementType(), (Object[]) jdbcObject);
+        }
+
+        if (prestoType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) prestoType;
+            BigDecimal value = (BigDecimal) jdbcObject;
+            if (decimalType.isShort()) {
+                return encodeShortScaledValue(value, decimalType.getScale());
+            }
+            return encodeScaledValue(value, decimalType.getScale());
+        }
+
+        if (REAL.equals(prestoType)) {
+            return floatToRawIntBits((float) jdbcObject);
+        }
+
+        if (DATE.equals(prestoType)) {
+            long localMillis = ((Date) jdbcObject).getTime();
+            // Convert it to a ~midnight in UTC.
+            long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+            // convert to days
+            return MILLISECONDS.toDays(utcMillis);
+        }
+
+        if (prestoType instanceof VarcharType) {
+            return utf8Slice((String) jdbcObject);
+        }
+
+        if (prestoType instanceof CharType) {
+            return utf8Slice(CharMatcher.is(' ').trimTrailingFrom((String) jdbcObject));
+        }
+
+        throw new PrestoException(NOT_SUPPORTED, format("Unsupported type %s and object type %s", prestoType, jdbcObject.getClass()));
+    }
+
+    private static Object prestoNativeToJdbcObject(ConnectorSession session, Type prestoType, Object prestoNative)
+    {
+        if (prestoNative == null) {
+            return null;
+        }
+
+        if (DOUBLE.equals(prestoType) || BOOLEAN.equals(prestoType) || BIGINT.equals(prestoType)) {
+            return prestoNative;
+        }
+
+        if (prestoType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) prestoType;
+            if (decimalType.isShort()) {
+                BigInteger unscaledValue = BigInteger.valueOf((long) prestoNative);
+                return new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+            }
+            BigInteger unscaledValue = decodeUnscaledValue((Slice) prestoNative);
+            return new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+        }
+
+        if (REAL.equals(prestoType)) {
+            return intBitsToFloat(toIntExact((long) prestoNative));
+        }
+
+        if (TINYINT.equals(prestoType)) {
+            return SignedBytes.checkedCast((long) prestoNative);
+        }
+
+        if (SMALLINT.equals(prestoType)) {
+            return Shorts.checkedCast((long) prestoNative);
+        }
+
+        if (INTEGER.equals(prestoType)) {
+            return toIntExact((long) prestoNative);
+        }
+
+        if (DATE.equals(prestoType)) {
+            // convert to midnight in default time zone
+            long millis = DAYS.toMillis((long) prestoNative);
+            return new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis));
+        }
+
+        if (prestoType instanceof VarcharType || prestoType instanceof CharType) {
+            return ((Slice) prestoNative).toStringUtf8();
+        }
+
+        if (prestoType instanceof ArrayType) {
+            // process subarray of multi-dimensional array
+            return getJdbcObjectArray(session, ((ArrayType) prestoType).getElementType(), (Block) prestoNative);
+        }
+
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported type: " + prestoType);
+    }
+}

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -56,12 +56,6 @@ public class TestPostgreSqlDistributedQueries
     }
 
     @Override
-    protected boolean supportsArrays()
-    {
-        return false;
-    }
-
-    @Override
     public void testCommentTable()
     {
         // PostgreSQL connector currently does not support comment on table

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -45,6 +45,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.io.BaseEncoding.base16;
 import static io.prestosql.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.tests.datatype.DataType.bigintDataType;
@@ -106,6 +107,7 @@ public class TestPostgreSqlTypeMapping
                 .addRoundTrip(smallintDataType(), (short) 32_456)
                 .addRoundTrip(doubleDataType(), 123.45d)
                 .addRoundTrip(realDataType(), 123.45f)
+                .addRoundTrip(dataType("tinyint", SMALLINT, Object::toString, result -> (short) result), (byte) 5)
                 .execute(getQueryRunner(), prestoCreateAsSelect("test_basic_types"));
     }
 


### PR DESCRIPTION
This adds support for multidimensional ARRAY types in base-jdbc.  There's also an example implementation in PostgreSql.