### PR TITLE
Improve naming of metastore classes

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/CreateEmptyPartitionProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/CreateEmptyPartitionProcedure.java
@@ -19,7 +19,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.prestosql.plugin.hive.LocationService.WriteInfo;
 import io.prestosql.plugin.hive.PartitionUpdate.UpdateMode;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.ConnectorSession;
@@ -56,12 +56,12 @@ public class CreateEmptyPartitionProcedure
             List.class);
 
     private final Supplier<TransactionalMetadata> hiveMetadataFactory;
-    private final ExtendedHiveMetastore metastore;
+    private final HiveMetastore metastore;
     private final LocationService locationService;
     private final JsonCodec<PartitionUpdate> partitionUpdateJsonCodec;
 
     @Inject
-    public CreateEmptyPartitionProcedure(Supplier<TransactionalMetadata> hiveMetadataFactory, ExtendedHiveMetastore metastore, LocationService locationService, JsonCodec<PartitionUpdate> partitionUpdateCodec)
+    public CreateEmptyPartitionProcedure(Supplier<TransactionalMetadata> hiveMetadataFactory, HiveMetastore metastore, LocationService locationService, JsonCodec<PartitionUpdate> partitionUpdateCodec)
     {
         this.hiveMetadataFactory = requireNonNull(hiveMetadataFactory, "hiveMetadataFactory is null");
         this.metastore = requireNonNull(metastore, "metastore is null");

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
@@ -23,7 +23,7 @@ import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationModule;
 import io.prestosql.plugin.hive.gcs.HiveGcsModule;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
 import io.prestosql.plugin.hive.s3.HiveS3Module;
 import io.prestosql.plugin.hive.security.HiveSecurityModule;
@@ -66,9 +66,9 @@ public class HiveConnectorFactory
 {
     private final String name;
     private final ClassLoader classLoader;
-    private final Optional<ExtendedHiveMetastore> metastore;
+    private final Optional<HiveMetastore> metastore;
 
-    public HiveConnectorFactory(String name, ClassLoader classLoader, Optional<ExtendedHiveMetastore> metastore)
+    public HiveConnectorFactory(String name, ClassLoader classLoader, Optional<HiveMetastore> metastore)
     {
         checkArgument(!isNullOrEmpty(name), "name is null or empty");
         this.name = name;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -17,7 +17,7 @@ import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
 import io.prestosql.spi.type.TypeManager;
@@ -42,7 +42,7 @@ public class HiveMetadataFactory
     private final boolean createsOfNonManagedTablesEnabled;
     private final long perTransactionCacheMaximumSize;
     private final int maxPartitions;
-    private final ExtendedHiveMetastore metastore;
+    private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
     private final DateTimeZone timeZone;
@@ -57,7 +57,7 @@ public class HiveMetadataFactory
     @SuppressWarnings("deprecation")
     public HiveMetadataFactory(
             HiveConfig hiveConfig,
-            ExtendedHiveMetastore metastore,
+            HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             HivePartitionManager partitionManager,
             @ForHive ExecutorService executorService,
@@ -89,7 +89,7 @@ public class HiveMetadataFactory
     }
 
     public HiveMetadataFactory(
-            ExtendedHiveMetastore metastore,
+            HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             HivePartitionManager partitionManager,
             DateTimeZone timeZone,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
@@ -19,7 +19,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.event.client.EventClient;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePageSinkMetadataProvider;
 import io.prestosql.plugin.hive.metastore.SortingColumn;
 import io.prestosql.spi.NodeManager;
@@ -50,7 +50,7 @@ public class HivePageSinkProvider
     private final Set<HiveFileWriterFactory> fileWriterFactories;
     private final HdfsEnvironment hdfsEnvironment;
     private final PageSorter pageSorter;
-    private final ExtendedHiveMetastore metastore;
+    private final HiveMetastore metastore;
     private final PageIndexerFactory pageIndexerFactory;
     private final TypeManager typeManager;
     private final int maxOpenPartitions;
@@ -71,7 +71,7 @@ public class HivePageSinkProvider
             Set<HiveFileWriterFactory> fileWriterFactories,
             HdfsEnvironment hdfsEnvironment,
             PageSorter pageSorter,
-            ExtendedHiveMetastore metastore,
+            HiveMetastore metastore,
             PageIndexerFactory pageIndexerFactory,
             TypeManager typeManager,
             HiveConfig config,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePlugin.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePlugin.java
@@ -14,7 +14,7 @@
 package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 
@@ -28,14 +28,14 @@ public class HivePlugin
         implements Plugin
 {
     private final String name;
-    private final Optional<ExtendedHiveMetastore> metastore;
+    private final Optional<HiveMetastore> metastore;
 
     public HivePlugin(String name)
     {
         this(name, Optional.empty());
     }
 
-    public HivePlugin(String name, Optional<ExtendedHiveMetastore> metastore)
+    public HivePlugin(String name, Optional<HiveMetastore> metastore)
     {
         checkArgument(!isNullOrEmpty(name), "name is null or empty");
         this.name = name;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/CachingHiveMetastore.java
@@ -69,9 +69,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  */
 @ThreadSafe
 public class CachingHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
-    protected final ExtendedHiveMetastore delegate;
+    protected final HiveMetastore delegate;
     private final LoadingCache<String, Optional<Database>> databaseCache;
     private final LoadingCache<String, List<String>> databaseNamesCache;
     private final LoadingCache<HiveTableName, Optional<Table>> tableCache;
@@ -87,7 +87,7 @@ public class CachingHiveMetastore
     private final LoadingCache<HivePrincipal, Set<RoleGrant>> roleGrantsCache;
 
     @Inject
-    public CachingHiveMetastore(@ForCachingHiveMetastore ExtendedHiveMetastore delegate, @ForCachingHiveMetastore ExecutorService executor, HiveConfig hiveConfig)
+    public CachingHiveMetastore(@ForCachingHiveMetastore HiveMetastore delegate, @ForCachingHiveMetastore ExecutorService executor, HiveConfig hiveConfig)
     {
         this(
                 delegate,
@@ -97,7 +97,7 @@ public class CachingHiveMetastore
                 hiveConfig.getMetastoreCacheMaximumSize());
     }
 
-    public CachingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, Duration cacheTtl, Duration refreshInterval, long maximumSize)
+    public CachingHiveMetastore(HiveMetastore delegate, ExecutorService executor, Duration cacheTtl, Duration refreshInterval, long maximumSize)
     {
         this(
                 delegate,
@@ -107,7 +107,7 @@ public class CachingHiveMetastore
                 maximumSize);
     }
 
-    public static CachingHiveMetastore memoizeMetastore(ExtendedHiveMetastore delegate, long maximumSize)
+    public static CachingHiveMetastore memoizeMetastore(HiveMetastore delegate, long maximumSize)
     {
         return new CachingHiveMetastore(
                 delegate,
@@ -117,7 +117,7 @@ public class CachingHiveMetastore
                 maximumSize);
     }
 
-    private CachingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, OptionalLong expiresAfterWriteMillis, OptionalLong refreshMills, long maximumSize)
+    private CachingHiveMetastore(HiveMetastore delegate, ExecutorService executor, OptionalLong expiresAfterWriteMillis, OptionalLong refreshMills, long maximumSize)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         requireNonNull(executor, "executor is null");

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-public interface ExtendedHiveMetastore
+public interface HiveMetastore
 {
     Optional<Database> getDatabase(String databaseName);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastoreModule.java
@@ -27,9 +27,9 @@ import static io.airlift.configuration.ConditionalModule.installModuleIf;
 public class HiveMetastoreModule
         extends AbstractConfigurationAwareModule
 {
-    private final Optional<ExtendedHiveMetastore> metastore;
+    private final Optional<HiveMetastore> metastore;
 
-    public HiveMetastoreModule(Optional<ExtendedHiveMetastore> metastore)
+    public HiveMetastoreModule(Optional<HiveMetastore> metastore)
     {
         this.metastore = metastore;
     }
@@ -38,7 +38,7 @@ public class HiveMetastoreModule
     protected void setup(Binder binder)
     {
         if (metastore.isPresent()) {
-            binder.bind(ExtendedHiveMetastore.class).toInstance(metastore.get());
+            binder.bind(HiveMetastore.class).toInstance(metastore.get());
         }
         else {
             bindMetastoreModule("thrift", new ThriftMetastoreModule());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
@@ -24,12 +24,12 @@ import static java.util.Objects.requireNonNull;
 
 public class HivePageSinkMetadataProvider
 {
-    private final ExtendedHiveMetastore delegate;
+    private final HiveMetastore delegate;
     private final SchemaTableName schemaTableName;
     private final Optional<Table> table;
     private final Map<List<String>, Optional<Partition>> modifiedPartitions;
 
-    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, ExtendedHiveMetastore delegate)
+    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, HiveMetastore delegate)
     {
         requireNonNull(pageSinkMetadata, "pageSinkMetadata is null");
         this.delegate = delegate;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
@@ -246,7 +246,7 @@ public class MetastoreUtil
         }
     }
 
-    public static void verifyCanDropColumn(ExtendedHiveMetastore metastore, String databaseName, String tableName, String columnName)
+    public static void verifyCanDropColumn(HiveMetastore metastore, String databaseName, String tableName, String columnName)
     {
         Table table = metastore.getTable(databaseName, tableName)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -52,9 +52,9 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class RecordingHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
-    private final ExtendedHiveMetastore delegate;
+    private final HiveMetastore delegate;
     private final String recordingPath;
     private final boolean replay;
 
@@ -76,7 +76,7 @@ public class RecordingHiveMetastore
     private final Cache<HivePrincipal, Set<RoleGrant>> roleGrantsCache;
 
     @Inject
-    public RecordingHiveMetastore(@ForRecordingHiveMetastore ExtendedHiveMetastore delegate, HiveConfig hiveConfig)
+    public RecordingHiveMetastore(@ForRecordingHiveMetastore HiveMetastore delegate, HiveConfig hiveConfig)
             throws IOException
     {
         this.delegate = requireNonNull(delegate, "delegate is null");

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -33,8 +33,8 @@ import io.prestosql.plugin.hive.TableAlreadyExistsException;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.HiveColumnStatistics;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.Partition;
@@ -105,7 +105,7 @@ import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 
 @ThreadSafe
 public class FileHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
     private static final String PUBLIC_ROLE_NAME = "public";
     private static final String ADMIN_ROLE_NAME = "admin";

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileMetastoreModule.java
@@ -18,7 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.prestosql.plugin.hive.ForCachingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -30,9 +30,9 @@ public class FileMetastoreModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(FileHiveMetastoreConfig.class);
-        binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(FileHiveMetastore.class).in(Scopes.SINGLETON);
-        binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(ExtendedHiveMetastore.class)
+        binder.bind(HiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(FileHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(HiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(HiveMetastore.class)
                 .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -67,7 +67,7 @@ import io.prestosql.plugin.hive.SchemaAlreadyExistsException;
 import io.prestosql.plugin.hive.TableAlreadyExistsException;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.Partition;
@@ -119,7 +119,7 @@ import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 
 public class GlueHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
     private static final Logger log = Logger.get(GlueHiveMetastore.class);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -19,7 +19,7 @@ import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.prestosql.plugin.hive.ForRecordingHiveMetastore;
 import io.prestosql.plugin.hive.HiveConfig;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.RecordingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.WriteHiveMetastoreRecordingProcedure;
 import io.prestosql.spi.procedure.Procedure;
@@ -37,14 +37,14 @@ public class GlueMetastoreModule
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
 
         if (buildConfigObject(HiveConfig.class).getRecordingPath() != null) {
-            binder.bind(ExtendedHiveMetastore.class)
+            binder.bind(HiveMetastore.class)
                     .annotatedWith(ForRecordingHiveMetastore.class)
                     .to(GlueHiveMetastore.class)
                     .in(Scopes.SINGLETON);
             binder.bind(GlueHiveMetastore.class).in(Scopes.SINGLETON);
             newExporter(binder).export(GlueHiveMetastore.class).withGeneratedName();
 
-            binder.bind(ExtendedHiveMetastore.class).to(RecordingHiveMetastore.class).in(Scopes.SINGLETON);
+            binder.bind(HiveMetastore.class).to(RecordingHiveMetastore.class).in(Scopes.SINGLETON);
             binder.bind(RecordingHiveMetastore.class).in(Scopes.SINGLETON);
             newExporter(binder).export(RecordingHiveMetastore.class).withGeneratedName();
 
@@ -52,8 +52,8 @@ public class GlueMetastoreModule
             procedures.addBinding().toProvider(WriteHiveMetastoreRecordingProcedure.class).in(Scopes.SINGLETON);
         }
         else {
-            binder.bind(ExtendedHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
-            newExporter(binder).export(ExtendedHiveMetastore.class)
+            binder.bind(HiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
+            newExporter(binder).export(HiveMetastore.class)
                     .as(generator -> generator.generatedNameOf(GlueHiveMetastore.class));
         }
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -18,7 +18,7 @@ import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.HiveUtil;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.Partition;
@@ -53,7 +53,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.function.UnaryOperator.identity;
 
 public class BridgingHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
     private final ThriftMetastore delegate;
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -55,10 +55,10 @@ import static java.util.function.UnaryOperator.identity;
 public class BridgingHiveMetastore
         implements ExtendedHiveMetastore
 {
-    private final HiveMetastore delegate;
+    private final ThriftMetastore delegate;
 
     @Inject
-    public BridgingHiveMetastore(HiveMetastore delegate)
+    public BridgingHiveMetastore(ThriftMetastore delegate)
     {
         this.delegate = delegate;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/HiveMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/HiveMetastoreClientFactory.java
@@ -52,7 +52,7 @@ public class HiveMetastoreClientFactory
         this(Optional.empty(), Optional.ofNullable(config.getMetastoreSocksProxy()), config.getMetastoreTimeout(), metastoreAuthentication);
     }
 
-    public HiveMetastoreClient create(HostAndPort address)
+    public ThriftMetastoreClient create(HostAndPort address)
             throws TTransportException
     {
         return new ThriftHiveMetastoreClient(Transport.create(address, sslContext, socksProxy, timeoutMillis, metastoreAuthentication));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/MetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/MetastoreLocator.java
@@ -18,8 +18,8 @@ import org.apache.thrift.TException;
 public interface MetastoreLocator
 {
     /**
-     * Create a connected {@link HiveMetastoreClient}
+     * Create a connected {@link ThriftMetastoreClient}
      */
-    HiveMetastoreClient createMetastoreClient()
+    ThriftMetastoreClient createMetastoreClient()
             throws TException;
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -62,7 +62,7 @@ public class StaticMetastoreLocator
      * connection succeeds or there are no more fallback metastores.
      */
     @Override
-    public HiveMetastoreClient createMetastoreClient()
+    public ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
         List<HostAndPort> metastores = new ArrayList<>(addresses);
@@ -71,7 +71,7 @@ public class StaticMetastoreLocator
         TException lastException = null;
         for (HostAndPort metastore : metastores) {
             try {
-                HiveMetastoreClient client = clientFactory.create(metastore);
+                ThriftMetastoreClient client = clientFactory.create(metastore);
                 if (!isNullOrEmpty(metastoreUsername)) {
                     client.setUGI(metastoreUsername);
                 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -142,7 +142,7 @@ public class ThriftHiveMetastore
             return retry()
                     .stopOnIllegalExceptions()
                     .run("getAllDatabases", stats.getGetAllDatabases().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return client.getAllDatabases();
                         }
                     }));
@@ -163,7 +163,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getDatabase", stats.getGetDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return Optional.of(client.getDatabase(databaseName));
                         }
                     }));
@@ -183,13 +183,13 @@ public class ThriftHiveMetastore
     public Optional<List<String>> getAllTables(String databaseName)
     {
         Callable<List<String>> getAllTables = stats.getGetAllTables().wrap(() -> {
-            try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+            try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                 return client.getAllTables(databaseName);
             }
         });
 
         Callable<Void> getDatabase = stats.getGetDatabase().wrap(() -> {
-            try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+            try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                 client.getDatabase(databaseName);
                 return null;
             }
@@ -227,7 +227,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, HiveViewNotSupportedException.class)
                     .stopOnIllegalExceptions()
                     .run("getTable", stats.getGetTable().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             Table table = client.getTable(databaseName, tableName);
                             if (table.getTableType().equals(TableType.VIRTUAL_VIEW.name()) && !isPrestoView(table)) {
                                 throw new HiveViewNotSupportedException(new SchemaTableName(databaseName, tableName));
@@ -278,7 +278,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, HiveViewNotSupportedException.class)
                     .stopOnIllegalExceptions()
                     .run("getTableColumnStatistics", stats.getGetTableColumnStatistics().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return groupStatisticsByColumn(client.getTableColumnStatistics(databaseName, tableName, columns), rowCount);
                         }
                     }));
@@ -336,7 +336,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class, UnknownTableException.class, UnknownDBException.class)
                     .stopOnIllegalExceptions()
                     .run("getFields", stats.getGetFields().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return Optional.of(ImmutableList.copyOf(client.getFields(databaseName, tableName)));
                         }
                     }));
@@ -373,7 +373,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, HiveViewNotSupportedException.class)
                     .stopOnIllegalExceptions()
                     .run("getPartitionColumnStatistics", stats.getGetPartitionColumnStatistics().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return client.getPartitionColumnStatistics(databaseName, tableName, ImmutableList.copyOf(partitionNames), columnNames);
                         }
                     }));
@@ -427,7 +427,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("setTableColumnStatistics", stats.getCreateDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.setTableColumnStatistics(databaseName, tableName, statistics);
                         }
                         return null;
@@ -451,7 +451,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("deleteTableColumnStatistics", stats.getCreateDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.deleteTableColumnStatistics(databaseName, tableName, columnName);
                         }
                         return null;
@@ -518,7 +518,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("setPartitionColumnStatistics", stats.getCreateDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics);
                         }
                         return null;
@@ -542,7 +542,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("deletePartitionColumnStatistics", stats.getCreateDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.deletePartitionColumnStatistics(databaseName, tableName, partitionName, columnName);
                         }
                         return null;
@@ -567,7 +567,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("createRole", stats.getCreateRole().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.createRole(role, grantor);
                             return null;
                         }
@@ -589,7 +589,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("dropRole", stats.getDropRole().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.dropRole(role);
                             return null;
                         }
@@ -611,7 +611,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("listRoles", stats.getListRoles().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return ImmutableSet.copyOf(client.getRoleNames());
                         }
                     }));
