### PR TITLE
Display proper view name for show create queries

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
 import com.google.common.primitives.Primitives;
 import io.prestosql.Session;
 import io.prestosql.connector.ConnectorId;
@@ -430,7 +431,7 @@ final class ShowQueriesRewrite
                 }
 
                 Query query = parseView(viewDefinition.get().getOriginalSql(), objectName, node);
-                List<Identifier> parts = node.getName().getOriginalParts();
+                List<Identifier> parts = Lists.reverse(node.getName().getOriginalParts());
                 Identifier tableName = parts.get(0);
                 Identifier schemaName = (parts.size() > 1) ? parts.get(1) : new Identifier(objectName.getSchemaName());
                 Identifier catalogName = (parts.size() > 2) ? parts.get(2) : new Identifier(objectName.getCatalogName());

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestDistributedQueries.java
@@ -749,6 +749,10 @@ public abstract class AbstractTestDistributedQueries
 
         assertEquals(getOnlyElement(actual.getOnlyColumnAsSet()), expectedSql);
 
+        actual = computeActual(format("SHOW CREATE VIEW %s.%s.meta_test_view", getSession().getCatalog().get(), getSession().getSchema().get()));
+
+        assertEquals(getOnlyElement(actual.getOnlyColumnAsSet()), expectedSql);
+
         assertUpdate("DROP VIEW meta_test_view");
     }
 


### PR DESCRIPTION
Fixes #433. When the query has a fully qualified view name for show create, generated result displays the name in a wrong order. This patch ensures that view name is shown in proper order. Test is also updated for the same. 