### PR TITLE
Add support for Search Guard in Elasticsearch connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -116,6 +116,99 @@ Use exponential backoff starting at 1s up to the value specified by this configu
 
 This property is optional; the default is ``10s``.
 
+Search Guard Authentication
+---------------------------
+
+The Elasticsearch connector provides additional security options to support Elasticsearch clusters that have been configured to use Search Guard.
+
+You can configure the certificate format by setting the ``searchguard.ssl.certificate_format`` config property in the Elasticsearch catalog properties file. The allowed values for this configuration are:
+
+========================== ========================================================
+Property Value	           Description
+========================== ========================================================
+``NONE`` (default)         Do not use Search Guard Authentication.
+``PEM``                    Use X.509 PEM certificates and PKCS #8 keys.
+``JKS``                    Use Keystore and Truststore files.
+========================== ========================================================
+
+If you use X.509 PEM certificates and PKCS #8 keys, the following properties must be set:
+
+===================================================== ==============================================================================
+Property Name                                         Description
+===================================================== ==============================================================================
+``searchguard.ssl.pemcert-filepath``                  Path to the X.509 node certificate chain.
+``searchguard.ssl.pemkey-filepath``                   Path to the certificates key file.
+``searchguard.ssl.pemkey-password``                   Key password. Omit this setting if the key has no password.
+``searchguard.ssl.pemtrustedcas-filepath``            Path to the root CA(s) (PEM format).
+===================================================== ==============================================================================
+
+If you use Keystore and Truststore files, the following properties must be set:
+
+===================================================== ==============================================================================
+Property Name                                         Description
+===================================================== ==============================================================================
+``searchguard.ssl.keystore-filepath``                 Path to the keystore file.
+``searchguard.ssl.keystore-password``                 Keystore password.
+``searchguard.ssl.truststore-filepath``               Path to the truststore file.
+``searchguard.ssl.truststore-password``               Truststore password.
+===================================================== ==============================================================================
+
+``searchguard.ssl.pemcert-filepath``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the X.509 node certificate chain. This file must be readable by the operating system user running Presto.
+
+This property is optional; the default is ``etc/elasticsearch/esnode.pem``.
+
+``searchguard.ssl.pemkey-filepath``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the certificates key file. This file must be readable by the operating system user running Presto.
+
+This property is optional; the default is ``etc/elasticsearch/esnode-key.pem``.
+
+``searchguard.ssl.pemkey-password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The key password for the key file specified by ``searchguard.ssl.pemkey-filepath``.
+
+This property is optional; the default is empty string.
+
+``searchguard.ssl.pemtrustedcas-filepath``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the root CA(s) (PEM format). This file must be readable by the operating system user running Presto.
+
+This property is optional; the default is ``etc/elasticsearch/root-ca.pem``.
+
+``searchguard.ssl.keystore-filepath``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the keystore file. This file must be readable by the operating system user running Presto.
+
+This property is optional; the default is ``etc/elasticsearch/keystore.jks``.
+
+``searchguard.ssl.keystore-password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The keystore password for the keystore file specified by ``searchguard.ssl.keystore-filepath``
+
+This property is optional; the default is empty string.
+
+``searchguard.ssl.truststore-filepath``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The path to the truststore file. This file must be readable by the operating system user running Presto.
+
+This property is optional; the default is ``etc/elasticsearch/truststore.jks``.
+
+``searchguard.ssl.truststore-password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The truststore password for the truststore file specified by ``searchguard.ssl.truststore-password``
+
+This property is optional; the default is empty string.
+
 Table Definition Files
 ----------------------
 

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -16,6 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.log4j.version>2.9.1</dep.log4j.version>
         <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.searchguard.version>6.0.1-25.4</dep.searchguard.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,18 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.floragunn</groupId>
+            <artifactId>search-guard-ssl</artifactId>
+            <version>${dep.searchguard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.elasticsearch.plugin</groupId>
+                    <artifactId>transport-netty4-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchClient.java
@@ -192,8 +192,8 @@ public class ElasticsearchClient
         verify(client != null, "client is null");
         String[] indices = getIndices(client, new GetIndexRequest());
         return Arrays.stream(indices)
-                    .filter(index -> index.startsWith(tableDescription.getIndex()))
-                    .collect(toImmutableList());
+                .filter(index -> index.startsWith(tableDescription.getIndex()))
+                .collect(toImmutableList());
     }
 
     public ClusterSearchShardsResponse getSearchShards(String index, ElasticsearchTableDescription tableDescription)

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConnectorConfig.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConnectorConfig.java
@@ -15,13 +15,16 @@ package io.prestosql.elasticsearch;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.Optional;
 
+import static io.prestosql.elasticsearch.SearchGuardCertificateFormat.NONE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -35,6 +38,15 @@ public class ElasticsearchConnectorConfig
     private Duration requestTimeout = new Duration(100, MILLISECONDS);
     private int maxRequestRetries = 5;
     private Duration maxRetryTime = new Duration(10, SECONDS);
