### PR TITLE
Remove @BeforeMethod in parallel tests

### DIFF
--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
@@ -38,7 +38,6 @@ import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.type.Type;
 import io.prestosql.testing.TestingConnectorContext;
 import io.prestosql.testing.TestingConnectorSession;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -123,16 +122,6 @@ public class TestCassandraConnector
         table = new SchemaTableName(database, TABLE_ALL_TYPES.toLowerCase(ENGLISH));
         tableUnpartitioned = new SchemaTableName(database, "presto_test_unpartitioned");
         invalidTable = new SchemaTableName(database, "totally_invalid_table_name");
-    }
-
-    @AfterMethod
-    public void tearDown()
-    {
-    }
-
-    @Test
-    public void testGetClient()
-    {
     }
 
     @Test

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -61,7 +61,7 @@ public class TestQueryRunner
         server.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
             throws IOException
     {

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/aggregation/TestGeometryStateFactory.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/aggregation/TestGeometryStateFactory.java
@@ -14,7 +14,6 @@
 package io.prestosql.plugin.geospatial.aggregation;
 
 import com.esri.core.geometry.ogc.OGCGeometry;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -24,13 +23,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestGeometryStateFactory
 {
-    private GeometryStateFactory factory;
-
-    @BeforeMethod
-    public void init()
-    {
-        factory = new GeometryStateFactory();
-    }
+    private final GeometryStateFactory factory = new GeometryStateFactory();
 
     @Test
     public void testCreateSingleStateEmpty()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveRoles.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveRoles.java
@@ -46,7 +46,7 @@ public class TestHiveRoles
         super(HiveQueryRunner::createQueryRunner);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void afterMethod()
     {
         for (String role : listRoles()) {

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
@@ -77,7 +77,7 @@ public class TestJdbcResultSet
         statement = connection.createStatement();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
     {
         closeQuietly(statement);

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcWarnings.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcWarnings.java
@@ -98,7 +98,7 @@ public class TestJdbcWarnings
         statement = connection.createStatement();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
     {
         closeQuietly(statement);

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestProgressMonitor.java
@@ -60,7 +60,7 @@ public class TestProgressMonitor
         server.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
             throws IOException
     {

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestQueryExecutor.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestQueryExecutor.java
@@ -46,7 +46,7 @@ public class TestQueryExecutor
         server.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
             throws IOException
     {

--- a/presto-main/src/test/java/io/prestosql/cost/TestSemiJoinStatsCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestSemiJoinStatsCalculator.java
@@ -15,7 +15,7 @@
 package io.prestosql.cost;
 
 import io.prestosql.sql.planner.Symbol;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.prestosql.cost.PlanNodeStatsAssertion.assertThat;
@@ -51,7 +51,7 @@ public class TestSemiJoinStatsCalculator
     private Symbol unknown = new Symbol("unknown");
     private Symbol fractionalNdv = new Symbol("fractionalNdv");
 
-    @BeforeMethod
+    @BeforeClass
     public void setUp()
             throws Exception
     {

--- a/presto-main/src/test/java/io/prestosql/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestMemoryRevokingScheduler.java
@@ -103,7 +103,7 @@ public class TestMemoryRevokingScheduler
         allOperatorContexts = null;
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         memoryPool = null;

--- a/presto-main/src/test/java/io/prestosql/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestNodeScheduler.java
@@ -103,7 +103,7 @@ public class TestNodeScheduler
         finalizerService.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         remoteTaskExecutor.shutdown();

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
@@ -74,7 +74,7 @@ public class TestSqlStageExecution
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/io/prestosql/memory/TestSystemMemoryBlocking.java
@@ -83,7 +83,7 @@ public class TestSystemMemoryBlocking
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestAggregationOperator.java
@@ -79,7 +79,7 @@ public class TestAggregationOperator
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestDistinctLimitOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestDistinctLimitOperator.java
@@ -66,7 +66,7 @@ public class TestDistinctLimitOperator
         joinCompiler = new JoinCompiler(MetadataManager.createTestMetadataManager());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestDriver.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestDriver.java
@@ -88,7 +88,7 @@ public class TestDriver
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
@@ -72,7 +72,7 @@ public class TestFilterAndProjectOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestGroupIdOperator.java
@@ -58,7 +58,7 @@ public class TestGroupIdOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashAggregationOperator.java
@@ -145,7 +145,7 @@ public class TestHashAggregationOperator
         return new Object[][] {{VARCHAR}, {BIGINT}};
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         spillerFactory = null;

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
@@ -69,7 +69,7 @@ public class TestHashSemiJoinOperator
         taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestLimitOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestLimitOperator.java
@@ -53,7 +53,7 @@ public class TestLimitOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestMarkDistinctOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestMarkDistinctOperator.java
@@ -66,7 +66,7 @@ public class TestMarkDistinctOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOrderByOperator.java
@@ -80,7 +80,7 @@ public class TestOrderByOperator
         spillerFactory = new DummySpillerFactory();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
@@ -83,7 +83,7 @@ public class TestStreamingAggregationOperator
                 new JoinCompiler(MetadataManager.createTestMetadataManager()));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
@@ -62,7 +62,7 @@ public class TestTopNOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestTopNRowNumberOperator.java
@@ -68,7 +68,7 @@ public class TestTopNRowNumberOperator
         joinCompiler = new JoinCompiler(MetadataManager.createTestMetadataManager());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestUnnestOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestUnnestOperator.java
@@ -67,7 +67,7 @@ public class TestUnnestOperator
                 .addDriverContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWindowOperator.java
@@ -105,7 +105,7 @@ public class TestWindowOperator
         spillerFactory = new DummySpillerFactory();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         executor.shutdownNow();

--- a/presto-main/src/test/java/io/prestosql/server/TestNodeResource.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestNodeResource.java
@@ -16,8 +16,8 @@ package io.prestosql.server;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.prestosql.server.testing.TestingPrestoServer;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -29,13 +29,12 @@ import static io.airlift.testing.Closeables.closeQuietly;
 import static io.prestosql.failuredetector.HeartbeatFailureDetector.Stats;
 import static org.testng.Assert.assertTrue;
 
-@Test(singleThreaded = true)
 public class TestNodeResource
 {
     private TestingPrestoServer server;
     private HttpClient client;
 
-    @BeforeMethod
+    @BeforeClass
     public void setup()
             throws Exception
     {
@@ -43,8 +42,8 @@ public class TestNodeResource
         client = new JettyHttpClient();
     }
 
-    @AfterMethod
-    public void teardown()
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
     {
         closeQuietly(server);
         closeQuietly(client);

--- a/presto-main/src/test/java/io/prestosql/server/TestServer.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServer.java
@@ -28,8 +28,8 @@ import io.prestosql.client.QueryResults;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.type.TimeZoneNotSupportedException;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -63,14 +63,13 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
-@Test(singleThreaded = true)
 public class TestServer
 {
     private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
     private TestingPrestoServer server;
     private HttpClient client;
 
-    @BeforeMethod
+    @BeforeClass
     public void setup()
             throws Exception
     {
@@ -79,8 +78,8 @@ public class TestServer
     }
 
     @SuppressWarnings("deprecation")
-    @AfterMethod
-    public void teardown()
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
     {
         Closeables.closeQuietly(server);
         Closeables.closeQuietly(client);

--- a/presto-main/src/test/java/io/prestosql/spiller/TestBinaryFileSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestBinaryFileSpiller.java
@@ -75,7 +75,7 @@ public class TestBinaryFileSpiller
         memoryContext = newSimpleAggregatedMemoryContext();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
             throws Exception
     {

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
@@ -53,7 +53,7 @@ public class TestFileSingleStreamSpiller
     private final ListeningExecutorService executor = listeningDecorator(newCachedThreadPool());
     private final File spillPath = Files.createTempDir();
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
             throws Exception
     {

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpiller.java
@@ -45,6 +45,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestFileSingleStreamSpiller
 {
     private static final List<Type> TYPES = ImmutableList.of(BIGINT, DOUBLE, VARBINARY);

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class TestFileSingleStreamSpillerFactory
 {
-    private final Closer closer = Closer.create();
+    private Closer closer;
     private ListeningExecutorService executor;
     private File spillPath1;
     private File spillPath2;
@@ -56,6 +56,7 @@ public class TestFileSingleStreamSpillerFactory
     @BeforeMethod
     public void setUp()
     {
+        closer = Closer.create();
         executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
         closer.register(() -> executor.shutdownNow());
         spillPath1 = Files.createTempDir();
@@ -64,7 +65,7 @@ public class TestFileSingleStreamSpillerFactory
         closer.register(() -> deleteRecursively(spillPath2.toPath(), ALLOW_INSECURE));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
             throws Exception
     {

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -188,7 +188,7 @@ public class TestExpressionCompiler
         futures = new ArrayList<>();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown(Method method)
     {
         assertTrue(Futures.allAsList(futures).isDone(), "Expression test futures are not complete");

--- a/presto-orc/src/test/java/io/prestosql/orc/TestStructStreamReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestStructStreamReader.java
@@ -75,7 +75,7 @@ public class TestStructStreamReader
         tempFile = new TempFile();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
             throws IOException
     {

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
@@ -113,7 +113,7 @@ public class TestDatabaseShardManager
         shardManager = createShardManager(dbi);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
             throws IOException
     {

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
@@ -133,7 +133,7 @@ public class TestRaptorSplitManager
         raptorSplitManager = new RaptorSplitManager(connectorId, nodeSupplier, shardManager, false);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown()
             throws IOException
     {

--- a/presto-tests/src/test/java/io/prestosql/execution/TestCompletedEventWarnings.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestCompletedEventWarnings.java
@@ -39,6 +39,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestCompletedEventWarnings
 {
     private static final int EXPECTED_EVENTS = 3;

--- a/presto-tests/src/test/java/io/prestosql/execution/TestWarnings.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestWarnings.java
@@ -20,8 +20,8 @@ import io.prestosql.client.Warning;
 import io.prestosql.spi.WarningCode;
 import io.prestosql.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -38,14 +38,14 @@ public class TestWarnings
     private static final int STAGE_COUNT_WARNING_THRESHOLD = 20;
     private QueryRunner queryRunner;
 
-    @BeforeMethod
+    @BeforeClass
     public void setUp()
             throws Exception
     {
         queryRunner = createQueryRunner(ImmutableMap.of("query.stage-count-warning-threshold", String.valueOf(STAGE_COUNT_WARNING_THRESHOLD)));
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         queryRunner.close();


### PR DESCRIPTION
`@BeforeMethod` without `@Test(singleThreaded = true)` is racy.