### PR TITLE
Remove deprecation from isLegacyTimestamp()

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -777,7 +777,6 @@ public final class SystemSessionProperties
         return session.getSystemProperty(ITERATIVE_OPTIMIZER, Boolean.class);
     }
 
-    @Deprecated
     public static boolean isLegacyTimestamp(Session session)
     {
         return session.getSystemProperty(LEGACY_TIMESTAMP, Boolean.class);

--- a/presto-main/src/main/java/io/prestosql/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/relational/SqlToRowExpressionTranslator.java
@@ -172,7 +172,6 @@ public final class SqlToRowExpressionTranslator
         private final TypeManager typeManager;
         private final Map<Symbol, Integer> layout;
         private final TimeZoneKey timeZoneKey;
-        @Deprecated
         private final boolean isLegacyTimestamp;
 
         private Visitor(

--- a/presto-main/src/main/java/io/prestosql/util/DateTimeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/util/DateTimeUtils.java
@@ -168,6 +168,7 @@ public final class DateTimeUtils
      * If the string doesn't specify a zone, it is interpreted in {@code timeZoneKey} zone.
      *
      * @return stack representation of legacy TIMESTAMP or TIMESTAMP WITH TIME ZONE type, depending on input
+     * @deprecated applicable in legacy timestamp semantics only
      */
     @Deprecated
     public static long parseTimestampLiteral(TimeZoneKey timeZoneKey, String value)
@@ -222,6 +223,7 @@ public final class DateTimeUtils
      * If the string doesn't specify a zone, it is interpreted in {@code timeZoneKey} zone.
      *
      * @return stack representation of legacy TIMESTAMP type
+     * @deprecated applicable in legacy timestamp semantics only
      */
     @Deprecated
     public static long parseTimestampWithoutTimeZone(TimeZoneKey timeZoneKey, String value)
@@ -241,6 +243,9 @@ public final class DateTimeUtils
         return TIMESTAMP_WITHOUT_TIME_ZONE_FORMATTER.print(timestamp);
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public static String printTimestampWithoutTimeZone(TimeZoneKey timeZoneKey, long timestamp)
     {
@@ -317,6 +322,7 @@ public final class DateTimeUtils
      * If the string doesn't specify a zone, it is interpreted in {@code timeZoneKey} zone.
      *
      * @return stack representation of legacy TIME or TIME WITH TIME ZONE type, depending on input
+     * @deprecated applicable in legacy timestamp semantics only
      */
     @Deprecated
     public static long parseTimeLiteral(TimeZoneKey timeZoneKey, String value)
@@ -360,6 +366,7 @@ public final class DateTimeUtils
      * Parse a string (without a zone) as a value of TIME type, interpreted in {@code timeZoneKey} zone.
      *
      * @return stack representation of legacy TIME type
+     * @deprecated applicable in legacy timestamp semantics only
      */
     @Deprecated
     public static long parseTimeWithoutTimeZone(TimeZoneKey timeZoneKey, String value)
@@ -379,6 +386,9 @@ public final class DateTimeUtils
         return TIME_FORMATTER.print(value);
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public static String printTimeWithoutTimeZone(TimeZoneKey timeZoneKey, long value)
     {

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
@@ -40,7 +40,6 @@ public interface ConnectorSession
 
     long getStartTime();
 
-    @Deprecated
     boolean isLegacyTimestamp();
 
     <T> T getProperty(String name, Class<T> type);

--- a/presto-spi/src/main/java/io/prestosql/spi/type/SqlTime.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/SqlTime.java
@@ -48,6 +48,9 @@ public final class SqlTime
         return millis;
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public long getMillisUtc()
     {
@@ -55,13 +58,15 @@ public final class SqlTime
         return millis;
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public Optional<TimeZoneKey> getSessionTimeZoneKey()
     {
         return sessionTimeZoneKey;
     }
 
-    @Deprecated
     public boolean isLegacyTimestamp()
     {
         return sessionTimeZoneKey.isPresent();

--- a/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimestamp.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimestamp.java
@@ -51,6 +51,9 @@ public final class SqlTimestamp
         return millis;
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public long getMillisUtc()
     {
@@ -58,13 +61,15 @@ public final class SqlTimestamp
         return millis;
     }
 
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
     @Deprecated
     public Optional<TimeZoneKey> getSessionTimeZoneKey()
     {
         return sessionTimeZoneKey;
     }
 
-    @Deprecated
     public boolean isLegacyTimestamp()
     {
         return sessionTimeZoneKey.isPresent();

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
@@ -18,10 +18,11 @@ import io.prestosql.spi.connector.ConnectorSession;
 
 import static io.prestosql.spi.type.TypeSignature.parseTypeSignature;
 
-//
-// A timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
+/**
+ * A timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC and is to be interpreted as date-time in UTC.
+ * In legacy timestamp semantics, timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC and is to be
+ * interpreted in session time zone.
+ */
 public final class TimestampType
         extends AbstractLongType
 {


### PR DESCRIPTION
As long as this method exists, it should not be avoided.