### PR TITLE
Fix timestamp handling in JDBC connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -229,7 +229,7 @@ public class BaseJdbcClient
     @Override
     public Optional<ColumnMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
     {
-        return jdbcTypeToPrestoType(typeHandle);
+        return jdbcTypeToPrestoType(session, typeHandle);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -276,7 +276,12 @@ public final class StandardColumnMappings
         };
     }
 
-    public static ColumnMapping timestampColumnMapping()
+    /**
+     * This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
+     * forward offset change (a 'gap'). This includes regular DST changes (e.g. Europe/Warsaw) and one-time policy changes
+     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
+     */
+    public static ColumnMapping timestampColumnMappingUsingSqlTimestamp()
     {
         return ColumnMapping.longMapping(
                 TIMESTAMP,
@@ -290,10 +295,15 @@ public final class StandardColumnMappings
                     Timestamp timestamp = resultSet.getTimestamp(columnIndex);
                     return timestamp.getTime();
                 },
-                timestampWriteFunction());
+                timestampWriteFunctionUsingSqlTimestamp());
     }
 
-    public static LongWriteFunction timestampWriteFunction()
+    /**
+     * This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
+     * forward offset change (a 'gap'). This includes regular DST changes (e.g. Europe/Warsaw) and one-time policy changes
+     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
+     */
+    public static LongWriteFunction timestampWriteFunctionUsingSqlTimestamp()
     {
         return (statement, index, value) -> {
             // Copied from `QueryBuilder.buildSql`
@@ -365,7 +375,7 @@ public final class StandardColumnMappings
                 return Optional.of(timeColumnMapping());
 
             case Types.TIMESTAMP:
-                return Optional.of(timestampColumnMapping());
+                return Optional.of(timestampColumnMappingUsingSqlTimestamp());
         }
         return Optional.empty();
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.jdbc;
 import com.google.common.base.CharMatcher;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
@@ -32,6 +33,9 @@ import java.sql.ResultSet;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -61,10 +65,10 @@ import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.joda.time.DateTimeZone.UTC;
 
 public final class StandardColumnMappings
 {
@@ -235,7 +239,7 @@ public final class StandardColumnMappings
                      */
                     long localMillis = resultSet.getDate(columnIndex).getTime();
                     // Convert it to a ~midnight in UTC.
-                    long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+                    long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(DateTimeZone.UTC, localMillis);
                     // convert to days
                     return MILLISECONDS.toDays(utcMillis);
                 },
@@ -247,7 +251,7 @@ public final class StandardColumnMappings
         return (statement, index, value) -> {
             // convert to midnight in default time zone
             long millis = DAYS.toMillis(value);
-            statement.setDate(index, new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis)));
+            statement.setDate(index, new Date(DateTimeZone.UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis)));
         };
     }
 
@@ -277,42 +281,106 @@ public final class StandardColumnMappings
     }
 
     /**
-     * This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
+     * @deprecated This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
      * forward offset change (a 'gap'). This includes regular DST changes (e.g. Europe/Warsaw) and one-time policy changes
-     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
+     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00). If driver only supports {@link LocalDateTime}, use
+     * {@link #timestampColumnMapping} instead.
      */
