### PR TITLE
Add krb5 service principal pattern

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -50,6 +50,9 @@ public class ClientOptions
     @Option(name = "--server", title = "server", description = "Presto server location (default: localhost:8080)")
     public String server = "localhost:8080";
 
+    @Option(name = "--krb5-service-principal-pattern", title = "krb5 remote service principal pattern", description = "Remote kerberos service principal pattern (default: ${SERVICE}@${HOST})")
+    public String krb5ServicePrincipalPattern = "${SERVICE}@${HOST}";
+
     @Option(name = "--krb5-remote-service-name", title = "krb5 remote service name", description = "Remote peer's kerberos service name")
     public String krb5RemoteServiceName;
 

--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -135,6 +135,7 @@ public class Console
                 Optional.ofNullable(clientOptions.user),
                 clientOptions.password ? Optional.of(getPassword()) : Optional.empty(),
                 Optional.ofNullable(clientOptions.krb5Principal),
+                Optional.ofNullable(clientOptions.krb5ServicePrincipalPattern),
                 Optional.ofNullable(clientOptions.krb5RemoteServiceName),
                 Optional.ofNullable(clientOptions.krb5ConfigPath),
                 Optional.ofNullable(clientOptions.krb5KeytabPath),

--- a/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
@@ -60,6 +60,7 @@ public class QueryRunner
             Optional<String> user,
             Optional<String> password,
             Optional<String> kerberosPrincipal,
+            Optional<String> krb5ServicePrincipalPattern,
             Optional<String> kerberosRemoteServiceName,
             Optional<String> kerberosConfigPath,
             Optional<String> kerberosKeytabPath,
@@ -87,6 +88,7 @@ public class QueryRunner
                     "Authentication using Kerberos requires HTTPS to be enabled");
             setupKerberos(
                     builder,
+                    krb5ServicePrincipalPattern.get(),
                     kerberosRemoteServiceName.get(),
                     kerberosUseCanonicalHostname,
                     kerberosPrincipal,

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -151,6 +151,7 @@ public class TestQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 false);
     }
 

--- a/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
@@ -254,6 +254,7 @@ public final class OkHttpUtil
 
     public static void setupKerberos(
             OkHttpClient.Builder clientBuilder,
+            String servicePrincipalPattern,
             String remoteServiceName,
             boolean useCanonicalHostname,
             Optional<String> principal,
@@ -261,13 +262,7 @@ public final class OkHttpUtil
             Optional<File> keytab,
             Optional<File> credentialCache)
     {
-        SpnegoHandler handler = new SpnegoHandler(
-                remoteServiceName,
-                useCanonicalHostname,
-                principal,
-                kerberosConfig,
-                keytab,
-                credentialCache);
+        SpnegoHandler handler = new SpnegoHandler(servicePrincipalPattern, remoteServiceName, useCanonicalHostname, principal, kerberosConfig, keytab, credentialCache);
         clientBuilder.addInterceptor(handler);
         clientBuilder.authenticator(handler);
     }

--- a/presto-client/src/main/java/io/prestosql/client/SpnegoHandler.java
+++ b/presto-client/src/main/java/io/prestosql/client/SpnegoHandler.java
@@ -74,6 +74,7 @@ public class SpnegoHandler
     private static final Oid SPNEGO_OID = createOid("1.3.6.1.5.5.2");
     private static final Oid KERBEROS_OID = createOid("1.2.840.113554.1.2.2");
 
+    private final String servicePrincipalPattern;
     private final String remoteServiceName;
     private final boolean useCanonicalHostname;
     private final Optional<String> principal;
