### PR TITLE
Add a system table to list all ANALYZE properties

### DIFF
--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -14,8 +14,10 @@ Description
 
 Collects table and column statistics for a given table.
 
-The optional ``WITH`` clause can be used to provide
-connector-specific properties.
+The optional ``WITH`` clause can be used to provide connector-specific properties.
+To list all available properties, run the following query::
+
+    SELECT * FROM system.metadata.analyze_properties
 
 Currently, this statement is only supported by the
 :ref:`Hive connector <hive_analyze>`.

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3071,6 +3071,14 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testAnalyzePropertiesSystemTable()
+    {
+        assertQuery(
+                "SELECT * FROM system.metadata.analyze_properties WHERE catalog_name = 'hive'",
+                "SELECT 'hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'");
+    }
+
+    @Test
     public void testAnalyzeEmptyTable()
     {
         String tableName = "test_analyze_empty_table";

--- a/presto-main/src/main/java/io/prestosql/connector/system/AnalyzePropertiesSystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/AnalyzePropertiesSystemTable.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.connector.system;
+
+import io.prestosql.metadata.Metadata;
+import io.prestosql.transaction.TransactionManager;
+
+import javax.inject.Inject;
+
+public class AnalyzePropertiesSystemTable
+        extends AbstractPropertiesSystemTable
+{
+    @Inject
+    public AnalyzePropertiesSystemTable(TransactionManager transactionManager, Metadata metadata)
+    {
+        super("analyze_properties", transactionManager, () -> metadata.getAnalyzePropertyManager().getAllProperties());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
@@ -52,6 +52,7 @@ public class SystemConnectorModule
         globalTableBinder.addBinding().to(SchemaPropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TablePropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(ColumnPropertiesSystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(AnalyzePropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TransactionsSystemTable.class).in(Scopes.SINGLETON);
 
         globalTableBinder.addBinding().to(AttributeJdbcTable.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -26,6 +26,7 @@ import io.prestosql.SystemSessionProperties;
 import io.prestosql.block.BlockEncodingManager;
 import io.prestosql.connector.ConnectorId;
 import io.prestosql.connector.ConnectorManager;
+import io.prestosql.connector.system.AnalyzePropertiesSystemTable;
 import io.prestosql.connector.system.CatalogSystemTable;
 import io.prestosql.connector.system.ColumnPropertiesSystemTable;
 import io.prestosql.connector.system.GlobalSystemConnector;
@@ -349,6 +350,7 @@ public class LocalQueryRunner
                 new SchemaPropertiesSystemTable(transactionManager, metadata),
                 new TablePropertiesSystemTable(transactionManager, metadata),
                 new ColumnPropertiesSystemTable(transactionManager, metadata),
+                new AnalyzePropertiesSystemTable(transactionManager, metadata),
                 new TransactionsSystemTable(typeRegistry, transactionManager)),
                 ImmutableSet.of());
 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -35,6 +35,11 @@ system| information_schema| views| table_catalog| varchar| YES| null| null|
 system| information_schema| views| table_schema| varchar| YES| null| null|
 system| information_schema| views| table_name| varchar| YES| null| null|
 system| information_schema| views| view_definition| varchar| YES| null| null|
+system| metadata| analyze_properties| catalog_name| varchar| YES| null| null|
+system| metadata| analyze_properties| property_name| varchar| YES| null| null|
+system| metadata| analyze_properties| default_value| varchar| YES| null| null|
+system| metadata| analyze_properties| type| varchar| YES| null| null|
+system| metadata| analyze_properties| description| varchar| YES| null| null|
 system| metadata| catalogs| catalog_name| varchar| YES| null| null|
 system| metadata| catalogs| connector_id| varchar| YES| null| null|
 system| metadata| column_properties| catalog_name| varchar| YES| null| null|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
@@ -1,5 +1,6 @@
 -- delimiter: |; ignoreOrder: true;
 catalogs|
+analyze_properties|
 schema_properties|
 table_properties|
 column_properties|

--- a/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
@@ -37,6 +37,12 @@ public class TestTpchDistributedQueries
     }
 
     @Test
+    public void testAnalyzePropertiesSystemTable()
+    {
+        assertQuery("SELECT COUNT(*) FROM system.metadata.analyze_properties WHERE catalog_name = 'tpch'", "SELECT 0");
+    }
+
+    @Test
     public void testAnalyze()
     {
         assertUpdate("ANALYZE orders", 15000);


### PR DESCRIPTION
Add a system table to list all ANALYZE properties

Extracted from: https://github.com/prestodb/presto/pull/12409