### PR TITLE
Prevent exceptions from CLI tests

### DIFF
--- a/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliLauncher.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliLauncher.java
@@ -59,8 +59,8 @@ public class PrestoCliLauncher
             throws InterruptedException
     {
         if (presto != null) {
-            presto.getProcessInput().println(EXIT_COMMAND);
-            presto.waitForWithTimeoutAndKill();
+            presto.close();
+            presto = null;
         }
     }
 


### PR DESCRIPTION
Some CLI tests expect that CLI exits with an error code.
Subsequently `stopPresto` will try to stop CLI again, throwing
because of non-zero exit code. Using `close` avoids the problem.