### PR TITLE
Add credential passthrough in base-jdbc connector

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.jdbc;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 public class BaseJdbcConfig
@@ -23,6 +24,8 @@ public class BaseJdbcConfig
     private String connectionUrl;
     private String connectionUser;
     private String connectionPassword;
+    private String userCredentialName;
+    private String passwordCredentialName;
 
     @NotNull
     public String getConnectionUrl()
@@ -59,6 +62,32 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setConnectionPassword(String connectionPassword)
     {
         this.connectionPassword = connectionPassword;
+        return this;
+    }
+    
+    @Nullable
+    public String getUserCredentialName()
+    {
+        return userCredentialName;
+    }
+
+    @Config("user-credential-name")
+    public BaseJdbcConfig setUserCredentialName(String userCredentialName)
+    {
+        this.userCredentialName = userCredentialName;
+        return this;
+    }
+
+    @Nullable
+    public String getPasswordCredentialName()
+    {
+        return passwordCredentialName;
+    }
+
+    @Config("password-credential-name")
+    public BaseJdbcConfig setPasswordCredentialName(String passwordCredentialName)
+    {
+        this.passwordCredentialName = passwordCredentialName;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -40,6 +40,7 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @Nullable
     public String getConnectionUser()
     {
         return connectionUser;
@@ -52,6 +53,7 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @Nullable
     public String getConnectionPassword()
     {
         return connectionPassword;
@@ -64,7 +66,7 @@ public class BaseJdbcConfig
         this.connectionPassword = connectionPassword;
         return this;
     }
-    
+
     @Nullable
     public String getUserCredentialName()
     {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
@@ -16,6 +16,8 @@ package io.prestosql.plugin.jdbc;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -27,10 +29,17 @@ public class DriverConnectionFactory
     private final Driver driver;
     private final String connectionUrl;
     private final Properties connectionProperties;
+    private final Optional<String> userCredentialName;
+    private final Optional<String> passwordCredentialName;
 
     public DriverConnectionFactory(Driver driver, BaseJdbcConfig config)
     {
-        this(driver, config.getConnectionUrl(), basicConnectionProperties(config));
+        this(
+                driver,
+                config.getConnectionUrl(),
+                Optional.ofNullable(config.getUserCredentialName()),
+                Optional.ofNullable(config.getPasswordCredentialName()),
+                basicConnectionProperties(config));
     }
 
     public static Properties basicConnectionProperties(BaseJdbcConfig config)
@@ -45,20 +54,33 @@ public class DriverConnectionFactory
         return connectionProperties;
     }
 
-    public DriverConnectionFactory(Driver driver, String connectionUrl, Properties connectionProperties)
+    public DriverConnectionFactory(Driver driver, String connectionUrl, Optional<String> userCredentialName, Optional<String> passwordCredentialName, Properties connectionProperties)
     {
         this.driver = requireNonNull(driver, "driver is null");
         this.connectionUrl = requireNonNull(connectionUrl, "connectionUrl is null");
         this.connectionProperties = new Properties();
         this.connectionProperties.putAll(requireNonNull(connectionProperties, "basicConnectionProperties is null"));
+        this.userCredentialName = requireNonNull(userCredentialName, "userCredentialName is null");
+        this.passwordCredentialName = requireNonNull(passwordCredentialName, "passwordCredentialName is null");
     }
 
     @Override
     public Connection openConnection(JdbcIdentity identity)
             throws SQLException
     {
+        userCredentialName.ifPresent(credentialName -> setConnectionProperty(connectionProperties, identity.getExtraCredentials(), credentialName, "user"));
+        passwordCredentialName.ifPresent(credentialName -> setConnectionProperty(connectionProperties, identity.getExtraCredentials(), credentialName, "password"));
+
         Connection connection = driver.connect(connectionUrl, connectionProperties);
         checkState(connection != null, "Driver returned null connection");
         return connection;
+    }
+
+    private static void setConnectionProperty(Properties connectionProperties, Map<String, String> extraCredentials, String credentialName, String propertyName)
+    {
+        String value = extraCredentials.get(credentialName);
+        if (value != null) {
+            connectionProperties.setProperty(propertyName, value);
+        }
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -27,7 +27,9 @@ public class TestBaseJdbcConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(BaseJdbcConfig.class)
                 .setConnectionUrl(null)
                 .setConnectionUser(null)
-                .setConnectionPassword(null));
+                .setConnectionPassword(null)
+                .setUserCredentialName(null)
+                .setPasswordCredentialName(null));
     }
 
     @Test
