### PR TITLE
Set actual value to information_shcema.tables.table_comment

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -1894,6 +1894,16 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testInformationSchemaTable()
+    {
+        assertUpdate("CREATE TABLE test_comment (c1 bigint) COMMENT 'foo'");
+        String selectTableComment = format("SELECT table_comment FROM information_schema.tables WHERE table_catalog = '%s' AND table_schema = '%s' AND table_name = 'test_comment'", getSession().getCatalog().get(), getSession().getSchema().get());
+        assertQuery(selectTableComment, "SELECT 'foo'");
+
+        assertUpdate("DROP TABLE IF EXISTS test_comment");
+    }
+
+    @Test
     public void testShowCreateTable()
     {
         String createTableSql = format("" +


### PR DESCRIPTION
Current information_schema.tables.table_comment column always returns `NULL`. This commit sets actual comment value to the column.

@findepi I tried to modify `io.prestosql.metadata.MetadataListing#listTables` from `Set<SchemaTableName>` to `Map<SchemaTableName, TableMetadata>` first. However, some connector may throw an exception during `getTableHandle`. Therefore, I put the logic on InformationSchemaPageSourceProvider.
https://github.com/prestosql/presto/issues/170#issuecomment-475170357