-    public static ColumnMapping timestampColumnMappingUsingSqlTimestamp()
+    @Deprecated
+    public static ColumnMapping timestampColumnMappingUsingSqlTimestamp(ConnectorSession session)
     {
+        if (session.isLegacyTimestamp()) {
+            ZoneId sessionZone = ZoneId.of(session.getTimeZoneKey().getId());
+            return ColumnMapping.longMapping(
+                    TIMESTAMP,
+                    (resultSet, columnIndex) -> {
+                        Timestamp timestamp = resultSet.getTimestamp(columnIndex);
+                        return toPrestoLegacyTimestamp(timestamp.toLocalDateTime(), sessionZone);
+                    },
+                    timestampWriteFunctionUsingSqlTimestamp(session));
+        }
+
         return ColumnMapping.longMapping(
                 TIMESTAMP,
                 (resultSet, columnIndex) -> {
-                    /*
-                     * TODO `resultSet.getTimestamp(columnIndex)` returns wrong value if JVM's zone had forward offset change and the local time
-                     * corresponding to timestamp value being retrieved was not present (a 'gap'), this includes regular DST changes (e.g. Europe/Warsaw)
-                     * and one-time policy changes (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
-                     * The problem can be averted by using `resultSet.getObject(columnIndex, LocalDateTime.class)` -- but this is not universally supported by JDBC drivers.
-                     */
                     Timestamp timestamp = resultSet.getTimestamp(columnIndex);
-                    return timestamp.getTime();
+                    return toPrestoTimestamp(timestamp.toLocalDateTime());
                 },
-                timestampWriteFunctionUsingSqlTimestamp());
+                timestampWriteFunctionUsingSqlTimestamp(session));
+    }
+
+    public static ColumnMapping timestampColumnMapping(ConnectorSession session)
+    {
+        if (session.isLegacyTimestamp()) {
+            ZoneId sessionZone = ZoneId.of(session.getTimeZoneKey().getId());
+            return ColumnMapping.longMapping(
+                    TIMESTAMP,
+                    (resultSet, columnIndex) -> toPrestoLegacyTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class), sessionZone),
+                    timestampWriteFunction(session));
+        }
+
+        return ColumnMapping.longMapping(
+                TIMESTAMP,
+                (resultSet, columnIndex) -> toPrestoTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class)),
+                timestampWriteFunction(session));
     }
 
     /**
-     * This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
+     * @deprecated This method uses {@link java.sql.Timestamp} and the class cannot represent date-time value when JVM zone had
      * forward offset change (a 'gap'). This includes regular DST changes (e.g. Europe/Warsaw) and one-time policy changes
-     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00).
+     * (Asia/Kathmandu's shift by 15 minutes on January 1, 1986, 00:00:00). If driver only supports {@link LocalDateTime}, use
+     * {@link #timestampWriteFunction} instead.
      */
-    public static LongWriteFunction timestampWriteFunctionUsingSqlTimestamp()
+    @Deprecated
+    public static LongWriteFunction timestampWriteFunctionUsingSqlTimestamp(ConnectorSession connectorSession)
     {
+        if (connectorSession.isLegacyTimestamp()) {
+            ZoneId sessionZone = ZoneId.of(connectorSession.getTimeZoneKey().getId());
+            return (statement, index, value) -> statement.setTimestamp(index, Timestamp.valueOf(fromPrestoLegacyTimestamp(value, sessionZone)));
+        }
+        return (statement, index, value) -> statement.setTimestamp(index, Timestamp.valueOf(fromPrestoTimestamp(value)));
+    }
+
+    public static LongWriteFunction timestampWriteFunction(ConnectorSession session)
+    {
+        if (session.isLegacyTimestamp()) {
+            ZoneId sessionZone = ZoneId.of(session.getTimeZoneKey().getId());
+            return (statement, index, value) -> statement.setObject(index, fromPrestoLegacyTimestamp(value, sessionZone));
+        }
         return (statement, index, value) -> {
-            // Copied from `QueryBuilder.buildSql`
-            // TODO verify correctness, add tests and support non-legacy timestamp
-            statement.setTimestamp(index, new Timestamp(value));
+            statement.setObject(index, fromPrestoTimestamp(value));
         };
     }
 
-    public static Optional<ColumnMapping> jdbcTypeToPrestoType(JdbcTypeHandle type)
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
+    @Deprecated
+    private static long toPrestoLegacyTimestamp(LocalDateTime localDateTime, ZoneId sessionZone)
+    {
+        return localDateTime.atZone(sessionZone).toInstant().toEpochMilli();
+    }
+
+    private static long toPrestoTimestamp(LocalDateTime localDateTime)
+    {
+        return localDateTime.atZone(UTC).toInstant().toEpochMilli();
+    }
+
+    /**
+     * @deprecated applicable in legacy timestamp semantics only
+     */
+    @Deprecated
+    private static LocalDateTime fromPrestoLegacyTimestamp(long value, ZoneId sessionZone)
+    {
+        return Instant.ofEpochMilli(value).atZone(sessionZone).toLocalDateTime();
+    }
+
+    private static LocalDateTime fromPrestoTimestamp(long value)
+    {
+        return Instant.ofEpochMilli(value).atZone(UTC).toLocalDateTime();
+    }
+
+    public static Optional<ColumnMapping> jdbcTypeToPrestoType(ConnectorSession session, JdbcTypeHandle type)
     {
         int columnSize = type.getColumnSize();
         switch (type.getJdbcType()) {
@@ -375,7 +443,8 @@ public final class StandardColumnMappings
                 return Optional.of(timeColumnMapping());
 
             case Types.TIMESTAMP:
-                return Optional.of(timestampColumnMappingUsingSqlTimestamp());
+                // TODO default to `timestampColumnMapping`
+                return Optional.of(timestampColumnMappingUsingSqlTimestamp(session));
         }
         return Optional.empty();
     }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -167,7 +167,8 @@ public class MySqlClient
             throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
         }
         if (TIMESTAMP.equals(type)) {
-            return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp());
+            // TODO use `timestampWriteFunction`
+            return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp(session));
         }
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("mediumblob", varbinaryWriteFunction());

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -48,7 +48,7 @@ import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
 import static io.prestosql.plugin.jdbc.DriverConnectionFactory.basicConnectionProperties;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.realWriteFunction;
