### PR TITLE
Refactor testExtractVariableConfiguration()

### DIFF
--- a/presto-resource-group-managers/src/test/resources/resource_groups_config_extract_variable.json
+++ b/presto-resource-group-managers/src/test/resources/resource_groups_config_extract_variable.json
@@ -22,7 +22,7 @@
   ],
   "selectors": [
     {
-      "source": "scheduler.(?<region>(.*)).(?<cluster>[0-9]*)",
+      "source": "scheduler\\.(?<region>(.*))\\.(?<cluster>[0-9]*)",
       "user": ".*@(?<domain>(.*)).io",
       "group": "global.${domain}:${region}:${cluster}"
     }


### PR DESCRIPTION
Instead of instantiating `SelectionContext` directly, let the manager to
the match and create it for us.