### PR TITLE
Add more coercions for table/partition mismatch issue in Hive connector

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
@@ -68,10 +68,13 @@ public class HiveCoercionPolicy
             return toHiveType.equals(HIVE_LONG);
         }
         if (fromHiveType.equals(HIVE_FLOAT)) {
-            return toHiveType.equals(HIVE_DOUBLE);
+            return toHiveType.equals(HIVE_DOUBLE) || toType instanceof DecimalType;
+        }
+        if (fromHiveType.equals(HIVE_DOUBLE)) {
+            return toType instanceof DecimalType;
         }
         if (fromType instanceof DecimalType) {
-            return toType instanceof DecimalType;
+            return toType instanceof DecimalType || toHiveType.equals(HIVE_FLOAT) || toHiveType.equals(HIVE_DOUBLE);
         }
 
         return canCoerceForList(fromHiveType, toHiveType) || canCoerceForMap(fromHiveType, toHiveType) || canCoerceForStruct(fromHiveType, toHiveType);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
@@ -71,7 +71,7 @@ public class HiveCoercionPolicy
             return toHiveType.equals(HIVE_DOUBLE) || toType instanceof DecimalType;
         }
         if (fromHiveType.equals(HIVE_DOUBLE)) {
-            return toType instanceof DecimalType;
+            return toHiveType.equals(HIVE_FLOAT) || toType instanceof DecimalType;
         }
         if (fromType instanceof DecimalType) {
             return toType instanceof DecimalType || toHiveType.equals(HIVE_FLOAT) || toHiveType.equals(HIVE_DOUBLE);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionPolicy.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
+import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.VarcharType;
@@ -68,6 +69,9 @@ public class HiveCoercionPolicy
         }
         if (fromHiveType.equals(HIVE_FLOAT)) {
             return toHiveType.equals(HIVE_DOUBLE);
+        }
+        if (fromType instanceof DecimalType) {
+            return toType instanceof DecimalType;
         }
 
         return canCoerceForList(fromHiveType, toHiveType) || canCoerceForMap(fromHiveType, toHiveType) || canCoerceForStruct(fromHiveType, toHiveType);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -13,14 +13,16 @@
  */
 package io.prestosql.plugin.hive;
 
-import io.airlift.slice.Slice;
 import io.prestosql.plugin.hive.HivePageSourceProvider.BucketAdaptation;
 import io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMapping;
+import io.prestosql.plugin.hive.coercions.FloatToDoubleCoercer;
+import io.prestosql.plugin.hive.coercions.IntegerNumberToVarcharCoercer;
+import io.prestosql.plugin.hive.coercions.IntegerNumberUpscaleCoercer;
+import io.prestosql.plugin.hive.coercions.VarcharToIntegerNumberCoercer;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.ArrayBlock;
 import io.prestosql.spi.block.Block;
-import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.block.ColumnarArray;
 import io.prestosql.spi.block.ColumnarMap;
 import io.prestosql.spi.block.ColumnarRow;
@@ -31,11 +33,9 @@ import io.prestosql.spi.block.RowBlock;
 import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.type.DecimalType;
-import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
-import io.prestosql.spi.type.UnscaledDecimal128Arithmetic;
 import io.prestosql.spi.type.VarcharType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
@@ -45,14 +45,12 @@ import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.plugin.hive.HiveBucketing.getHiveBucket;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
@@ -81,7 +79,7 @@ import static io.prestosql.plugin.hive.HiveUtil.smallintPartitionKey;
 import static io.prestosql.plugin.hive.HiveUtil.timestampPartitionKey;
 import static io.prestosql.plugin.hive.HiveUtil.tinyintPartitionKey;
 import static io.prestosql.plugin.hive.HiveUtil.varcharPartitionKey;
-import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.block.ColumnarArray.toColumnarArray;
 import static io.prestosql.spi.block.ColumnarMap.toColumnarMap;
@@ -92,20 +90,13 @@ import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.isLongDecimal;
 import static io.prestosql.spi.type.Decimals.isShortDecimal;
-import static io.prestosql.spi.type.Decimals.longTenToNth;
-import static io.prestosql.spi.type.Decimals.overflows;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.rescale;
-import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
-import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
-import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLongUnsafe;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -364,376 +355,6 @@ public class HivePageSource
         }
 
         throw new PrestoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));
