### PR TITLE
Add csv output option without quotes

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -122,7 +122,7 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
-    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL] (default: CSV)")
+    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, CSV_UNQUOTED, CSV_HEADER_UNQUOTED, NULL] (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 
     @Option(name = "--resource-estimate", title = "resource-estimate", description = "Resource estimate (property can be used multiple times; format is key=value)")
@@ -150,10 +150,12 @@ public class ClientOptions
     {
         ALIGNED,
         VERTICAL,
-        CSV,
         TSV,
-        CSV_HEADER,
         TSV_HEADER,
+        CSV,
+        CSV_HEADER,
+        CSV_UNQUOTED,
+        CSV_HEADER_UNQUOTED,
         NULL
     }
 

--- a/presto-cli/src/main/java/io/prestosql/cli/CsvPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/CsvPrinter.java
@@ -33,19 +33,28 @@ public class CsvPrinter
 
     public enum CsvOutputFormat
     {
-        STANDARD(true),
-        NO_HEADER(false);
+        STANDARD(true, true),
+        NO_HEADER(false, true),
+        NO_QUOTES(true, false),
+        NO_HEADER_AND_QUOTES(false, false);
 
         private boolean header;
+        private boolean quote;
 
-        CsvOutputFormat(boolean header)
+        CsvOutputFormat(boolean header, boolean quote)
         {
             this.header = header;
+            this.quote = quote;
         }
 
         public boolean showHeader()
         {
             return header;
+        }
+
+        public boolean isQuoted()
+        {
+            return quote;
         }
     }
 
@@ -54,7 +63,7 @@ public class CsvPrinter
         requireNonNull(fieldNames, "fieldNames is null");
         requireNonNull(writer, "writer is null");
         this.fieldNames = ImmutableList.copyOf(fieldNames);
-        this.writer = new CSVWriter(writer);
+        this.writer = csvOutputFormat.isQuoted() ? new CSVWriter(writer) : new CSVWriter(writer, CSVWriter.DEFAULT_SEPARATOR, CSVWriter.NO_QUOTE_CHARACTER);
         this.needHeader = csvOutputFormat.showHeader();
     }
 

--- a/presto-cli/src/main/java/io/prestosql/cli/CsvPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/CsvPrinter.java
@@ -31,13 +31,31 @@ public class CsvPrinter
 
     private boolean needHeader;
 
-    public CsvPrinter(List<String> fieldNames, Writer writer, boolean header)
+    public enum CsvOutputFormat
+    {
+        STANDARD(true),
+        NO_HEADER(false);
+
+        private boolean header;
+
+        CsvOutputFormat(boolean header)
+        {
+            this.header = header;
+        }
+
+        public boolean showHeader()
+        {
+            return header;
+        }
+    }
+
+    public CsvPrinter(List<String> fieldNames, Writer writer, CsvOutputFormat csvOutputFormat)
     {
         requireNonNull(fieldNames, "fieldNames is null");
         requireNonNull(writer, "writer is null");
         this.fieldNames = ImmutableList.copyOf(fieldNames);
         this.writer = new CSVWriter(writer);
-        this.needHeader = header;
+        this.needHeader = csvOutputFormat.showHeader();
     }
 
     @Override

--- a/presto-cli/src/main/java/io/prestosql/cli/Query.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Query.java
@@ -46,6 +46,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.prestosql.cli.ConsolePrinter.REAL_TERMINAL;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.STANDARD;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -298,9 +300,9 @@ public class Query
             case VERTICAL:
                 return new VerticalRecordPrinter(fieldNames, writer);
             case CSV:
-                return new CsvPrinter(fieldNames, writer, false);
+                return new CsvPrinter(fieldNames, writer, NO_HEADER);
             case CSV_HEADER:
-                return new CsvPrinter(fieldNames, writer, true);
+                return new CsvPrinter(fieldNames, writer, STANDARD);
             case TSV:
                 return new TsvPrinter(fieldNames, writer, false);
             case TSV_HEADER:

--- a/presto-cli/src/main/java/io/prestosql/cli/Query.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Query.java
@@ -47,6 +47,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.prestosql.cli.ConsolePrinter.REAL_TERMINAL;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER_AND_QUOTES;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_QUOTES;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.STANDARD;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -303,6 +305,10 @@ public class Query
                 return new CsvPrinter(fieldNames, writer, NO_HEADER);
             case CSV_HEADER:
                 return new CsvPrinter(fieldNames, writer, STANDARD);
+            case CSV_UNQUOTED:
+                return new CsvPrinter(fieldNames, writer, NO_HEADER_AND_QUOTES);
+            case CSV_HEADER_UNQUOTED:
+                return new CsvPrinter(fieldNames, writer, NO_QUOTES);
             case TSV:
                 return new TsvPrinter(fieldNames, writer, false);
             case TSV_HEADER:

