### PR TITLE
Allow tables with same name in different schemas in Blackhole

### DIFF
--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
@@ -62,7 +62,7 @@ public class BlackHoleMetadata
     public static final String SCHEMA_NAME = "default";
 
     private final List<String> schemas = new ArrayList<>();
-    private final Map<String, BlackHoleTableHandle> tables = new ConcurrentHashMap<>();
+    private final Map<SchemaTableName, BlackHoleTableHandle> tables = new ConcurrentHashMap<>();
 
     public BlackHoleMetadata()
     {
@@ -87,7 +87,7 @@ public class BlackHoleMetadata
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        return tables.get(tableName.getTableName());
+        return tables.get(tableName);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class BlackHoleMetadata
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         BlackHoleTableHandle blackHoleTableHandle = (BlackHoleTableHandle) tableHandle;
-        tables.remove(blackHoleTableHandle.getTableName());
+        tables.remove(blackHoleTableHandle.toSchemaTableName());
     }
 
     @Override
@@ -149,8 +149,8 @@ public class BlackHoleMetadata
                 oldTableHandle.getRowsPerPage(),
                 oldTableHandle.getFieldsLength(),
                 oldTableHandle.getPageProcessingDelay());
-        tables.remove(oldTableHandle.getTableName());
-        tables.put(newTableName.getTableName(), newTableHandle);
+        tables.remove(oldTableHandle.toSchemaTableName());
+        tables.put(newTableName, newTableHandle);
     }
 
     @Override
@@ -222,7 +222,7 @@ public class BlackHoleMetadata
     {
         BlackHoleOutputTableHandle blackHoleOutputTableHandle = (BlackHoleOutputTableHandle) tableHandle;
         BlackHoleTableHandle table = blackHoleOutputTableHandle.getTable();
-        tables.put(table.getTableName(), table);
+        tables.put(table.toSchemaTableName(), table);
         return Optional.empty();
     }
 

--- a/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleSmoke.java
@@ -69,8 +69,14 @@ public class TestBlackHoleSmoke
     public void testCreateSchema()
     {
         assertEquals(queryRunner.execute("SHOW SCHEMAS FROM blackhole").getRowCount(), 2);
+        assertThatQueryReturnsValue("CREATE TABLE test_schema as SELECT * FROM tpch.tiny.nation", 25L);
+
         queryRunner.execute("CREATE SCHEMA blackhole.test");
         assertEquals(queryRunner.execute("SHOW SCHEMAS FROM blackhole").getRowCount(), 3);
+        assertThatQueryReturnsValue("CREATE TABLE test.test_schema as SELECT * FROM tpch.tiny.region", 5L);
+
+        assertThatQueryReturnsValue("DROP TABLE test_schema", true);
+        assertThatQueryReturnsValue("DROP TABLE test.test_schema", true);
     }
 
     @Test

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
@@ -1435,7 +1435,7 @@ public class TestPrestoDriver
         AtomicReference<Throwable> queryFailure = new AtomicReference<>();
 
         Future<?> queryFuture = executorService.submit(() -> {
-            try (Connection connection = createConnection("blackhole", "default");
+            try (Connection connection = createConnection("blackhole", "blackhole");
                     Statement statement = connection.createStatement();
                     ResultSet resultSet = statement.executeQuery("SELECT * FROM slow_test_table")) {
                 queryId.set(resultSet.unwrap(PrestoResultSet.class).getQueryId());
@@ -1478,7 +1478,7 @@ public class TestPrestoDriver
         AtomicReference<String> queryId = new AtomicReference<>();
         AtomicReference<Throwable> queryFailure = new AtomicReference<>();
 
-        try (Connection connection = createConnection("blackhole", "default");
+        try (Connection connection = createConnection("blackhole", "blackhole");
                 Statement statement = connection.createStatement()) {
             // execute the slow query on another thread
             executorService.execute(() -> {
@@ -1519,7 +1519,7 @@ public class TestPrestoDriver
         AtomicReference<Throwable> queryFailure = new AtomicReference<>();
         String queryUuid = "/* " + UUID.randomUUID().toString() + " */";
 
-        try (Connection connection = createConnection("blackhole", "default");
+        try (Connection connection = createConnection("blackhole", "blackhole");
                 Statement statement = connection.createStatement()) {
             // execute the slow update on another thread
             executorService.execute(() -> {
@@ -1573,7 +1573,7 @@ public class TestPrestoDriver
         AtomicReference<Throwable> queryFailure = new AtomicReference<>();
 
         executorService.submit(() -> {
-            try (Connection connection = createConnection("blackhole", "default");
+            try (Connection connection = createConnection("blackhole", "blackhole");
                     Statement statement = connection.createStatement()) {
                 statement.setQueryTimeout(1);
                 try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test_query_timeout")) {
@@ -1606,7 +1606,7 @@ public class TestPrestoDriver
     public void testQueryPartialCancel()
             throws Exception
     {
-        try (Connection connection = createConnection("blackhole", "default");
+        try (Connection connection = createConnection("blackhole", "blackhole");
                 Statement statement = connection.createStatement();
                 ResultSet resultSet = statement.executeQuery("SELECT count(*) FROM slow_test_table")) {
             statement.unwrap(PrestoStatement.class).partialCancel();
@@ -1621,7 +1621,7 @@ public class TestPrestoDriver
     {
         CountDownLatch queryRunning = new CountDownLatch(1);
 
-        try (Connection connection = createConnection("blackhole", "default");
+        try (Connection connection = createConnection("blackhole", "blackhole");
                 Statement statement = connection.createStatement()) {
             // execute the slow update on another thread
             Future<Integer> future = executorService.submit(() ->


### PR DESCRIPTION
Minor bug fix in BlackHoleConnector

BlackholeConnector cannot have tables with same table names in different
schemas.

This is because originally BlackHoleConnector only supports `default`
schema so it use the table name string to identify table. When creating
schema was supported in 4e522f355ed7f0711d877e2259e489a8ebf626b9, the
table identity should be updated to use SchemaTableName.

Extracted from: https://github.com/prestodb/presto/pull/12457