-    }
-
-    private static class IntegerNumberUpscaleCoercer
-            implements Function<Block, Block>
-    {
-        private final Type fromType;
-        private final Type toType;
-
-        public IntegerNumberUpscaleCoercer(Type fromType, Type toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                toType.writeLong(blockBuilder, fromType.getLong(block, i));
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class IntegerNumberToVarcharCoercer
-            implements Function<Block, Block>
-    {
-        private final Type fromType;
-        private final Type toType;
-
-        public IntegerNumberToVarcharCoercer(Type fromType, Type toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                toType.writeSlice(blockBuilder, utf8Slice(String.valueOf(fromType.getLong(block, i))));
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class VarcharToIntegerNumberCoercer
-            implements Function<Block, Block>
-    {
-        private final Type fromType;
-        private final Type toType;
-
-        private final long minValue;
-        private final long maxValue;
-
-        public VarcharToIntegerNumberCoercer(Type fromType, Type toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-
-            if (toType.equals(TINYINT)) {
-                minValue = Byte.MIN_VALUE;
-                maxValue = Byte.MAX_VALUE;
-            }
-            else if (toType.equals(SMALLINT)) {
-                minValue = Short.MIN_VALUE;
-                maxValue = Short.MAX_VALUE;
-            }
-            else if (toType.equals(INTEGER)) {
-                minValue = Integer.MIN_VALUE;
-                maxValue = Integer.MAX_VALUE;
-            }
-            else if (toType.equals(BIGINT)) {
-                minValue = Long.MIN_VALUE;
-                maxValue = Long.MAX_VALUE;
-            }
-            else {
-                throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from from varchar to %s", toType));
-            }
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                try {
-                    long value = Long.parseLong(fromType.getSlice(block, i).toStringUtf8());
-                    if (minValue <= value && value <= maxValue) {
-                        toType.writeLong(blockBuilder, value);
-                    }
-                    else {
-                        blockBuilder.appendNull();
-                    }
-                }
-                catch (NumberFormatException e) {
-                    blockBuilder.appendNull();
-                }
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class FloatToDoubleCoercer
-            implements Function<Block, Block>
-    {
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                DOUBLE.writeDouble(blockBuilder, intBitsToFloat((int) REAL.getLong(block, i)));
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static Function<Block, Block> createDecimalToDecimalCoercer(DecimalType fromType, DecimalType toType)
-    {
-        if (fromType.isShort()) {
-            if (toType.isShort()) {
-                return new ShortDecimalToShortDecimalCoercer(fromType, toType);
-            }
-            else {
-                return new ShortDecimalToLongDecimalCoercer(fromType, toType);
-            }
-        }
-        else {
-            if (toType.isShort()) {
-                return new LongDecimalToShortDecimalCoercer(fromType, toType);
-            }
-            else {
-                return new LongDecimalToLongDecimalCoercer(fromType, toType);
-            }
-        }
-    }
-
-    private static class ShortDecimalToShortDecimalCoercer
-            implements Function<Block, Block>
-    {
-        private final DecimalType fromType;
-        private final DecimalType toType;
-        private final long rescale;
-
-        public ShortDecimalToShortDecimalCoercer(DecimalType fromType, DecimalType toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-            rescale = longTenToNth(Math.abs(toType.getScale() - fromType.getScale()));
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                long returnValue = shortToShortCast(fromType.getLong(block, i),
-                        fromType.getPrecision(),
-                        fromType.getScale(),
-                        toType.getPrecision(),
-                        toType.getScale(),
-                        rescale,
-                        rescale / 2);
-                toType.writeLong(blockBuilder, returnValue);
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class ShortDecimalToLongDecimalCoercer
-            implements Function<Block, Block>
-    {
-        private final DecimalType fromType;
-        private final DecimalType toType;
-
-        public ShortDecimalToLongDecimalCoercer(DecimalType fromType, DecimalType toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                Slice coercedValue = shortToLongCast(fromType.getLong(block, i),
-                        fromType.getPrecision(),
-                        fromType.getScale(),
-                        toType.getPrecision(),
-                        toType.getScale());
-                toType.writeSlice(blockBuilder, coercedValue);
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class LongDecimalToShortDecimalCoercer
-            implements Function<Block, Block>
-    {
-        private final DecimalType fromType;
-        private final DecimalType toType;
-
-        public LongDecimalToShortDecimalCoercer(DecimalType fromType, DecimalType toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                long returnValue = longToShortCast(fromType.getSlice(block, i),
-                        fromType.getPrecision(),
-                        fromType.getScale(),
-                        toType.getPrecision(),
-                        toType.getScale());
-                toType.writeLong(blockBuilder, returnValue);
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static class LongDecimalToLongDecimalCoercer
-            implements Function<Block, Block>
-    {
-        private final DecimalType fromType;
-        private final DecimalType toType;
-
-        public LongDecimalToLongDecimalCoercer(DecimalType fromType, DecimalType toType)
-        {
-            this.fromType = requireNonNull(fromType, "fromType is null");
-            this.toType = requireNonNull(toType, "toType is null");
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                if (block.isNull(i)) {
-                    blockBuilder.appendNull();
-                    continue;
-                }
-                Slice coercedValue = longToLongCast(fromType.getSlice(block, i),
-                        fromType.getPrecision(),
-                        fromType.getScale(),
-                        toType.getPrecision(),
-                        toType.getScale());
-                toType.writeSlice(blockBuilder, coercedValue);
-            }
-            return blockBuilder.build();
-        }
-    }
-
-    private static long shortToShortCast(
-            long value,
-            long sourcePrecision,
-            long sourceScale,
-            long resultPrecision,
-            long resultScale,
-            long scalingFactor,
-            long halfOfScalingFactor)
-    {
-        long returnValue;
-        if (resultScale >= sourceScale) {
-            returnValue = value * scalingFactor;
-        }
-        else {
-            returnValue = value / scalingFactor;
-            if (value >= 0) {
-                if (value % scalingFactor >= halfOfScalingFactor) {
-                    returnValue++;
-                }
-            }
-            else {
-                if (value % scalingFactor <= -halfOfScalingFactor) {
-                    returnValue--;
-                }
-            }
-        }
-        if (overflows(returnValue, (int) resultPrecision)) {
-            throw throwCastException(value, sourcePrecision, sourceScale, resultPrecision, resultScale);
-        }
-        return returnValue;
-    }
-
-    private static Slice shortToLongCast(
-            long value,
-            long sourcePrecision,
-            long sourceScale,
-            long resultPrecision,
-            long resultScale)
-    {
-        return longToLongCast(unscaledDecimal(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
-    }
-
-    private static long longToShortCast(
-            Slice value,
-            long sourcePrecision,
-            long sourceScale,
-            long resultPrecision,
-            long resultScale)
-    {
-        return unscaledDecimalToUnscaledLongUnsafe(longToLongCast(value, sourcePrecision, sourceScale, resultPrecision, resultScale));
-    }
-
-    private static Slice longToLongCast(
-            Slice value,
-            long sourcePrecision,
-            long sourceScale,
-            long resultPrecision,
-            long resultScale)
-    {
-        try {
-            Slice result = rescale(value, (int) (resultScale - sourceScale));
-            if (UnscaledDecimal128Arithmetic.overflows(result, (int) resultPrecision)) {
-                throw throwCastException(unscaledDecimalToBigInteger(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
-            }
-            return result;
-        }
-        catch (ArithmeticException e) {
-            throw throwCastException(unscaledDecimalToBigInteger(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
-        }
-    }
-
-    private static PrestoException throwCastException(long value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
-    {
-        return new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
-                Decimals.toString(value, (int) sourceScale),
-                resultPrecision, resultScale));
-    }
-
-    private static PrestoException throwCastException(BigInteger value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
-    {
-        return new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
-                Decimals.toString(value, (int) sourceScale),
-                resultPrecision, resultScale));
     }
 
     private static class ListCoercer

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -80,6 +80,10 @@ import static io.prestosql.plugin.hive.HiveUtil.timestampPartitionKey;
 import static io.prestosql.plugin.hive.HiveUtil.tinyintPartitionKey;
 import static io.prestosql.plugin.hive.HiveUtil.varcharPartitionKey;
 import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
+import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
+import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createDecimalToRealCoercer;
+import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createDoubleToDecimalCoercer;
+import static io.prestosql.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.block.ColumnarArray.toColumnarArray;
 import static io.prestosql.spi.block.ColumnarMap.toColumnarMap;
@@ -343,6 +347,18 @@ public class HivePageSource
         }
         if (fromType instanceof DecimalType && toType instanceof DecimalType) {
             return createDecimalToDecimalCoercer((DecimalType) fromType, (DecimalType) toType);
+        }
+        if (fromType instanceof DecimalType && toType == DOUBLE) {
+            return createDecimalToDoubleCoercer((DecimalType) fromType);
+        }
+        if (fromType instanceof DecimalType && toType == REAL) {
+            return createDecimalToRealCoercer((DecimalType) fromType);
+        }
+        if (fromType == DOUBLE && toType instanceof DecimalType) {
+            return createDoubleToDecimalCoercer((DecimalType) toType);
+        }
+        if (fromType == REAL && toType instanceof DecimalType) {
+            return createRealToDecimalCoercer((DecimalType) toType);
         }
         if (isArrayType(fromType) && isArrayType(toType)) {
             return new ListCoercer(typeManager, fromHiveType, toHiveType);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive;
 
 import io.prestosql.plugin.hive.HivePageSourceProvider.BucketAdaptation;
 import io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMapping;
+import io.prestosql.plugin.hive.coercions.DoubleToFloatCoercer;
 import io.prestosql.plugin.hive.coercions.FloatToDoubleCoercer;
 import io.prestosql.plugin.hive.coercions.IntegerNumberToVarcharCoercer;
 import io.prestosql.plugin.hive.coercions.IntegerNumberUpscaleCoercer;
@@ -344,6 +345,9 @@ public class HivePageSource
         }
         if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
             return new FloatToDoubleCoercer();
+        }
+        if (fromHiveType.equals(HIVE_DOUBLE) && toHiveType.equals(HIVE_FLOAT)) {
+            return new DoubleToFloatCoercer();
         }
         if (fromType instanceof DecimalType && toType instanceof DecimalType) {
             return createDecimalToDecimalCoercer((DecimalType) fromType, (DecimalType) toType);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DecimalCoercers.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DecimalCoercers.java
@@ -20,19 +20,32 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
+import io.prestosql.spi.type.DoubleType;
+import io.prestosql.spi.type.RealType;
+import io.prestosql.spi.type.UnscaledDecimal128Arithmetic;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.prestosql.spi.type.Decimals.longTenToNth;
 import static io.prestosql.spi.type.Decimals.overflows;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.compareAbsolute;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.overflows;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.rescale;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLongUnsafe;
+import static java.lang.Double.parseDouble;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Float.parseFloat;
 import static java.lang.String.format;
+import static java.math.RoundingMode.HALF_UP;
 
 public class DecimalCoercers
 {
@@ -145,6 +158,185 @@ public class DecimalCoercers
         }
     }
 
+    public static Function<Block, Block> createDecimalToDoubleCoercer(DecimalType fromType)
+    {
+        if (fromType.isShort()) {
+            return new ShortDecimalToDoubleCoercer(fromType);
+        }
+        else {
+            return new LongDecimalToDoubleCoercer(fromType);
+        }
+    }
+
+    private static class ShortDecimalToDoubleCoercer
+            extends TypeCoercer<DecimalType, DoubleType>
+    {
+        private final long rescale;
+
+        public ShortDecimalToDoubleCoercer(DecimalType fromType)
+        {
+            super(fromType, DOUBLE);
+            rescale = longTenToNth(fromType.getScale());
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeDouble(blockBuilder,
+                    shortDecimalToDouble(fromType.getLong(block, position), rescale));
+        }
+    }
+
+    private static class LongDecimalToDoubleCoercer
+            extends TypeCoercer<DecimalType, DoubleType>
+    {
+        public LongDecimalToDoubleCoercer(DecimalType fromType)
+        {
+            super(fromType, DOUBLE);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeDouble(blockBuilder,
+                    longDecimalToDouble(fromType.getSlice(block, position), fromType.getScale()));
+        }
+    }
+
+    public static Function<Block, Block> createDecimalToRealCoercer(DecimalType fromType)
+    {
+        if (fromType.isShort()) {
+            return new ShortDecimalToRealCoercer(fromType);
+        }
+        else {
+            return new LongDecimalToRealCoercer(fromType);
+        }
+    }
+
+    private static class ShortDecimalToRealCoercer
+            extends TypeCoercer<DecimalType, RealType>
+    {
+        private final long rescale;
+
+        public ShortDecimalToRealCoercer(DecimalType fromType)
+        {
+            super(fromType, REAL);
+            rescale = longTenToNth(fromType.getScale());
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeLong(blockBuilder,
+                    shortDecimalToReal(fromType.getLong(block, position), rescale));
+        }
+    }
+
+    private static class LongDecimalToRealCoercer
+            extends TypeCoercer<DecimalType, RealType>
+    {
+        public LongDecimalToRealCoercer(DecimalType fromType)
+        {
+            super(fromType, REAL);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeLong(blockBuilder,
+                    longDecimalToReal(fromType.getSlice(block, position), fromType.getScale()));
+        }
+    }
+
+    public static Function<Block, Block> createDoubleToDecimalCoercer(DecimalType toType)
+    {
+        if (toType.isShort()) {
+            return new DoubleToShortDecimalCoercer(toType);
+        }
+        else {
+            return new DoubleToLongDecimalCoercer(toType);
+        }
+    }
+
+    private static class DoubleToShortDecimalCoercer
+            extends TypeCoercer<DoubleType, DecimalType>
+    {
+        public DoubleToShortDecimalCoercer(DecimalType toType)
+        {
+            super(DOUBLE, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeLong(blockBuilder,
+                    doubleToShortDecimal(fromType.getDouble(block, position), toType.getPrecision(), toType.getScale()));
+        }
+    }
+
+    private static class DoubleToLongDecimalCoercer
+            extends TypeCoercer<DoubleType, DecimalType>
+    {
+        public DoubleToLongDecimalCoercer(DecimalType toType)
+        {
+            super(DOUBLE, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeSlice(blockBuilder,
+                    doubleToLongDecimal(fromType.getDouble(block, position), toType.getPrecision(), toType.getScale()));
+        }
+    }
+
+    public static Function<Block, Block> createRealToDecimalCoercer(DecimalType toType)
+    {
+        if (toType.isShort()) {
+            return new RealToShortDecimalCoercer(toType);
+        }
+        else {
+            return new RealToLongDecimalCoercer(toType);
+        }
+    }
+
+    private static class RealToShortDecimalCoercer
+            extends TypeCoercer<RealType, DecimalType>
+    {
+        public RealToShortDecimalCoercer(DecimalType toType)
+        {
+            super(REAL, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeLong(blockBuilder,
+                    realToShortDecimal(fromType.getLong(block, position), toType.getPrecision(), toType.getScale()));
+        }
+    }
+
+    private static class RealToLongDecimalCoercer
+            extends TypeCoercer<RealType, DecimalType>
+    {
+        public RealToLongDecimalCoercer(DecimalType toType)
+        {
+            super(REAL, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            toType.writeSlice(blockBuilder,
+                    realToLongDecimal(fromType.getLong(block, position), toType.getPrecision(), toType.getScale()));
+        }
+    }
+
+    /**
+     * most of the following cast logic is directly copied from io.prestosql.type.DecimalToDecimalCasts
+     * and io.prestosql.type.DecimalCasts.DecimalCasts
+     * TODO: abstract the logic can be reused.
+     */
     private static long shortToShortCast(
             long value,
             long sourcePrecision,
@@ -223,7 +415,9 @@ public class DecimalCoercers
     private static PrestoException throwCastException(long value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
     {
         return new PrestoException(INVALID_CAST_ARGUMENT,
-                format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
+                format("Cannot cast DECIMAL(%d, %d) '%s' to DECIMAL(%d, %d)",
+                        sourcePrecision,
+                        sourceScale,
                         Decimals.toString(value, (int) sourceScale),
                         resultPrecision,
                         resultScale));
@@ -232,9 +426,152 @@ public class DecimalCoercers
     private static PrestoException throwCastException(BigInteger value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
     {
         return new PrestoException(INVALID_CAST_ARGUMENT,
-                format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
+                format("Cannot cast DECIMAL(%d, %d) '%s' to DECIMAL(%d, %d)",
+                        sourcePrecision,
+                        sourceScale,
                         Decimals.toString(value, (int) sourceScale),
                         resultPrecision,
                         resultScale));
+    }
+
+    /**
+     * Powers of 10 which can be represented exactly in double.
+     */
+    private static final double[] DOUBLE_10_POW = {
+            1.0e0, 1.0e1, 1.0e2, 1.0e3, 1.0e4, 1.0e5,
+            1.0e6, 1.0e7, 1.0e8, 1.0e9, 1.0e10, 1.0e11,
+            1.0e12, 1.0e13, 1.0e14, 1.0e15, 1.0e16, 1.0e17,
+            1.0e18, 1.0e19, 1.0e20, 1.0e21, 1.0e22
+    };
+
+    private static final Slice MAX_EXACT_DOUBLE = unscaledDecimal((1L << 52) - 1);
+
+    /**
+     * Powers of 10 which can be represented exactly in float.
+     */
+    private static final float[] FLOAT_10_POW = {
+            1.0e0f, 1.0e1f, 1.0e2f, 1.0e3f, 1.0e4f, 1.0e5f,
+            1.0e6f, 1.0e7f, 1.0e8f, 1.0e9f, 1.0e10f
+    };
+    private static final Slice MAX_EXACT_FLOAT = unscaledDecimal((1L << 22) - 1);
+
+    public static double shortDecimalToDouble(long decimal, long tenToScale)
+    {
+        return ((double) decimal) / tenToScale;
+    }
+
+    private static double longDecimalToDouble(Slice decimal, long scale)
+    {
+        // If both decimal and scale can be represented exactly in double then compute rescaled and rounded result directly in double.
+        if (scale < DOUBLE_10_POW.length && compareAbsolute(decimal, MAX_EXACT_DOUBLE) <= 0) {
+            return (double) unscaledDecimalToUnscaledLongUnsafe(decimal) / DOUBLE_10_POW[intScale(scale)];
+        }
+
+        // TODO: optimize and convert directly to double in similar fashion as in double to decimal casts
+        return parseDouble(Decimals.toString(decimal, intScale(scale)));
+    }
+
+    private static long shortDecimalToReal(long decimal, long tenToScale)
+    {
+        return floatToRawIntBits(((float) decimal) / tenToScale);
+    }
+
+    private static long longDecimalToReal(Slice decimal, long scale)
+    {
+        // If both decimal and scale can be represented exactly in float then compute rescaled and rounded result directly in float.
+        if (scale < FLOAT_10_POW.length && compareAbsolute(decimal, MAX_EXACT_FLOAT) <= 0) {
+            return floatToRawIntBits((float) unscaledDecimalToUnscaledLongUnsafe(decimal) / FLOAT_10_POW[intScale(scale)]);
+        }
+
+        // TODO: optimize and convert directly to float in similar fashion as in double to decimal casts
+        return floatToRawIntBits(parseFloat(Decimals.toString(decimal, intScale(scale))));
+    }
+
+    private static long doubleToShortDecimal(double value, long precision, long scale)
+    {
+        // TODO: implement specialized version for short decimals
+        Slice decimal = doubleToLongDecimal(value, precision, scale);
+
+        long low = UnscaledDecimal128Arithmetic.getLong(decimal, 0);
+        long high = UnscaledDecimal128Arithmetic.getLong(decimal, 1);
+
+        checkState(high == 0 && low >= 0, "Unexpected long decimal");
+
+        if (UnscaledDecimal128Arithmetic.isNegative(decimal)) {
+            return -low;
+        }
+        else {
+            return low;
+        }
+    }
+
+    private static Slice doubleToLongDecimal(double value, long precision, long scale)
+    {
+        if (Double.isInfinite(value) || Double.isNaN(value)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+        }
+
+        try {
+            // todo consider changing this implementation to more performant one which does not use intermediate String objects
+            BigDecimal bigDecimal = BigDecimal.valueOf(value).setScale(intScale(scale), HALF_UP);
+            Slice decimal = Decimals.encodeScaledValue(bigDecimal);
+            if (UnscaledDecimal128Arithmetic.overflows(decimal, intScale(precision))) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT,
+                        format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+        }
+    }
+
+    private static long realToShortDecimal(long value, long precision, long scale)
+    {
+        // TODO: implement specialized version for short decimals
+        Slice decimal = realToLongDecimal(value, precision, scale);
+
+        long low = UnscaledDecimal128Arithmetic.getLong(decimal, 0);
+        long high = UnscaledDecimal128Arithmetic.getLong(decimal, 1);
+
+        checkState(high == 0 && low >= 0, "Unexpected long decimal");
+
+        if (UnscaledDecimal128Arithmetic.isNegative(decimal)) {
+            return -low;
+        }
+        else {
+            return low;
+        }
+    }
+
+    private static Slice realToLongDecimal(long value, long precision, long scale)
+    {
+        float floatValue = intBitsToFloat(intScale(value));
+        if (Float.isInfinite(floatValue) || Float.isNaN(floatValue)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+        }
+
+        try {
+            // todo consider changing this implementation to more performant one which does not use intermediate String objects
+            BigDecimal bigDecimal = new BigDecimal(String.valueOf(floatValue)).setScale(intScale(scale), HALF_UP);
+            Slice decimal = Decimals.encodeScaledValue(bigDecimal);
+            if (UnscaledDecimal128Arithmetic.overflows(decimal, intScale(precision))) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT,
+                        format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+            }
+            return decimal;
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+        }
+    }
+
+    @SuppressWarnings("NumericCastThatLosesPrecision")
+    private static int intScale(long scale)
+    {
+        return (int) scale;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DecimalCoercers.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DecimalCoercers.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.airlift.slice.Slice;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.Decimals;
+
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.prestosql.spi.type.Decimals.longTenToNth;
+import static io.prestosql.spi.type.Decimals.overflows;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.overflows;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.rescale;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLongUnsafe;
+import static java.lang.String.format;
+
+public class DecimalCoercers
+{
+    private DecimalCoercers()
+    {
+    }
+
+    public static Function<Block, Block> createDecimalToDecimalCoercer(DecimalType fromType, DecimalType toType)
+    {
+        if (fromType.isShort()) {
+            if (toType.isShort()) {
+                return new ShortDecimalToShortDecimalCoercer(fromType, toType);
+            }
+            else {
+                return new ShortDecimalToLongDecimalCoercer(fromType, toType);
+            }
+        }
+        else {
+            if (toType.isShort()) {
+                return new LongDecimalToShortDecimalCoercer(fromType, toType);
+            }
+            else {
+                return new LongDecimalToLongDecimalCoercer(fromType, toType);
+            }
+        }
+    }
+
+    private static class ShortDecimalToShortDecimalCoercer
+            extends TypeCoercer<DecimalType, DecimalType>
+    {
+        private final long rescale;
+
+        public ShortDecimalToShortDecimalCoercer(DecimalType fromType, DecimalType toType)
+        {
+            super(fromType, toType);
+            rescale = longTenToNth(Math.abs(toType.getScale() - fromType.getScale()));
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            long returnValue = shortToShortCast(fromType.getLong(block, position),
+                    fromType.getPrecision(),
+                    fromType.getScale(),
+                    toType.getPrecision(),
+                    toType.getScale(),
+                    rescale,
+                    rescale / 2);
+            toType.writeLong(blockBuilder, returnValue);
+        }
+    }
+
+    private static class ShortDecimalToLongDecimalCoercer
+            extends TypeCoercer<DecimalType, DecimalType>
+    {
+        public ShortDecimalToLongDecimalCoercer(DecimalType fromType, DecimalType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            Slice coercedValue = shortToLongCast(fromType.getLong(block, position),
+                    fromType.getPrecision(),
+                    fromType.getScale(),
+                    toType.getPrecision(),
+                    toType.getScale());
+            toType.writeSlice(blockBuilder, coercedValue);
+        }
+    }
+
+    private static class LongDecimalToShortDecimalCoercer
+            extends TypeCoercer<DecimalType, DecimalType>
+    {
+        public LongDecimalToShortDecimalCoercer(DecimalType fromType, DecimalType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            long returnValue = longToShortCast(fromType.getSlice(block, position),
+                    fromType.getPrecision(),
+                    fromType.getScale(),
+                    toType.getPrecision(),
+                    toType.getScale());
+            toType.writeLong(blockBuilder, returnValue);
+        }
+    }
+
+    private static class LongDecimalToLongDecimalCoercer
+            extends TypeCoercer<DecimalType, DecimalType>
+    {
+        public LongDecimalToLongDecimalCoercer(DecimalType fromType, DecimalType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            Slice coercedValue = longToLongCast(fromType.getSlice(block, position),
+                    fromType.getPrecision(),
+                    fromType.getScale(),
+                    toType.getPrecision(),
+                    toType.getScale());
+            toType.writeSlice(blockBuilder, coercedValue);
+        }
+    }
+
+    private static long shortToShortCast(
+            long value,
+            long sourcePrecision,
+            long sourceScale,
+            long resultPrecision,
+            long resultScale,
+            long scalingFactor,
+            long halfOfScalingFactor)
+    {
+        long returnValue;
+        if (resultScale >= sourceScale) {
+            returnValue = value * scalingFactor;
+        }
+        else {
+            returnValue = value / scalingFactor;
+            if (value >= 0) {
+                if (value % scalingFactor >= halfOfScalingFactor) {
+                    returnValue++;
+                }
+            }
+            else {
+                if (value % scalingFactor <= -halfOfScalingFactor) {
+                    returnValue--;
+                }
+            }
+        }
+        if (overflows(returnValue, (int) resultPrecision)) {
+            throw throwCastException(value, sourcePrecision, sourceScale, resultPrecision, resultScale);
+        }
+        return returnValue;
+    }
+
+    /**
+     * most of the following cast logic is directly copied from io.prestosql.type.DecimalToDecimalCasts
+     * TODO: abstract the logic can be reused.
+     */
+    private static Slice shortToLongCast(
+            long value,
+            long sourcePrecision,
+            long sourceScale,
+            long resultPrecision,
+            long resultScale)
+    {
+        return longToLongCast(unscaledDecimal(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
+    }
+
+    private static long longToShortCast(
+            Slice value,
+            long sourcePrecision,
+            long sourceScale,
+            long resultPrecision,
+            long resultScale)
+    {
+        return unscaledDecimalToUnscaledLongUnsafe(longToLongCast(value, sourcePrecision, sourceScale, resultPrecision, resultScale));
+    }
+
+    private static Slice longToLongCast(
+            Slice value,
+            long sourcePrecision,
+            long sourceScale,
+            long resultPrecision,
+            long resultScale)
+    {
+        try {
+            Slice result = rescale(value, (int) (resultScale - sourceScale));
+            if (overflows(result, (int) resultPrecision)) {
+                throw throwCastException(unscaledDecimalToBigInteger(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
+            }
+            return result;
+        }
+        catch (ArithmeticException e) {
+            throw throwCastException(unscaledDecimalToBigInteger(value), sourcePrecision, sourceScale, resultPrecision, resultScale);
+        }
+    }
+
+    private static PrestoException throwCastException(long value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
+    {
+        return new PrestoException(INVALID_CAST_ARGUMENT,
+                format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
+                        Decimals.toString(value, (int) sourceScale),
+                        resultPrecision,
+                        resultScale));
+    }
+
+    private static PrestoException throwCastException(BigInteger value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
+    {
+        return new PrestoException(INVALID_CAST_ARGUMENT,
+                format("Cannot cast DECIMAL '%s' to DECIMAL(%d, %d)",
+                        Decimals.toString(value, (int) sourceScale),
+                        resultPrecision,
+                        resultScale));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DoubleToFloatCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/DoubleToFloatCoercer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RealType.REAL;
+import static java.lang.Float.floatToRawIntBits;
+
+public class DoubleToFloatCoercer
+        extends TypeCoercer
+{
+    public DoubleToFloatCoercer()
+    {
+        super(DOUBLE, REAL);
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        REAL.writeLong(blockBuilder, floatToRawIntBits((float) DOUBLE.getDouble(block, position)));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/FloatToDoubleCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/FloatToDoubleCoercer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RealType.REAL;
+import static java.lang.Float.intBitsToFloat;
+
+public class FloatToDoubleCoercer
+        extends TypeCoercer
+{
+    public FloatToDoubleCoercer()
+    {
+        super(REAL, DOUBLE);
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        DOUBLE.writeDouble(blockBuilder, intBitsToFloat((int) REAL.getLong(block, position)));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
+
+import static io.airlift.slice.Slices.utf8Slice;
+
+public class IntegerNumberToVarcharCoercer
+        extends TypeCoercer
+{
+    public IntegerNumberToVarcharCoercer(Type fromType, Type toType)
+    {
+        super(fromType, toType);
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        toType.writeSlice(blockBuilder, utf8Slice(String.valueOf(fromType.getLong(block, position))));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/IntegerNumberUpscaleCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/IntegerNumberUpscaleCoercer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
+
+public class IntegerNumberUpscaleCoercer
+        extends TypeCoercer
+{
+    public IntegerNumberUpscaleCoercer(Type fromType, Type toType)
+    {
+        super(fromType, toType);
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        toType.writeLong(blockBuilder, fromType.getLong(block, position));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/TypeCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/TypeCoercer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class TypeCoercer<F extends Type, T extends Type>
+        implements Function<Block, Block>
+{
+    protected final F fromType;
+    protected final T toType;
+
+    protected TypeCoercer(F fromType, T toType)
+    {
+        this.fromType = requireNonNull(fromType);
+        this.toType = requireNonNull(toType);
+    }
+
+    @Override
+    public Block apply(Block block)
+    {
+        BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (block.isNull(i)) {
+                blockBuilder.appendNull();
+                continue;
+            }
+            applyCoercedValue(blockBuilder, block, i);
+        }
+        return blockBuilder.build();
+    }
+
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/VarcharToIntegerNumberCoercer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/coercions/VarcharToIntegerNumberCoercer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.coercions;
+
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static java.lang.String.format;
+
+public class VarcharToIntegerNumberCoercer
+        extends TypeCoercer
+{
+    private final long minValue;
+    private final long maxValue;
+
+    public VarcharToIntegerNumberCoercer(Type fromType, Type toType)
+    {
+        super(fromType, toType);
+
+        if (toType.equals(TINYINT)) {
+            minValue = Byte.MIN_VALUE;
+            maxValue = Byte.MAX_VALUE;
+        }
+        else if (toType.equals(SMALLINT)) {
+            minValue = Short.MIN_VALUE;
+            maxValue = Short.MAX_VALUE;
+        }
+        else if (toType.equals(INTEGER)) {
+            minValue = Integer.MIN_VALUE;
+            maxValue = Integer.MAX_VALUE;
+        }
+        else if (toType.equals(BIGINT)) {
+            minValue = Long.MIN_VALUE;
+            maxValue = Long.MAX_VALUE;
+        }
+        else {
+            throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from from varchar to %s", toType));
+        }
+    }
+
+    @Override
+    protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+    {
+        try {
+            long value = Long.parseLong(fromType.getSlice(block, position).toStringUtf8());
+            if (minValue <= value && value <= maxValue) {
+                toType.writeLong(blockBuilder, value);
+            }
+            else {
+                blockBuilder.appendNull();
+            }
+        }
+        catch (NumberFormatException e) {
+            blockBuilder.appendNull();
+        }
+    }
+}


### PR DESCRIPTION
Trying to address https://github.com/prestosql/presto/issues/137

To do:
- [x] decimal to decimal.
- [x] decimal and double convert.
- [x] decimal and float convert.
- [x] double to float.

<del> Currently only support HivePageSource, add support for RecordPageSource.

Updated: this PR supports HivePageSource first.