### PR TITLE
Ensure to load web assets with absolute path

### DIFF
--- a/presto-main/src/main/resources/webapp/embedded_plan.html
+++ b/presto-main/src/main/resources/webapp/embedded_plan.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Query Details - Presto">
     <title>Live Plan - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,23 +19,23 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- Code highlighting -->
     <link rel="stylesheet" href="vendor/highlightjs/9.3/styles/solarized-dark.css">
-    <script src="vendor/highlightjs/9.3/highlight.pack.js"></script>
+    <script src="/ui/vendor/highlightjs/9.3/highlight.pack.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -44,7 +44,7 @@
     <div class="loader">Loading...</div>
 </div>
 
-<script type="text/javascript" src="dist/embedded_plan.js"></script>
+<script type="text/javascript" src="/ui/dist/embedded_plan.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">

--- a/presto-main/src/main/resources/webapp/index.html
+++ b/presto-main/src/main/resources/webapp/index.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Cluster Overview - Presto">
     <title>Cluster Overview - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,19 +19,19 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -54,7 +54,7 @@
 
 </div> <!-- /container -->
 
-<script type="text/javascript" src="dist/index.js"></script>
+<script type="text/javascript" src="/ui/dist/index.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">

--- a/presto-main/src/main/resources/webapp/plan.html
+++ b/presto-main/src/main/resources/webapp/plan.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Query Details - Presto">
     <title>Live Plan - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,23 +19,23 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- Code highlighting -->
     <link rel="stylesheet" href="vendor/highlightjs/9.3/styles/solarized-dark.css">
-    <script src="vendor/highlightjs/9.3/highlight.pack.js"></script>
+    <script src="/ui/vendor/highlightjs/9.3/highlight.pack.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -48,7 +48,7 @@
     </div>
 </div> <!-- /container -->
 
-<script type="text/javascript" src="dist/plan.js"></script>
+<script type="text/javascript" src="/ui/dist/plan.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">

--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Query Details - Presto">
     <title>Query Overview - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,26 +19,26 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- Code highlighting -->
-    <link rel="stylesheet" href="vendor/highlightjs/9.3/styles/solarized-dark.css">
-    <script src="vendor/highlightjs/9.3/highlight.pack.js"></script>
+    <link rel="stylesheet" href="/ui/vendor/highlightjs/9.3/styles/solarized-dark.css">
+    <script src="/ui/vendor/highlightjs/9.3/highlight.pack.js"></script>
 
     <!-- Clipboard -->
-    <script src="vendor/clipboardjs/clipboard.min.js"></script>
+    <script src="/ui/vendor/clipboardjs/clipboard.min.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -50,7 +50,7 @@
 
 </div> <!-- /container -->
 
-<script type="text/javascript" src="dist/query.js"></script>
+<script type="text/javascript" src="/ui/dist/query.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">

--- a/presto-main/src/main/resources/webapp/src/components/PageTitle.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/PageTitle.jsx
@@ -109,7 +109,7 @@ export class PageTitle extends React.Component<Props, State> {
                                 <tbody>
                                 <tr>
                                     <td>
-                                        <a href="/ui/"><img src="assets/logo.png"/></a>
+                                        <a href="/ui/"><img src="/ui/assets/logo.png"/></a>
                                     </td>
                                     <td>
                                         <span className="navbar-brand">{this.props.title}</span>

--- a/presto-main/src/main/resources/webapp/stage.html
+++ b/presto-main/src/main/resources/webapp/stage.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Query Details - Presto">
     <title>Stage Performance - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,23 +19,23 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- Code highlighting -->
     <link rel="stylesheet" href="vendor/highlightjs/9.3/styles/solarized-dark.css">
-    <script src="vendor/highlightjs/9.3/highlight.pack.js"></script>
+    <script src="/ui/vendor/highlightjs/9.3/highlight.pack.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -59,7 +59,7 @@
     </div>
 </div> <!-- /container -->
 
-<script type="text/javascript" src="dist/stage.js"></script>
+<script type="text/javascript" src="/ui/dist/stage.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">

--- a/presto-main/src/main/resources/webapp/timeline.html
+++ b/presto-main/src/main/resources/webapp/timeline.html
@@ -3,12 +3,12 @@
 <head xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
     <meta charset="utf-8">
 
-    <script src="vendor/d3/d3-3.3.4.js"></script>
+    <script src="/ui/vendor/d3/d3-3.3.4.js"></script>
 
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet" type="text/css">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet" type="text/css">
 
-    <link rel="stylesheet" href="vendor/vis/dist/vis.min.css">
-    <script src="vendor/vis/dist/vis.min.js"></script>
+    <link rel="stylesheet" href="/ui/vendor/vis/dist/vis.min.css">
+    <script src="/ui/vendor/vis/dist/vis.min.js"></script>
 
     <style type="text/css">
         .vis.timeline .item {

--- a/presto-main/src/main/resources/webapp/worker.html
+++ b/presto-main/src/main/resources/webapp/worker.html
@@ -7,10 +7,10 @@
     <meta name="description" content="Query Details - Presto">
     <title>Worker Status - Presto</title>
 
-    <link rel="icon" href="assets/favicon.ico">
+    <link rel="icon" href="/ui/assets/favicon.ico">
 
     <!-- Bootstrap core -->
-    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -19,22 +19,22 @@
     <![endif]-->
 
     <!-- jQuery -->
-    <script type="text/javascript" src="vendor/jquery/jquery-2.2.3.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-2.2.3.min.js"></script>
 
     <!-- Bootstrap JS -->
-    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
 
     <!-- Sparkline -->
-    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
 
     <!-- CSS loader -->
-    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Clipboard -->
-    <script src="vendor/clipboardjs/clipboard.min.js"></script>
+    <script src="/ui/vendor/clipboardjs/clipboard.min.js"></script>
 
     <!-- Custom CSS -->
-    <link href="assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/presto.css" rel="stylesheet">
 </head>
 
 <body>
@@ -50,7 +50,7 @@
     </div>
 </div> <!-- /container -->
 
-<script type="text/javascript" src="dist/worker.js"></script>
+<script type="text/javascript" src="/ui/dist/worker.js"></script>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">


### PR DESCRIPTION
Loading by relative path is problematic in case of the change of request path. (e.g. `/ui/` or `/ui`)
Loading by an absolute path (`/ui/*`) makes it robust.

<img width="824" alt="Screen Shot 2019-03-23 at 22 55 13" src="https://user-images.githubusercontent.com/1713047/54867504-5d8d9780-4dc4-11e9-9fc9-a61dc1f7de5b.png">

See: https://github.com/prestosql/presto/issues/500