### PR TITLE
Add missing WindowOperator#isBlocked method

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/WindowOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WindowOperator.java
@@ -335,6 +335,17 @@ public class WindowOperator
     }
 
     @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        // We can block e.g. because of self-triggered spill
+        if (outputPages.isBlocked()) {
+            return outputPages.getBlockedFuture();
+        }
+
+        return NOT_BLOCKED;
+    }
+
+    @Override
     public boolean needsInput()
     {
         return pendingInput == null && !operatorFinishing;


### PR DESCRIPTION
WindowOperator can block when spilling,
therefore it needs to explicitly support isBlocked
method.