### PR TITLE
Remove useless output from EXPLAIN

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planPrinter/TextRenderer.java
@@ -96,7 +96,7 @@ public class TextRenderer
     {
         StringBuilder output = new StringBuilder();
         if (!node.getStats().isPresent() || !(plan.getTotalCpuTime().isPresent() && plan.getTotalScheduledTime().isPresent())) {
-            return "Cost: ?, Output: ? rows (?B)\n";
+            return "";
         }
 
         PlanNodeStats nodeStats = node.getStats().get();


### PR DESCRIPTION
Before the change, EXPLAIN would print "Cost: ?, Output: ? rows (?B)"
for every node. This information is available only in EXPLAIN ANALYZE.