-import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampWriteFunctionUsingSqlTimestamp;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
@@ -167,7 +167,7 @@ public class MySqlClient
             throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
         }
         if (TIMESTAMP.equals(type)) {
-            return WriteMapping.longMapping("datetime", timestampWriteFunction());
+            return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp());
         }
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("mediumblob", varbinaryWriteFunction());

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
@@ -251,14 +251,14 @@ public class TestMySqlTypeMapping
     @Test
     public void testDatetime()
     {
-        // TODO MySQL datetime is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
+        // TODO MySQL datetime is not correctly read (see comment in StandardColumnMappings.timestampColumnMappingUsingSqlTimestamp)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 
     @Test
     public void testTimestamp()
     {
-        // TODO MySQL timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
+        // TODO MySQL timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMappingUsingSqlTimestamp)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.prestosql.Session;
 import io.prestosql.spi.type.TimeZoneKey;
+import io.prestosql.testing.TestingSession;
 import io.prestosql.tests.AbstractTestQueryFramework;
 import io.prestosql.tests.datatype.CreateAndInsertDataSetup;
 import io.prestosql.tests.datatype.CreateAsSelectDataSetup;
@@ -26,12 +27,15 @@ import io.prestosql.tests.datatype.DataTypeTest;
 import io.prestosql.tests.sql.JdbcSqlExecutor;
 import io.prestosql.tests.sql.PrestoSqlExecutor;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -51,6 +55,7 @@ import static io.prestosql.tests.datatype.DataType.integerDataType;
 import static io.prestosql.tests.datatype.DataType.jsonDataType;
 import static io.prestosql.tests.datatype.DataType.realDataType;
 import static io.prestosql.tests.datatype.DataType.smallintDataType;
+import static io.prestosql.tests.datatype.DataType.timestampDataType;
 import static io.prestosql.tests.datatype.DataType.varbinaryDataType;
 import static io.prestosql.tests.datatype.DataType.varcharDataType;
 import static io.prestosql.type.JsonType.JSON;
@@ -239,13 +244,13 @@ public class TestPostgreSqlTypeMapping
         ZoneId jvmZone = ZoneId.systemDefault();
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
-        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay()).isEmpty());
+        checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
 
         ZoneId someZone = ZoneId.of("Europe/Vilnius");
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
-        verify(someZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInSomeZone.atStartOfDay()).isEmpty());
+        checkIsGap(someZone, dateOfLocalTimeChangeForwardAtMidnightInSomeZone.atStartOfDay());
         LocalDate dateOfLocalTimeChangeBackwardAtMidnightInSomeZone = LocalDate.of(1983, 10, 1);
-        verify(someZone.getRules().getValidOffsets(dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1)).size() == 2);
+        checkIsDoubled(someZone, dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1));
 
         DataTypeTest testCases = DataTypeTest.create()
                 .addRoundTrip(dateDataType(), LocalDate.of(1952, 4, 3)) // before epoch
@@ -286,11 +291,103 @@ public class TestPostgreSqlTypeMapping
         }
     }
 
