### PR TITLE
Base ScanFilterAndProjectOperator on WorkProcessors

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -62,6 +63,11 @@ public interface WorkProcessor<T>
     default WorkProcessor<T> yielding(BooleanSupplier yieldSignal)
     {
         return WorkProcessorUtils.yielding(this, yieldSignal);
+    }
+
+    default WorkProcessor<T> withProcessStateMonitor(Consumer<ProcessState<? extends T>> monitor)
+    {
+        return WorkProcessorUtils.processStateMonitor(this, monitor);
     }
 
     default <R> WorkProcessor<R> flatMap(Function<T, WorkProcessor<R>> mapper)
@@ -295,7 +301,7 @@ public interface WorkProcessor<T>
         private static final ProcessState<?> YIELD_STATE = new ProcessState<>(Type.YIELD, Optional.empty(), Optional.empty());
         private static final ProcessState<?> FINISHED_STATE = new ProcessState<>(Type.FINISHED, Optional.empty(), Optional.empty());
 
-        enum Type
+        public enum Type
         {
             BLOCKED,
             YIELD,
@@ -348,17 +354,17 @@ public interface WorkProcessor<T>
             return (ProcessState<T>) FINISHED_STATE;
         }
 
-        Type getType()
+        public Type getType()
         {
             return type;
         }
 
-        Optional<T> getResult()
+        public Optional<T> getResult()
         {
             return result;
         }
 
-        Optional<ListenableFuture<?>> getBlocked()
+        public Optional<ListenableFuture<?>> getBlocked()
         {
             return blocked;
         }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
@@ -161,7 +161,7 @@ public interface WorkProcessor<T>
         /**
          * Processes input elements and returns current transformation state.
          *
-         * @param elementOptional an element to be transformed. Will be empty
+         * @param element an element to be transformed. Will be null
          * when there are no more elements. In such case transformation should
          * finish processing and flush any remaining data.
          * @return the current transformation state, optionally bearing a result
@@ -172,7 +172,7 @@ public interface WorkProcessor<T>
          * @see TransformationState#ofResult(Object, boolean)
          * @see TransformationState#finished()
          */
