### PR TITLE
Skip unsupported column type in Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
@@ -119,7 +119,7 @@ public enum CassandraType
         }
     }
 
-    public static CassandraType getCassandraType(DataType.Name name)
+    public static CassandraType toCassandraType(DataType.Name name)
     {
         switch (name) {
             case ASCII:

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.net.InetAddresses.toAddrString;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -119,57 +120,57 @@ public enum CassandraType
         }
     }
 
-    public static CassandraType toCassandraType(DataType.Name name)
+    public static Optional<CassandraType> toCassandraType(DataType.Name name)
     {
         switch (name) {
             case ASCII:
-                return ASCII;
+                return Optional.of(ASCII);
             case BIGINT:
-                return BIGINT;
+                return Optional.of(BIGINT);
             case BLOB:
-                return BLOB;
+                return Optional.of(BLOB);
             case BOOLEAN:
-                return BOOLEAN;
+                return Optional.of(BOOLEAN);
             case COUNTER:
-                return COUNTER;
+                return Optional.of(COUNTER);
             case CUSTOM:
-                return CUSTOM;
+                return Optional.of(CUSTOM);
             case DATE:
-                return DATE;
+                return Optional.of(DATE);
             case DECIMAL:
-                return DECIMAL;
+                return Optional.of(DECIMAL);
             case DOUBLE:
-                return DOUBLE;
+                return Optional.of(DOUBLE);
             case FLOAT:
-                return FLOAT;
+                return Optional.of(FLOAT);
             case INET:
-                return INET;
+                return Optional.of(INET);
             case INT:
-                return INT;
+                return Optional.of(INT);
             case LIST:
-                return LIST;
+                return Optional.of(LIST);
             case MAP:
-                return MAP;
+                return Optional.of(MAP);
             case SET:
-                return SET;
+                return Optional.of(SET);
             case SMALLINT:
-                return SMALLINT;
+                return Optional.of(SMALLINT);
             case TEXT:
-                return TEXT;
+                return Optional.of(TEXT);
             case TIMESTAMP:
-                return TIMESTAMP;
+                return Optional.of(TIMESTAMP);
             case TIMEUUID:
-                return TIMEUUID;
+                return Optional.of(TIMEUUID);
             case TINYINT:
-                return TINYINT;
+                return Optional.of(TINYINT);
             case UUID:
-                return UUID;
+                return Optional.of(UUID);
             case VARCHAR:
-                return VARCHAR;
+                return Optional.of(VARCHAR);
             case VARINT:
-                return VARINT;
+                return Optional.of(VARINT);
             default:
-                return null;
+                return Optional.empty();
         }
     }
 

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/NativeCassandraSession.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/NativeCassandraSession.java
@@ -74,6 +74,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
 import static io.prestosql.plugin.cassandra.CassandraErrorCode.CASSANDRA_VERSION_ERROR;
+import static io.prestosql.plugin.cassandra.CassandraType.toCassandraType;
 import static io.prestosql.plugin.cassandra.util.CassandraCqlUtils.validSchemaName;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
@@ -319,16 +320,16 @@ public class NativeCassandraSession
 
     private CassandraColumnHandle buildColumnHandle(AbstractTableMetadata tableMetadata, ColumnMetadata columnMeta, boolean partitionKey, boolean clusteringKey, int ordinalPosition, boolean hidden)
     {
-        CassandraType cassandraType = CassandraType.getCassandraType(columnMeta.getType().getName());
+        CassandraType cassandraType = toCassandraType(columnMeta.getType().getName());
         List<CassandraType> typeArguments = null;
         if (cassandraType != null && cassandraType.getTypeArgumentSize() > 0) {
             List<DataType> typeArgs = columnMeta.getType().getTypeArguments();
             switch (cassandraType.getTypeArgumentSize()) {
                 case 1:
-                    typeArguments = ImmutableList.of(CassandraType.getCassandraType(typeArgs.get(0).getName()));
+                    typeArguments = ImmutableList.of(toCassandraType(typeArgs.get(0).getName()));
                     break;
                 case 2:
-                    typeArguments = ImmutableList.of(CassandraType.getCassandraType(typeArgs.get(0).getName()), CassandraType.getCassandraType(typeArgs.get(1).getName()));
+                    typeArguments = ImmutableList.of(toCassandraType(typeArgs.get(0).getName()), toCassandraType(typeArgs.get(1).getName()));
                     break;
                 default:
                     throw new IllegalArgumentException("Invalid type arguments: " + typeArgs);


### PR DESCRIPTION
Fix https://github.com/prestosql/presto/issues/591

New expected behavior (skip unsupported type c2, c4)
```sql
cqlsh> create table test.test_tuple (c1 int, c2 tuple<int>, c3 int, c4 set<frozen<tuple<int>>>, primary key (c1));
```

```sql
presto> desc cassandra.test.test_tuple;
 Column |  Type   | Extra | Comment 
--------+---------+-------+---------
 c1     | integer |       |         
 c3     | integer |       |         
(2 rows)
```