-    @Test
-    public void testTimestamp()
+    @Test(dataProvider = "testTimestampDataProvider")
+    public void testTimestamp(boolean legacyTimestamp, boolean insertWithPresto)
     {
-        // TODO timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMappingUsingSqlTimestamp)
-        // testing this is hard because of https://github.com/prestodb/presto/issues/7122
+        LocalDateTime beforeEpoch = LocalDateTime.of(1958, 1, 1, 13, 18, 3, 123_000_000);
+        LocalDateTime epoch = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
+        LocalDateTime afterEpoch = LocalDateTime.of(2019, 03, 18, 10, 01, 17, 987_000_000);
+
+        ZoneId jvmZone = ZoneId.systemDefault();
+
+        LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+        checkIsGap(jvmZone, timeGapInJvmZone1);
+        LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
+        checkIsGap(jvmZone, timeGapInJvmZone2);
+        LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
+        checkIsDoubled(jvmZone, timeDoubledInJvmZone);
+
+        // no DST in 1970, but has DST in later years (e.g. 2018)
+        ZoneId vilnius = ZoneId.of("Europe/Vilnius");
+
+        LocalDateTime timeGapInVilnius = LocalDateTime.of(2018, 3, 25, 3, 17, 17);
+        checkIsGap(vilnius, timeGapInVilnius);
+        LocalDateTime timeDoubledInVilnius = LocalDateTime.of(2018, 10, 28, 3, 33, 33, 333_000_000);
+        checkIsDoubled(vilnius, timeDoubledInVilnius);
+
+        // minutes offset change since 1970-01-01, no DST
+        // using two non-JVM zones so that we don't need to worry what Postgres system zone is
+        ZoneId kathmandu = ZoneId.of("Asia/Kathmandu");
+
+        LocalDateTime timeGapInKathmandu = LocalDateTime.of(1986, 1, 1, 0, 13, 7);
+        checkIsGap(kathmandu, timeGapInKathmandu);
+
+        for (ZoneId sessionZone : ImmutableList.of(ZoneOffset.UTC, jvmZone, vilnius, kathmandu, ZoneId.of(TestingSession.DEFAULT_TIME_ZONE_KEY.getId()))) {
+            DataTypeTest tests = DataTypeTest.create()
+                    .addRoundTrip(timestampDataType(), beforeEpoch)
+                    .addRoundTrip(timestampDataType(), afterEpoch)
+                    .addRoundTrip(timestampDataType(), timeDoubledInJvmZone)
+                    .addRoundTrip(timestampDataType(), timeDoubledInVilnius);
+
+            if (!insertWithPresto) {
+                // when writing, Postgres JDBC driver converts LocalDateTime to string representing date-time in JVM zone
+                // TODO upgrade driver or find a different way to write timestamp values
+                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, epoch); // epoch also is a gap in JVM zone
+                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone1);
+                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone2);
+            }
+
+            addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInVilnius);
+            addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInKathmandu);
+
+            Session session = Session.builder(getQueryRunner().getDefaultSession())
+                    .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
+                    .setSystemProperty("legacy_timestamp", Boolean.toString(legacyTimestamp))
+                    .build();
+
+            if (insertWithPresto) {
+                tests.execute(getQueryRunner(), session, prestoCreateAsSelect(session, "test_timestamp"));
+            }
+            else {
+                tests.execute(getQueryRunner(), session, postgresCreateAndInsert("tpch.test_timestamp"));
+            }
+        }
+    }
+
+    private void addTimestampTestIfSupported(DataTypeTest tests, boolean legacyTimestamp, ZoneId sessionZone, LocalDateTime dateTime)
+    {
+        if (legacyTimestamp && isGap(sessionZone, dateTime)) {
+            // in legacy timestamp semantics we cannot represent this dateTime
+            return;
+        }
+
+        tests.addRoundTrip(timestampDataType(), dateTime);
+    }
+
+    @DataProvider
+    public Object[][] testTimestampDataProvider()
+    {
+        return new Object[][] {
+                {true, true},
+                {false, true},
+                {true, false},
+                {false, false},
+        };
+    }
+
+    private static void checkIsGap(ZoneId zone, LocalDateTime dateTime)
+    {
+        verify(isGap(zone, dateTime), "Expected %s to be a gap in %s", dateTime, zone);
+    }
+
+    private static boolean isGap(ZoneId zone, LocalDateTime dateTime)
+    {
+        return zone.getRules().getValidOffsets(dateTime).isEmpty();
+    }
+
+    private static void checkIsDoubled(ZoneId zone, LocalDateTime dateTime)
+    {
+        verify(zone.getRules().getValidOffsets(dateTime).size() == 2, "Expected %s to be doubled in %s", dateTime, zone);
     }
 
     @Test
@@ -359,6 +456,11 @@ public class TestPostgreSqlTypeMapping
     private DataSetup prestoCreateAsSelect(String tableNamePrefix)
     {
         return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
+    }
+
+    private DataSetup prestoCreateAsSelect(Session session, String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
     }
 
     private DataSetup postgresCreateAndInsert(String tableNamePrefix)

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -289,7 +289,7 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testTimestamp()
     {
-        // TODO timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMapping)
+        // TODO timestamp is not correctly read (see comment in StandardColumnMappings.timestampColumnMappingUsingSqlTimestamp)
         // testing this is hard because of https://github.com/prestodb/presto/issues/7122
     }
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
@@ -19,48 +19,89 @@ import io.prestosql.tempto.fulfillment.table.jdbc.RelationalTableDefinition;
 
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.List;
 
 import static io.prestosql.tests.sqlserver.TestConstants.CONNECTOR_NAME;
+import static java.util.Collections.nCopies;
 
