### PR TITLE
Add Presto Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!presto-docker-image/*
+!presto-server/target/presto-server-*.tar.gz
+!presto-cli/target/presto-cli-*-executable.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - ARTIFACTS_UPLOAD_PATH_PR=travis_build_artifacts_pr/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}
     - TEST_FLAGS=""
   matrix:
-    - MAVEN_CHECKS=true
+    - MAVEN_CHECKS=true BUILD_PRESTO_DOCKER=true
     - WEBUI_CHECKS=true
     - TEST_SPECIFIC_MODULES=presto-tests
     - TEST_SPECIFIC_MODULES=presto-tests TEST_FLAGS="-P ci-only"
@@ -84,6 +84,10 @@ script:
   - |
     if [[ -v MAVEN_CHECKS ]]; then
       ./mvnw install -DskipTests -B -T C1 -P ci
+    fi
+  - |
+    if [[ -v BUILD_PRESTO_DOCKER ]]; then
+      presto-docker-image/build-local.sh
     fi
   - |
     if [[ -v WEBUI_CHECKS ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM centos:centos7
+LABEL maintainer="Presto community <https://prestosql.io/community.html>"
+
+ENV JAVA_HOME /usr/lib/jvm/java-11
+RUN \
+    set -xeu && \
+    yum -y -q update && \
+    yum -y -q install java-11-openjdk-devel less && \
+    yum -q clean all && \
+    rm -rf /var/cache/yum && \
+    rm -rf /tmp/* /var/tmp/*
+
+RUN \
+    set -xeu && \
+    mkdir -p /data/presto
+
+ARG PRESTO_VERSION
+ARG PRESTO_LOCATION=presto-server/target/presto-server-${PRESTO_VERSION}.tar.gz
+ADD ${PRESTO_LOCATION} /tmp
+
+ARG CLIENT_VERSION=${PRESTO_VERSION}
+ARG CLIENT_LOCATION=presto-cli/target/presto-cli-${CLIENT_VERSION}-executable.jar
+ADD ${CLIENT_LOCATION} /usr/bin/presto
+
+RUN \
+    set -xeu && \
+    if [[ ! -d /tmp/presto-server-${PRESTO_VERSION} ]]; then \
+        tar -C /tmp -xzf /tmp/presto-server-${PRESTO_VERSION}.tar.gz && \
+        rm /tmp/presto-server-${PRESTO_VERSION}.tar.gz; \
+    fi && \
+    cp -r /tmp/presto-server-${PRESTO_VERSION} /usr/lib/presto && \
+    rm -r /tmp/presto-server-${PRESTO_VERSION} && \
+    chmod 755 /usr/bin/presto
+
+COPY presto-docker-image/bin /usr/lib/presto/bin
+COPY presto-docker-image/etc /usr/lib/presto/default/etc
+
+EXPOSE 8080
+
+RUN \
+    set -xeu && \
+    groupadd presto --gid 1000 && \
+    useradd presto --uid 1000 --gid 1000 && \
+    chown -R "presto:presto" /usr/lib/presto /data/presto
+
+USER presto:presto
+CMD ["/usr/lib/presto/bin/run-presto"]

--- a/presto-docker-image/README.md
+++ b/presto-docker-image/README.md
@@ -1,0 +1,28 @@
+# presto-docker-image
+
+## About the Container
+This Docker image is designed to provide the following
+* An out-of-the-box single node cluster with the JMX, memory, TPC-DS, and TPC-H
+ catalogs
+* An image that can be deployed as a full cluster by mounting in configuration
+* An image to be used as the basis for the Kubernetes Presto operator
+
+## Configuration
+
+Configuration is expected to be mounted to either  to `/etc/presto` or
+`/usr/lib/presto/etc` (the latter takes precedence). If neither of these exists
+then the default single node configuration will be used.
+
+### Specific Config Options
+
+#### `node.id`
+The container supplied `run-presto` command will set the config property
+`node.id` to the hostname of the container if it is not specified in the
+`node.properties` file. This allows for `node.properties` to be a static file
+across all worker nodes if desired. Additionally this has the added benefit of
+`node.id` being consistent, predictable, and stable through restarts.
+
+#### `node.data-dir`
+The default configuration uses `/data/presto` as the default for
+`node.data-dir`. Thus if using the default configuration and a mounted volume
+is desired for the data directory it should be mounted to `/data/presto`.

--- a/presto-docker-image/bin/run-presto
+++ b/presto-docker-image/bin/run-presto
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+if [[ ! -d /usr/lib/presto/etc ]]; then
+    if [[ -d /etc/presto ]]; then
+        ln -s /etc/presto /usr/lib/presto/etc
+    else
+        ln -s /usr/lib/presto/default/etc /usr/lib/presto/etc
+    fi
+fi
+
+set +e
+grep -s -q 'node.id' /usr/lib/presto/etc/node.properties
+NODE_ID_EXISTS=$?
+set -e
+
+NODE_ID=""
+if [[ ${NODE_ID_EXISTS} != 0 ]] ; then
+    NODE_ID="-Dnode.id=${HOSTNAME}"
+fi
+
+exec /usr/lib/presto/bin/launcher run ${NODE_ID} "$@"

--- a/presto-docker-image/build-local.sh
+++ b/presto-docker-image/build-local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Retrieve the script directory.
+SCRIPT_DIR="${BASH_SOURCE%/*}"
+
+# Move to the root directory, as that
+# is where the Dockerfile resides.
+cd ${SCRIPT_DIR}/..
+
+PRESTO_VERSION=$(./mvnw --quiet --batch-mode --non-recursive  exec:exec -Dexec.executable='echo' -Dexec.args='${project.version}')
+docker build . --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}"
+
+# Source common testing functions
+. ${SCRIPT_DIR}/container-test.sh
+
+test_container "presto:${PRESTO_VERSION}"

--- a/presto-docker-image/build-remote.sh
+++ b/presto-docker-image/build-remote.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Retrieve the script directory.
+SCRIPT_DIR="${BASH_SOURCE%/*}"
+
+# Move to the root directory, as that
+# is where the Dockerfile resides.
+cd ${SCRIPT_DIR}/..
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 PRESTO_VERSION"
+    echo "Missing PRESTO_VERSION"
+    exit 1
+fi
+
+PRESTO_VERSION=$1
+PRESTO_LOCATION="https://repo1.maven.org/maven2/io/prestosql/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz"
+CLIENT_LOCATION="https://repo1.maven.org/maven2/io/prestosql/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar"
+docker build . -t "presto:${PRESTO_VERSION}" --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" --build-arg "CLIENT_LOCATION=${CLIENT_LOCATION}" --build-arg "PRESTO_LOCATION=${PRESTO_LOCATION}"
+
+# Source common testing functions
+. ${SCRIPT_DIR}/container-test.sh
+
+test_container "presto:${PRESTO_VERSION}"

--- a/presto-docker-image/container-test.sh
+++ b/presto-docker-image/container-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+CONTAINER_ID=
+
+function cleanup {
+    if [[ ! -z ${CONTAINER_ID:-} ]]; then
+        docker stop "${CONTAINER_ID}"
+    fi
+}
+
+function test_container {
+    local QUERY_TIMEOUT=150
+    local QUERY_PERIOD=15
+    local QUERY_RETRIES=$((QUERY_TIMEOUT/QUERY_PERIOD))
+
+    trap cleanup EXIT
+
+    local CONTAINER_NAME=$1
+    CONTAINER_ID=$(docker run -d --rm "${CONTAINER_NAME}")
+
+    set +e
+    I=0
+    until RESULT=$(docker exec "${CONTAINER_ID}" presto --execute "SELECT 'success'"); do
+        if [[ $((I++)) -ge ${QUERY_RETRIES} ]]; then
+            echo "Too many retries waiting for Presto to start."
+            break
+        fi
+        sleep ${QUERY_PERIOD}
+    done
+    set -e
+
+    # Return proper exit code.
+    [[ ${RESULT} == '"success"' ]]
+}

--- a/presto-docker-image/etc/catalog/jmx.properties
+++ b/presto-docker-image/etc/catalog/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/presto-docker-image/etc/catalog/memory.properties
+++ b/presto-docker-image/etc/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/presto-docker-image/etc/catalog/tpcds.properties
+++ b/presto-docker-image/etc/catalog/tpcds.properties
@@ -1,0 +1,2 @@
+connector.name=tpcds
+tpcds.splits-per-node=4

--- a/presto-docker-image/etc/catalog/tpch.properties
+++ b/presto-docker-image/etc/catalog/tpch.properties
@@ -1,0 +1,2 @@
+connector.name=tpch
+tpch.splits-per-node=4

--- a/presto-docker-image/etc/config.properties
+++ b/presto-docker-image/etc/config.properties
@@ -1,0 +1,6 @@
+#single node install config
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery-server.enabled=true
+discovery.uri=http://localhost:8080

--- a/presto-docker-image/etc/jvm.config
+++ b/presto-docker-image/etc/jvm.config
@@ -1,0 +1,12 @@
+-server
+-Xmx1G
+-XX:-UseBiasedLocking
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+UseGCOverheadLimit
+-XX:+ExitOnOutOfMemoryError
+-XX:ReservedCodeCacheSize=256M
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/presto-docker-image/etc/log.properties
+++ b/presto-docker-image/etc/log.properties
@@ -1,0 +1,2 @@
+# Enable verbose logging from Presto
+#io.prestosql=DEBUG

--- a/presto-docker-image/etc/node.properties
+++ b/presto-docker-image/etc/node.properties
@@ -1,0 +1,3 @@
+node.environment=docker
+node.data-dir=/data/presto
+plugin.dir=/usr/lib/presto/plugin


### PR DESCRIPTION
A Dockerfile to build a Docker container for Presto. Ideally this would then be used to build a Docker container for each release.

This container provides the following:
- An out-of-the-box single node cluster with the JMX, memory, TPC-DS, and TPC-H catalogs.
- An image that can be deployed as a full cluster by mounting configuration to `/usr/lib/presto/etc`
- An image to be used as a starting point for the planned Kubernetes operator (#396)