### PR TITLE
Add argument comment for StatsCalculator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/cost/StatsCalculator.java
+++ b/presto-main/src/main/java/io/prestosql/cost/StatsCalculator.java
@@ -27,7 +27,7 @@ public interface StatsCalculator
      * @param node The node to compute stats for.
      * @param sourceStats The stats provider for any child nodes' stats, if needed to compute stats for the {@code node}
      * @param lookup Lookup to be used when resolving source nodes, allowing stats calculation to work within {@link IterativeOptimizer}
-     * @param types
+     * @param types The type provider for all symbols in the scope.
      */
     PlanNodeStatsEstimate calculateStats(
             PlanNode node,


### PR DESCRIPTION
Add a missing javadoc for `types` parameter in StatsCalculator.