### PR TITLE
Reduce the identifier length in generated code for nested columns

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/gen/SqlTypeBytecodeExpression.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/SqlTypeBytecodeExpression.java
@@ -40,6 +40,16 @@ public class SqlTypeBytecodeExpression
         return new SqlTypeBytecodeExpression(type, binding, BOOTSTRAP_METHOD);
     }
 
+    private static String generateName(Type type)
+    {
+        String name = type.getTypeSignature().toString();
+        if (name.length() > 20) {
+            // Use type base to reduce the identifier size in generated code
+            name = type.getTypeSignature().getBase();
+        }
+        return name.replaceAll("\\W+", "_");
+    }
+
     private final Type type;
     private final Binding binding;
     private final Method bootstrapMethod;
@@ -47,7 +57,6 @@ public class SqlTypeBytecodeExpression
     private SqlTypeBytecodeExpression(Type type, Binding binding, Method bootstrapMethod)
     {
         super(type(Type.class));
-
         this.type = requireNonNull(type, "type is null");
         this.binding = requireNonNull(binding, "binding is null");
         this.bootstrapMethod = requireNonNull(bootstrapMethod, "bootstrapMethod is null");
@@ -56,7 +65,7 @@ public class SqlTypeBytecodeExpression
     @Override
     public BytecodeNode getBytecode(MethodGenerationContext generationContext)
     {
-        return InvokeInstruction.invokeDynamic(type.getTypeSignature().toString().replaceAll("\\W+", "_"), binding.getType(), bootstrapMethod, binding.getBindingId());
+        return InvokeInstruction.invokeDynamic(generateName(type), binding.getType(), bootstrapMethod, binding.getBindingId());
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -621,6 +621,35 @@ public class TestExpressionCompiler
         Futures.allAsList(futures).get();
     }
 
+    @Test
+    public void testNestedColumnFilter()
+    {
+        assertFilter("bound_row.nested_column_0 = 1234", true);
+        assertFilter("bound_row.nested_column_0 = 1223", false);
+        assertFilter("bound_row.nested_column_1 = 34", true);
+        assertFilter("bound_row.nested_column_1 = 33", false);
+        assertFilter("bound_row.nested_column_2 = 'hello'", true);
+        assertFilter("bound_row.nested_column_2 = 'value1'", false);
+        assertFilter("bound_row.nested_column_3 = 12.34", true);
+        assertFilter("bound_row.nested_column_3 = 34.34", false);
+        assertFilter("bound_row.nested_column_4 = true", true);
+        assertFilter("bound_row.nested_column_4 = false", false);
+        assertFilter("bound_row.nested_column_6.nested_nested_column = 'innerFieldValue'", true);
+        assertFilter("bound_row.nested_column_6.nested_nested_column != 'innerFieldValue'", false);
+
+        // combination of types in one filter
+        assertFilter(
+                ImmutableList.of(
+                        "bound_row.nested_column_0 = 1234", "bound_row.nested_column_7 >= 1234",
+                        "bound_row.nested_column_1 = 34", "bound_row.nested_column_8 >= 33",
+                        "bound_row.nested_column_2 = 'hello'", "bound_row.nested_column_9 >= 'hello'",
+                        "bound_row.nested_column_3 = 12.34", "bound_row.nested_column_10 >= 12.34",
+                        "bound_row.nested_column_4 = true", "NOT (bound_row.nested_column_11 = false)",
+                        "bound_row.nested_column_6.nested_nested_column = 'innerFieldValue'", "bound_row.nested_column_13.nested_nested_column LIKE 'innerFieldValue'")
+                        .stream().collect(joining(" AND ")),
+                true);
+    }
+
     private static VarcharType varcharType(String... values)
     {
         return varcharType(Arrays.asList(values));

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
@@ -237,6 +237,10 @@ public class InMemoryRecordSet
                     checkArgument(value instanceof Block,
                             "Expected value %d to be an instance of Block, but is a %s", i, value.getClass().getSimpleName());
                 }
+                else if (type.getTypeSignature().getBase().equals("row")) {
+                    checkArgument(value instanceof Block,
+                            "Expected value %d to be an instance of Block, but is a %s", i, value.getClass().getSimpleName());
+                }
                 else {
                     throw new IllegalStateException("Unsupported column type " + types.get(i));
                 }


### PR DESCRIPTION
Currently the type signature is used as name which could be long if the
type is a nested type. We recently hit the limit of identifier length in
ASM [1] on one of the wide tables which has nested column deferences in
project/filter.

Change the name to a short name based on the Java object type of the `Type`,
as the instruction definition is based on the Java object type. This reduces
the size of the code generated too.

Bytecode for the test query used in unittests:
Before fix: https://gist.github.com/vkorukanti/64bfab1842c192fdb21f12f54006def3#file-before_fix
After fix: https://gist.github.com/vkorukanti/64bfab1842c192fdb21f12f54006def3#file-after-fix

[1] https://gitlab.ow2.org/asm/asm/blob/master/asm/src/main/java/org/objectweb/asm/ByteVector.java#L246