-public class SqlServerDataTypesTableDefinition
+public final class SqlServerDataTypesTableDefinition
 {
+    private SqlServerDataTypesTableDefinition() {}
+
     public static final RelationalTableDefinition SQLSERVER_ALL_TYPES;
 
     public static final RelationalTableDefinition SQLSERVER_INSERT;
-
-    private SqlServerDataTypesTableDefinition() {}
 
     private static final String ALL_TYPES_TABLE_NAME = "all_types";
 
     private static final String INSERT_TABLE_NAME = "insert_table";
 
     private static final String ALL_TYPES_DDL =
-            "CREATE TABLE %NAME% (bi bigint, si smallint, i int, ti tinyint, f float, r real," +
-                    "c char(4), vc varchar(6), te text, nc nchar(5), nvc nvarchar(7), nt text," +
-                    "d date, dt datetime, dt2 datetime2, sdt smalldatetime, pf30 float(30), pf22 float(22))";
+            "CREATE TABLE %NAME% (" +
+                    "bi bigint, " +
+                    "si smallint, " +
+                    "i int, " +
+                    "ti tinyint, " +
+                    "f float, " +
+                    "r real," +
+                    "c char(4), " +
+                    "vc varchar(6), " +
+                    "te text, " +
+                    "nc nchar(5), " +
+                    "nvc nvarchar(7), " +
+                    "nt text," +
+                    "d date, " +
+                    "dt datetime, " +
+                    "dt2 datetime2, " +
+                    "sdt smalldatetime, " +
+                    "pf30 float(30), " +
+                    "pf22 float(22))";
 
     private static final String INSERT_DDL =
-            "CREATE TABLE %NAME% (bi bigint, si smallint, i int, f float," +
-                    "c char(4), vc varchar(6), " +
-                    "pf30 float(30), d date) ";
+            "CREATE TABLE %NAME% (bi bigint, si smallint, i int, f float,c char(4), vc varchar(6), pf30 float(30), d date) ";
 
     static {
         RelationalDataSource dataSource = () -> {
             return ImmutableList.<List<Object>>of(
-                    ImmutableList.of(Long.MIN_VALUE, Short.MIN_VALUE, Integer.MIN_VALUE, Byte.MIN_VALUE,
-                            Double.MIN_VALUE, Float.valueOf("-3.40E+38"), "\0", "\0", "\0", "\0", "\0", "\0",
-                            Date.valueOf("1953-01-02"), Timestamp.valueOf("1753-01-01 00:00:00.000"),
-                            Timestamp.valueOf("0001-01-01 00:00:00.000"), Timestamp.valueOf("1900-01-01 00:00:00"),
-                            Double.MIN_VALUE, Float.valueOf("-3.40E+38")),
-                    ImmutableList.of(Long.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Byte.MAX_VALUE,
-                            Double.MAX_VALUE, Float.MAX_VALUE, "abcd", "abcdef", "abcd", "abcde", "abcdefg", "abcd",
-                            Date.valueOf("9999-12-31"), Timestamp.valueOf("9999-12-31 23:59:59.997"),
-                            Timestamp.valueOf("9999-12-31 23:59:59.999"), Timestamp.valueOf("2079-06-05 23:59:59"),
-                            Double.valueOf("12345678912.3456756"), Float.valueOf("12345678.6557")),
-                    Arrays.asList(null, null, null, null, null, null, null, null, null, null, null, null,
-                            null, null, null, null, null, null))
+                    ImmutableList.of(
+                            Long.MIN_VALUE,
+                            Short.MIN_VALUE,
+                            Integer.MIN_VALUE,
+                            Byte.MIN_VALUE,
+                            Double.MIN_VALUE,
+                            -3.40E+38f,
+                            "\0",
+                            "\0",
+                            "\0",
+                            "\0",
+                            "\0",
+                            "\0",
+                            Date.valueOf("1953-01-02"),
+                            Timestamp.valueOf("1753-01-01 00:00:00.000"),
+                            Timestamp.valueOf("0001-01-01 00:00:00.000"),
+                            Timestamp.valueOf("1900-01-01 00:00:00"),
+                            Double.MIN_VALUE,
+                            -3.40E+38f),
+                    ImmutableList.of(
+                            Long.MAX_VALUE,
+                            Short.MAX_VALUE,
+                            Integer.MAX_VALUE,
+                            Byte.MAX_VALUE,
+                            Double.MAX_VALUE,
+                            Float.MAX_VALUE,
+                            "abcd",
+                            "abcdef",
+                            "abcd",
+                            "abcde",
+                            "abcdefg",
+                            "abcd",
+                            Date.valueOf("9999-12-31"),
+                            Timestamp.valueOf("9999-12-31 23:59:59.997"),
+                            Timestamp.valueOf("9999-12-31 23:59:59.999"),
+                            Timestamp.valueOf("2079-06-05 23:59:59"),
+                            12345678912.3456756,
+                            12345678.6557f),
+                    nCopies(18, null))
                     .iterator();
         };
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
@@ -77,9 +77,9 @@ public final class SqlServerDataTypesTableDefinition
                             "\0",
                             "\0",
                             Date.valueOf("1953-01-02"),
-                            Timestamp.valueOf("1753-01-01 00:00:00.000"),
-                            Timestamp.valueOf("0001-01-01 00:00:00.000"),
-                            Timestamp.valueOf("1900-01-01 00:00:00"),
+                            Timestamp.valueOf("1953-01-01 00:00:00.000"),
+                            Timestamp.valueOf("2001-01-01 00:00:00.000"),
+                            Timestamp.valueOf("1960-01-01 00:00:00"),
                             Double.MIN_VALUE,
                             -3.40E+38f),
                     ImmutableList.of(

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/SqlServerDataTypesTableDefinition.java
@@ -53,6 +53,7 @@ public final class SqlServerDataTypesTableDefinition
                     "d date, " +
                     "dt datetime, " +
                     "dt2 datetime2, " +
+                    "dt3 datetime2, " +
                     "sdt smalldatetime, " +
                     "pf30 float(30), " +
                     "pf22 float(22))";
@@ -78,7 +79,8 @@ public final class SqlServerDataTypesTableDefinition
                             "\0",
                             Date.valueOf("1953-01-02"),
                             Timestamp.valueOf("1953-01-01 00:00:00.000"),
-                            Timestamp.valueOf("2001-01-01 00:00:00.000"),
+                            Timestamp.valueOf("2001-01-01 00:00:00.123"),
+                            Timestamp.valueOf("1970-01-01 00:00:00"),
                             Timestamp.valueOf("1960-01-01 00:00:00"),
                             Double.MIN_VALUE,
                             -3.40E+38f),
