### PR TITLE
Refactor test code for readability

### DIFF
--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.resourcegroups;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.google.common.annotations.VisibleForTesting;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
@@ -116,11 +115,5 @@ public class FileResourceGroupConfigurationManager
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst();
-    }
-
-    @VisibleForTesting
-    public List<ResourceGroupSelector> getSelectors()
-    {
-        return selectors;
     }
 }


### PR DESCRIPTION
* extract `queryTypeSelectionCriteria` method
* reorder methods so that helper methods are last
* merge `testInvalidQueryTypeConfiguration`, `testNonExistentGroup` with
  other `testInvalid` test cases