-        TransformationState<R> process(Optional<T> elementOptional);
+        TransformationState<R> process(@Nullable T element);
     }
 
     interface Process<T>

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
@@ -16,6 +16,7 @@ package io.prestosql.operator;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Comparator;
@@ -191,9 +192,9 @@ public interface WorkProcessor<T>
     @Immutable
     final class TransformationState<T>
     {
-        private static final TransformationState<?> NEEDS_MORE_DATE_STATE = new TransformationState<>(Type.NEEDS_MORE_DATA, true, Optional.empty(), Optional.empty());
-        private static final TransformationState<?> YIELD_STATE = new TransformationState<>(Type.YIELD, false, Optional.empty(), Optional.empty());
-        private static final TransformationState<?> FINISHED_STATE = new TransformationState<>(Type.FINISHED, false, Optional.empty(), Optional.empty());
+        private static final TransformationState<?> NEEDS_MORE_DATE_STATE = new TransformationState<>(Type.NEEDS_MORE_DATA, true, null, null);
+        private static final TransformationState<?> YIELD_STATE = new TransformationState<>(Type.YIELD, false, null, null);
+        private static final TransformationState<?> FINISHED_STATE = new TransformationState<>(Type.FINISHED, false, null, null);
 
         enum Type
         {
@@ -206,15 +207,17 @@ public interface WorkProcessor<T>
 
         private final Type type;
         private final boolean needsMoreData;
-        private final Optional<T> result;
-        private final Optional<ListenableFuture<?>> blocked;
+        @Nullable
+        private final T result;
+        @Nullable
+        private final ListenableFuture<?> blocked;
 
-        private TransformationState(Type type, boolean needsMoreData, Optional<T> result, Optional<ListenableFuture<?>> blocked)
+        private TransformationState(Type type, boolean needsMoreData, @Nullable T result, @Nullable ListenableFuture<?> blocked)
         {
             this.type = requireNonNull(type, "type is null");
             this.needsMoreData = needsMoreData;
-            this.result = requireNonNull(result, "result is null");
-            this.blocked = requireNonNull(blocked, "blocked is null");
+            this.result = result;
+            this.blocked = blocked;
         }
 
         /**
@@ -234,7 +237,7 @@ public interface WorkProcessor<T>
          */
         public static <T> TransformationState<T> blocked(ListenableFuture<?> blocked)
         {
-            return new TransformationState<>(Type.BLOCKED, false, Optional.empty(), Optional.of(blocked));
+            return new TransformationState<>(Type.BLOCKED, false, null, requireNonNull(blocked, "blocked is null"));
         }
 
         /**
@@ -262,7 +265,7 @@ public interface WorkProcessor<T>
          */
         public static <T> TransformationState<T> ofResult(T result, boolean needsMoreData)
         {
-            return new TransformationState<>(Type.RESULT, needsMoreData, Optional.of(result), Optional.empty());
+            return new TransformationState<>(Type.RESULT, needsMoreData, requireNonNull(result, "result is null"), null);
         }
 
         /**
@@ -284,12 +287,14 @@ public interface WorkProcessor<T>
             return needsMoreData;
         }
 
-        Optional<T> getResult()
+        @Nullable
+        T getResult()
         {
             return result;
         }
 
-        Optional<ListenableFuture<?>> getBlocked()
+        @Nullable
+        ListenableFuture<?> getBlocked()
         {
             return blocked;
         }
@@ -298,8 +303,8 @@ public interface WorkProcessor<T>
     @Immutable
     final class ProcessState<T>
     {
-        private static final ProcessState<?> YIELD_STATE = new ProcessState<>(Type.YIELD, Optional.empty(), Optional.empty());
-        private static final ProcessState<?> FINISHED_STATE = new ProcessState<>(Type.FINISHED, Optional.empty(), Optional.empty());
+        private static final ProcessState<?> YIELD_STATE = new ProcessState<>(Type.YIELD, null, null);
+        private static final ProcessState<?> FINISHED_STATE = new ProcessState<>(Type.FINISHED, null, null);
 
         public enum Type
         {
@@ -310,14 +315,16 @@ public interface WorkProcessor<T>
         }
 
         private final Type type;
-        private final Optional<T> result;
-        private final Optional<ListenableFuture<?>> blocked;
+        @Nullable
+        private final T result;
+        @Nullable
+        private final ListenableFuture<?> blocked;
 
-        private ProcessState(Type type, Optional<T> result, Optional<ListenableFuture<?>> blocked)
+        private ProcessState(Type type, @Nullable T result, @Nullable ListenableFuture<?> blocked)
         {
             this.type = requireNonNull(type, "type is null");
-            this.result = requireNonNull(result, "result is null");
-            this.blocked = requireNonNull(blocked, "blocked is null");
+            this.result = result;
+            this.blocked = blocked;
         }
 
         /**
@@ -325,7 +332,7 @@ public interface WorkProcessor<T>
          */
         public static <T> ProcessState<T> blocked(ListenableFuture<?> blocked)
         {
-            return new ProcessState<>(Type.BLOCKED, Optional.empty(), Optional.of(blocked));
+            return new ProcessState<>(Type.BLOCKED, null, requireNonNull(blocked, "blocked is null"));
         }
 
         /**
@@ -342,7 +349,7 @@ public interface WorkProcessor<T>
          */
         public static <T> ProcessState<T> ofResult(T result)
         {
-            return new ProcessState<>(Type.RESULT, Optional.of(result), Optional.empty());
+            return new ProcessState<>(Type.RESULT, requireNonNull(result, "result is null"), null);
         }
 
         /**
@@ -359,12 +366,14 @@ public interface WorkProcessor<T>
             return type;
         }
 
-        public Optional<T> getResult()
+        @Nullable
+        public T getResult()
         {
             return result;
         }
 
-        public Optional<ListenableFuture<?>> getBlocked()
+        @Nullable
+        public ListenableFuture<?> getBlocked()
         {
             return blocked;
         }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorUtils.java
@@ -301,11 +301,11 @@ public final class WorkProcessorUtils
                         case NEEDS_MORE_DATA:
                             break;
                         case BLOCKED:
-                            return ProcessState.blocked(state.getBlocked().get());
+                            return ProcessState.blocked(state.getBlocked());
                         case YIELD:
                             return ProcessState.yield();
                         case RESULT:
-                            return ProcessState.ofResult(state.getResult().get());
+                            return ProcessState.ofResult(state.getResult());
                         case FINISHED:
                             return ProcessState.finished();
                     }
@@ -353,14 +353,14 @@ public final class WorkProcessorUtils
         @Override
         public boolean isBlocked()
         {
-            return state != null && state.getType() == ProcessState.Type.BLOCKED && !state.getBlocked().get().isDone();
+            return state != null && state.getType() == ProcessState.Type.BLOCKED && !state.getBlocked().isDone();
         }
 
         @Override
         public ListenableFuture<?> getBlockedFuture()
         {
             checkState(state != null && state.getType() == ProcessState.Type.BLOCKED, "Must be blocked to get blocked future");
-            return state.getBlocked().get();
+            return state.getBlocked();
         }
 
         @Override
@@ -373,7 +373,7 @@ public final class WorkProcessorUtils
         public T getResult()
         {
             checkState(state != null && state.getType() == ProcessState.Type.RESULT, "process() must return true and must not be finished");
-            return state.getResult().get();
+            return state.getResult();
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -91,7 +91,7 @@ public class MergingHashAggregationBuilder
             boolean reset = true;
             long memorySize;
 
-            public TransformationState<WorkProcessor<Page>> process(Optional<Page> inputPageOptional)
+            public TransformationState<WorkProcessor<Page>> process(Page inputPage)
             {
                 if (reset) {
                     rebuildHashAggregationBuilder();
@@ -99,14 +99,13 @@ public class MergingHashAggregationBuilder
                     reset = false;
                 }
 
-                boolean inputFinished = !inputPageOptional.isPresent();
+                boolean inputFinished = inputPage == null;
                 if (inputFinished && memorySize == 0) {
                     // no more pages and aggregation builder is empty
                     return TransformationState.finished();
                 }
 
                 if (!inputFinished) {
-                    Page inputPage = inputPageOptional.get();
                     boolean done = hashAggregationBuilder.processPage(inputPage).process();
                     // TODO: this class does not yield wrt memory limit; enable it
                     verify(done);

--- a/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
@@ -23,7 +23,6 @@ import io.prestosql.spi.PageBuilder;
 import io.prestosql.spi.type.Type;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.operator.WorkProcessor.TransformationState.finished;
@@ -109,7 +108,7 @@ public class MergePages
         }
 
         @Override
-        public TransformationState<Page> process(Optional<Page> inputPageOptional)
+        public TransformationState<Page> process(Page inputPage)
         {
             if (queuedPage != null) {
                 Page output = queuedPage;
@@ -118,7 +117,7 @@ public class MergePages
                 return ofResult(output);
             }
 
-            boolean inputFinished = !inputPageOptional.isPresent();
+            boolean inputFinished = inputPage == null;
             if (inputFinished) {
                 if (pageBuilder.isEmpty()) {
                     memoryContext.close();
@@ -128,7 +127,6 @@ public class MergePages
                 return ofResult(flush(), false);
             }
 
-            Page inputPage = inputPageOptional.get();
             if (inputPage.getPositionCount() >= minRowCount || inputPage.getSizeInBytes() >= minPageSizeInBytes) {
                 if (pageBuilder.isEmpty()) {
                     return ofResult(inputPage);

--- a/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
@@ -129,7 +129,7 @@ public class MergePages
             }
 
             Page inputPage = inputPageOptional.get();
-            if (inputPage.getSizeInBytes() >= minPageSizeInBytes || inputPage.getPositionCount() >= minRowCount) {
+            if (inputPage.getPositionCount() >= minRowCount || inputPage.getSizeInBytes() >= minPageSizeInBytes) {
                 if (pageBuilder.isEmpty()) {
                     return ofResult(inputPage);
                 }

--- a/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.project;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.operator.WorkProcessor;
+import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.operator.WorkProcessor.TransformationState.finished;
+import static io.prestosql.operator.WorkProcessor.TransformationState.needsMoreData;
+import static io.prestosql.operator.WorkProcessor.TransformationState.ofResult;
+import static io.prestosql.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is intended to be used right after the PageProcessor to ensure
+ * that the size of the pages returned by FilterAndProject and ScanFilterAndProject
+ * is big enough so it does not introduce considerable synchronization overhead.
+ * <p>
+ * As long as the input page contains more than {@link MergePagesTransformation#minRowCount} rows
+ * or is bigger than {@link MergePagesTransformation#minPageSizeInBytes} it is returned as is without
+ * additional memory copy.
+ * <p>
+ * The page data that has been buffered so far before receiving a "big" page is being flushed
+ * before transferring a "big" page.
+ * <p>
+ * Although it is still possible that the {@link MergePages} may return a tiny page,
+ * this situation is considered to be rare due to the assumption that filter selectivity may not
+ * vary a lot based on the particular input page.
+ * <p>
+ * Considering the CPU time required to process(filter, project) a full (~1MB) page returned by a
+ * connector, the CPU cost of memory copying (< 50kb, < 1024 rows) is supposed to be negligible.
+ */
+public class MergePages
+{
+    private static final int MAX_MIN_PAGE_SIZE = 1024 * 1024;
+
+    private MergePages() {}
+
+    public static WorkProcessor<Page> mergePages(
+            Iterable<? extends Type> types,
+            long minPageSizeInBytes,
+            int minRowCount,
+            WorkProcessor<Page> pages,
+            AggregatedMemoryContext memoryContext)
+    {
+        return mergePages(types, minPageSizeInBytes, minRowCount, DEFAULT_MAX_PAGE_SIZE_IN_BYTES, pages, memoryContext);
+    }
+
+    public static WorkProcessor<Page> mergePages(
+            Iterable<? extends Type> types,
+            long minPageSizeInBytes,
+            int minRowCount,
+            int maxPageSizeInBytes,
+            WorkProcessor<Page> pages,
+            AggregatedMemoryContext memoryContext)
+    {
+        return pages.transform(new MergePagesTransformation(
+                types,
+                minPageSizeInBytes,
+                minRowCount,
+                maxPageSizeInBytes,
+                memoryContext.newLocalMemoryContext(MergePages.class.getSimpleName())));
+    }
+
+    private static class MergePagesTransformation
+            implements WorkProcessor.Transformation<Page, Page>
+    {
+        private final List<Type> types;
+        private final long minPageSizeInBytes;
+        private final int minRowCount;
+        private final LocalMemoryContext memoryContext;
+        private final PageBuilder pageBuilder;
+
+        private Page queuedPage;
+
+        private MergePagesTransformation(Iterable<? extends Type> types, long minPageSizeInBytes, int minRowCount, int maxPageSizeInBytes, LocalMemoryContext memoryContext)
+        {
+            this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+            checkArgument(minPageSizeInBytes >= 0, "minPageSizeInBytes must be greater or equal than zero");
+            checkArgument(minRowCount >= 0, "minRowCount must be greater or equal than zero");
+            checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be greater than zero");
+            checkArgument(maxPageSizeInBytes >= minPageSizeInBytes, "maxPageSizeInBytes must be greater or equal than minPageSizeInBytes");
+            checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %d", MAX_MIN_PAGE_SIZE);
+            this.minPageSizeInBytes = minPageSizeInBytes;
+            this.minRowCount = minRowCount;
+            this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+            pageBuilder = PageBuilder.withMaxPageSize(maxPageSizeInBytes, this.types);
+        }
+
+        @Override
+        public TransformationState<Page> process(Optional<Page> inputPageOptional)
+        {
+            if (queuedPage != null) {
+                Page output = queuedPage;
+                queuedPage = null;
+                memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
+                return ofResult(output);
+            }
+
+            boolean inputFinished = !inputPageOptional.isPresent();
+            if (inputFinished) {
+                if (pageBuilder.isEmpty()) {
+                    memoryContext.close();
+                    return finished();
+                }
+
+                return ofResult(flush(), false);
+            }
+
+            Page inputPage = inputPageOptional.get();
+            if (inputPage.getSizeInBytes() >= minPageSizeInBytes || inputPage.getPositionCount() >= minRowCount) {
+                if (pageBuilder.isEmpty()) {
+                    return ofResult(inputPage);
+                }
+
+                Page output = pageBuilder.build();
+                pageBuilder.reset();
+                // inputPage is preserved until next process(...) call
+                queuedPage = inputPage;
+                memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes() + inputPage.getRetainedSizeInBytes());
+                return ofResult(output, false);
+            }
+
+            appendPage(inputPage);
+
+            if (pageBuilder.isFull()) {
+                return ofResult(flush());
+            }
+
+            memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
+            return needsMoreData();
+        }
+
+        private void appendPage(Page page)
+        {
+            pageBuilder.declarePositions(page.getPositionCount());
+            for (int channel = 0; channel < types.size(); channel++) {
+                Type type = types.get(channel);
+                for (int position = 0; position < page.getPositionCount(); position++) {
+                    type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+                }
+            }
+        }
+
+        private Page flush()
+        {
+            Page output = pageBuilder.build();
+            pageBuilder.reset();
+            memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
+            return output;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/project/MergingPageOutput.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/MergingPageOutput.java
@@ -148,7 +148,7 @@ public class MergingPageOutput
         requireNonNull(page, "page is null");
 
         // avoid memory copying for pages that are big enough
-        if (page.getSizeInBytes() >= minPageSizeInBytes || page.getPositionCount() >= minRowCount) {
+        if (page.getPositionCount() >= minRowCount || page.getSizeInBytes() >= minPageSizeInBytes) {
             flush();
             outputQueue.add(page);
             return;

--- a/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
@@ -102,7 +102,7 @@ public class PageProcessor
         return processor.yieldingIterator();
     }
 
-    private WorkProcessor<Page> createWorkProcessor(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page)
+    public WorkProcessor<Page> createWorkProcessor(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page)
     {
         // limit the scope of the dictionary ids to just one page
         dictionarySourceIdFunction.reset();

--- a/presto-main/src/main/java/io/prestosql/util/MergeSortedPages.java
+++ b/presto-main/src/main/java/io/prestosql/util/MergeSortedPages.java
@@ -105,14 +105,14 @@ public final class MergeSortedPages
         PageBuilder pageBuilder = new PageBuilder(outputTypes);
         return pageWithPositions
                 .yielding(yieldSignal::isSet)
-                .transform(pageWithPositionOptional -> {
-                    boolean finished = !pageWithPositionOptional.isPresent();
+                .transform(pageWithPosition -> {
+                    boolean finished = pageWithPosition == null;
                     if (finished && pageBuilder.isEmpty()) {
                         memoryContext.close();
                         return TransformationState.finished();
                     }
 
-                    if (finished || pageBreakPredicate.test(pageBuilder, pageWithPositionOptional.get())) {
+                    if (finished || pageBreakPredicate.test(pageBuilder, pageWithPosition)) {
                         if (!updateMemoryAfterEveryPosition) {
                             // update memory usage just before producing page to cap from top
                             memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
@@ -121,7 +121,7 @@ public final class MergeSortedPages
                         Page page = pageBuilder.build();
                         pageBuilder.reset();
                         if (!finished) {
-                            pageWithPositionOptional.get().appendTo(pageBuilder, outputChannels, outputTypes);
+                            pageWithPosition.appendTo(pageBuilder, outputChannels, outputTypes);
                         }
 
                         if (updateMemoryAfterEveryPosition) {
@@ -131,7 +131,7 @@ public final class MergeSortedPages
                         return TransformationState.ofResult(page, !finished);
                     }
 
-                    pageWithPositionOptional.get().appendTo(pageBuilder, outputChannels, outputTypes);
+                    pageWithPosition.appendTo(pageBuilder, outputChannels, outputTypes);
 
                     if (updateMemoryAfterEveryPosition) {
                         memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -263,10 +263,6 @@ public class BenchmarkScanFilterAndProjectOperator
         operator.addSplit(new Split(new ConnectorId("test"), createLocalSplit(), Lifespan.taskWide()));
 
         for (int loops = 0; !operator.isFinished() && loops < 1_000_000; loops++) {
-            if (operator.isFinished()) {
-                break;
-            }
-
             Page outputPage = operator.getOutput();
             if (outputPage != null) {
                 outputPages.add(outputPage);

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
@@ -463,9 +463,9 @@ public class TestWorkProcessor
     private static <T, R> WorkProcessor.Transformation<T, R> transformationFrom(List<Transform<T, R>> transformations)
     {
         Iterator<Transform<T, R>> iterator = transformations.iterator();
-        return elementOptional -> {
+        return element -> {
             assertTrue(iterator.hasNext());
-            return iterator.next().transform(elementOptional);
+            return iterator.next().transform(Optional.ofNullable(element));
         };
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
@@ -206,12 +206,12 @@ public class TestWorkProcessor
         // processor should progress since it yielded last time
         assertResult(processor, 2);
 
+        // yield signal is still set
+        assertYields(processor);
+
         // base scenario future blocks
         assertBlocks(processor);
         assertUnblocks(processor, future);
-
-        // yield signal is still set
-        assertYields(processor);
 
         // continue to process normally
         yieldSignal.set(false);

--- a/presto-main/src/test/java/io/prestosql/operator/WorkProcessorAssertion.java
+++ b/presto-main/src/test/java/io/prestosql/operator/WorkProcessorAssertion.java
@@ -15,6 +15,8 @@ package io.prestosql.operator;
 
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.util.function.Consumer;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -46,10 +48,15 @@ public final class WorkProcessorAssertion
 
     public static <T> void assertResult(WorkProcessor<T> processor, T result)
     {
+        validateResult(processor, actualResult -> assertEquals(processor.getResult(), result));
+    }
+
+    public static <T> void validateResult(WorkProcessor<T> processor, Consumer<T> validator)
+    {
         assertTrue(processor.process());
         assertFalse(processor.isBlocked());
         assertFalse(processor.isFinished());
-        assertEquals(processor.getResult(), result);
+        validator.accept(processor.getResult());
     }
 
     public static <T> void assertFinishes(WorkProcessor<T> processor)

--- a/presto-main/src/test/java/io/prestosql/operator/project/TestMergePages.java
+++ b/presto-main/src/test/java/io/prestosql/operator/project/TestMergePages.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.project;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.operator.WorkProcessor;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.prestosql.SequencePageBuilder.createSequencePage;
+import static io.prestosql.execution.buffer.PageSplitterUtil.splitPage;
+import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.prestosql.operator.PageAssertions.assertPageEquals;
+import static io.prestosql.operator.WorkProcessorAssertion.assertFinishes;
+import static io.prestosql.operator.WorkProcessorAssertion.validateResult;
+import static io.prestosql.operator.project.MergePages.mergePages;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RealType.REAL;
+import static java.lang.Math.toIntExact;
+
+public class TestMergePages
+{
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, REAL, DOUBLE);
+
+    @Test
+    public void testMinPageSizeThreshold()
+    {
+        Page page = createSequencePage(TYPES, 10);
+
+        WorkProcessor<Page> mergePages = mergePages(
+                TYPES,
+                page.getSizeInBytes(),
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE,
+                pagesSource(page),
+                newSimpleAggregatedMemoryContext());
+
+        validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
+        assertFinishes(mergePages);
+    }
+
+    @Test
+    public void testMinRowCountThreshold()
+    {
+        Page page = createSequencePage(TYPES, 10);
+
+        WorkProcessor<Page> mergePages = mergePages(
+                TYPES,
+                1024 * 1024,
+                page.getPositionCount(),
+                Integer.MAX_VALUE,
+                pagesSource(page),
+                newSimpleAggregatedMemoryContext());
+
+        validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
+        assertFinishes(mergePages);
+    }
+
+    @Test
+    public void testBufferSmallPages()
+    {
+        int singlePageRowCount = 10;
+        Page page = createSequencePage(TYPES, singlePageRowCount * 2);
+        List<Page> splits = splitPage(page, page.getSizeInBytes() / 2);
+
+        WorkProcessor<Page> mergePages = mergePages(
+                TYPES,
+                page.getSizeInBytes() + 1,
+                page.getPositionCount() + 1,
+                Integer.MAX_VALUE,
+                pagesSource(splits.get(0), splits.get(1)),
+                newSimpleAggregatedMemoryContext());
+
+        validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
+        assertFinishes(mergePages);
+    }
+
+    @Test
+    public void testFlushOnBigPage()
+    {
+        Page smallPage = createSequencePage(TYPES, 10);
+        Page bigPage = createSequencePage(TYPES, 100);
+
+        WorkProcessor<Page> mergePages = mergePages(
+                TYPES,
+                bigPage.getSizeInBytes(),
+                bigPage.getPositionCount(),
+                Integer.MAX_VALUE,
+                pagesSource(smallPage, bigPage),
+                newSimpleAggregatedMemoryContext());
+
+        validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, smallPage));
+        validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, bigPage));
+        assertFinishes(mergePages);
+    }
+
+    @Test
+    public void testFlushOnFullPage()
+    {
+        int singlePageRowCount = 10;
+        List<Type> types = ImmutableList.of(BIGINT);
+        Page page = createSequencePage(types, singlePageRowCount * 2);
+        List<Page> splits = splitPage(page, page.getSizeInBytes() / 2);
+
+        WorkProcessor<Page> mergePages = mergePages(
+                types,
+                page.getSizeInBytes() / 2 + 1,
+                page.getPositionCount() / 2 + 1,
+                toIntExact(page.getSizeInBytes()),
+                pagesSource(splits.get(0), splits.get(1), splits.get(0), splits.get(1)),
+                newSimpleAggregatedMemoryContext());
+
+        validateResult(mergePages, actualPage -> assertPageEquals(types, actualPage, page));
+        validateResult(mergePages, actualPage -> assertPageEquals(types, actualPage, page));
+        assertFinishes(mergePages);
+    }
+
+    private static WorkProcessor<Page> pagesSource(Page... pages)
+    {
+        return WorkProcessor.fromIterable(ImmutableList.copyOf(pages));
+    }
+}


### PR DESCRIPTION
Part of: https://github.com/prestosql/presto/issues/49

This paves way for:
1. Late source pages materialization.
2. Reusing pages source (e.g: ORC) resources between pages.