@@ -98,10 +100,11 @@ public final class SqlServerDataTypesTableDefinition
                             Date.valueOf("9999-12-31"),
                             Timestamp.valueOf("9999-12-31 23:59:59.997"),
                             Timestamp.valueOf("9999-12-31 23:59:59.999"),
+                            Timestamp.valueOf("9999-12-31 23:59:59.999"),
                             Timestamp.valueOf("2079-06-05 23:59:59"),
                             12345678912.3456756,
                             12345678.6557f),
-                    nCopies(18, null))
+                    nCopies(19, null))
                     .iterator();
         };
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
@@ -163,9 +163,9 @@ public class TestSelect
                                 "\0",
                                 "\0",
                                 Date.valueOf("1953-01-02"),
-                                Timestamp.valueOf("1753-01-01 00:00:00.000"),
-                                Timestamp.valueOf("0001-01-01 00:00:00.000"),
-                                Timestamp.valueOf("1900-01-01 00:00:00"),
+                                Timestamp.valueOf("1953-01-01 00:00:00.000"),
+                                Timestamp.valueOf("2001-01-01 00:00:00.000"),
+                                Timestamp.valueOf("1960-01-01 00:00:00"),
                                 Double.MIN_VALUE,
                                 -3.40E+38f),
                         row(

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
@@ -146,6 +146,7 @@ public class TestSelect
                         TIMESTAMP,
                         TIMESTAMP,
                         TIMESTAMP,
+                        TIMESTAMP,
                         DOUBLE,
                         REAL)
                 .containsOnly(
@@ -164,7 +165,8 @@ public class TestSelect
                                 "\0",
                                 Date.valueOf("1953-01-02"),
                                 Timestamp.valueOf("1953-01-01 00:00:00.000"),
-                                Timestamp.valueOf("2001-01-01 00:00:00.000"),
+                                Timestamp.valueOf("2001-01-01 00:00:00.123"),
+                                Timestamp.valueOf("1970-01-01 00:00:00.000"),
                                 Timestamp.valueOf("1960-01-01 00:00:00"),
                                 Double.MIN_VALUE,
                                 -3.40E+38f),
@@ -184,10 +186,11 @@ public class TestSelect
                                 Date.valueOf("9999-12-31"),
                                 Timestamp.valueOf("9999-12-31 23:59:59.997"),
                                 Timestamp.valueOf("9999-12-31 23:59:59.999"),
