### PR TITLE
Avoid variable expansion when finding group spec

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
@@ -219,7 +219,7 @@ public final class InternalResourceGroupManager<C>
         if (!groups.containsKey(id)) {
             InternalResourceGroup group;
             if (id.getParent().isPresent()) {
-                createGroupIfNecessary(new SelectionContext<>(id.getParent().get(), context.getContext()), executor);
+                createGroupIfNecessary(configurationManager.get().parentGroupContext(context), executor);
                 InternalResourceGroup parent = groups.get(id.getParent().get());
                 requireNonNull(parent, "parent is null");
                 group = parent.getOrCreateSubGroup(id.getLastSegment());

--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/LegacyResourceGroupConfigurationManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/LegacyResourceGroupConfigurationManager.java
@@ -60,4 +60,12 @@ public class LegacyResourceGroupConfigurationManager
     {
         return Optional.of(new SelectionContext<>(GLOBAL, VoidContext.NONE));
     }
+
+    @Override
+    public SelectionContext<VoidContext> parentGroupContext(SelectionContext<VoidContext> context)
+    {
+        return new SelectionContext<>(
+                context.getResourceGroupId().getParent().orElseThrow(() -> new IllegalArgumentException("Group has no parent group: " + context.getResourceGroupId())),
+                VoidContext.NONE);
+    }
 }

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
@@ -31,7 +31,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
@@ -101,14 +100,13 @@ public class FileResourceGroupConfigurationManager
     }
 
     @Override
-    public void configure(ResourceGroup group, SelectionContext<VariableMap> context)
+    public void configure(ResourceGroup group, SelectionContext<ResourceGroupIdTemplate> context)
     {
-        Map.Entry<ResourceGroupIdTemplate, ResourceGroupSpec> entry = getMatchingSpec(group, context);
-        configureGroup(group, entry.getValue());
+        configureGroup(group, getMatchingSpec(group, context));
     }
 
     @Override
-    public Optional<SelectionContext<VariableMap>> match(SelectionCriteria criteria)
+    public Optional<SelectionContext<ResourceGroupIdTemplate>> match(SelectionCriteria criteria)
     {
         return selectors.stream()
                 .map(s -> s.match(criteria))

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/FileResourceGroupConfigurationManagerFactory.java
@@ -35,7 +35,7 @@ public class FileResourceGroupConfigurationManagerFactory
     }
 
     @Override
-    public ResourceGroupConfigurationManager<VariableMap> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
+    public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
         try {
             Bootstrap app = new Bootstrap(

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/ResourceGroupSelector.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/ResourceGroupSelector.java
@@ -20,5 +20,5 @@ import java.util.Optional;
 
 public interface ResourceGroupSelector
 {
-    Optional<SelectionContext<VariableMap>> match(SelectionCriteria criteria);
+    Optional<SelectionContext<ResourceGroupIdTemplate>> match(SelectionCriteria criteria);
 }

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/StaticSelector.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/StaticSelector.java
@@ -74,7 +74,7 @@ public class StaticSelector
     }
 
     @Override
-    public Optional<SelectionContext<VariableMap>> match(SelectionCriteria criteria)
+    public Optional<SelectionContext<ResourceGroupIdTemplate>> match(SelectionCriteria criteria)
     {
         Map<String, String> variables = new HashMap<>();
 
@@ -116,10 +116,8 @@ public class StaticSelector
         // Special handling for source, which is an optional field that is part of the standard variables
         variables.putIfAbsent(SOURCE_VARIABLE, criteria.getSource().orElse(""));
 
-        VariableMap map = new VariableMap(variables);
-        ResourceGroupId id = group.expandTemplate(map);
-
-        return Optional.of(new SelectionContext<>(id, map));
+        ResourceGroupId id = group.expandTemplate(new VariableMap(variables));
+        return Optional.of(new SelectionContext<>(id, group));
     }
 
     private static void addNamedGroups(Pattern pattern, HashSet<String> variables)

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.resourcegroups.db;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
-import io.prestosql.plugin.resourcegroups.VariableMap;
 import io.prestosql.spi.memory.ClusterMemoryPoolManager;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManager;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManagerContext;
@@ -36,7 +35,7 @@ public class DbResourceGroupConfigurationManagerFactory
     }
 
     @Override
