### PR TITLE
[WIP] Fix incorrect FILTER clause evaluation order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -664,7 +664,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.197</version>
+                <version>1.4.199</version>
             </dependency>
 
             <dependency>

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestAggregations.java
@@ -323,6 +323,12 @@ public abstract class AbstractTestAggregations
     }
 
     @Test
+    public void testAggregationFilterEvaluationOrdering()
+    {
+        assertQuery("SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a)");
+    }
+
+    @Test
     public void testAggregationWithProjection()
     {
         assertQuery("SELECT sum(totalprice * 2) - sum(totalprice) FROM orders");


### PR DESCRIPTION
- adding a unit test to reproduce the bug https://github.com/prestosql/presto/issues/7
- the bug seems to be in the h2database library that's used for testing, and not actually an issue in the presto core code itself. I also verified this with the hive connector through the presto-cli. 
- bumping the underlying version of h2database to the latest release fixes this with https://github.com/h2database/h2database/commit/34aaf06604382b5160cbed14ec038c016905fc05

example test output: 
```

java.lang.AssertionError: Execution of 'expected' query failed: SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a)

	at org.testng.Assert.fail(Assert.java:83)
	at io.prestosql.tests.QueryAssertions.assertQuery(QueryAssertions.java:164)
	at io.prestosql.tests.QueryAssertions.assertQuery(QueryAssertions.java:106)
	at io.prestosql.tests.AbstractTestQueryFramework.assertQuery(AbstractTestQueryFramework.java:133)
	at io.prestosql.tests.AbstractTestQueryFramework.assertQuery(AbstractTestQueryFramework.java:128)
	at io.prestosql.tests.AbstractTestAggregations.testAggregationFilterEvaluationOrdering(AbstractTestAggregations.java:328)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at org.testng.TestRunner.privateRun(TestRunner.java:756)
	at org.testng.TestRunner.run(TestRunner.java:610)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:387)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:382)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1293)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1218)
	at org.testng.TestNG.runSuites(TestNG.java:1133)
	at org.testng.TestNG.run(TestNG.java:1104)
	at org.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:72)
	at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: org.jdbi.v3.core.statement.UnableToExecuteStatementException: org.h2.jdbc.JdbcSQLException: Division by zero: "1"; SQL statement:
SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a) [22012-197] [statement:"SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a)", rewritten:"SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a)", parsed:"ParsedSql{sql='SELECT sum(1 / a) FILTER (WHERE a <> 0) FROM (VALUES (1), (0)) t(a)', parameters=ParsedParameters{positional=false, parameterNames=[]}}", arguments:{positional:{}, named:{}, finder:[]}]
	

...
```

