### PR TITLE
Fix potential NPE in JdbcRecordCursor

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
@@ -227,7 +227,9 @@ public class JdbcRecordCursor
         try (Connection connection = this.connection;
                 Statement statement = this.statement;
                 ResultSet resultSet = this.resultSet) {
-            jdbcClient.abortReadConnection(connection);
+            if (connection != null) {
+                jdbcClient.abortReadConnection(connection);
+            }
         }
         catch (SQLException e) {
             // ignore exception from close


### PR DESCRIPTION
Fix potential NPE in JdbcRecordCursor

When exception is thrown from `jdbcClient.getConnection()`,
then connection variable could be still null.