+                                Timestamp.valueOf("9999-12-31 23:59:59.999"),
                                 Timestamp.valueOf("2079-06-06 00:00:00"),
                                 12345678912.3456756,
                                 12345678.6557f),
-                        row(nCopies(18, null).toArray()));
+                        row(nCopies(19, null).toArray()));
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})

--- a/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/sqlserver/TestSelect.java
@@ -50,11 +50,14 @@ import static java.sql.JDBCType.SMALLINT;
 import static java.sql.JDBCType.TIMESTAMP;
 import static java.sql.JDBCType.TINYINT;
 import static java.sql.JDBCType.VARCHAR;
+import static java.util.Collections.nCopies;
 
 public class TestSelect
         extends ProductTest
         implements RequirementsProvider
 {
+    private static final Logger log = Logger.get(TestSelect.class);
+
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
@@ -76,19 +79,14 @@ public class TestSelect
             onPresto().executeQuery(format("DROP TABLE IF EXISTS %s", CREATE_TABLE_AS_SELECT));
         }
         catch (Exception e) {
-            Logger.get(getClass()).warn(e, "failed to drop table");
+            log.warn(e, "failed to drop table");
         }
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testSelectNation()
     {
-        String sql = format(
-                "SELECT n_nationkey, n_name, n_regionkey, n_comment FROM %s",
-                NATION_TABLE_NAME);
-        QueryResult queryResult = onPresto()
-                .executeQuery(sql);
-
+        QueryResult queryResult = onPresto().executeQuery("SELECT n_nationkey, n_name, n_regionkey, n_comment FROM " + NATION_TABLE_NAME);
         assertThat(queryResult).matches(PRESTO_NATION_RESULT);
     }
 