@@ -645,7 +645,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("grantRole", stats.getGrantRole().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.grantRole(role, granteeName, granteeType, grantorName, grantorType, grantOption);
                             return null;
                         }
@@ -679,7 +679,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("revokeRole", stats.getRevokeRole().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.revokeRole(role, granteeName, granteeType, grantOption);
                             return null;
                         }
@@ -701,7 +701,7 @@ public class ThriftHiveMetastore
                     .stopOn(MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("listRoleGrants", stats.getListRoleGrants().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return fromRolePrincipalGrants(client.listRoleGrants(principal.getName(), fromPrestoPrincipalType(principal.getType())));
                         }
                     }));
@@ -722,7 +722,7 @@ public class ThriftHiveMetastore
                     .stopOn(UnknownDBException.class)
                     .stopOnIllegalExceptions()
                     .run("getAllViews", stats.getGetAllViews().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             String filter = HIVE_FILTER_FIELD_PARAMS + PRESTO_VIEW_FLAG + " = \"true\"";
                             return Optional.of(client.getTableNamesByFilter(databaseName, filter));
                         }
@@ -747,7 +747,7 @@ public class ThriftHiveMetastore
                     .stopOn(AlreadyExistsException.class, InvalidObjectException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("createDatabase", stats.getCreateDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.createDatabase(database);
                         }
                         return null;
@@ -772,7 +772,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, InvalidOperationException.class)
                     .stopOnIllegalExceptions()
                     .run("dropDatabase", stats.getDropDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.dropDatabase(databaseName, false, false);
                         }
                         return null;