--- a/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
@@ -21,6 +21,8 @@ import java.io.StringWriter;
 import java.util.List;
 
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER_AND_QUOTES;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_QUOTES;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.STANDARD;
 import static io.prestosql.cli.TestAlignedTablePrinter.row;
 import static io.prestosql.cli.TestAlignedTablePrinter.rows;
@@ -89,6 +91,77 @@ public class TestCsvPrinter
         String expected = "" +
                 "\"hello\",\"world\",\"123\"\n" +
                 "\"a\",\"\",\"4.5\"\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testCsvPrintingWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_QUOTES);
+
+        printRows(
+                printer,
+                row("hello", "world", 123),
+                row("a", null, 4.5));
+        printer.finish();
+
+        String expected = "" +
+                "first,last,quantity\n" +
+                "hello,world,123\n" +
+                "a,,4.5\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testCsvPrintingNoRowsWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_QUOTES);
+
+        printer.finish();
+
+        assertEquals(writer.getBuffer().toString(), "first,last\n");
+    }
+
+    @Test
+    public void testCsvPrintingNoHeaderWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER_AND_QUOTES);
+
+        printRows(
+                printer,
+                row("hello", "world", 123),
+                row("a", null, 4.5));
+        printer.finish();
+
+        String expected = "" +
+                "hello,world,123\n" +
+                "a,,4.5\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testCsvPrintingNoRowsWithNoHeaderAndWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER_AND_QUOTES);
+
+        printer.finish();
+
+        String expected = "";
 
         assertEquals(writer.getBuffer().toString(), expected);
     }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER;
+import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.STANDARD;
 import static io.prestosql.cli.TestAlignedTablePrinter.row;
 import static io.prestosql.cli.TestAlignedTablePrinter.rows;
 import static org.testng.Assert.assertEquals;
@@ -32,7 +34,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, true);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, STANDARD);
 
         printer.printRows(rows(
                 row("hello", "world", 123),
@@ -63,7 +65,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, true);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, STANDARD);
 
         printer.finish();
 
@@ -76,7 +78,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, false);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER);
 
         printer.printRows(rows(
                 row("hello", "world", 123),
@@ -97,7 +99,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, false);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER);
 
         printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
         printer.finish();

--- a/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestCsvPrinter.java
@@ -36,12 +36,12 @@ public class TestCsvPrinter
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
         OutputPrinter printer = new CsvPrinter(fieldNames, writer, STANDARD);
 
-        printer.printRows(rows(
+        printRows(
+                printer,
                 row("hello", "world", 123),
                 row("a", null, 4.5),
                 row("some long\ntext that\ndoes not\nfit on\none line", "more\ntext", 4567),
-                row("bye", "done", -15)),
-                true);
+                row("bye", "done", -15));
         printer.finish();
 
         String expected = "" +
@@ -80,10 +80,10 @@ public class TestCsvPrinter
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
         OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER);
 
-        printer.printRows(rows(
+        printRows(
+                printer,
                 row("hello", "world", 123),
-                row("a", null, 4.5)),
-                true);
+                row("a", null, 4.5));
         printer.finish();
 
         String expected = "" +
@@ -101,11 +101,17 @@ public class TestCsvPrinter
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
         OutputPrinter printer = new CsvPrinter(fieldNames, writer, NO_HEADER);
 
-        printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
+        printRows(printer, row("hello".getBytes(), null, 123));
         printer.finish();
 
         String expected = "\"68 65 6c 6c 6f\",\"\",\"123\"\n";
 
         assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    private static void printRows(OutputPrinter printer, List<?>... rows)
+            throws IOException
+    {
+        printer.printRows(rows(rows), true);
     }
 }


### PR DESCRIPTION
Add new output format option `CSV_WITHOUT_QUOTES` and `CSV_HEADER_WITHOUT_QUOTES`

```sh
# new
$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format CSV_WITHOUT_QUOTES
1,Customer#000000001

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format CSV_HEADER_WITHOUT_QUOTES
custkey,name
750001,Customer#000750001


# regression
$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format ALIGNED
 custkey |        name        
---------+--------------------
 1125001 | Customer#001125001 
(1 row)

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format VERTICAL
-[ RECORD 1 ]---------------
custkey | 1
name    | Customer#000000001

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format TSV
1       Customer#000000001

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format CSV
"1","Customer#000000001"

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" --output-format CSV_HEADER
"custkey","name"
"1125001","Customer#001125001"

$ presto --execute "select custkey, name from tpch.sf10.customer limit 1;" 
"1","Customer#000000001"
```

Ref: https://github.com/prestodb/presto/issues/8845, https://github.com/prestodb/presto/pull/10101
