### PR TITLE
Fix tests JVM time zone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1229,7 +1229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration combine.children="append">
+                <configuration>
                     <includes>
                         <include>**/Test*.java</include>
                         <include>**/Benchmark*.java</include>

--- a/presto-main/src/test/java/io/prestosql/tests/TestVerifyPrestoMainTestSetup.java
+++ b/presto-main/src/test/java/io/prestosql/tests/TestVerifyPrestoMainTestSetup.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import org.testng.annotations.Test;
+
+import java.time.ZoneId;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestVerifyPrestoMainTestSetup
+{
+    @Test
+    public void testJvmZone()
+    {
+        // Ensure that the zone defined in the POM is correctly set in the test JVM
+        assertEquals(ZoneId.systemDefault().getId(), "America/Bahia_Banderas");
+    }
+}

--- a/presto-tests/src/test/java/io/prestosql/tests/TestVerifyPrestoTestsTestSetup.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestVerifyPrestoTestsTestSetup.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import org.testng.annotations.Test;
+
+import java.time.ZoneId;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestVerifyPrestoTestsTestSetup
+{
+    @Test
+    public void testJvmZone()
+    {
+        // Ensure that the zone defined in the POM is correctly set in the test JVM
+        assertEquals(ZoneId.systemDefault().getId(), "America/Bahia_Banderas");
+    }
+}


### PR DESCRIPTION
- airbase defines test time zone and configures Surefire using
  `systemPropertyVariables`
- presto-root was defining Surefire configuration using
  `combine.children="append"`
- presto-main was defining Surefire configuration
  `systemPropertyVariables`

As a result, presto-main's `systemPropertyVariables` were the only ones
effective, and the ones set in airbase were ignored.