### PR TITLE
Add output types back to EXPLAIN output

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/NodeRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/NodeRepresentation.java
@@ -32,7 +32,7 @@ public class NodeRepresentation
     private final String name;
     private final String type;
     private final String identifier;
-    private final List<Symbol> outputs;
+    private final List<TypedSymbol> outputs;
     private final List<PlanNodeId> children;
     private final List<PlanFragmentId> remoteSources;
     private final Optional<PlanNodeStats> stats;
@@ -46,7 +46,7 @@ public class NodeRepresentation
             String name,
             String type,
             String identifier,
-            List<Symbol> outputs,
+            List<TypedSymbol> outputs,
             Optional<PlanNodeStats> stats,
             List<PlanNodeStatsEstimate> estimatedStats,
             List<PlanCostEstimate> estimatedCost,
@@ -103,7 +103,7 @@ public class NodeRepresentation
         return identifier;
     }
 
-    public List<Symbol> getOutputs()
+    public List<TypedSymbol> getOutputs()
     {
         return outputs;
     }
@@ -136,5 +136,27 @@ public class NodeRepresentation
     public List<PlanCostEstimate> getEstimatedCost()
     {
         return estimatedCost;
+    }
+
+    public static class TypedSymbol
+    {
+        private final Symbol symbol;
+        private final String type;
+
+        public TypedSymbol(Symbol symbol, String type)
+        {
+            this.symbol = symbol;
+            this.type = type;
+        }
+
+        public Symbol getSymbol()
+        {
+            return symbol;
+        }
+
+        public String getType()
+        {
+            return type;
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/PlanPrinter.java
@@ -99,6 +99,7 @@ import io.prestosql.sql.planner.plan.UnionNode;
 import io.prestosql.sql.planner.plan.UnnestNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.planner.planPrinter.NodeRepresentation.TypedSymbol;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FunctionCall;
@@ -1178,7 +1179,9 @@ public class PlanPrinter
                     name,
                     rootNode.getClass().getSimpleName(),
                     identifier,
-                    rootNode.getOutputSymbols(),
+                    rootNode.getOutputSymbols().stream()
+                            .map(s -> new TypedSymbol(s, types.get(s).getDisplayName()))
+                            .collect(toImmutableList()),
                     stats.map(s -> s.get(rootNode.getId())),
                     estimatedStats,
                     estimatedCosts,


### PR DESCRIPTION
Add output types back to EXPLAIN output

Output types were removed unintentionally in
1630408e2b940b059159c225d7b90c00a083e002

Extracted from: https://github.com/prestodb/presto/pull/12393