-    public ResourceGroupConfigurationManager<VariableMap> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
+    public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
         try {
             Bootstrap app = new Bootstrap(

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbSourceExactMatchSelector.java
@@ -15,8 +15,8 @@ package io.prestosql.plugin.resourcegroups.db;
 
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
+import io.prestosql.plugin.resourcegroups.ResourceGroupIdTemplate;
 import io.prestosql.plugin.resourcegroups.ResourceGroupSelector;
-import io.prestosql.plugin.resourcegroups.VariableMap;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.resourcegroups.SelectionContext;
 import io.prestosql.spi.resourcegroups.SelectionCriteria;
@@ -25,8 +25,8 @@ import org.jdbi.v3.core.JdbiException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.Duration.nanosSince;
-import static io.prestosql.plugin.resourcegroups.VariableMap.emptyVariableMap;
 import static java.util.Objects.requireNonNull;
 
 public class DbSourceExactMatchSelector
@@ -45,7 +45,7 @@ public class DbSourceExactMatchSelector
     }
 
     @Override
-    public Optional<SelectionContext<VariableMap>> match(SelectionCriteria criteria)
+    public Optional<SelectionContext<ResourceGroupIdTemplate>> match(SelectionCriteria criteria)
     {
         if (!criteria.getSource().isPresent()) {
             return Optional.empty();
@@ -62,13 +62,16 @@ public class DbSourceExactMatchSelector
                 return Optional.empty();
             }
 
+            ResourceGroupId groupId;
             try {
-                return Optional.of(new SelectionContext<>(resourceGroupIdCodec.fromJson(resourceGroupId), emptyVariableMap()));
+                groupId = resourceGroupIdCodec.fromJson(resourceGroupId);
             }
             catch (IllegalArgumentException e) {
                 log.warn("Failed to decode resource group from DB: %s", resourceGroupId);
                 return Optional.empty();
             }
+
+            return Optional.of(new SelectionContext<>(groupId, toTemplate(groupId)));
         }
         catch (JdbiException e) {
             if (daoOfflineStart.compareAndSet(null, System.nanoTime())) {
@@ -77,5 +80,12 @@ public class DbSourceExactMatchSelector
 
             return Optional.empty();
         }
+    }
+
+    private static ResourceGroupIdTemplate toTemplate(ResourceGroupId groupId)
+    {
+        ResourceGroupIdTemplate template = new ResourceGroupIdTemplate(groupId.toString());
+        checkArgument(template.getVariableNames().isEmpty(), "Group ID contains variable references: %s", groupId);
+        return template;
     }
 }

--- a/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -13,15 +13,14 @@
  */
 package io.prestosql.plugin.resourcegroups.db;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.prestosql.execution.resourcegroups.InternalResourceGroup;
+import io.prestosql.plugin.resourcegroups.ResourceGroupIdTemplate;
 import io.prestosql.plugin.resourcegroups.ResourceGroupSelector;
 import io.prestosql.plugin.resourcegroups.ResourceGroupSpec;
 import io.prestosql.plugin.resourcegroups.StaticSelector;
-import io.prestosql.plugin.resourcegroups.VariableMap;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.resourcegroups.SchedulingPolicy;
@@ -85,7 +84,7 @@ public class TestDbResourceGroupConfigurationManager
         List<ResourceGroupSpec> groups = manager.getRootGroups();
         assertEquals(groups.size(), 1);
         InternalResourceGroup prodGlobal = new InternalResourceGroup.RootInternalResourceGroup("prod_global", (group, export) -> {}, directExecutor());