@@ -37,12 +39,16 @@ public class TestBaseJdbcConfig
                 .put("connection-url", "jdbc:h2:mem:config")
                 .put("connection-user", "user")
                 .put("connection-password", "password")
+                .put("user-credential-name", "foo")
+                .put("password-credential-name", "bar")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setConnectionUser("user")
-                .setConnectionPassword("password");
+                .setConnectionPassword("password")
+                .setUserCredentialName("foo")
+                .setPasswordCredentialName("bar");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -44,7 +45,7 @@ final class TestingDatabase
         jdbcClient = new BaseJdbcClient(
                 new BaseJdbcConfig(),
                 "\"",
-                new DriverConnectionFactory(new Driver(), connectionUrl, new Properties()));
+                new DriverConnectionFactory(new Driver(), connectionUrl, Optional.empty(), Optional.empty(), new Properties()));
 
         connection = DriverManager.getConnection(connectionUrl);
         connection.createStatement().execute("CREATE SCHEMA example");

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -89,7 +89,12 @@ public class MySqlClient
             connectionProperties.setProperty("connectTimeout", String.valueOf(mySqlConfig.getConnectionTimeout().toMillis()));
         }
 
-        return new DriverConnectionFactory(new Driver(), config.getConnectionUrl(), connectionProperties);
+        return new DriverConnectionFactory(
+                new Driver(),
+                config.getConnectionUrl(),
+                Optional.ofNullable(config.getUserCredentialName()),
+                Optional.ofNullable(config.getPasswordCredentialName()),
+                connectionProperties);
     }
 
     @Override

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestCredentialPassthrough.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestCredentialPassthrough.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.testing.mysql.TestingMySqlServer;
+import io.prestosql.Session;
+import io.prestosql.spi.security.Identity;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+
+public class TestCredentialPassthrough
+{
+    private static final String TEST_SCHEMA = "test_database";
+    private final TestingMySqlServer mysqlServer;
+    private final QueryRunner mySqlQueryRunner;
+
+    public TestCredentialPassthrough()
+            throws Exception
+    {
+        mysqlServer = new TestingMySqlServer("testuser", "testpass", TEST_SCHEMA);
+        mySqlQueryRunner = createQueryRunner(mysqlServer);
+    }
+
+    @Test
+    public void testCredentialPassthrough()
+            throws Exception
+    {
+        mySqlQueryRunner.execute(getSession(mysqlServer), "CREATE TABLE test_create (a bigint, b double, c varchar)");
+    }
+
+    public static QueryRunner createQueryRunner(TestingMySqlServer mySqlServer)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+            queryRunner.installPlugin(new MySqlPlugin());
+            Map<String, String> properties = ImmutableMap.<String, String>builder()
+                    .put("connection-url", getConnectionUrl(mySqlServer))
+                    .put("user-credential-name", "mysql.user")
+                    .put("password-credential-name", "mysql.password")
+                    .build();
+            queryRunner.createCatalog("mysql", "mysql", properties);
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner, mySqlServer);
+            throw e;
+        }
+    }
+
+    private static Session getSession(TestingMySqlServer mySqlServer)
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of("mysql.user", mySqlServer.getUser(), "mysql.password", mySqlServer.getPassword());
+        return testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema(TEST_SCHEMA)
+                .setIdentity(new Identity(mySqlServer.getUser(), Optional.empty(), ImmutableMap.of(), extraCredentials))
+                .build();
+    }
+
+    private static String getConnectionUrl(TestingMySqlServer mySqlServer)
+    {
+        return format("jdbc:mysql://localhost:%s?useSSL=false&allowPublicKeyRetrieval=true", mySqlServer.getPort());
+    }
+}


### PR DESCRIPTION
I was working on adding credential passthrough in `presto-base-jdbc` connector and others extend it. Thanks to `JdbcIdentity` added by  @kokosing  this is straighforward.

To specify the credential for different jdbc connectors, we need to have a namespace based on catalog name, so I recreate the `JdbcConnectorId` deleted by @kokosing but name it `JdbcCatalogName` (as we are replacing `connector id` with `catalog name`).

Create this PR to collect feedback on this feature, as well as the implementation.

@electrum @findepi @kokosing 