### PR TITLE
Replace internal network rows/data stats in UI

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1320,18 +1320,18 @@ export class QueryDetail extends React.Component {
                                     </tr>
                                     <tr>
                                         <td className="info-title">
-                                            Internal Network Data
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.internalNetworkInputDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
                                             Internal Network Rows
                                         </td>
                                         <td className="info-text">
                                             {formatCount(query.queryStats.internalNetworkInputPositions)}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="info-title">
+                                            Internal Network Data
+                                        </td>
+                                        <td className="info-text">
+                                            {query.queryStats.internalNetworkInputDataSize}
                                         </td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
The convention is that rows should come before data.