### PR TITLE
[WIP] Adding Dockerfiles for Base, coordinator and worker

### DIFF
--- a/presto-docker/.travis.yml
+++ b/presto-docker/.travis.yml
@@ -1,0 +1,22 @@
+language: bash
+services: docker
+
+env:
+  - VERSION=307
+  - VERSION=306
+
+
+install:
+  # - pip install docker-admin
+
+before_script:
+  - env | sort
+  - 
+    
+script:
+  - 
+    
+after_script:
+  - 
+
+# vim:set et ts=2 sw=2:  

--- a/presto-docker/Makefile
+++ b/presto-docker/Makefile
@@ -1,0 +1,21 @@
+PRESTO_VERSION := 307
+
+build:
+	docker build --build-arg VERSION=${PRESTO_VERSION} -t prestosql/presto-base:${PRESTO_VERSION} base
+	docker build --build-arg VERSION=${PRESTO_VERSION} -t prestosql/presto-coordinator:${PRESTO_VERSION} coordinator
+	docker build --build-arg VERSION=${PRESTO_VERSION} -t prestosql/presto-worker:${PRESTO_VERSION} worker
+	# docker-compose build
+
+.PHONY: test clean
+
+push: build
+	docker push prestosql/presto-base:$(PRESTO_VERSION)
+	docker push prestosql/presto-coordinator:$(PRESTO_VERSION)
+	docker push prestosql/presto-worker:$(PRESTO_VERSION)
+
+run:
+	docker-compose up -d
+	echo "Please check http://localhost:8080"
+
+down:
+	docker-compose down