@@ -129,41 +127,76 @@ public class TestSelect
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testAllDatatypes()
     {
-        String sql = format(
-                "SELECT bi, si, i, ti, f, r, c, vc, te, nc, nvc, nt, d, dt, dt2, sdt, pf30, pf22 " +
-                        "FROM %s", ALL_TYPES_TABLE_NAME);
-        QueryResult queryResult = onPresto()
-                .executeQuery(sql);
-
+        QueryResult queryResult = onPresto().executeQuery("SELECT * FROM " + ALL_TYPES_TABLE_NAME);
         assertThat(queryResult)
-                .hasColumns(BIGINT, SMALLINT, INTEGER, TINYINT, DOUBLE, REAL, CHAR, VARCHAR, VARCHAR,
-                        CHAR, VARCHAR, VARCHAR, DATE, TIMESTAMP, TIMESTAMP, TIMESTAMP, DOUBLE, REAL)
+                .hasColumns(
+                        BIGINT,
+                        SMALLINT,
+                        INTEGER,
+                        TINYINT,
+                        DOUBLE,
+                        REAL,
+                        CHAR,
+                        VARCHAR,
+                        VARCHAR,
+                        CHAR,
+                        VARCHAR,
+                        VARCHAR,
+                        DATE,
+                        TIMESTAMP,
+                        TIMESTAMP,
+                        TIMESTAMP,
+                        DOUBLE,
+                        REAL)
                 .containsOnly(
-                        row(Long.MIN_VALUE, Short.MIN_VALUE, Integer.MIN_VALUE, Byte.MIN_VALUE, Double.MIN_VALUE,
-                                Float.valueOf("-3.40E+38"), "\0   ", "\0", "\0", "\0    ", "\0", "\0",
-                                Date.valueOf("1953-01-02"), Timestamp.valueOf("1753-01-01 00:00:00.000"),
-                                Timestamp.valueOf("0001-01-01 00:00:00.000"), Timestamp.valueOf("1900-01-01 00:00:00"),
-                                Double.MIN_VALUE, Float.valueOf("-3.40E+38")),
-                        row(Long.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Byte.MAX_VALUE, Double.MAX_VALUE,
-                                Float.MAX_VALUE, "abcd", "abcdef", "abcd", "abcde", "abcdefg", "abcd",
-                                Date.valueOf("9999-12-31"), Timestamp.valueOf("9999-12-31 23:59:59.997"),
-                                Timestamp.valueOf("9999-12-31 23:59:59.999"), Timestamp.valueOf("2079-06-06 00:00:00"),
-                                Double.valueOf("12345678912.3456756"), Float.valueOf("12345678.6557")),
-                        row(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
+                        row(
+                                Long.MIN_VALUE,
+                                Short.MIN_VALUE,
+                                Integer.MIN_VALUE,
+                                Byte.MIN_VALUE,
+                                Double.MIN_VALUE,
+                                -3.40E+38f,
+                                "\0   ",
+                                "\0",
+                                "\0",
+                                "\0    ",
+                                "\0",
+                                "\0",
+                                Date.valueOf("1953-01-02"),
+                                Timestamp.valueOf("1753-01-01 00:00:00.000"),
+                                Timestamp.valueOf("0001-01-01 00:00:00.000"),
+                                Timestamp.valueOf("1900-01-01 00:00:00"),
+                                Double.MIN_VALUE,
+                                -3.40E+38f),
+                        row(
+                                Long.MAX_VALUE,
+                                Short.MAX_VALUE,
+                                Integer.MAX_VALUE,
+                                Byte.MAX_VALUE,
+                                Double.MAX_VALUE,
+                                Float.MAX_VALUE,
+                                "abcd",
+                                "abcdef",
+                                "abcd",
+                                "abcde",
+                                "abcdefg",
+                                "abcd",
+                                Date.valueOf("9999-12-31"),
+                                Timestamp.valueOf("9999-12-31 23:59:59.997"),
+                                Timestamp.valueOf("9999-12-31 23:59:59.999"),
+                                Timestamp.valueOf("2079-06-06 00:00:00"),
+                                12345678912.3456756,
+                                12345678.6557f),
+                        row(nCopies(18, null).toArray()));
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testCreateTableAsSelect()
     {
-        String sql = format(
-                "CREATE TABLE %s AS SELECT * FROM %s", CREATE_TABLE_AS_SELECT, NATION_TABLE_NAME);
-        onPresto().executeQuery(sql);
+        onPresto().executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", CREATE_TABLE_AS_SELECT, NATION_TABLE_NAME));
 
-        sql = format(
-                "SELECT n_nationkey, n_name, n_regionkey, n_comment FROM %s.%s.%s",
-                "master", KEY_SPACE, CTAS_TABLE_NAME);
         QueryResult queryResult = onSqlServer()
-                .executeQuery(sql);
+                .executeQuery(format("SELECT n_nationkey, n_name, n_regionkey, n_comment FROM %s.%s.%s", "master", KEY_SPACE, CTAS_TABLE_NAME));
 
         assertThat(queryResult).matches(PRESTO_NATION_RESULT);
     }

--- a/presto-tests/src/main/java/io/prestosql/tests/datatype/DataType.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/datatype/DataType.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.type.VarcharType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.function.Function;
@@ -35,6 +36,7 @@ import static com.google.common.io.BaseEncoding.base16;
 import static io.prestosql.spi.type.CharType.createCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.type.JsonType.JSON;
 import static java.lang.String.format;
@@ -145,9 +147,18 @@ public class DataType<T>
     public static DataType<LocalDate> dateDataType()
     {
         return dataType(
-                "DATE",
+                "date",
                 DATE,
                 DateTimeFormatter.ofPattern("'DATE '''yyyy-MM-dd''")::format,
+                identity());
+    }
+
+    public static DataType<LocalDateTime> timestampDataType()
+    {
+        return dataType(
+                "timestamp",
+                TIMESTAMP,
+                DateTimeFormatter.ofPattern("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss.SSS''")::format,
                 identity());
     }
 

--- a/presto-tests/src/main/java/io/prestosql/tests/sql/PrestoSqlExecutor.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/sql/PrestoSqlExecutor.java
@@ -13,23 +13,33 @@
  */
 package io.prestosql.tests.sql;
 
+import io.prestosql.Session;
 import io.prestosql.testing.QueryRunner;
+
+import static java.util.Objects.requireNonNull;
 
 public class PrestoSqlExecutor
         implements SqlExecutor
 {
     private final QueryRunner queryRunner;
+    private final Session session;
 
     public PrestoSqlExecutor(QueryRunner queryRunner)
     {
-        this.queryRunner = queryRunner;
+        this(queryRunner, queryRunner.getDefaultSession());
+    }
+
+    public PrestoSqlExecutor(QueryRunner queryRunner, Session session)
+    {
+        this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
+        this.session = requireNonNull(session, "session is null");
     }
 
     @Override
     public void execute(String sql)
     {
         try {
-            queryRunner.execute(queryRunner.getDefaultSession(), sql);
+            queryRunner.execute(session, sql);
         }
         catch (Throwable e) {
             throw new RuntimeException("Error executing sql:\n" + sql, e);


### PR DESCRIPTION
The existing `timestamp` handling was not correct, regardless of
timestamp semantics.

This commit introduces
- as good as possible timestamp hanlding that is guaranteed to work
  (using `java.sql.Timestamp`)
- timestamp handling that can work, if only driver supports
  `LocalDateTime`
- tests for Postgres