@@ -84,6 +85,7 @@ public class SpnegoHandler
     private Session clientSession;
 
     public SpnegoHandler(
+            String servicePrincipalPattern,
             String remoteServiceName,
             boolean useCanonicalHostname,
             Optional<String> principal,
@@ -91,6 +93,7 @@ public class SpnegoHandler
             Optional<File> keytab,
             Optional<File> credentialCache)
     {
+        this.servicePrincipalPattern = requireNonNull(servicePrincipalPattern, "servicePrincipalPattern is null");
         this.remoteServiceName = requireNonNull(remoteServiceName, "remoteServiceName is null");
         this.useCanonicalHostname = useCanonicalHostname;
         this.principal = requireNonNull(principal, "principal is null");
@@ -133,7 +136,7 @@ public class SpnegoHandler
     private Request authenticate(Request request)
     {
         String hostName = request.url().host();
-        String principal = makeServicePrincipal(remoteServiceName, hostName, useCanonicalHostname);
+        String principal = makeServicePrincipal(servicePrincipalPattern, remoteServiceName, hostName, useCanonicalHostname);
         byte[] token = generateToken(principal);
 
         String credential = format("%s %s", NEGOTIATE, Base64.getEncoder().encodeToString(token));
@@ -237,13 +240,13 @@ public class SpnegoHandler
         return new Session(loginContext, clientCredential);
     }
 
-    private static String makeServicePrincipal(String serviceName, String hostName, boolean useCanonicalHostname)
+    private static String makeServicePrincipal(String servicePrincipalPattern, String serviceName, String hostName, boolean useCanonicalHostname)
     {
         String serviceHostName = hostName;
         if (useCanonicalHostname) {
             serviceHostName = canonicalizeServiceHostName(hostName);
         }
-        return format("%s@%s", serviceName, serviceHostName.toLowerCase(Locale.US));
+        return servicePrincipalPattern.replaceAll("\\$\\{SERVICE}", serviceName).replaceAll("\\$\\{HOST}", serviceHostName.toLowerCase(Locale.US));
     }
 
     private static String canonicalizeServiceHostName(String hostName)

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
@@ -46,6 +46,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> SSL_KEY_STORE_PASSWORD = new SslKeyStorePassword();
     public static final ConnectionProperty<String> SSL_TRUST_STORE_PATH = new SslTrustStorePath();
     public static final ConnectionProperty<String> SSL_TRUST_STORE_PASSWORD = new SslTrustStorePassword();
+    public static final ConnectionProperty<String> KERBEROS_SERVICE_PRINCIPAL_PATTERN = new KerberosServicePrincipalPattern();
     public static final ConnectionProperty<String> KERBEROS_REMOTE_SERVICE_NAME = new KerberosRemoteServiceName();
     public static final ConnectionProperty<Boolean> KERBEROS_USE_CANONICAL_HOSTNAME = new KerberosUseCanonicalHostname();
     public static final ConnectionProperty<String> KERBEROS_PRINCIPAL = new KerberosPrincipal();
@@ -67,6 +68,7 @@ final class ConnectionProperties
             .add(SSL_TRUST_STORE_PATH)
             .add(SSL_TRUST_STORE_PASSWORD)
             .add(KERBEROS_REMOTE_SERVICE_NAME)
+            .add(KERBEROS_SERVICE_PRINCIPAL_PATTERN)
             .add(KERBEROS_USE_CANONICAL_HOSTNAME)
             .add(KERBEROS_PRINCIPAL)
             .add(KERBEROS_CONFIG_PATH)
@@ -226,6 +228,15 @@ final class ConnectionProperties
     private static Predicate<Properties> isKerberosEnabled()
     {
         return checkedPredicate(properties -> KERBEROS_REMOTE_SERVICE_NAME.getValue(properties).isPresent());
+    }
+
+    private static class KerberosServicePrincipalPattern
+            extends AbstractConnectionProperty<String>
+    {
+        public KerberosServicePrincipalPattern()
+        {
+            super("KerberosServicePrincipalPattern", Optional.of("${SERVICE}@${HOST}"), isKerberosEnabled(), ALLOWED, STRING_CONVERTER);
+        }
     }
 
     private static class KerberosPrincipal

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -49,6 +49,7 @@ import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_CREDENTIAL_CACHE_P
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_KEYTAB_PATH;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_PRINCIPAL;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
+import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static io.prestosql.jdbc.ConnectionProperties.PASSWORD;
 import static io.prestosql.jdbc.ConnectionProperties.SOCKS_PROXY;
@@ -177,6 +178,7 @@ final class PrestoDriverUri
                 }
                 setupKerberos(
                         builder,
+                        KERBEROS_SERVICE_PRINCIPAL_PATTERN.getRequiredValue(properties),
                         KERBEROS_REMOTE_SERVICE_NAME.getRequiredValue(properties),
                         KERBEROS_USE_CANONICAL_HOSTNAME.getRequiredValue(properties),
                         KERBEROS_PRINCIPAL.getValue(properties),


### PR DESCRIPTION
Support krb5 service principal pattern in `okhttp` for client-coordinator communication.

Ref: https://github.com/airlift/airlift/pull/716

@electrum 