### PR TITLE
Update CACHE_KEY when setting credential in HDFS configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
             <dependency>
                 <groupId>io.prestosql.hadoop</groupId>
                 <artifactId>hadoop-apache</artifactId>
-                <version>2.7.4-7</version>
+                <version>2.7.4-8</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/DynamicConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/DynamicConfigurationProvider.java
@@ -18,8 +18,17 @@ import org.apache.hadoop.conf.Configuration;
 import java.net.URI;
 
 import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import static org.apache.hadoop.fs.PrestoFileSystemCache.CACHE_KEY;
 
 public interface DynamicConfigurationProvider
 {
     void updateConfiguration(Configuration configuration, HdfsContext context, URI uri);
+
+    /**
+     * Set a cache key to invalidate the file system on credential (or other configuration) change.
+     */
+    static void setCacheKey(Configuration configuration, String value)
+    {
+        configuration.set(CACHE_KEY, configuration.get(CACHE_KEY, "") + "|" + value);
+    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/gcs/GcsConfigurationProvider.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import java.net.URI;
 
+import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
 import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import static io.prestosql.plugin.hive.gcs.GcsAccessTokenProvider.GCS_ACCESS_TOKEN_CONF;
 
@@ -37,6 +38,7 @@ public class GcsConfigurationProvider
         String accessToken = context.getIdentity().getExtraCredentials().get(GCS_OAUTH_KEY);
         if (accessToken != null) {
             configuration.set(GCS_ACCESS_TOKEN_CONF, accessToken);
+            setCacheKey(configuration, accessToken);
         }
     }
 }


### PR DESCRIPTION
The `PrestoFileSystemCache` is caching file system instances with stale credentials. Adding a `CACHE_KEY` property to pass to `PrestoFileSystemCache` so the cache will recreate the file system instance when `CACHE_KEY` changes.

Ref: prestosql/presto-hadoop-apache/pull/1.