### PR TITLE
Improve ORC double and float performance with batch reads

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/stream/DoubleInputStream.java
@@ -16,18 +16,21 @@ package io.prestosql.orc.stream;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.prestosql.orc.checkpoint.DoubleStreamCheckpoint;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.Type;
 
 import java.io.IOException;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static java.lang.Integer.min;
 
 public class DoubleInputStream
         implements ValueInputStream<DoubleStreamCheckpoint>
 {
+    private static final int BUFFER_SIZE = 128;
     private final OrcInputStream input;
-    private final byte[] buffer = new byte[SIZE_OF_DOUBLE];
+    private final byte[] buffer = new byte[SIZE_OF_DOUBLE * BUFFER_SIZE];
     private final Slice slice = Slices.wrappedBuffer(buffer);
 
     public DoubleInputStream(OrcInputStream input)
@@ -63,11 +66,51 @@ public class DoubleInputStream
         return slice.getDouble(0);
     }
 
-    public void nextVector(Type type, int items, BlockBuilder builder)
+    public Block nextBlock(Type type, boolean[] isNull)
             throws IOException
     {
-        for (int i = 0; i < items; i++) {
-            type.writeDouble(builder, next());
+        int items = isNull.length;
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, items);
+
+        for (int batchBase = 0; batchBase < items; batchBase += BUFFER_SIZE) {
+            int batchSize = min(items - batchBase, BUFFER_SIZE);
+
+            // stream is null suppressed, so count the present values
+            int nonNullCount = 0;
+            for (int i = batchBase; i < batchBase + batchSize; i++) {
+                if (!isNull[i]) {
+                    nonNullCount++;
+                }
+            }
+            input.readFully(buffer, 0, SIZE_OF_DOUBLE * nonNullCount);
+
+            int bufferIndex = 0;
+            for (int i = batchBase; i < batchBase + batchSize; i++) {
+                if (!isNull[i]) {
+                    type.writeDouble(blockBuilder, slice.getDouble(bufferIndex * SIZE_OF_DOUBLE));
+                    bufferIndex++;
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
+            }
         }
+        return blockBuilder.build();
+    }
+
+    public Block nextBlock(Type type, int items)
+            throws IOException
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, items);
+        for (int batchBase = 0; batchBase < items; batchBase += BUFFER_SIZE) {
+            int batchSize = min(items - batchBase, BUFFER_SIZE);
+
+            input.readFully(buffer, 0, SIZE_OF_DOUBLE * batchSize);
+
+            for (int i = 0; i < batchSize; i++) {
+                type.writeDouble(blockBuilder, slice.getDouble(i * SIZE_OF_DOUBLE));
+            }
+        }
+        return blockBuilder.build();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/stream/FloatInputStream.java
@@ -16,19 +16,22 @@ package io.prestosql.orc.stream;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.prestosql.orc.checkpoint.FloatStreamCheckpoint;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.Type;
 
 import java.io.IOException;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
-import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.floatToIntBits;
+import static java.lang.Integer.min;
 
 public class FloatInputStream
         implements ValueInputStream<FloatStreamCheckpoint>
 {
+    private static final int BUFFER_SIZE = 128;
     private final OrcInputStream input;
-    private final byte[] buffer = new byte[SIZE_OF_FLOAT];
+    private final byte[] buffer = new byte[SIZE_OF_FLOAT * BUFFER_SIZE];
     private final Slice slice = Slices.wrappedBuffer(buffer);
 
     public FloatInputStream(OrcInputStream input)
@@ -64,11 +67,51 @@ public class FloatInputStream
         return slice.getFloat(0);
     }
 
-    public void nextVector(Type type, int items, BlockBuilder builder)
+    public Block nextBlock(Type type, boolean[] isNull)
             throws IOException
     {
-        for (int i = 0; i < items; i++) {
-            type.writeLong(builder, floatToRawIntBits(next()));
+        int items = isNull.length;
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, items);
+
+        for (int batchBase = 0; batchBase < items; batchBase += BUFFER_SIZE) {
+            int batchSize = min(items - batchBase, BUFFER_SIZE);
+
+            // stream is null suppressed, so count the present values
+            int nonNullCount = 0;
+            for (int i = batchBase; i < batchBase + batchSize; i++) {
+                if (!isNull[i]) {
+                    nonNullCount++;
+                }
+            }
+            input.readFully(buffer, 0, SIZE_OF_FLOAT * nonNullCount);
+
+            int bufferIndex = 0;
+            for (int i = batchBase; i < batchBase + batchSize; i++) {
+                if (!isNull[i]) {
+                    type.writeLong(blockBuilder, floatToIntBits(slice.getFloat(bufferIndex * SIZE_OF_FLOAT)));
+                    bufferIndex++;
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
+            }
         }
+        return blockBuilder.build();
+    }
+
+    public Block nextBlock(Type type, int items)
+            throws IOException
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, items);
+        for (int batchBase = 0; batchBase < items; batchBase += BUFFER_SIZE) {
+            int batchSize = min(items - batchBase, BUFFER_SIZE);
+
+            input.readFully(buffer, 0, SIZE_OF_FLOAT * batchSize);
+
+            for (int i = 0; i < batchSize; i++) {
+                type.writeLong(blockBuilder, floatToIntBits(slice.getFloat(i * SIZE_OF_FLOAT)));
+            }
+        }
+        return blockBuilder.build();
     }
 }


### PR DESCRIPTION
### Speedup:
```
Benchmark                                  Speedup
BenchmarkStreamReaders.readDoubleNoNull      3.93x
BenchmarkStreamReaders.readDoubleWithNull    1.57x
BenchmarkStreamReaders.readFloatNoNull       5.17x
BenchmarkStreamReaders.readFloatWithNull     1.70x
```

### Before:
```
Benchmark                                  Mode  Cnt  Score   Error  Units
BenchmarkStreamReaders.readDoubleNoNull    avgt   60  0.228 ± 0.004   s/op
BenchmarkStreamReaders.readDoubleWithNull  avgt   60  0.173 ± 0.002   s/op
BenchmarkStreamReaders.readFloatNoNull     avgt   60  0.212 ± 0.003   s/op
BenchmarkStreamReaders.readFloatWithNull   avgt   60  0.179 ± 0.003   s/op
```

### After:
```
Benchmark                                  Mode  Cnt  Score   Error  Units
BenchmarkStreamReaders.readDoubleNoNull    avgt   60  0.058 ± 0.001   s/op
BenchmarkStreamReaders.readDoubleWithNull  avgt   60  0.110 ± 0.002   s/op
BenchmarkStreamReaders.readFloatNoNull     avgt   60  0.041 ± 0.001   s/op
BenchmarkStreamReaders.readFloatWithNull   avgt   60  0.105 ± 0.001   s/op
```