### PR TITLE
Flush Elasticsearch testcase data loading to resolve data inconsistency issue

### DIFF
--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
@@ -39,6 +39,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.client.Requests.flushRequest;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.common.xcontent.XContentType.JSON;
 
@@ -103,6 +104,7 @@ public class ElasticsearchLoader
                     throw new UncheckedIOException("Error loading data into Elasticsearch index: " + tableName, e);
                 }
             }
+            client.admin().indices().flush(flushRequest(tableName)).actionGet();
         }
 
         @Override


### PR DESCRIPTION
Flush Elasticsearch testcase data loading to resolve data inconsistency issue

Extracted from: https://github.com/prestodb/presto/pull/12396
