### PR TITLE
Ignore exception in JdbcPageSink abort

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -170,7 +170,7 @@ public class JdbcPageSink
             connection.rollback();
         }
         catch (SQLException e) {
-            throw new PrestoException(JDBC_ERROR, e);
+            // ignore exception from close
         }
     }
 


### PR DESCRIPTION
Drivers often throw during close, but propagating this is not useful.

Fixes #443 