### PR TITLE
Limit amount of native memory used for NIO buffers

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -80,6 +80,7 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+    -Djdk.nio.maxCachedBufferSize=2000000
 
 Because an ``OutOfMemoryError`` will typically leave the JVM in an
 inconsistent state, we write a heap dump (for debugging) and forcibly

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -17,3 +17,4 @@
 -Duser.timezone=Asia/Kathmandu
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 -XX:ErrorFile=/docker/volumes/logs/product-tests-presto-jvm-error-file.log
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/presto-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/presto-server-rpm/src/main/resources/dist/config/jvm.config
@@ -7,3 +7,4 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=512M
+-Djdk.nio.maxCachedBufferSize=2000000


### PR DESCRIPTION
Set the default value of jdk.nio.maxCachedBufferSize to 2MB. If we did not set this JVM would take the entire System memory as the maximumbuffer size and it will result in increase in non-heap memory for the JVM process.