-        manager.configure(prodGlobal, new SelectionContext<>(prodGlobal.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(prodGlobal, new SelectionContext<>(prodGlobal.getId(), new ResourceGroupIdTemplate("prod_global")));
         assertEqualsResourceGroup(prodGlobal, "10MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
         assertEquals(manager.getSelectors().size(), 1);
         ResourceGroupSelector prodSelector = manager.getSelectors().get(0);
@@ -96,7 +95,7 @@ public class TestDbResourceGroupConfigurationManager
         manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), devEnvironment);
         assertEquals(groups.size(), 1);
         InternalResourceGroup devGlobal = new InternalResourceGroup.RootInternalResourceGroup("dev_global", (group, export) -> {}, directExecutor());
-        manager.configure(devGlobal, new SelectionContext<>(prodGlobal.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(devGlobal, new SelectionContext<>(prodGlobal.getId(), new ResourceGroupIdTemplate("dev_global")));
         assertEqualsResourceGroup(devGlobal, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
         assertEquals(manager.getSelectors().size(), 1);
         ResourceGroupSelector devSelector = manager.getSelectors().get(0);
@@ -119,11 +118,11 @@ public class TestDbResourceGroupConfigurationManager
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         AtomicBoolean exported = new AtomicBoolean();
         InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
-        manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
         assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
         exported.set(false);
         InternalResourceGroup sub = global.getOrCreateSubGroup("sub");
-        manager.configure(sub, new SelectionContext<>(sub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(sub, new SelectionContext<>(sub.getId(), new ResourceGroupIdTemplate("global.sub")));
         assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));
     }
 
@@ -180,9 +179,9 @@ public class TestDbResourceGroupConfigurationManager
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor());
 
-        assertThatThrownBy(() -> manager.configure(missing, new SelectionContext<>(missing.getId(), new VariableMap(ImmutableMap.of("USER", "user")))))
+        assertThatThrownBy(() -> manager.configure(missing, new SelectionContext<>(missing.getId(), new ResourceGroupIdTemplate("missing"))))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("No matching configuration found for: missing");
+                .hasMessage("No matching configuration found for [missing] using [missing]");
     }
 
     @Test(timeOut = 60_000)
@@ -202,9 +201,9 @@ public class TestDbResourceGroupConfigurationManager
         manager.start();
         AtomicBoolean exported = new AtomicBoolean();
         InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
-        manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
         InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub");
-        manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
+        manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new ResourceGroupIdTemplate("global.sub")));
         // Verify record exists
         assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));
         dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", 1L, ENVIRONMENT);

--- a/presto-resource-group-managers/src/test/resources/resource_groups_config_extract_variable.json
+++ b/presto-resource-group-managers/src/test/resources/resource_groups_config_extract_variable.json
@@ -11,6 +11,13 @@
       "jmxExport": true,
       "subGroups": [
         {
+          "name": "${resourceGroupName}",
+          "softMemoryLimit": "100%",
+          "hardConcurrencyLimit": 115,
+          "maxQueued": 1,
+          "schedulingWeight": 3
+        },
+        {
           "name": "${domain}:${region}:${cluster}",
           "softMemoryLimit": "2MB",
           "hardConcurrencyLimit": 3,
@@ -21,6 +28,10 @@
     }
   ],
   "selectors": [
+    {
+      "source": "rg-(?<resourceGroupName>.*)",
+      "group": "global.${resourceGroupName}"
+    },
     {
       "source": "scheduler\\.(?<region>(.*))\\.(?<cluster>[0-9]*)",
       "user": ".*@(?<domain>(.*)).io",

--- a/presto-spi/src/main/java/io/prestosql/spi/resourcegroups/ResourceGroupConfigurationManager.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/resourcegroups/ResourceGroupConfigurationManager.java
@@ -41,4 +41,14 @@ public interface ResourceGroupConfigurationManager<C>
      * This method is called for every query that is submitted, so it should be fast.
      */
     Optional<SelectionContext<C>> match(SelectionCriteria criteria);
+
+    /**
+     * This method is called when parent group of the one specified by {@link #match(SelectionCriteria)}'s
+     * {@link SelectionContext#getResourceGroupId()} does not exist yet. It should return a {@link SelectionContext}
+     * appropriate for {@link #configure(ResourceGroup, SelectionContext) configuration} of the parent group.
+     *
+     * @param context a selection context returned from {@link #match(SelectionCriteria)}
+     * @return a selection context suitable for {@link #configure(ResourceGroup, SelectionContext)} for the parent group
+     */
+    SelectionContext<C> parentGroupContext(SelectionContext<C> context);
 }

--- a/presto-tests/src/test/java/io/prestosql/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -17,7 +17,6 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.airlift.node.NodeModule;
-import io.prestosql.plugin.resourcegroups.VariableMap;
 import io.prestosql.plugin.resourcegroups.db.DbResourceGroupConfigurationManager;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.memory.ClusterMemoryPoolManager;
@@ -47,7 +46,7 @@ public class H2ResourceGroupConfigurationManagerFactory
     }
 
     @Override
-    public ResourceGroupConfigurationManager<VariableMap> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
+    public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(


### PR DESCRIPTION
Selector specs group ID template ands group specs' group name templates
must match exactly, as validated by
`io.prestosql.plugin.resourcegroups.AbstractResourceConfigurationManager#validateSelectors`.
Once a resource group is matched, there is no need to redo variable
expansion to find the group's spec. This fixes a bug when resource group
names use different sets of variables. Previously, name expansion would
fail because some variables remain unbound.