### PR TITLE
Fix logging of etc directory location

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
@@ -113,10 +113,10 @@ public class PrestoServer
         Bootstrap app = new Bootstrap(modules.build());
 
         try {
+            Injector injector = app.strictConfig().initialize();
+
             log.info("Working directory: %s", Paths.get(".").toAbsolutePath().toRealPath());
             log.info("Etc directory: %s", Paths.get("etc").toAbsolutePath().toRealPath());
-
-            Injector injector = app.strictConfig().initialize();
 
             injector.getInstance(PluginManager.class).loadPlugins();
 


### PR DESCRIPTION
Logging destination is set up in
`io.airlift.bootstrap.Bootstrap#initialize` (by calling
`io.airlift.log.Logging#configure`). Before that point, logging goes to
launcher.log which is rarely consulted.