### PR TITLE
Add BlockReadFunction and BlockWriteFunction

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BlockReadFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BlockReadFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.prestosql.spi.block.Block;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface BlockReadFunction
+        extends ReadFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return Block.class;
+    }
+
+    Block readBlock(ResultSet resultSet, int columnIndex)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BlockWriteFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BlockWriteFunction.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.prestosql.spi.block.Block;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface BlockWriteFunction
+        extends WriteFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return Block.class;
+    }
+
+    void set(PreparedStatement statement, int index, Block value)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ColumnMapping.java
@@ -66,6 +66,16 @@ public final class ColumnMapping
         return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
     }
 
+    public static ColumnMapping blockMapping(Type prestoType, BlockReadFunction readFunction, BlockWriteFunction writeFunction)
+    {
+        return blockMapping(prestoType, readFunction, writeFunction, UnaryOperator.identity());
+    }
+
+    public static ColumnMapping blockMapping(Type prestoType, BlockReadFunction readFunction, BlockWriteFunction writeFunction, UnaryOperator<Domain> pushdownConverter)
+    {
+        return new ColumnMapping(prestoType, readFunction, writeFunction, pushdownConverter);
+    }
+
     private final Type type;
     private final ReadFunction readFunction;
     private final WriteFunction writeFunction;

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -134,6 +134,9 @@ public class JdbcPageSink
         else if (javaType == Slice.class) {
             ((SliceWriteFunction) writeFunction).set(statement, parameterIndex, type.getSlice(block, position));
         }
+        else if (javaType == Block.class) {
+            ((BlockWriteFunction) writeFunction).set(statement, parameterIndex, (Block) type.getObject(block, position));
+        }
         else {
             throw new VerifyException(format("Unexpected type %s with java type %s", type, javaType.getName()));
         }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
@@ -17,6 +17,7 @@ import com.google.common.base.VerifyException;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.RecordCursor;
 import io.prestosql.spi.type.Type;
@@ -44,6 +45,7 @@ public class JdbcRecordCursor
     private final DoubleReadFunction[] doubleReadFunctions;
     private final LongReadFunction[] longReadFunctions;
     private final SliceReadFunction[] sliceReadFunctions;
+    private final BlockReadFunction[] blockReadFunctions;
 
     private final JdbcClient jdbcClient;
     private final Connection connection;
@@ -61,6 +63,7 @@ public class JdbcRecordCursor
         doubleReadFunctions = new DoubleReadFunction[columnHandles.size()];
         longReadFunctions = new LongReadFunction[columnHandles.size()];
         sliceReadFunctions = new SliceReadFunction[columnHandles.size()];
+        blockReadFunctions = new BlockReadFunction[columnHandles.size()];
 
         for (int i = 0; i < this.columnHandles.length; i++) {
             ColumnMapping columnMapping = jdbcClient.toPrestoType(session, columnHandles.get(i).getJdbcTypeHandle())
@@ -79,6 +82,9 @@ public class JdbcRecordCursor
             }
             else if (javaType == Slice.class) {
                 sliceReadFunctions[i] = (SliceReadFunction) readFunction;
+            }
+            else if (javaType == Block.class) {
+                blockReadFunctions[i] = (BlockReadFunction) readFunction;
             }
             else {
                 throw new IllegalStateException(format("Unsupported java type %s", javaType));
@@ -180,7 +186,13 @@ public class JdbcRecordCursor
     @Override
     public Object getObject(int field)
     {
-        throw new UnsupportedOperationException();
+        checkState(!closed, "cursor is closed");
+        try {
+            return blockReadFunctions[field].readBlock(resultSet, field + 1);
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.Domain;
@@ -151,6 +152,9 @@ public class QueryBuilder
             }
             else if (javaType == Slice.class) {
                 ((SliceWriteFunction) writeFunction).set(statement, parameterIndex, (Slice) value);
+            }
+            else if (javaType == Block.class) {
+                ((BlockWriteFunction) writeFunction).set(statement, parameterIndex, (Block) value);
             }
             else {
                 throw new VerifyException(format("Unexpected type %s with java type %s", type, javaType.getName()));

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteMapping.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/WriteMapping.java
@@ -38,6 +38,11 @@ public final class WriteMapping
         return new WriteMapping(dataType, writeFunction);
     }
 
+    public static WriteMapping blockMapping(String dataType, BlockWriteFunction writeFunction)
+    {
+        return new WriteMapping(dataType, writeFunction);
+    }
+
     private final String dataType;
     private final WriteFunction writeFunction;
 


### PR DESCRIPTION
It seems in base-jdbc, we're missing the Read/WriteFunction mappings for one `javaType` - the `Block` type.  This would be useful for things like implementing ARRAY support (#317).

One thing I'm not sure about here is in `JdbcRecordCursor` - there is only a `getObject()` function.  Can we assume `getObject()` will only be called for Block types, and hence add a call to `blockReadFunctions` there?  Or do we need to add a `getBlock` (but that would be a change to `RecordCursor`)?