@@ -797,7 +797,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("alterDatabase", stats.getAlterDatabase().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.alterDatabase(databaseName, database);
                         }
                         return null;
@@ -822,7 +822,7 @@ public class ThriftHiveMetastore
                     .stopOn(AlreadyExistsException.class, InvalidObjectException.class, MetaException.class, NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("createTable", stats.getCreateTable().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.createTable(table);
                         }
                         return null;
@@ -850,7 +850,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("dropTable", stats.getDropTable().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.dropTable(databaseName, tableName, deleteData);
                         }
                         return null;
@@ -875,7 +875,7 @@ public class ThriftHiveMetastore
                     .stopOn(InvalidOperationException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("alterTable", stats.getAlterTable().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             Optional<Table> source = getTable(databaseName, tableName);
                             if (!source.isPresent()) {
                                 throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
@@ -904,7 +904,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getPartitionNames", stats.getGetPartitionNames().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return Optional.of(client.getPartitionNames(databaseName, tableName));
                         }
                     }));
@@ -928,7 +928,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getPartitionNamesByParts", stats.getGetPartitionNamesPs().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return Optional.of(client.getPartitionNamesFiltered(databaseName, tableName, parts));
                         }
                     }));
@@ -966,7 +966,7 @@ public class ThriftHiveMetastore
                     .stopOn(AlreadyExistsException.class, InvalidObjectException.class, MetaException.class, NoSuchObjectException.class, PrestoException.class)
                     .stopOnIllegalExceptions()
                     .run("addPartitions", stats.getAddPartitions().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             int partitionsAdded = client.addPartitions(partitions);
                             if (partitionsAdded != partitions.size()) {
                                 throw new PrestoException(HIVE_METASTORE_ERROR,
@@ -998,7 +998,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("dropPartition", stats.getDropPartition().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.dropPartition(databaseName, tableName, parts, deleteData);
                         }
                         return null;
@@ -1030,7 +1030,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("alterPartition", stats.getAlterPartition().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.alterPartition(databaseName, tableName, partition);
                         }
                         return null;
@@ -1109,7 +1109,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getPartition", stats.getGetPartition().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return Optional.of(client.getPartition(databaseName, tableName, partitionValues));
                         }
                     }));
