### PR TITLE
Skip JDBC rollback when connection is closed

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -170,7 +170,10 @@ public class JdbcPageSink
         // rollback and close
         try (Connection connection = this.connection;
                 PreparedStatement statement = this.statement) {
-            connection.rollback();
+            // skip rollback if implicitly closed due to an error
+            if (!connection.isClosed()) {
+                connection.rollback();
+            }
         }
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);


### PR DESCRIPTION
Some drivers will implicitly close the connection on error.
When this happens, calling rollback will throw an exception.