### PR TITLE
information_schema should not fail for illegal storage format

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/StorageFormat.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/StorageFormat.java
@@ -16,12 +16,15 @@ package io.prestosql.plugin.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.prestosql.plugin.hive.HiveStorageFormat;
+import io.prestosql.spi.PrestoException;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -43,7 +46,7 @@ public class StorageFormat
     public String getSerDe()
     {
         if (serDe == null) {
-            throw new IllegalStateException("serDe should not be accessed from a null StorageFormat");
+            throw new PrestoException(HIVE_INVALID_METADATA, "SerDe is not present in StorageFormat");
         }
         return serDe;
     }
@@ -51,7 +54,7 @@ public class StorageFormat
     public String getInputFormat()
     {
         if (inputFormat == null) {
-            throw new IllegalStateException("inputFormat should not be accessed from a null StorageFormat");
+            throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, "InputFormat is not present in StorageFormat");
         }
         return inputFormat;
     }
@@ -59,7 +62,7 @@ public class StorageFormat
     public String getOutputFormat()
     {
         if (outputFormat == null) {
-            throw new IllegalStateException("outputFormat should not be accessed from a null StorageFormat");
+            throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, "OutputFormat is not present in StorageFormat");
         }
         return outputFormat;
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -108,6 +108,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
+import org.iq80.leveldb.table.TableBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.AfterClass;
@@ -2641,6 +2642,48 @@ public abstract class AbstractTestHive
         }
         finally {
             dropTable(tableName);
+        }
+    }
+
+    /**
+     * During table scan, the illegal storage format for some specific table should not fail the whole table scan
+     */
+    @Test
+    public void testIllegalStorageFormatDuringTableScan()
+    {
+        SchemaTableName schemaTableName = temporaryTable("test_illegal_storage_format");
+        try (Transaction transaction = newTransaction()) {
+            ConnectorSession session = newSession();
+            List<Column> columns = ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty()));
+            String tableOwner = session.getUser();
+            String schemaName = schemaTableName.getSchemaName();
+            String tableName = schemaTableName.getTableName();
+            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(schemaName), session, schemaName, tableName);
+            Path targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
+            Table.Builder tableBuilder = Table.builder()
+                    .setDatabaseName(schemaName)
+                    .setTableName(tableName)
+                    .setOwner(tableOwner)
+                    .setTableType(TableType.MANAGED_TABLE.name())
+                    .setParameters(ImmutableMap.of(
+                            PRESTO_VERSION_NAME, TEST_SERVER_VERSION,
+                            PRESTO_QUERY_ID_NAME, session.getQueryId()))
+                    .setDataColumns(columns)
+                    .withStorage(storage -> storage
+                            .setLocation(targetPath.toString())
+                            .setStorageFormat(StorageFormat.createNullable(null, null, null))
+                            .setSerdeParameters(ImmutableMap.of()));
+            PrincipalPrivileges principalPrivileges = testingPrincipalPrivilege(tableOwner, session.getUser());
+            transaction.getMetastore(schemaName).createTable(session, tableBuilder.build(), principalPrivileges, Optional.empty(), true, EMPTY_TABLE_STATISTICS);
+            transaction.commit();
+        }
+
+        //we retrieve the table whose storageFormat has null serde/inputFormat/outputFormat to make
+        //sure it can still be retrieved instead of throwing exception
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            Map<SchemaTableName, List<ColumnMetadata>> allColumns = metadata.listTableColumns(newSession(), new SchemaTablePrefix(schemaTableName.getSchemaName()));
+            assertTrue(allColumns.containsKey(schemaTableName));
         }
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -108,7 +108,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.iq80.leveldb.table.TableBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.AfterClass;
@@ -2660,6 +2659,7 @@ public abstract class AbstractTestHive
             String tableName = schemaTableName.getTableName();
             LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(schemaName), session, schemaName, tableName);
             Path targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
+            //create table whose storage format is null
             Table.Builder tableBuilder = Table.builder()
                     .setDatabaseName(schemaName)
                     .setTableName(tableName)
@@ -2684,6 +2684,9 @@ public abstract class AbstractTestHive
             ConnectorMetadata metadata = transaction.getMetadata();
             Map<SchemaTableName, List<ColumnMetadata>> allColumns = metadata.listTableColumns(newSession(), new SchemaTablePrefix(schemaTableName.getSchemaName()));
             assertTrue(allColumns.containsKey(schemaTableName));
+        }
+        finally {
+            dropTable(schemaTableName);
         }
     }
 


### PR DESCRIPTION
Hi @electrum  @kokosing 
I have just migrated the original PR(https://github.com/prestodb/presto/pull/11847) from prestodb to prestosql.