@@ -1136,7 +1136,7 @@ public class ThriftHiveMetastore
                     .stopOn(NoSuchObjectException.class)
                     .stopOnIllegalExceptions()
                     .run("getPartitionsByNames", stats.getGetPartitionsByNames().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             return client.getPartitionsByNames(databaseName, tableName, partitionNames);
                         }
                     }));
@@ -1165,7 +1165,7 @@ public class ThriftHiveMetastore
             retry()
                     .stopOnIllegalExceptions()
                     .run("grantTablePrivileges", stats.getGrantTablePrivileges().wrap(() -> {
-                        try (HiveMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
                             Set<HivePrivilegeInfo> existingPrivileges = listTablePrivileges(databaseName, tableName, grantee);
 
                             Set<PrivilegeGrantInfo> privilegesToGrant = new HashSet<>(requestedPrivileges);
@@ -1216,7 +1216,7 @@ public class ThriftHiveMetastore
             retry()
                     .stopOnIllegalExceptions()
                     .run("revokeTablePrivileges", stats.getRevokeTablePrivileges().wrap(() -> {
-                        try (HiveMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient metastoreClient = clientProvider.createMetastoreClient()) {
                             Set<HivePrivilege> existingHivePrivileges = listTablePrivileges(databaseName, tableName, grantee).stream()
                                     .map(HivePrivilegeInfo::getHivePrivilege)
                                     .collect(toSet());
@@ -1249,7 +1249,7 @@ public class ThriftHiveMetastore
             return retry()
                     .stopOnIllegalExceptions()
                     .run("listTablePrivileges", stats.getListTablePrivileges().wrap(() -> {
-                        try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = clientProvider.createMetastoreClient()) {
                             Table table = client.getTable(databaseName, tableName);
                             ImmutableSet.Builder<HivePrivilegeInfo> privileges = ImmutableSet.builder();
                             List<HiveObjectPrivilege> hiveObjectPrivilegeList;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -107,7 +107,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_
 
 @ThreadSafe
 public class ThriftHiveMetastore
-        implements HiveMetastore
+        implements ThriftMetastore
 {
     private final ThriftHiveMetastoreStats stats = new ThriftHiveMetastoreStats();
     private final MetastoreLocator clientProvider;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftHiveMetastoreClient
-        implements HiveMetastoreClient
+        implements ThriftMetastoreClient
 {
     private final TTransport transport;
     private final ThriftHiveMetastore.Client client;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 
-public interface HiveMetastore
+public interface ThriftMetastore
 {
     void createDatabase(Database database);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -30,7 +30,7 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 
-public interface HiveMetastoreClient
+public interface ThriftMetastoreClient
         extends Closeable
 {
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -21,7 +21,7 @@ import io.prestosql.plugin.hive.ForCachingHiveMetastore;
 import io.prestosql.plugin.hive.ForRecordingHiveMetastore;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.RecordingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.WriteHiveMetastoreRecordingProcedure;
 import io.prestosql.spi.procedure.Procedure;
@@ -44,11 +44,11 @@ public class ThriftMetastoreModule
         binder.bind(ThriftMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
 
         if (buildConfigObject(HiveConfig.class).getRecordingPath() != null) {
-            binder.bind(ExtendedHiveMetastore.class)
+            binder.bind(HiveMetastore.class)
                     .annotatedWith(ForRecordingHiveMetastore.class)
                     .to(BridgingHiveMetastore.class)
                     .in(Scopes.SINGLETON);
-            binder.bind(ExtendedHiveMetastore.class)
+            binder.bind(HiveMetastore.class)
                     .annotatedWith(ForCachingHiveMetastore.class)
                     .to(RecordingHiveMetastore.class)
                     .in(Scopes.SINGLETON);
@@ -59,16 +59,16 @@ public class ThriftMetastoreModule
             procedures.addBinding().toProvider(WriteHiveMetastoreRecordingProcedure.class).in(Scopes.SINGLETON);
         }
         else {
-            binder.bind(ExtendedHiveMetastore.class)
+            binder.bind(HiveMetastore.class)
                     .annotatedWith(ForCachingHiveMetastore.class)
                     .to(BridgingHiveMetastore.class)
                     .in(Scopes.SINGLETON);
         }
 
-        binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(HiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ThriftMetastore.class)
                 .as(generator -> generator.generatedNameOf(ThriftHiveMetastore.class));
-        newExporter(binder).export(ExtendedHiveMetastore.class)
+        newExporter(binder).export(HiveMetastore.class)
                 .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -41,7 +41,7 @@ public class ThriftMetastoreModule
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
         configBinder(binder).bindConfig(ThriftHiveMetastoreConfig.class);
 
-        binder.bind(HiveMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
 
         if (buildConfigObject(HiveConfig.class).getRecordingPath() != null) {
             binder.bind(ExtendedHiveMetastore.class)
@@ -66,7 +66,7 @@ public class ThriftMetastoreModule
         }
 
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(HiveMetastore.class)
+        newExporter(binder).export(ThriftMetastore.class)
                 .as(generator -> generator.generatedNameOf(ThriftHiveMetastore.class));
         newExporter(binder).export(ExtendedHiveMetastore.class)
                 .as(generator -> generator.generatedNameOf(CachingHiveMetastore.class));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -30,7 +30,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.CachingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
 import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
@@ -450,7 +450,7 @@ public abstract class AbstractTestHiveFileSystem
         private final Path basePath;
         private final HdfsEnvironment hdfsEnvironment;
 
-        public TestingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, HiveConfig hiveConfig, Path basePath, HdfsEnvironment hdfsEnvironment)
+        public TestingHiveMetastore(HiveMetastore delegate, ExecutorService executor, HiveConfig hiveConfig, Path basePath, HdfsEnvironment hdfsEnvironment)
         {
             super(delegate, executor, hiveConfig);
             this.basePath = basePath;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveLocal.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveLocal.java
@@ -15,7 +15,7 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.io.Files;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.connector.ConnectorMetadata;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.SchemaTableName;
@@ -49,14 +49,14 @@ public abstract class AbstractTestHiveLocal
         this.testDbName = requireNonNull(testDbName, "testDbName is null");
     }
 
-    protected abstract ExtendedHiveMetastore createMetastore(File tempDir);
+    protected abstract HiveMetastore createMetastore(File tempDir);
 
     @BeforeClass
     public void initialize()
     {
         tempDir = Files.createTempDir();
 
-        ExtendedHiveMetastore metastore = createMetastore(tempDir);
+        HiveMetastore metastore = createMetastore(tempDir);
 
         metastore.createDatabase(Database.builder()
                 .setDatabaseName(testDbName)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveBenchmarkQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveBenchmarkQueryRunner.java
@@ -18,7 +18,7 @@ import com.google.common.io.Files;
 import io.prestosql.Session;
 import io.prestosql.benchmark.BenchmarkSuite;
 import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.tpch.TpchConnectorFactory;
 import io.prestosql.spi.security.PrincipalType;
 import io.prestosql.testing.LocalQueryRunner;
@@ -67,7 +67,7 @@ public final class HiveBenchmarkQueryRunner
 
         // add hive
         File hiveDir = new File(tempDir, "hive_data");
-        ExtendedHiveMetastore metastore = createTestingFileHiveMetastore(hiveDir);
+        HiveMetastore metastore = createTestingFileHiveMetastore(hiveDir);
         metastore.createDatabase(Database.builder()
                 .setDatabaseName("tpch")
                 .setOwnerName("public")

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
@@ -15,7 +15,7 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import org.testng.SkipException;
 
@@ -25,7 +25,7 @@ public class TestHiveFileMetastore
         extends AbstractTestHiveLocal
 {
     @Override
-    protected ExtendedHiveMetastore createMetastore(File tempDir)
+    protected HiveMetastore createMetastore(File tempDir)
     {
         File baseDir = new File(tempDir, "metastore");
         HiveConfig hiveConfig = new HiveConfig();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.InMemoryThriftMetastore;
 
@@ -23,7 +23,7 @@ public class TestHiveInMemoryMetastore
         extends AbstractTestHiveLocal
 {
     @Override
-    protected ExtendedHiveMetastore createMetastore(File tempDir)
+    protected HiveMetastore createMetastore(File tempDir)
     {
         File baseDir = new File(tempDir, "metastore");
         InMemoryThriftMetastore hiveMetastore = new InMemoryThriftMetastore(baseDir);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
@@ -15,7 +15,7 @@ package io.prestosql.plugin.hive;
 
 import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.thrift.InMemoryHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.InMemoryThriftMetastore;
 
 import java.io.File;
 
@@ -26,7 +26,7 @@ public class TestHiveInMemoryMetastore
     protected ExtendedHiveMetastore createMetastore(File tempDir)
     {
         File baseDir = new File(tempDir, "metastore");
-        InMemoryHiveMetastore hiveMetastore = new InMemoryHiveMetastore(baseDir);
+        InMemoryThriftMetastore hiveMetastore = new InMemoryThriftMetastore(baseDir);
         return new BridgingHiveMetastore(hiveMetastore);
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -26,7 +26,7 @@ import io.airlift.tpch.TpchColumnType;
 import io.airlift.tpch.TpchColumnTypes;
 import io.prestosql.GroupByHashPageIndexerFactory;
 import io.prestosql.metadata.MetadataManager;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePageSinkMetadata;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
@@ -99,7 +99,7 @@ public class TestHivePageSink
         HiveConfig config = new HiveConfig();
         File tempDir = Files.createTempDir();
         try {
-            ExtendedHiveMetastore metastore = createTestingFileHiveMetastore(new File(tempDir, "metastore"));
+            HiveMetastore metastore = createTestingFileHiveMetastore(new File(tempDir, "metastore"));
             for (HiveStorageFormat format : HiveStorageFormat.values()) {
                 config.setHiveStorageFormat(format);
                 config.setHiveCompressionCodec(NONE);
@@ -126,7 +126,7 @@ public class TestHivePageSink
         return tempDir.getAbsolutePath() + "/" + config.getHiveStorageFormat().name() + "." + config.getHiveCompressionCodec().name();
     }
 
-    private static long writeTestFile(HiveConfig config, ExtendedHiveMetastore metastore, String outputPath)
+    private static long writeTestFile(HiveConfig config, HiveMetastore metastore, String outputPath)
     {
         HiveTransactionHandle transaction = new HiveTransactionHandle();
         HiveWriterStats stats = new HiveWriterStats();
@@ -233,7 +233,7 @@ public class TestHivePageSink
         return provider.createPageSource(transaction, getSession(config), split, ImmutableList.copyOf(getColumnHandles()));
     }
 
-    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveConfig config, ExtendedHiveMetastore metastore, Path outputPath, HiveWriterStats stats)
+    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveConfig config, HiveMetastore metastore, Path outputPath, HiveWriterStats stats)
     {
         LocationHandle locationHandle = new LocationHandle(outputPath, outputPath, false, DIRECT_TO_TARGET_NEW_DIRECTORY);
         HiveOutputTableHandle handle = new HiveOutputTableHandle(

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
@@ -18,12 +18,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.thrift.HiveMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
-import io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient;
+import io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreStats;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreClient;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -33,12 +33,12 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.BAD_DATABASE;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.TEST_DATABASE;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.TEST_PARTITION1;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.TEST_PARTITION2;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.TEST_ROLES;
-import static io.prestosql.plugin.hive.metastore.thrift.MockHiveMetastoreClient.TEST_TABLE;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.BAD_DATABASE;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_DATABASE;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION2;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_ROLES;
+import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_TABLE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -47,14 +47,14 @@ import static org.testng.Assert.assertNotNull;
 @Test(singleThreaded = true)
 public class TestCachingHiveMetastore
 {
-    private MockHiveMetastoreClient mockClient;
+    private MockThriftMetastoreClient mockClient;
     private CachingHiveMetastore metastore;
     private ThriftHiveMetastoreStats stats;
 
     @BeforeMethod
     public void setUp()
     {
-        mockClient = new MockHiveMetastoreClient();
+        mockClient = new MockThriftMetastoreClient();
         MetastoreLocator metastoreLocator = new MockMetastoreLocator(mockClient);
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
         ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(metastoreLocator, new ThriftHiveMetastoreConfig());
@@ -260,15 +260,15 @@ public class TestCachingHiveMetastore
     private static class MockMetastoreLocator
             implements MetastoreLocator
     {
-        private final HiveMetastoreClient client;
+        private final ThriftMetastoreClient client;
 
-        private MockMetastoreLocator(HiveMetastoreClient client)
+        private MockMetastoreLocator(ThriftMetastoreClient client)
         {
             this.client = client;
         }
 
         @Override
-        public HiveMetastoreClient createMetastoreClient()
+        public ThriftMetastoreClient createMetastoreClient()
         {
             return client;
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -122,7 +122,7 @@ public class TestRecordingHiveMetastore
         validateMetadata(recordingHiveMetastore);
     }
 
-    private void validateMetadata(ExtendedHiveMetastore hiveMetastore)
+    private void validateMetadata(HiveMetastore hiveMetastore)
     {
         assertEquals(hiveMetastore.getDatabase("database"), Optional.of(DATABASE));
         assertEquals(hiveMetastore.getAllDatabases(), ImmutableList.of("database"));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 class UnimplementedHiveMetastore
-        implements ExtendedHiveMetastore
+        implements HiveMetastore
 {
     @Override
     public Optional<Database> getDatabase(String databaseName)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -21,7 +21,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
-import io.prestosql.plugin.hive.metastore.ExtendedHiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 
 import java.io.File;
 
@@ -42,7 +42,7 @@ public class TestHiveGlueMetastore
      * on ways to set your AWS credentials which will be needed to run this test.
      */
     @Override
-    protected ExtendedHiveMetastore createMetastore(File tempDir)
+    protected HiveMetastore createMetastore(File tempDir)
     {
         HiveConfig hiveConfig = new HiveConfig();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveConfig), ImmutableSet.of());

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -67,8 +67,8 @@ import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 
-public class InMemoryHiveMetastore
-        implements HiveMetastore
+public class InMemoryThriftMetastore
+        implements ThriftMetastore
 {
     @GuardedBy("this")
     private final Map<String, Database> databases = new HashMap<>();
@@ -87,7 +87,7 @@ public class InMemoryHiveMetastore
 
     private final File baseDirectory;
 
-    public InMemoryHiveMetastore(File baseDirectory)
+    public InMemoryThriftMetastore(File baseDirectory)
     {
         this.baseDirectory = requireNonNull(baseDirectory, "baseDirectory is null");
         checkArgument(!baseDirectory.exists(), "Base directory already exists");
@@ -223,7 +223,7 @@ public class InMemoryHiveMetastore
         }
     }
 
-    private static List<String> listAllDataPaths(HiveMetastore metastore, String schemaName, String tableName)
+    private static List<String> listAllDataPaths(ThriftMetastore metastore, String schemaName, String tableName)
     {
         ImmutableList.Builder<String> locations = ImmutableList.builder();
         Table table = metastore.getTable(schemaName, tableName).get();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockHiveMetastoreClientFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockHiveMetastoreClientFactory.java
@@ -28,20 +28,20 @@ import static java.util.Objects.requireNonNull;
 public class MockHiveMetastoreClientFactory
         extends HiveMetastoreClientFactory
 {
-    private final List<HiveMetastoreClient> clients;
+    private final List<ThriftMetastoreClient> clients;
 
-    public MockHiveMetastoreClientFactory(Optional<HostAndPort> socksProxy, Duration timeout, List<HiveMetastoreClient> clients)
+    public MockHiveMetastoreClientFactory(Optional<HostAndPort> socksProxy, Duration timeout, List<ThriftMetastoreClient> clients)
     {
         super(Optional.empty(), socksProxy, timeout, new NoHiveMetastoreAuthentication());
         this.clients = new ArrayList<>(requireNonNull(clients, "clients is null"));
     }
 
     @Override
-    public HiveMetastoreClient create(HostAndPort address)
+    public ThriftMetastoreClient create(HostAndPort address)
             throws TTransportException
     {
         checkState(!clients.isEmpty(), "mock not given enough clients");
-        HiveMetastoreClient client = clients.remove(0);
+        ThriftMetastoreClient client = clients.remove(0);
         if (client == null) {
             throw new TTransportException(TTransportException.TIMED_OUT);
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -43,8 +43,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
 
-public class MockHiveMetastoreClient
-        implements HiveMetastoreClient
+public class MockThriftMetastoreClient
+        implements ThriftMetastoreClient
 {
     public static final String TEST_DATABASE = "testdb";
     public static final String BAD_DATABASE = "baddb";

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -28,8 +28,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestStaticMetastoreLocator
 {
-    private static final HiveMetastoreClient DEFAULT_CLIENT = createFakeMetastoreClient();
-    private static final HiveMetastoreClient FALLBACK_CLIENT = createFakeMetastoreClient();
+    private static final ThriftMetastoreClient DEFAULT_CLIENT = createFakeMetastoreClient();
+    private static final ThriftMetastoreClient FALLBACK_CLIENT = createFakeMetastoreClient();
 
     private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK = new StaticMetastoreConfig()
             .setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090");
@@ -97,13 +97,13 @@ public class TestStaticMetastoreLocator
                 .hasMessage(message);
     }
 
-    private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, List<HiveMetastoreClient> clients)
+    private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, List<ThriftMetastoreClient> clients)
     {
         return new StaticMetastoreLocator(config, new MockHiveMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
     }
 
-    private static HiveMetastoreClient createFakeMetastoreClient()
+    private static ThriftMetastoreClient createFakeMetastoreClient()
     {
-        return new MockHiveMetastoreClient();
+        return new MockThriftMetastoreClient();
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
@@ -33,7 +33,7 @@ public class TestingMetastoreLocator
     }
 
     @Override
-    public HiveMetastoreClient createMetastoreClient()
+    public ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
         return new HiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(address);


### PR DESCRIPTION
After the renames, this is what we have:

* `HiveMetastore` -- High level metastore interface used by main Hive connector code. Has Presto metastore classes and operations like `renameTable()` and `replaceTable()`.
* `ThriftMetastore` -- Metastore interface that uses Thrift metastore classes and low level operations like `alterTable()`. It is expected to handle retries and throw `PrestoException`.
* `ThriftMetastoreClient` -- Low level Thrift metastore client that throws `TException`.

I left the implementations `ThriftHiveMetastore` and `ThriftHiveMetastoreClient` alone because I didn't see any obvious good names and didn't want to break existing JMX stats.