+    private SearchGuardCertificateFormat certificateFormat = NONE;
+    private File pemcertFilepath = new File("etc/elasticsearch/esnode.pem");
+    private File pemkeyFilepath = new File("etc/elasticsearch/esnode-key.pem");
+    private String pemkeyPassword;
+    private File pemtrustedcasFilepath = new File("etc/elasticsearch/root-ca.pem");
+    private File keystoreFilepath = new File("etc/elasticsearch/keystore.jks");
+    private String keystorePassword;
+    private File truststoreFilepath = new File("etc/elasticsearch/truststore.jks");
+    private String truststorePassword;
 
     @NotNull
     public File getTableDescriptionDirectory()
@@ -147,6 +159,132 @@ public class ElasticsearchConnectorConfig
     public ElasticsearchConnectorConfig setMaxRetryTime(Duration maxRetryTime)
     {
         this.maxRetryTime = maxRetryTime;
+        return this;
+    }
+
+    @NotNull
+    public SearchGuardCertificateFormat getCertificateFormat()
+    {
+        return certificateFormat;
+    }
+
+    @Config("searchguard.ssl.certificate-format")
+    @ConfigDescription("Certificate format")
+    public ElasticsearchConnectorConfig setCertificateFormat(SearchGuardCertificateFormat certificateFormat)
+    {
+        this.certificateFormat = certificateFormat;
+        return this;
+    }
+
+    @NotNull
+    public File getPemcertFilepath()
+    {
+        return pemcertFilepath;
+    }
+
+    @Config("searchguard.ssl.pemcert-filepath")
+    @ConfigDescription("Path to the X.509 node certificate chain")
+    public ElasticsearchConnectorConfig setPemcertFilepath(File pemcertFilepath)
+    {
+        this.pemcertFilepath = pemcertFilepath;
+        return this;
+    }
+
+    @NotNull
+    public File getPemkeyFilepath()
+    {
+        return pemkeyFilepath;
+    }
+
+    @Config("searchguard.ssl.pemkey-filepath")
+    @ConfigDescription("Path to the certificates key file")
+    public ElasticsearchConnectorConfig setPemkeyFilepath(File pemkeyFilepath)
+    {
+        this.pemkeyFilepath = pemkeyFilepath;
+        return this;
+    }
+
+    public Optional<String> getPemkeyPassword()
+    {
+        return Optional.ofNullable(pemkeyPassword);
+    }
+
+    @Config("searchguard.ssl.pemkey-password")
+    @ConfigDescription("Key password. Omit this setting if the key has no password.")
+    @ConfigSecuritySensitive
+    public ElasticsearchConnectorConfig setPemkeyPassword(String pemkeyPassword)
+    {
+        this.pemkeyPassword = pemkeyPassword;
+        return this;
+    }
+
+    @NotNull
+    public File getPemtrustedcasFilepath()
+    {
+        return pemtrustedcasFilepath;
+    }
+
+    @Config("searchguard.ssl.pemtrustedcas-filepath")
+    @ConfigDescription("Path to the root CA(s) (PEM format)")
+    public ElasticsearchConnectorConfig setPemtrustedcasFilepath(File pemtrustedcasFilepath)
+    {
+        this.pemtrustedcasFilepath = pemtrustedcasFilepath;
+        return this;
+    }
+
+    @NotNull
+    public File getKeystoreFilepath()
+    {
+        return keystoreFilepath;
+    }
+
+    @Config("searchguard.ssl.keystore-filepath")
+    @ConfigDescription("Path to the keystore file")
+    public ElasticsearchConnectorConfig setKeystoreFilepath(File keystoreFilepath)
+    {
+        this.keystoreFilepath = keystoreFilepath;
+        return this;
+    }
+
+    public Optional<String> getKeystorePassword()
+    {
+        return Optional.ofNullable(keystorePassword);
+    }
+
+    @Config("searchguard.ssl.keystore-password")
+    @ConfigDescription("Keystore password")
+    @ConfigSecuritySensitive
+    public ElasticsearchConnectorConfig setKeystorePassword(String keystorePassword)
+    {
+        this.keystorePassword = keystorePassword;
+        return this;
+    }
+
+    @NotNull
+    public File getTruststoreFilepath()
+    {
+        return truststoreFilepath;
+    }
+
+    @Config("searchguard.ssl.truststore-filepath")
+    @ConfigDescription("Path to the truststore file")
+    public ElasticsearchConnectorConfig setTruststoreFilepath(File truststoreFilepath)
+    {
+        this.truststoreFilepath = truststoreFilepath;
+        return this;
+    }
+
+    public Optional<String> getTruststorePassword()
+    {
+        return Optional.ofNullable(truststorePassword);
+    }
+
+    @Config("searchguard.ssl.truststore-password")
+    @ConfigDescription("Truststore password")
+    @ConfigSecuritySensitive
+    public ElasticsearchConnectorConfig setTruststorePassword(String truststorePassword)
+    {
+        this.truststorePassword = truststorePassword;
         return this;
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.type.Type;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -34,7 +33,6 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -45,6 +43,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.elasticsearch.ElasticsearchClient.createTransportClient;
 import static io.prestosql.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_CONNECTION_ERROR;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
@@ -80,17 +79,14 @@ public class ElasticsearchQueryBuilder
         index = split.getIndex();
         shard = split.getShard();
         type = split.getType();
-        Settings settings = Settings.builder()
-                .put("client.transport.ignore_cluster_name", true)
-                .build();
+        InetAddress address;
         try {
-            InetAddress address = InetAddress.getByName(split.getSearchNode());
-            client = new PreBuiltTransportClient(settings)
-                    .addTransportAddress(new TransportAddress(address, split.getPort()));
+            address = InetAddress.getByName(split.getSearchNode());
         }
         catch (UnknownHostException e) {
-            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, format("Error connecting to search node (%s:%d)", split.getSearchNode(), split.getPort()), e);
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, format("Failed to resolve search node (%s:%d)", split.getSearchNode(), split.getPort()), e);
         }
