### PR TITLE
Simplify ClassLoader management in Plugins

### DIFF
--- a/presto-atop/src/main/java/io/prestosql/plugin/atop/AtopPlugin.java
+++ b/presto-atop/src/main/java/io/prestosql/plugin/atop/AtopPlugin.java
@@ -17,19 +17,12 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 public class AtopPlugin
         implements Plugin
 {
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new AtopConnectorFactory(AtopProcessFactory.class, getClassLoader()));
-    }
-
-    private static ClassLoader getClassLoader()
-    {
-        return firstNonNull(Thread.currentThread().getContextClassLoader(), AtopPlugin.class.getClassLoader());
+        return ImmutableList.of(new AtopConnectorFactory(AtopProcessFactory.class, AtopPlugin.class.getClassLoader()));
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPlugin.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPlugin.java
@@ -18,7 +18,6 @@ import com.google.inject.Module;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
@@ -39,11 +38,6 @@ public class JdbcPlugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new JdbcConnectorFactory(name, module, getClassLoader()));
-    }
-
-    private static ClassLoader getClassLoader()
-    {
-        return firstNonNull(Thread.currentThread().getContextClassLoader(), JdbcPlugin.class.getClassLoader());
+        return ImmutableList.of(new JdbcConnectorFactory(name, module, JdbcPlugin.class.getClassLoader()));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePlugin.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePlugin.java
@@ -45,15 +45,6 @@ public class HivePlugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new HiveConnectorFactory(name, getClassLoader(), metastore));
-    }
-
-    private static ClassLoader getClassLoader()
-    {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader == null) {
-            classLoader = HivePlugin.class.getClassLoader();
-        }
-        return classLoader;
+        return ImmutableList.of(new HiveConnectorFactory(name, HivePlugin.class.getClassLoader(), metastore));
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/execution/resourceGroups/db/H2ResourceGroupManagerPlugin.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/resourceGroups/db/H2ResourceGroupManagerPlugin.java
@@ -17,8 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 public class H2ResourceGroupManagerPlugin
         implements Plugin
 {
@@ -26,11 +24,6 @@ public class H2ResourceGroupManagerPlugin
     public Iterable<ResourceGroupConfigurationManagerFactory> getResourceGroupConfigurationManagerFactories()
     {
         return ImmutableList.of(
-                new H2ResourceGroupConfigurationManagerFactory(getClassLoader()));
-    }
-
-    private static ClassLoader getClassLoader()
-    {
-        return firstNonNull(Thread.currentThread().getContextClassLoader(), H2ResourceGroupManagerPlugin.class.getClassLoader());
+                new H2ResourceGroupConfigurationManagerFactory(H2ResourceGroupManagerPlugin.class.getClassLoader()));
     }
 }


### PR DESCRIPTION
`PluginManager` instantiates `Plugin` and calls factory-providing
methods with Thread Context Class Loader (TCCL) always set to plugin
class loader. A Plugin needs not consider cases when TCCL is set or not.