--- a/presto-docker/README.md
+++ b/presto-docker/README.md
@@ -1,0 +1,36 @@
+# Docker PrestoSQL Cluster
+
+## Build image
+
+```
+$ make build
+
+## make push
+```
+
+## Launch presto
+
+Presto cluster can be launched by using docker-compose.
+
+```
+$ make run
+```
+
+## docker-compose.yml
+
+Images will be uploaded in [DockerHub](https://hub.docker.com/prestosql). 
+These images are build with the corresponding version of Presto. 
+`command` is required to pass node id information which must be unique in a cluster.
+
+### Run
+
+```
+$ docker-compose up -d
+```
+
+# Contact the awesome Presto community to learn more about PrestoSQL
+
+User Mailing List: [presto-users](https://groups.google.com/group/presto-users)
+Users & Development Slack: [prestosql.slack.com](https://join.slack.com/t/prestosql/shared_invite/enQtNTMyNzU2NzQ1NzQ4LWRhMTE4ZTA4NjM0NDA1NmFkZjEyZDJmN2MxNGY1ZTk4NmM4MzMxZDk4OGQ0NjZhNmQxMWUyNGIxMDliODk0MmU) 
+Twitter: @prestosql #prestosql #prestodb
+YouTube: Presto Channel

--- a/presto-docker/base/Dockerfile
+++ b/presto-docker/base/Dockerfile
@@ -1,0 +1,40 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM openjdk:8-slim
+LABEL MAINTAINER "Presto Software Foundation <prestosql.io>"
+
+ARG VERSION
+ENV PRESTO_VERSION=${VERSION}
+ENV PRESTO_HOME=/usr/local/presto
+ENV BASE_URL=https://repo1.maven.org/maven2
+
+# install dev tools
+RUN apt-get update
+RUN apt-get install -y curl tar sudo rsync python wget python-pip python-dev build-essential
+RUN pip install jinja2
+
+ENV JAVA_HOME /usr/java/default
+ENV PATH $PATH:$JAVA_HOME/bin
+
+WORKDIR /usr/local
+
+RUN wget -q ${BASE_URL}/io/prestosql/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
+RUN tar xvzf presto-server-${PRESTO_VERSION}.tar.gz -C /usr/local/
+RUN ln -s /usr/local/presto-server-${PRESTO_VERSION} $PRESTO_HOME
+
+ADD scripts ${PRESTO_HOME}/scripts
+
+# Create data dir
+RUN mkdir -p $PRESTO_HOME/data
+VOLUME ["$PRESTO_HOME/data"]

--- a/presto-docker/base/Dockerfile
+++ b/presto-docker/base/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM openjdk:8-slim
+FROM openjdk:11-slim
 LABEL MAINTAINER "Presto Software Foundation <prestosql.io>"
 
 ARG VERSION

--- a/presto-docker/base/scripts/presto.sh
+++ b/presto-docker/base/scripts/presto.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+node_id=$1
+python /usr/local/presto/scripts/render.py --node-id $node_id etc/node.properties.template
+/usr/local/presto/bin/launcher run
+
+
+
+

--- a/presto-docker/base/scripts/render.py
+++ b/presto-docker/base/scripts/render.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from jinja2 import Environment, FileSystemLoader
+
+import argparse
+
+def render(vars, files):
+  '''
+  Render Jinja2 template to replace version tag
+  :param args: variables to be embedded, files: file to be rendered
+  :return:
+  '''
+  for path in files:
+    env = Environment(loader=FileSystemLoader('/usr/local/presto/', encoding='utf8'))
+    tpl = env.get_template(path)
+    rendered = tpl.render(vars)
+
+    # Remove *.template
+    with open(path[:-9], 'w') as f:
+      f.write(rendered)
+      print("Rendered {}".format(path[:-9]))  
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description="Process build args from Docker")
+  parser.add_argument('files', help='File to be rendered', nargs='*')
+  parser.add_argument('--node-id', help='Node ID', dest='node_id')
+  args = parser.parse_args()
+
+  vars = {
+    'node_id': args.node_id,
+  }
+  render(vars, args.files)

--- a/presto-docker/coordinator/Dockerfile
+++ b/presto-docker/coordinator/Dockerfile
@@ -1,0 +1,24 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ARG VERSION
+
+FROM prestosql/presto-base:${VERSION}
+LABEL MAINTAINER "Presto Software Foundation <prestosql.io>"
+
+ADD etc /usr/local/presto/etc
+
+EXPOSE 8080
+
+WORKDIR /usr/local/presto
+ENTRYPOINT ["./scripts/presto.sh"]

--- a/presto-docker/coordinator/etc/catalog/jmx.properties
+++ b/presto-docker/coordinator/etc/catalog/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/presto-docker/coordinator/etc/catalog/tpcds.properties
+++ b/presto-docker/coordinator/etc/catalog/tpcds.properties
@@ -1,0 +1,1 @@
+connector.name=tpcds

--- a/presto-docker/coordinator/etc/catalog/tpch.properties
+++ b/presto-docker/coordinator/etc/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch

--- a/presto-docker/coordinator/etc/config.properties
+++ b/presto-docker/coordinator/etc/config.properties
@@ -1,0 +1,7 @@
+coordinator=true
+node-scheduler.include-coordinator=false
+http-server.http.port=8080
+query.max-memory=50GB
+query.max-memory-per-node=1GB
+discovery-server.enabled=true
+discovery.uri=http://coordinator:8080

--- a/presto-docker/coordinator/etc/config.properties
+++ b/presto-docker/coordinator/etc/config.properties
@@ -3,5 +3,6 @@ node-scheduler.include-coordinator=false
 http-server.http.port=8080
 query.max-memory=50GB
 query.max-memory-per-node=1GB
+query.max-total-memory-per-node=2GB
 discovery-server.enabled=true
 discovery.uri=http://coordinator:8080

--- a/presto-docker/coordinator/etc/jvm.config
+++ b/presto-docker/coordinator/etc/jvm.config
@@ -1,0 +1,8 @@
+-server
+-Xmx16G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:OnOutOfMemoryError=kill -9 %p

--- a/presto-docker/coordinator/etc/jvm.config
+++ b/presto-docker/coordinator/etc/jvm.config
@@ -5,4 +5,6 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
--XX:OnOutOfMemoryError=kill -9 %p
+-XX:+ExitOnOutOfMemoryError
+-Djdk.nio.maxCachedBufferSize=2000000
+

--- a/presto-docker/coordinator/etc/log.properties
+++ b/presto-docker/coordinator/etc/log.properties
@@ -1,0 +1,1 @@
+com.facebook.presto=LOG

--- a/presto-docker/coordinator/etc/log.properties
+++ b/presto-docker/coordinator/etc/log.properties
@@ -1,1 +1,1 @@
-com.facebook.presto=LOG
+io.prestosql=INFO

--- a/presto-docker/coordinator/etc/node.properties.template
+++ b/presto-docker/coordinator/etc/node.properties.template
@@ -1,0 +1,3 @@
+node.environment=development
+node.id={{ node_id }}
+node.data-dir=/usr/local/presto/data

--- a/presto-docker/coordinator/etc/node.properties.template
+++ b/presto-docker/coordinator/etc/node.properties.template
@@ -1,3 +1,3 @@
-node.environment=development
+node.environment=production
 node.id={{ node_id }}
 node.data-dir=/usr/local/presto/data

--- a/presto-docker/docker-compose.yml
+++ b/presto-docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  coordinator:
+    image: prestosql/presto-coordinator:307
+    ports:
+      - "8080:8080"
+    container_name: "coordinator"
+    command: coordinator
+  worker0:
+    image: prestosql/presto-worker:307
+    container_name: "worker0"
+    ports:
+      - "8081:8081"
+    command: worker0
+  worker1:
+    image: prestosql/presto-worker:307
+    container_name: "worker1"
+    ports:
+      - "8082:8081"
+    command: worker1

--- a/presto-docker/tests/README.MD
+++ b/presto-docker/tests/README.MD
@@ -1,0 +1,6 @@
+# Tests for Docker images.
+
+Include tests to bring up a docker container based on a locally installed image (passed via an argument), and verify that the functionality of the docker image is intact. 
+
+The tests require an environment to have docker installed.
+

--- a/presto-docker/worker/Dockerfile
+++ b/presto-docker/worker/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ARG VERSION
+
+FROM prestosql/presto-base:${VERSION}
+LABEL MAINTAINER "Presto Software Foundation <prestosql.io>"
+
+COPY etc /usr/local/presto/etc
+EXPOSE 8081
+
+WORKDIR /usr/local/presto
+ENTRYPOINT [ "./scripts/presto.sh" ]

--- a/presto-docker/worker/etc/catalog/jmx.properties
+++ b/presto-docker/worker/etc/catalog/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/presto-docker/worker/etc/catalog/tpcds.properties
+++ b/presto-docker/worker/etc/catalog/tpcds.properties
@@ -1,0 +1,1 @@
+connector.name=tpcds

--- a/presto-docker/worker/etc/catalog/tpch.properties
+++ b/presto-docker/worker/etc/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch

--- a/presto-docker/worker/etc/config.properties
+++ b/presto-docker/worker/etc/config.properties
@@ -1,0 +1,5 @@
+coordinator=false
+http-server.http.port=8080
+query.max-memory=50GB
+query.max-memory-per-node=1GB
+discovery.uri=http://coordinator:8080

--- a/presto-docker/worker/etc/config.properties
+++ b/presto-docker/worker/etc/config.properties
@@ -2,4 +2,5 @@ coordinator=false
 http-server.http.port=8080
 query.max-memory=50GB
 query.max-memory-per-node=1GB
+query.max-total-memory-per-node=2GB
 discovery.uri=http://coordinator:8080

--- a/presto-docker/worker/etc/jvm.config
+++ b/presto-docker/worker/etc/jvm.config
@@ -1,0 +1,8 @@
+-server
+-Xmx16G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:OnOutOfMemoryError=kill -9 %p

--- a/presto-docker/worker/etc/jvm.config
+++ b/presto-docker/worker/etc/jvm.config
@@ -5,4 +5,5 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
+-Djdk.nio.maxCachedBufferSize=2000000
 -XX:OnOutOfMemoryError=kill -9 %p

--- a/presto-docker/worker/etc/log.properties
+++ b/presto-docker/worker/etc/log.properties
@@ -1,0 +1,1 @@
+com.facebook.presto=DEBUG

--- a/presto-docker/worker/etc/log.properties
+++ b/presto-docker/worker/etc/log.properties
@@ -1,1 +1,1 @@
-com.facebook.presto=DEBUG
+io.prestosql=INFO

--- a/presto-docker/worker/etc/node.properties.template
+++ b/presto-docker/worker/etc/node.properties.template
@@ -1,0 +1,3 @@
+node.environment=development
+node.id={{ node_id }}
+node.data-dir=/var/presto/data

--- a/presto-docker/worker/etc/node.properties.template
+++ b/presto-docker/worker/etc/node.properties.template
@@ -1,3 +1,3 @@
-node.environment=development
+node.environment=production
 node.id={{ node_id }}
 node.data-dir=/var/presto/data


### PR DESCRIPTION
Adding Presto Dockerfiles to build docker images which can be used by all users...

Building presto's docker files:
1. Presto base Images
2. Presto worker Images
3. Presto Coordinator Images

Further Changes to do:

1. Adding Presto-admin
2. Using presto-admin changing the configs in presto workers
3. Using presto-admin to add new config properties files.