+        client = createTransportClient(config, new TransportAddress(address, split.getPort()));
         scrollTimeout = config.getScrollTimeout();
         scrollSize = config.getScrollSize();
     }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/SearchGuardCertificateFormat.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/SearchGuardCertificateFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.elasticsearch;
+
+public enum SearchGuardCertificateFormat
+{
+    /**
+     * Use X.509 PEM certificates and PKCS #8 keys
+     */
+    PEM,
+    /**
+     * Use Keystore and Truststore files
+     */
+    JKS,
+    /**
+     * Default value
+     */
+    NONE
+}

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchConnectorConfig.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchConnectorConfig.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.elasticsearch.SearchGuardCertificateFormat.NONE;
+import static io.prestosql.elasticsearch.SearchGuardCertificateFormat.PEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -39,7 +41,16 @@ public class TestElasticsearchConnectorConfig
                 .setMaxHits(1000)
                 .setRequestTimeout(new Duration(100, MILLISECONDS))
                 .setMaxRequestRetries(5)
-                .setMaxRetryTime(new Duration(10, SECONDS)));
+                .setMaxRetryTime(new Duration(10, SECONDS))
+                .setCertificateFormat(NONE)
+                .setPemcertFilepath(new File("etc/elasticsearch/esnode.pem"))
+                .setPemkeyFilepath(new File("etc/elasticsearch/esnode-key.pem"))
+                .setPemkeyPassword(null)
+                .setPemtrustedcasFilepath(new File("etc/elasticsearch/root-ca.pem"))
+                .setKeystoreFilepath(new File("etc/elasticsearch/keystore.jks"))
+                .setKeystorePassword(null)
+                .setTruststoreFilepath(new File("etc/elasticsearch/truststore.jks"))
+                .setTruststorePassword(null));
     }
 
     @Test
@@ -54,6 +65,15 @@ public class TestElasticsearchConnectorConfig
                 .put("elasticsearch.request-timeout", "1s")
                 .put("elasticsearch.max-request-retries", "3")
                 .put("elasticsearch.max-request-retry-time", "5s")
+                .put("searchguard.ssl.certificate-format", "PEM")
+                .put("searchguard.ssl.pemcert-filepath", "etc/elasticsearch/esnode-2.pem")
+                .put("searchguard.ssl.pemkey-filepath", "etc/elasticsearch/esnode-key-2.pem")
+                .put("searchguard.ssl.pemkey-password", "111111")
+                .put("searchguard.ssl.pemtrustedcas-filepath", "etc/elasticsearch/root-ca-2.pem")
+                .put("searchguard.ssl.keystore-filepath", "etc/elasticsearch/keystore-2.jks")
+                .put("searchguard.ssl.keystore-password", "222222")
+                .put("searchguard.ssl.truststore-filepath", "etc/elasticsearch/truststore-2.jks")
+                .put("searchguard.ssl.truststore-password", "333333")
                 .build();
 
         ElasticsearchConnectorConfig expected = new ElasticsearchConnectorConfig()
@@ -64,7 +84,16 @@ public class TestElasticsearchConnectorConfig
                 .setMaxHits(20000)
                 .setRequestTimeout(new Duration(1, SECONDS))
                 .setMaxRequestRetries(3)
-                .setMaxRetryTime(new Duration(5, SECONDS));
+                .setMaxRetryTime(new Duration(5, SECONDS))
+                .setCertificateFormat(PEM)
+                .setPemcertFilepath(new File("etc/elasticsearch/esnode-2.pem"))
+                .setPemkeyFilepath(new File("etc/elasticsearch/esnode-key-2.pem"))
+                .setPemkeyPassword("111111")
+                .setPemtrustedcasFilepath(new File("etc/elasticsearch/root-ca-2.pem"))
+                .setKeystoreFilepath(new File("etc/elasticsearch/keystore-2.jks"))
+                .setKeystorePassword("222222")
+                .setTruststoreFilepath(new File("etc/elasticsearch/truststore-2.jks"))
+                .setTruststorePassword("333333");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add support for Search Guard in Elasticsearch connector

Extracted from: https://github.com/prestodb/presto/pull/12422
