### PR TITLE
Make ST_Centroid try-friendly

### DIFF
--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
@@ -383,22 +383,30 @@ public final class GeoFunctions
         }
 
         Point centroid;
-        switch (geometryType) {
-            case MULTI_POINT:
-                centroid = computePointsCentroid((MultiVertexGeometry) geometry.getEsriGeometry());
-                break;
-            case LINE_STRING:
-            case MULTI_LINE_STRING:
-                centroid = computeLineCentroid((Polyline) geometry.getEsriGeometry());
-                break;
-            case POLYGON:
-                centroid = computePolygonCentroid((Polygon) geometry.getEsriGeometry());
-                break;
-            case MULTI_POLYGON:
-                centroid = computeMultiPolygonCentroid((OGCMultiPolygon) geometry);
-                break;
-            default:
-                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Unexpected geometry type: " + geometryType);
+        try {
+            switch (geometryType) {
+                case MULTI_POINT:
+                    centroid = computePointsCentroid((MultiVertexGeometry) geometry.getEsriGeometry());
+                    break;
+                case LINE_STRING:
+                case MULTI_LINE_STRING:
+                    centroid = computeLineCentroid((Polyline) geometry.getEsriGeometry());
+                    break;
+                case POLYGON:
+                    centroid = computePolygonCentroid((Polygon) geometry.getEsriGeometry());
+                    break;
+                case MULTI_POLYGON:
+                    centroid = computeMultiPolygonCentroid((OGCMultiPolygon) geometry);
+                    break;
+                default:
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Unexpected geometry type: " + geometryType);
+            }
+        }
+        catch (RuntimeException e) {
+            if (e instanceof PrestoException && ((PrestoException) e).getErrorCode() == INVALID_FUNCTION_ARGUMENT.toErrorCode()) {
+                throw e;
+            }
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Cannot compute centroid: %s Use ST_IsValid to confirm that input geometry is valid or compute centroid for a bounding box using ST_Envelope.", e.getMessage()), e);
         }
         return serialize(createFromEsriGeometry(centroid, geometry.getEsriSpatialReference()));
     }

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
@@ -199,15 +199,20 @@ public class TestGeoFunctions
     @Test
     public void testSTCentroid()
     {
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('LINESTRING EMPTY')))", VARCHAR, "POINT EMPTY");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('POINT (3 5)')))", VARCHAR, "POINT (3 5)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('MULTIPOINT (1 2, 2 4, 3 6, 4 8)')))", VARCHAR, "POINT (2.5 5)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('LINESTRING (1 1, 2 2, 3 3)')))", VARCHAR, "POINT (2 2)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))')))", VARCHAR, "POINT (3 2)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')))", VARCHAR, "POINT (2.5 2.5)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('POLYGON ((1 1, 5 1, 3 4))')))", VARCHAR, "POINT (3 2)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 6, 6 4)))')))", VARCHAR, "POINT (3.3333333333333335 4)");
-        assertFunction("ST_AsText(ST_Centroid(ST_GeometryFromText('POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))')))", VARCHAR, "POINT (2.5416666666666665 2.5416666666666665)");
+        assertCentroid("LINESTRING EMPTY", new Point());
+        assertCentroid("POINT (3 5)", new Point(3, 5));
+        assertCentroid("MULTIPOINT (1 2, 2 4, 3 6, 4 8)", new Point(2.5, 5));
+        assertCentroid("LINESTRING (1 1, 2 2, 3 3)", new Point(2, 2));
+        assertCentroid("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))", new Point(3, 2));
+        assertCentroid("POLYGON ((1 1, 1 4, 4 4, 4 1))", new Point(2.5, 2.5));
+        assertCentroid("POLYGON ((1 1, 5 1, 3 4))", new Point(3, 2));
+        assertCentroid("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 6, 6 4)))", new Point(3.3333333333333335, 4));
+        assertCentroid("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))", new Point(2.5416666666666665, 2.5416666666666665));
+    }
+
+    private void assertCentroid(String wkt, Point centroid)
+    {
+        assertFunction(format("ST_AsText(ST_Centroid(ST_GeometryFromText('%s')))", wkt), VARCHAR, new OGCPoint(centroid, null).asText());
     }
 
     @Test

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
@@ -208,6 +208,9 @@ public class TestGeoFunctions
         assertCentroid("POLYGON ((1 1, 5 1, 3 4))", new Point(3, 2));
         assertCentroid("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 6, 6 4)))", new Point(3.3333333333333335, 4));
         assertCentroid("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))", new Point(2.5416666666666665, 2.5416666666666665));
+
+        // invalid geometry
+        assertInvalidFunction("ST_Centroid(ST_GeometryFromText('MULTIPOLYGON (((4.903234300000006 52.08474289999999, 4.903234265193165 52.084742934806826, 4.903234299999999 52.08474289999999, 4.903234300000006 52.08474289999999)))'))", "Cannot compute centroid: .* Use ST_IsValid to confirm that input geometry is valid or compute centroid for a bounding box using ST_Envelope.");
     }
 
     private void assertCentroid(String wkt, Point centroid)


### PR DESCRIPTION
Make ST_Centroid try-friendly

When input geometries are not valid, the computation may fail in unexpected
ways. Catch all exceptions and convert them  to IllegalArgumentException so that
they can be caught with SQL function try.

Extracted from: https://github.com/prestodb/presto/pull/12450
