### PR TITLE
WorkProcessorOperator framework + TopN, Table scan WorkProcessorOperators

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -114,6 +114,7 @@ public final class SystemSessionProperties
     public static final String IGNORE_STATS_CALCULATOR_FAILURES = "ignore_stats_calculator_failures";
     public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
+    public static final String WORK_PROCESSOR_PIPELINES = "work_processor_pipelines";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -541,6 +542,11 @@ public final class SystemSessionProperties
                         DEFAULT_FILTER_FACTOR_ENABLED,
                         "use a default filter factor for unknown filters in a filter node",
                         featuresConfig.isDefaultFilterFactorEnabled(),
+                        false),
+                booleanProperty(
+                        WORK_PROCESSOR_PIPELINES,
+                        "Experimental: Use WorkProcessor pipelines",
+                        featuresConfig.isWorkProcessorPipelines(),
                         false));
     }
 
@@ -917,5 +923,10 @@ public final class SystemSessionProperties
     public static boolean isDefaultFilterFactorEnabled(Session session)
     {
         return session.getSystemProperty(DEFAULT_FILTER_FACTOR_ENABLED, Boolean.class);
+    }
+
+    public static boolean isWorkProcessorPipelines(Session session)
+    {
+        return session.getSystemProperty(WORK_PROCESSOR_PIPELINES, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
+++ b/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
@@ -347,6 +347,7 @@ public class QueryContext
         String topConsumers = queryAllocations.entrySet().stream()
                 .sorted(comparingByValue(Comparator.reverseOrder()))
                 .limit(3)
+                .filter(e -> e.getValue() >= 0)
                 .collect(toImmutableMap(Entry::getKey, e -> succinctBytes(e.getValue())))
                 .toString();
 

--- a/presto-main/src/main/java/io/prestosql/operator/GroupedTopNBuilder.java
+++ b/presto-main/src/main/java/io/prestosql/operator/GroupedTopNBuilder.java
@@ -133,7 +133,6 @@ public class GroupedTopNBuilder
 
         // save the new page
         PageReference newPageReference = new PageReference(newPage);
-        memorySizeInBytes += newPageReference.getEstimatedSizeInBytes();
         int newPageId;
         if (emptyPageReferenceSlots.isEmpty()) {
             // all the previous slots are full; create a new one
@@ -195,10 +194,20 @@ public class GroupedTopNBuilder
             memorySizeInBytes += rows.getEstimatedSizeInBytes();
         }
 
-        // may compact the new page as well
-        if (newPageReference.getUsedPositionCount() * COMPACT_THRESHOLD < newPage.getPositionCount()) {
-            verify(!pagesToCompact.contains(newPageId));
-            pagesToCompact.add(newPageId);
+        // unreference new page if it was not used
+        if (newPageReference.getUsedPositionCount() == 0) {
+            pageReferences.set(newPageId, null);
+        }
+        else {
+            // assure new page is loaded
+            newPageReference.loadPage();
+            memorySizeInBytes += newPageReference.getEstimatedSizeInBytes();
+
+            // may compact the new page as well
+            if (newPageReference.getUsedPositionCount() * COMPACT_THRESHOLD < newPage.getPositionCount()) {
+                verify(!pagesToCompact.contains(newPageId));
+                pagesToCompact.add(newPageId);
+            }
         }
 
         // compact pages
@@ -329,6 +338,11 @@ public class GroupedTopNBuilder
             }
             page = new Page(usedPositionCount, blocks);
             reference = newReference;
+        }
+
+        public void loadPage()
+        {
+            page = page.getLoadedPage();
         }
 
         public Page getPage()

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
@@ -282,9 +282,21 @@ public class OperatorContext
     }
 
     // caller should close this context as it's a new context
+    public AggregatedMemoryContext newAggregateUserMemoryContext()
+    {
+        return new InternalAggregatedMemoryContext(operatorMemoryContext.newAggregateUserMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, true);
+    }
+
+    // caller should close this context as it's a new context
     public AggregatedMemoryContext newAggregateSystemMemoryContext()
     {
         return new InternalAggregatedMemoryContext(operatorMemoryContext.newAggregateSystemMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, true);
+    }
+
+    // caller should close this context as it's a new context
+    public AggregatedMemoryContext newAggregateRevocableMemoryContext()
+    {
+        return new InternalAggregatedMemoryContext(operatorMemoryContext.newAggregateRevocableMemoryContext(), revocableMemoryFuture, this::updatePeakMemoryReservations, true);
     }
 
     // listen to all memory allocations and update the peak memory reservations accordingly

--- a/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
@@ -16,7 +16,9 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.prestosql.Session;
 import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.metadata.Split;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.spi.Page;
@@ -44,7 +46,7 @@ public class TableScanOperator
         implements SourceOperator, Closeable
 {
     public static class TableScanOperatorFactory
-            implements SourceOperatorFactory
+            implements SourceOperatorFactory, WorkProcessorSourceOperatorFactory
     {
         private final int operatorId;
         private final PlanNodeId sourceId;
@@ -68,6 +70,12 @@ public class TableScanOperator
         }
 
         @Override
+        public int getOperatorId()
+        {
+            return operatorId;
+        }
+
+        @Override
         public PlanNodeId getSourceId()
         {
             return sourceId;
@@ -81,6 +89,22 @@ public class TableScanOperator
             return new TableScanOperator(
                     operatorContext,
                     sourceId,
+                    pageSourceProvider,
+                    table,
+                    columns);
+        }
+
+        @Override
+        public WorkProcessorSourceOperator create(
+                Session session,
+                MemoryTrackingContext memoryTrackingContext,
+                DriverYieldSignal yieldSignal,
+                WorkProcessor<Split> splits)
+        {
+            return new TableScanWorkProcessorOperator(
+                    session,
+                    memoryTrackingContext,
+                    splits,
                     pageSourceProvider,
                     table,
                     columns);

--- a/presto-main/src/main/java/io/prestosql/operator/TableScanWorkProcessorOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TableScanWorkProcessorOperator.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.metadata.Split;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.operator.WorkProcessor.ProcessState;
+import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.UpdatablePageSource;
+import io.prestosql.split.PageSourceProvider;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static java.util.Objects.requireNonNull;
+
+public class TableScanWorkProcessorOperator
+        implements WorkProcessorSourceOperator
+{
+    private final WorkProcessor<Page> pages;
+    private final SplitToPages splitToPages;
+
+    public TableScanWorkProcessorOperator(
+            Session session,
+            MemoryTrackingContext memoryTrackingContext,
+            WorkProcessor<Split> splits,
+            PageSourceProvider pageSourceProvider,
+            TableHandle table,
+            Iterable<ColumnHandle> columns)
+    {
+        this.splitToPages = new SplitToPages(
+                session,
+                pageSourceProvider,
+                table,
+                columns,
+                memoryTrackingContext.aggregateSystemMemoryContext());
+        this.pages = splits.flatTransform(splitToPages);
+    }
+
+    @Override
+    public WorkProcessor<Page> getOutputPages()
+    {
+        return pages;
+    }
+
+    @Override
+    public Supplier<Optional<UpdatablePageSource>> getUpdatablePageSourceSupplier()
+    {
+        return splitToPages.getUpdatablePageSourceSupplier();
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        splitToPages.close();
+    }
+
+    private static class SplitToPages
+            implements WorkProcessor.Transformation<Split, WorkProcessor<Page>>
+    {
+        final Session session;
+        final PageSourceProvider pageSourceProvider;
+        final TableHandle table;
+        final List<ColumnHandle> columns;
+        final AggregatedMemoryContext aggregatedMemoryContext;
+
+        ConnectorPageSource source;
+
+        SplitToPages(
+                Session session,
+                PageSourceProvider pageSourceProvider,
+                TableHandle table,
+                Iterable<ColumnHandle> columns,
+                AggregatedMemoryContext aggregatedMemoryContext)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+            this.table = requireNonNull(table, "table is null");
+            this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+            this.aggregatedMemoryContext = requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null");
+        }
+
+        @Override
+        public TransformationState<WorkProcessor<Page>> process(Split split)
+        {
+            if (split == null) {
+                return TransformationState.finished();
+            }
+
+            checkState(source == null, "Table scan split already set");
+            source = pageSourceProvider.createPageSource(session, split, table, columns);
+            return TransformationState.ofResult(
+                    WorkProcessor.create(new ConnectorPageSourceToPages(aggregatedMemoryContext, source)));
+        }
+
+        Supplier<Optional<UpdatablePageSource>> getUpdatablePageSourceSupplier()
+        {
+            return () -> {
+                if (source instanceof UpdatablePageSource) {
+                    return Optional.of((UpdatablePageSource) source);
+                }
+                return Optional.empty();
+            };
+        }
+
+        void close()
+        {
+            if (source != null) {
+                try {
+                    source.close();
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+    }
+
+    private static class ConnectorPageSourceToPages
+            implements WorkProcessor.Process<Page>
+    {
+        final ConnectorPageSource pageSource;
+        final LocalMemoryContext memoryContext;
+
+        ConnectorPageSourceToPages(AggregatedMemoryContext aggregatedMemoryContext, ConnectorPageSource pageSource)
+        {
+            this.pageSource = pageSource;
+            this.memoryContext = aggregatedMemoryContext
+                    .newLocalMemoryContext(TableScanWorkProcessorOperator.class.getSimpleName());
+        }
+
+        @Override
+        public ProcessState<Page> process()
+        {
+            if (pageSource.isFinished()) {
+                memoryContext.close();
+                return ProcessState.finished();
+            }
+
+            CompletableFuture<?> isBlocked = pageSource.isBlocked();
+            if (!isBlocked.isDone()) {
+                return ProcessState.blocked(toListenableFuture(isBlocked));
+            }
+
+            Page page = pageSource.getNextPage();
+            memoryContext.setBytes(pageSource.getSystemMemoryUsage());
+
+            if (page == null) {
+                if (pageSource.isFinished()) {
+                    memoryContext.close();
+                    return ProcessState.finished();
+                }
+                else {
+                    return ProcessState.yield();
+                }
+            }
+
+            // TODO: report operator stats
+            return ProcessState.ofResult(page);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/TopNProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNProcessor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.SortOrder;
+import io.prestosql.spi.type.Type;
+
+import javax.annotation.Nullable;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static java.util.Collections.emptyIterator;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Returns the top N rows from the source sorted according to the specified ordering in the keyChannelIndex channel.
+ */
+public class TopNProcessor
+{
+    private final LocalMemoryContext localUserMemoryContext;
+
+    @Nullable
+    private GroupedTopNBuilder topNBuilder;
+    private Iterator<Page> outputIterator;
+
+    public TopNProcessor(
+            AggregatedMemoryContext aggregatedMemoryContext,
+            List<Type> types,
+            int n,
+            List<Integer> sortChannels,
+            List<SortOrder> sortOrders)
+    {
+        requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null");
+        this.localUserMemoryContext = aggregatedMemoryContext.newLocalMemoryContext(TopNProcessor.class.getSimpleName());
+        checkArgument(n >= 0, "n must be positive");
+
+        if (n == 0) {
+            outputIterator = emptyIterator();
+        }
+        else {
+            topNBuilder = new GroupedTopNBuilder(
+                    types,
+                    new SimplePageWithPositionComparator(types, sortChannels, sortOrders),
+                    n,
+                    false,
+                    new NoChannelGroupByHash());
+        }
+    }
+
+    public void addInput(Page page)
+    {
+        requireNonNull(topNBuilder, "topNBuilder is null");
+        boolean done = topNBuilder.processPage(requireNonNull(page, "page is null")).process();
+        // there is no grouping so work will always be done
+        verify(done);
+        updateMemoryReservation();
+    }
+
+    public Page getOutput()
+    {
+        if (outputIterator == null) {
+            // start flushing
+            outputIterator = topNBuilder.buildResult();
+        }
+
+        Page output = null;
+        if (outputIterator.hasNext()) {
+            output = outputIterator.next();
+        }
+        else {
+            outputIterator = emptyIterator();
+        }
+        updateMemoryReservation();
+        return output;
+    }
+
+    public boolean noMoreOutput()
+    {
+        return outputIterator != null && !outputIterator.hasNext();
+    }
+
+    private void updateMemoryReservation()
+    {
+        requireNonNull(topNBuilder, "topNBuilder is null");
+        localUserMemoryContext.setBytes(topNBuilder.getEstimatedSizeInBytes());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/TopNWorkProcessorOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNWorkProcessorOperator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.SortOrder;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Returns the top N rows from the source sorted according to the specified ordering in the keyChannelIndex channel.
+ */
+public class TopNWorkProcessorOperator
+        implements WorkProcessorOperator
+{
+    private final TopNProcessor topNProcessor;
+    private final WorkProcessor<Page> pages;
+
+    public TopNWorkProcessorOperator(
+            MemoryTrackingContext memoryTrackingContext,
+            WorkProcessor<Page> sourcePages,
+            List<Type> types,
+            int n,
+            List<Integer> sortChannels,
+            List<SortOrder> sortOrders)
+    {
+        this.topNProcessor = new TopNProcessor(
+                requireNonNull(memoryTrackingContext, "memoryTrackingContext is null").aggregateUserMemoryContext(),
+                types,
+                n,
+                sortChannels,
+                sortOrders);
+
+        if (n == 0) {
+            pages = WorkProcessor.of();
+        }
+        else {
+            pages = sourcePages.transform(new TopNPages());
+        }
+    }
+
+    @Override
+    public WorkProcessor<Page> getOutputPages()
+    {
+        return pages;
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {}
+
+    private class TopNPages
+            implements WorkProcessor.Transformation<Page, Page>
+    {
+        @Override
+        public TransformationState<Page> process(Page inputPage)
+        {
+            if (inputPage != null) {
+                topNProcessor.addInput(inputPage);
+                return TransformationState.needsMoreData();
+            }
+
+            // no more input, return results
+            Page page = null;
+            while (page == null && !topNProcessor.noMoreOutput()) {
+                page = topNProcessor.getOutput();
+            }
+
+            if (page != null) {
+                return TransformationState.ofResult(page, false);
+            }
+
+            return TransformationState.finished();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessor.java
@@ -71,6 +71,11 @@ public interface WorkProcessor<T>
         return WorkProcessorUtils.processStateMonitor(this, monitor);
     }
 
+    default WorkProcessor<T> finishWhen(BooleanSupplier finishSignal)
+    {
+        return WorkProcessorUtils.finishWhen(this, finishSignal);
+    }
+
     default <R> WorkProcessor<R> flatMap(Function<T, WorkProcessor<R>> mapper)
     {
         return WorkProcessorUtils.flatMap(this, mapper);

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperator.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.spi.Page;
+
+// TODO: support spill
+public interface WorkProcessorOperator
+        extends AutoCloseable
+{
+    WorkProcessor<Page> getOutputPages();
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.Session;
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.spi.Page;
+
+public interface WorkProcessorOperatorFactory
+{
+    int getOperatorId();
+
+    WorkProcessorOperator create(
+            Session session,
+            MemoryTrackingContext memoryTrackingContext,
+            DriverYieldSignal yieldSignal,
+            WorkProcessor<Page> sourcePages);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.log.Logger;
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.metadata.Split;
+import io.prestosql.operator.WorkProcessor.ProcessState;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.UpdatablePageSource;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.prestosql.operator.WorkProcessor.ProcessState.Type.FINISHED;
+import static java.util.Objects.requireNonNull;
+
+public class WorkProcessorPipelineSourceOperator
+        implements SourceOperator
+{
+    private static final Logger log = Logger.get(WorkProcessorPipelineSourceOperator.class);
+
+    private final PlanNodeId sourceId;
+    private final OperatorContext operatorContext;
+    private final WorkProcessor<Page> pages;
+    // operator instances including source operator
+    private final List<WorkProcessorOperatorContext> workProcessorOperatorContexts = new ArrayList<>();
+    private final List<Split> pendingSplits = new ArrayList<>();
+
+    private WorkProcessorSourceOperator sourceOperator;
+    private SettableFuture<?> blockedOnSplits = SettableFuture.create();
+    private boolean operatorFinishing;
+
+    public static List<OperatorFactory> convertOperators(int operatorId, List<OperatorFactory> operatorFactories)
+    {
+        if (operatorFactories.isEmpty() || !(operatorFactories.get(0) instanceof WorkProcessorSourceOperatorFactory)) {
+            return operatorFactories;
+        }
+
+        WorkProcessorSourceOperatorFactory sourceOperatorFactory = (WorkProcessorSourceOperatorFactory) operatorFactories.get(0);
+        ImmutableList.Builder<WorkProcessorOperatorFactory> workProcessorOperatorFactoriesBuilder = ImmutableList.builder();
+        int operatorIndex = 1;
+        for (; operatorIndex < operatorFactories.size(); ++operatorIndex) {
+            if (!(operatorFactories.get(operatorIndex) instanceof WorkProcessorOperatorFactory)) {
+                break;
+            }
+            workProcessorOperatorFactoriesBuilder.add((WorkProcessorOperatorFactory) operatorFactories.get(operatorIndex));
+        }
+
+        List<WorkProcessorOperatorFactory> workProcessorOperatorFactories = workProcessorOperatorFactoriesBuilder.build();
+        if (workProcessorOperatorFactories.isEmpty()) {
+            return operatorFactories;
+        }
+
+        return ImmutableList.<OperatorFactory>builder()
+                .add(new WorkProcessorPipelineSourceOperatorFactory(operatorId, sourceOperatorFactory, workProcessorOperatorFactories))
+                .addAll(operatorFactories.subList(operatorIndex, operatorFactories.size()))
+                .build();
+    }
+
+    private WorkProcessorPipelineSourceOperator(
+            int operatorId,
+            DriverContext driverContext,
+            WorkProcessorSourceOperatorFactory sourceOperatorFactory,
+            List<WorkProcessorOperatorFactory> operatorFactories)
+    {
+        requireNonNull(driverContext, "driverContext is null");
+        requireNonNull(sourceOperatorFactory, "sourceOperatorFactory is null");
+        requireNonNull(operatorFactories, "operatorFactories is null");
+        this.sourceId = sourceOperatorFactory.getSourceId();
+        // TODO: make OperatorContext aware of WorkProcessorOperators
+        this.operatorContext = driverContext.addOperatorContext(operatorId, sourceId, WorkProcessorPipelineSourceOperator.class.getSimpleName());
+
+        // TODO: measure and report WorkProcessorOperator memory usage
+        MemoryTrackingContext sourceOperatorMemoryTrackingContext = createMemoryTrackingContext(operatorContext);
+        WorkProcessor<Split> splits = WorkProcessor.create(new Splits());
+
+        sourceOperator = sourceOperatorFactory.create(
+                operatorContext.getSession(),
+                sourceOperatorMemoryTrackingContext,
+                operatorContext.getDriverContext().getYieldSignal(),
+                splits);
+        sourceOperatorMemoryTrackingContext.initializeLocalMemoryContexts(sourceOperator.getClass().getSimpleName());
+        workProcessorOperatorContexts.add(new WorkProcessorOperatorContext(
+                sourceOperator,
+                sourceOperatorFactory.getOperatorId(),
+                sourceOperatorMemoryTrackingContext));
+        WorkProcessor<Page> pages = sourceOperator.getOutputPages();
+        pages = pages.withProcessStateMonitor(state -> {
+            if (state.getType() == FINISHED) {
+                // immediately close source operator
+                closeOperators(0);
+            }
+        });
+
+        for (int i = 0; i < operatorFactories.size(); ++i) {
+            MemoryTrackingContext operatorMemoryTrackingContext = createMemoryTrackingContext(operatorContext);
+            WorkProcessorOperator operator = operatorFactories.get(i).create(
+                    operatorContext.getSession(),
+                    operatorMemoryTrackingContext,
+                    operatorContext.getDriverContext().getYieldSignal(),
+                    pages);
+            operatorMemoryTrackingContext.initializeLocalMemoryContexts(operator.getClass().getSimpleName());
+            workProcessorOperatorContexts.add(new WorkProcessorOperatorContext(
+                    operator,
+                    operatorFactories.get(i).getOperatorId(),
+                    operatorMemoryTrackingContext));
+            pages = operator.getOutputPages();
+            int operatorIndex = i + 1;
+            pages = pages.withProcessStateMonitor(state -> {
+                if (state.getType() == FINISHED) {
+                    // immediately close all upstream operators (including finished operator)
+                    closeOperators(operatorIndex);
+                }
+            });
+        }
+
+        // materialize output pages as there are no semantics guarantees for non WorkProcessor operators
+        pages = pages.map(Page::getLoadedPage);
+
+        // finish early when entire pipeline is closed
+        this.pages = pages.finishWhen(() -> operatorFinishing);
+    }
+
+    private static MemoryTrackingContext createMemoryTrackingContext(OperatorContext operatorContext)
+    {
+        return new MemoryTrackingContext(
+                operatorContext.newAggregateUserMemoryContext(),
+                operatorContext.newAggregateRevocableMemoryContext(),
+                operatorContext.newAggregateSystemMemoryContext());
+    }
+
+    @Override
+    public PlanNodeId getSourceId()
+    {
+        return sourceId;
+    }
+
+    @Override
+    public Supplier<Optional<UpdatablePageSource>> addSplit(Split split)
+    {
+        if (sourceOperator == null) {
+            return Optional::empty;
+        }
+
+        Object splitInfo = split.getInfo();
+        if (splitInfo != null) {
+            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+        }
+
+        pendingSplits.add(split);
+        blockedOnSplits.set(null);
+
+        return sourceOperator.getUpdatablePageSourceSupplier();
+    }
+
+    @Override
+    public void noMoreSplits()
+    {
+        blockedOnSplits.set(null);
+        sourceOperator = null;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return false;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (!pages.process()) {
+            return null;
+        }
+
+        if (pages.isFinished()) {
+            return null;
+        }
+
+        return pages.getResult();
+    }
+
+    @Override
+    public ListenableFuture<?> startMemoryRevoke()
+    {
+        // TODO: support spill
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishMemoryRevoke()
+    {
+        // TODO: support spill
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finish()
+    {
+        // operator is finished early without waiting for all pages to process
+        operatorFinishing = true;
+        noMoreSplits();
+        closeOperators(workProcessorOperatorContexts.size() - 1);
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pages.isFinished();
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (!pages.isBlocked()) {
+            return NOT_BLOCKED;
+        }
+
+        return pages.getBlockedFuture();
+    }
+
+    @Override
+    public void close()
+    {
+        finish();
+    }
+
+    private class Splits
+            implements WorkProcessor.Process<Split>
+    {
+        @Override
+        public ProcessState<Split> process()
+        {
+            boolean noMoreSplits = sourceOperator == null;
+
+            if (pendingSplits.isEmpty()) {
+                if (noMoreSplits) {
+                    return ProcessState.finished();
+                }
+
+                blockedOnSplits = SettableFuture.create();
+                return ProcessState.blocked(blockedOnSplits);
+            }
+
+            return ProcessState.ofResult(pendingSplits.remove(0));
+        }
+    }
+
+    private void closeOperators(int lastOperatorIndex)
+    {
+        // record the current interrupted status (and clear the flag); we'll reset it later
+        boolean wasInterrupted = Thread.interrupted();
+        Throwable inFlightException = null;
+        try {
+            for (int i = 0; i <= lastOperatorIndex; ++i) {
+                WorkProcessorOperatorContext workProcessorOperatorContext = workProcessorOperatorContexts.get(i);
+                if (workProcessorOperatorContext == null) {
+                    continue;
+                }
+
+                try {
+                    workProcessorOperatorContext.operator.close();
+                }
+                catch (InterruptedException t) {
+                    // don't record the stack
+                    wasInterrupted = true;
+                }
+                catch (Throwable t) {
+                    inFlightException = handleOperatorCloseError(
+                            inFlightException,
+                            t,
+                            "Error closing WorkProcessor operator %s for task %s",
+                            workProcessorOperatorContext.operatorId,
+                            operatorContext.getDriverContext().getTaskId());
+                }
+                finally {
+                    workProcessorOperatorContext.memoryTrackingContext.close();
+                    workProcessorOperatorContexts.set(i, null);
+                }
+            }
+        }
+        finally {
+            // reset the interrupted flag
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (inFlightException != null) {
+            throwIfUnchecked(inFlightException);
+            throw new RuntimeException(inFlightException);
+        }
+    }
+
+    private static Throwable handleOperatorCloseError(Throwable inFlightException, Throwable newException, String message, Object... args)
+    {
+        if (newException instanceof Error) {
+            if (inFlightException == null) {
+                inFlightException = newException;
+            }
+            else {
+                // Self-suppression not permitted
+                if (inFlightException != newException) {
+                    inFlightException.addSuppressed(newException);
+                }
+            }
+        }
+        else {
+            // log normal exceptions instead of rethrowing them
+            log.error(newException, message, args);
+        }
+        return inFlightException;
+    }
+
+    private class WorkProcessorOperatorContext
+    {
+        final WorkProcessorOperator operator;
+        final int operatorId;
+        final MemoryTrackingContext memoryTrackingContext;
+
+        private WorkProcessorOperatorContext(
+                WorkProcessorOperator operator,
+                int operatorId,
+                MemoryTrackingContext memoryTrackingContext)
+        {
+            this.operator = operator;
+            this.operatorId = operatorId;
+            this.memoryTrackingContext = memoryTrackingContext;
+        }
+    }
+
+    public static class WorkProcessorPipelineSourceOperatorFactory
+            implements SourceOperatorFactory
+    {
+        private final int operatorId;
+        private final WorkProcessorSourceOperatorFactory sourceOperatorFactory;
+        private final List<WorkProcessorOperatorFactory> operatorFactories;
+        private boolean closed;
+
+        private WorkProcessorPipelineSourceOperatorFactory(
+                int operatorId,
+                WorkProcessorSourceOperatorFactory sourceOperatorFactory,
+                List<WorkProcessorOperatorFactory> operatorFactories)
+        {
+            this.operatorId = operatorId;
+            this.sourceOperatorFactory = requireNonNull(sourceOperatorFactory, "sourceOperatorFactory is null");
+            this.operatorFactories = requireNonNull(operatorFactories, "operatorFactories is null");
+        }
+
+        @Override
+        public PlanNodeId getSourceId()
+        {
+            return sourceOperatorFactory.getSourceId();
+        }
+
+        @Override
+        public SourceOperator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            return new WorkProcessorPipelineSourceOperator(operatorId, driverContext, sourceOperatorFactory, operatorFactories);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.spi.connector.UpdatablePageSource;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+// TODO: support spill
+// TODO: provide source operator metrics
+public interface WorkProcessorSourceOperator
+        extends WorkProcessorOperator
+{
+    Supplier<Optional<UpdatablePageSource>> getUpdatablePageSourceSupplier();
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.Session;
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.metadata.Split;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+
+public interface WorkProcessorSourceOperatorFactory
+{
+    int getOperatorId();
+
+    PlanNodeId getSourceId();
+
+    WorkProcessorSourceOperator create(
+            Session session,
+            MemoryTrackingContext memoryTrackingContext,
+            DriverYieldSignal yieldSignal,
+            WorkProcessor<Split> splits);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorUtils.java
@@ -193,6 +193,19 @@ public final class WorkProcessorUtils
         });
     }
 
+    static <T> WorkProcessor<T> finishWhen(WorkProcessor<T> processor, BooleanSupplier finishSignal)
+    {
+        requireNonNull(processor, "processor is null");
+        requireNonNull(finishSignal, "finishSignal is null");
+        return WorkProcessor.create(() -> {
+            if (finishSignal.getAsBoolean()) {
+                return ProcessState.finished();
+            }
+
+            return getNextState(processor);
+        });
+    }
+
     private static <T> ProcessState<T> getNextState(WorkProcessor<T> processor)
     {
         if (processor.process()) {

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -119,6 +119,7 @@ public class FeaturesConfig
     private boolean useMarkDistinct = true;
     private boolean preferPartialAggregation = true;
     private boolean optimizeTopNRowNumber = true;
+    private boolean workProcessorPipelines;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
 
@@ -864,6 +865,18 @@ public class FeaturesConfig
     public FeaturesConfig setMaxGroupingSets(int maxGroupingSets)
     {
         this.maxGroupingSets = maxGroupingSets;
+        return this;
+    }
+
+    public boolean isWorkProcessorPipelines()
+    {
+        return workProcessorPipelines;
+    }
+
+    @Config("experimental.work-processor-pipelines")
+    public FeaturesConfig setWorkProcessorPipelines(boolean workProcessorPipelines)
+    {
+        this.workProcessorPipelines = workProcessorPipelines;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -93,6 +93,7 @@ import io.prestosql.operator.TopNRowNumberOperator;
 import io.prestosql.operator.ValuesOperator.ValuesOperatorFactory;
 import io.prestosql.operator.WindowFunctionDefinition;
 import io.prestosql.operator.WindowOperator.WindowOperatorFactory;
+import io.prestosql.operator.WorkProcessorPipelineSourceOperator;
 import io.prestosql.operator.aggregation.AccumulatorFactory;
 import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.operator.aggregation.LambdaProvider;
@@ -558,6 +559,11 @@ public class LocalExecutionPlanner
                     checkArgument(firstOperatorFactory instanceof LocalExchangeSourceOperatorFactory || firstOperatorFactory instanceof LookupOuterOperatorFactory);
                 }
             }
+
+            if (SystemSessionProperties.isWorkProcessorPipelines(taskContext.getSession())) {
+                operatorFactories = WorkProcessorPipelineSourceOperator.convertOperators(getNextOperatorId(), operatorFactories);
+            }
+
             driverFactories.add(new DriverFactory(getNextPipelineId(), inputDriver, outputDriver, operatorFactories, driverInstances, pipelineExecutionStrategy));
         }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
@@ -250,6 +250,32 @@ public class TestWorkProcessor
     }
 
     @Test(timeOut = 5000)
+    public void testFinishWheb()
+    {
+        AtomicBoolean finished = new AtomicBoolean();
+        SettableFuture<?> future = SettableFuture.create();
+
+        List<ProcessState<Integer>> scenario = ImmutableList.of(
+                ProcessState.ofResult(1),
+                ProcessState.yield(),
+                ProcessState.blocked(future),
+                ProcessState.ofResult(2));
+
+        WorkProcessor<Integer> processor = processorFrom(scenario)
+                .finishWhen(finished::get);
+
+        assertResult(processor, 1);
+        assertYields(processor);
+        assertBlocks(processor);
+
+        finished.set(true);
+        assertBlocks(processor);
+
+        assertUnblocks(processor, future);
+        assertFinishes(processor);
+    }
+
+    @Test(timeOut = 5000)
     public void testFlatMap()
     {
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessor.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;
 import io.prestosql.operator.WorkProcessor.ProcessState;
 import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.operator.WorkProcessorAssertion.Transform;
 import org.testng.annotations.Test;
 
 import java.util.Comparator;
@@ -34,7 +35,8 @@ import static io.prestosql.operator.WorkProcessorAssertion.assertFinishes;
 import static io.prestosql.operator.WorkProcessorAssertion.assertResult;
 import static io.prestosql.operator.WorkProcessorAssertion.assertUnblocks;
 import static io.prestosql.operator.WorkProcessorAssertion.assertYields;
-import static java.util.Objects.requireNonNull;
+import static io.prestosql.operator.WorkProcessorAssertion.processorFrom;
+import static io.prestosql.operator.WorkProcessorAssertion.transformationFrom;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -484,51 +486,5 @@ public class TestWorkProcessor
         assertYields(processor);
         assertResult(processor, 2);
         assertFinishes(processor);
-    }
-
-    private static <T, R> WorkProcessor.Transformation<T, R> transformationFrom(List<Transform<T, R>> transformations)
-    {
-        Iterator<Transform<T, R>> iterator = transformations.iterator();
-        return element -> {
-            assertTrue(iterator.hasNext());
-            return iterator.next().transform(Optional.ofNullable(element));
-        };
-    }
-
-    private static <T> WorkProcessor<T> processorFrom(List<ProcessState<T>> states)
-    {
-        return WorkProcessorUtils.create(processFrom(states));
-    }
-
-    private static <T> WorkProcessor.Process<T> processFrom(List<ProcessState<T>> states)
-    {
-        Iterator<ProcessState<T>> iterator = states.iterator();
-        return () -> {
-            assertTrue(iterator.hasNext());
-            return iterator.next();
-        };
-    }
-
-    private static class Transform<T, R>
-    {
-        final Optional<T> from;
-        final TransformationState<R> to;
-
-        Transform(Optional<T> from, TransformationState<R> to)
-        {
-            this.from = requireNonNull(from);
-            this.to = requireNonNull(to);
-        }
-
-        static <T, R> Transform<T, R> of(Optional<T> from, TransformationState<R> to)
-        {
-            return new Transform<>(from, to);
-        }
-
-        TransformationState<R> transform(Optional<T> from)
-        {
-            assertEquals(from, this.from);
-            return to;
-        }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorOperator.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.prestosql.operator.WorkProcessor.ProcessState;
+import io.prestosql.spi.Page;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class TestWorkProcessorOperator
+        implements Operator
+{
+    private final OperatorContext operatorContext;
+    private final WorkProcessor<Page> pages;
+
+    private boolean noMoreInput;
+    private Page inputPage;
+
+    private TestWorkProcessorOperator(
+            OperatorContext operatorContext,
+            WorkProcessorOperatorFactory workProcessorOperatorFactory)
+    {
+        this.operatorContext = operatorContext;
+        this.pages = workProcessorOperatorFactory.create(
+                operatorContext.getSession(),
+                operatorContext.getOperatorMemoryContext(),
+                operatorContext.getDriverContext().getYieldSignal(),
+                WorkProcessor.create(new Pages()))
+                .getOutputPages();
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !noMoreInput && !isFinished() && inputPage == null;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        inputPage = page;
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (!pages.process()) {
+            return null;
+        }
+
+        if (pages.isFinished()) {
+            return null;
+        }
+
+        return pages.getResult();
+    }
+
+    @Override
+    public void finish()
+    {
+        noMoreInput = true;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (!pages.isBlocked()) {
+            return NOT_BLOCKED;
+        }
+
+        return pages.getBlockedFuture();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pages.isFinished();
+    }
+
+    private class Pages
+            implements WorkProcessor.Process<Page>
+    {
+        @Override
+        public ProcessState<Page> process()
+        {
+            if (noMoreInput) {
+                return ProcessState.finished();
+            }
+
+            if (inputPage == null) {
+                return ProcessState.yield();
+            }
+
+            Page page = inputPage;
+            inputPage = null;
+            return ProcessState.ofResult(page);
+        }
+    }
+
+    static class TestWorkProcessorOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final WorkProcessorOperatorFactory workProcessorOperatorFactory;
+
+        private boolean closed;
+
+        TestWorkProcessorOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                WorkProcessorOperatorFactory workProcessorOperatorFactory)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.workProcessorOperatorFactory = requireNonNull(workProcessorOperatorFactory, "workProcessorOperatorFactory is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, TestWorkProcessorOperator.class.getSimpleName());
+            return new TestWorkProcessorOperator(operatorContext, workProcessorOperatorFactory);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.SettableFuture;
+import io.prestosql.Session;
+import io.prestosql.connector.CatalogName;
+import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.metadata.Split;
+import io.prestosql.operator.WorkProcessor.Transformation;
+import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.operator.WorkProcessorAssertion.Transform;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.UpdatablePageSource;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.RowPagesBuilder.rowPagesBuilder;
+import static io.prestosql.execution.Lifespan.taskWide;
+import static io.prestosql.operator.WorkProcessorAssertion.transformationFrom;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.testing.TestingSplit.createLocalSplit;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestWorkProcessorPipelineSourceOperator
+{
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        scheduledExecutor = newSingleThreadScheduledExecutor();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testWorkProcessorPipelineSourceOperator()
+    {
+        Split split = createSplit();
+
+        Page page1 = createPage(1);
+        Page page2 = createPage(2);
+        Page page3 = createPage(3);
+        Page page4 = createPage(4);
+        Page page5 = createPage(5);
+
+        Transformation<Split, Page> sourceOperatorPages = transformationFrom(ImmutableList.of(
+                Transform.of(Optional.of(split), TransformationState.ofResult(page1, false)),
+                Transform.of(Optional.of(split), TransformationState.ofResult(page2, true))));
+
+        Transformation<Page, Page> firstOperatorPages = transformationFrom(ImmutableList.of(
+                Transform.of(Optional.of(page1), TransformationState.ofResult(page3, true)),
+                Transform.of(Optional.of(page2), TransformationState.ofResult(page4, false)),
+                Transform.of(Optional.of(page2), TransformationState.finished())));
+
+        SettableFuture<?> blockedFuture = SettableFuture.create();
+        Transformation<Page, Page> secondOperatorPages = transformationFrom(ImmutableList.of(
+                Transform.of(Optional.of(page3), TransformationState.ofResult(page5, true)),
+                Transform.of(Optional.of(page4), TransformationState.needsMoreData()),
+                Transform.of(Optional.empty(), TransformationState.blocked(blockedFuture))));
+
+        TestWorkProcessorSourceOperatorFactory sourceOperatorFactory = new TestWorkProcessorSourceOperatorFactory(
+                1,
+                new PlanNodeId("1"),
+                sourceOperatorPages);
+        TestWorkProcessorOperatorFactory firstOperatorFactory = new TestWorkProcessorOperatorFactory(2, firstOperatorPages);
+        TestWorkProcessorOperatorFactory secondOperatorFactory = new TestWorkProcessorOperatorFactory(3, secondOperatorPages);
+
+        SourceOperatorFactory pipelineOperatorFactory = (SourceOperatorFactory) getOnlyElement(WorkProcessorPipelineSourceOperator.convertOperators(
+                99,
+                ImmutableList.of(sourceOperatorFactory, firstOperatorFactory, secondOperatorFactory)));
+
+        DriverContext driverContext = TestingOperatorContext.create(scheduledExecutor).getDriverContext();
+        SourceOperator pipelineOperator = pipelineOperatorFactory.createOperator(driverContext);
+
+        // make sure WorkProcessorOperator memory is accounted for
+        sourceOperatorFactory.sourceOperator.memoryTrackingContext.localUserMemoryContext().setBytes(123);
+        assertEquals(driverContext.getMemoryUsage(), 123);
+
+        assertNull(pipelineOperator.getOutput());
+        assertFalse(pipelineOperator.isBlocked().isDone());
+
+        pipelineOperator.addSplit(split);
+        assertTrue(pipelineOperator.isBlocked().isDone());
+
+        assertEquals(pipelineOperator.getOutput(), page5);
+
+        // sourceOperator should yield
+        driverContext.getYieldSignal().forceYieldForTesting();
+        assertNull(pipelineOperator.getOutput());
+        driverContext.getYieldSignal().resetYieldForTesting();
+
+        // firstOperatorPages should finish. This should cause sourceOperator and firstOperatorPages to close.
+        // secondOperatorPages should block
+        assertNull(pipelineOperator.getOutput());
+        assertFalse(pipelineOperator.isBlocked().isDone());
+        assertTrue(sourceOperatorFactory.sourceOperator.closed);
+        assertTrue(firstOperatorFactory.operator.closed);
+        assertFalse(secondOperatorFactory.operator.closed);
+
+        // cause early operator finish
+        pipelineOperator.finish();
+
+        // operator is still blocked on blockedFuture
+        assertFalse(pipelineOperator.isFinished());
+        assertTrue(secondOperatorFactory.operator.closed);
+
+        blockedFuture.set(null);
+        assertTrue(pipelineOperator.isBlocked().isDone());
+        assertNull(pipelineOperator.getOutput());
+        assertTrue(pipelineOperator.isFinished());
+    }
+
+    private Split createSplit()
+    {
+        return new Split(
+                new CatalogName("catalog_name"),
+                createLocalSplit(),
+                taskWide());
+    }
+
+    private Page createPage(int pageNumber)
+    {
+        return getOnlyElement(rowPagesBuilder(BIGINT).addSequencePage(1, pageNumber).build());
+    }
+
+    private class TestWorkProcessorSourceOperatorFactory
+            implements WorkProcessorSourceOperatorFactory, SourceOperatorFactory
+    {
+        final int operatorId;
+        final PlanNodeId sourceId;
+        final Transformation<Split, Page> transformation;
+
+        TestWorkProcessorSourceOperator sourceOperator;
+
+        TestWorkProcessorSourceOperatorFactory(int operatorId, PlanNodeId sourceId, Transformation<Split, Page> transformation)
+        {
+            this.operatorId = operatorId;
+            this.sourceId = sourceId;
+            this.transformation = transformation;
+        }
+
+        @Override
+        public int getOperatorId()
+        {
+            return operatorId;
+        }
+
+        @Override
+        public PlanNodeId getSourceId()
+        {
+            return sourceId;
+        }
+
+        @Override
+        public WorkProcessorSourceOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Split> splits)
+        {
+            assertNull(sourceOperator, "source operator already created");
+            sourceOperator = new TestWorkProcessorSourceOperator(
+                    splits
+                            .transform(transformation)
+                            .yielding(yieldSignal::isSet),
+                    memoryTrackingContext);
+            return sourceOperator;
+        }
+
+        @Override
+        public SourceOperator createOperator(DriverContext driverContext)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private class TestWorkProcessorSourceOperator
+            implements WorkProcessorSourceOperator
+    {
+        final WorkProcessor<Page> pages;
+
+        boolean closed;
+        MemoryTrackingContext memoryTrackingContext;
+
+        TestWorkProcessorSourceOperator(WorkProcessor<Page> pages, MemoryTrackingContext memoryTrackingContext)
+        {
+            this.pages = pages;
+            this.memoryTrackingContext = memoryTrackingContext;
+        }
+
+        @Override
+        public Supplier<Optional<UpdatablePageSource>> getUpdatablePageSourceSupplier()
+        {
+            return Optional::empty;
+        }
+
+        @Override
+        public WorkProcessor<Page> getOutputPages()
+        {
+            return pages;
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+
+    private class TestWorkProcessorOperatorFactory
+            implements WorkProcessorOperatorFactory, OperatorFactory
+    {
+        final int operatorId;
+        final Transformation<Page, Page> transformation;
+
+        TestWorkProcessorOperator operator;
+
+        TestWorkProcessorOperatorFactory(int operatorId, Transformation<Page, Page> transformation)
+        {
+            this.operatorId = operatorId;
+            this.transformation = transformation;
+        }
+
+        @Override
+        public int getOperatorId()
+        {
+            return operatorId;
+        }
+
+        @Override
+        public WorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Page> sourcePages)
+        {
+            assertNull(operator, "source operator already created");
+            operator = new TestWorkProcessorOperator(sourcePages.transform(transformation));
+            return operator;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private class TestWorkProcessorOperator
+            implements WorkProcessorOperator
+    {
+        final WorkProcessor<Page> pages;
+
+        boolean closed;
+
+        TestWorkProcessorOperator(WorkProcessor<Page> pages)
+        {
+            this.pages = pages;
+        }
+
+        @Override
+        public WorkProcessor<Page> getOutputPages()
+        {
+            return pages;
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -103,7 +103,8 @@ public class TestFeaturesConfig
                 .setArrayAggGroupImplementation(ArrayAggGroupImplementation.NEW)
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.NEW)
                 .setDistributedSortEnabled(true)
-                .setMaxGroupingSets(2048));
+                .setMaxGroupingSets(2048)
+                .setWorkProcessorPipelines(false));
     }
 
     @Test
@@ -167,6 +168,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-top-n-row-number", "false")
                 .put("distributed-sort", "false")
                 .put("analyzer.max-grouping-sets", "2047")
+                .put("experimental.work-processor-pipelines", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -226,7 +228,8 @@ public class TestFeaturesConfig
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.LEGACY)
                 .setDistributedSortEnabled(false)
                 .setMaxGroupingSets(2047)
-                .setDefaultFilterFactorEnabled(true);
+                .setDefaultFilterFactorEnabled(true)
+                .setWorkProcessorPipelines(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-memory-context/src/main/java/io/prestosql/memory/context/MemoryTrackingContext.java
+++ b/presto-memory-context/src/main/java/io/prestosql/memory/context/MemoryTrackingContext.java
@@ -122,6 +122,16 @@ public final class MemoryTrackingContext
         return systemAggregateMemoryContext;
     }
 
+    public AggregatedMemoryContext newAggregateUserMemoryContext()
+    {
+        return userAggregateMemoryContext.newAggregatedMemoryContext();
+    }
+
+    public AggregatedMemoryContext newAggregateRevocableMemoryContext()
+    {
+        return revocableAggregateMemoryContext.newAggregatedMemoryContext();
+    }
+
     public AggregatedMemoryContext newAggregateSystemMemoryContext()
     {
         return systemAggregateMemoryContext.newAggregatedMemoryContext();

--- a/presto-tests/src/test/java/io/prestosql/tests/TestWorkProcessorPipelineQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestWorkProcessorPipelineQueries.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.Test;
+
+import static io.prestosql.SystemSessionProperties.WORK_PROCESSOR_PIPELINES;
+
+public class TestWorkProcessorPipelineQueries
+        extends AbstractTestQueryFramework
+{
+    protected TestWorkProcessorPipelineQueries()
+    {
+        super(() -> TpchQueryRunnerBuilder
+                .builder()
+                .amendSession(builder -> builder.setSystemProperty(WORK_PROCESSOR_PIPELINES, "true"))
+                .build());
+    }
+
+    @Test
+    public void testTopN()
+    {
+        assertQuery("select * from orders order by totalprice limit 10");
+    }
+}


### PR DESCRIPTION
TODO:
* WorkProcessorOperator metrics support
* spill support

Next steps:
* Support for reader (ORC) resource (blocks) reusing in `TableScan + TaskOutoutOperator` pipeline
* Late materialization through `ScanFilterAndProjectOperator`.

Example Results:
Query:
```
presto> select * from hive.tpch_sf10_orc.lineitem order by partkey limit 10;
```
Results:
```
WITHOUT WorkProcessor pipeline and late materialization

1) Fragment 2 [SOURCE]
     CPU: 51.04s, Scheduled: 5.64m, Input: 59986052 rows (7.30GB); per task: avg.: 59986052.00 std.dev.: 0.00, Output: 480 rows (71.47kB)
     Output layout: [orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment]
     Output partitioning: SINGLE []
     Grouped Execution: false
     - TopNPartial[10 by (partkey ASC_NULLS_LAST)] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, returnflag:varchar(1), linestatus:varchar(1), shipdate:date, commitda
             CPU: 4.33s (0.73%), Scheduled: 7.20s (14.10%), Output: 480 rows (71.47kB)
             Input avg.: 1153577.92 rows, Input std.dev.: 30.50%
         - TableScan[hive:tpch_sf10_orc:lineitem, grouped = false] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, returnflag:varchar(1), linestatus:varchar(1), shipdat
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 CPU: 46.71s (7.88%), Scheduled: 9.76m (1147.09%), Output: 59986052 rows (7.30GB)
                 Input avg.: 1153577.92 rows, Input std.dev.: 30.50%
                 returnflag := returnflag:varchar(1):8:REGULAR
                 linenumber := linenumber:int:3:REGULAR
                 quantity := quantity:double:4:REGULAR
                 orderkey := orderkey:bigint:0:REGULAR
                 shipmode := shipmode:varchar(10):14:REGULAR
                 discount := discount:double:6:REGULAR
                 tax := tax:double:7:REGULAR
                 suppkey := suppkey:bigint:2:REGULAR
                 partkey := partkey:bigint:1:REGULAR
                 shipinstruct := shipinstruct:varchar(25):13:REGULAR
                 linestatus := linestatus:varchar(1):9:REGULAR
                 extendedprice := extendedprice:double:5:REGULAR
                 comment := comment:varchar(44):15:REGULAR
                 receiptdate := receiptdate:date:12:REGULAR
                 commitdate := commitdate:date:11:REGULAR
                 shipdate := shipdate:date:10:REGULAR

2) WITH WorkProcessor pipeline and late materialization

 Fragment 2 [SOURCE]
     CPU: 22.81s, Scheduled: 4.44m, Input: 0 rows (0B); per task: avg.: 0.00 std.dev.: 0.00, Output: 480 rows (71.47kB)
     Output layout: [orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment]
     Output partitioning: SINGLE []
     Grouped Execution: false
     - TopNPartial[10 by (partkey ASC_NULLS_LAST)] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, returnflag:varchar(1), linestatus:varchar(1), shipdate:date, commitda
             CPU: 10.00ms (0.00%), Scheduled: 14.00ms (0.06%), Output: 480 rows (71.47kB)
             Input avg.: 9.23 rows, Input std.dev.: 28.87%
         - TableScan[hive:tpch_sf10_orc:lineitem, grouped = false] => [orderkey:bigint, partkey:bigint, suppkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, returnflag:varchar(1), linestatus:varchar(1), shipdat
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 CPU: 22.80s (8.56%), Scheduled: 4.44m (1167.50%), Output: 480 rows (71.47kB)
                 Input avg.: 0.00 rows, Input std.dev.: ?%
                 returnflag := returnflag:varchar(1):8:REGULAR
                 linenumber := linenumber:int:3:REGULAR
                 quantity := quantity:double:4:REGULAR
                 orderkey := orderkey:bigint:0:REGULAR
                 shipmode := shipmode:varchar(10):14:REGULAR
                 discount := discount:double:6:REGULAR
                 tax := tax:double:7:REGULAR
                 suppkey := suppkey:bigint:2:REGULAR
                 partkey := partkey:bigint:1:REGULAR
                 shipinstruct := shipinstruct:varchar(25):13:REGULAR
                 linestatus := linestatus:varchar(1):9:REGULAR
                 extendedprice := extendedprice:double:5:REGULAR
                 comment := comment:varchar(44):15:REGULAR
                 receiptdate := receiptdate:date:12:REGULAR
                 commitdate := commitdate:date:11:REGULAR
                 shipdate := shipdate:date:10:REGULAR
```

`TableScan` CPU stats in `2)` are stats for `WorkProcessorPipelineOperators` that combines `TableScan` and `TopNPartial` operators and uses late materialization. As one can see CPU reduction is over `50%`

Stats for `TopNPartial` in `2)` are actually stats for `TaskOutputOperator` (that's how `LocalExecutionPlanner` works).

FYI: @dain 

Part of: https://github.com/prestosql/presto/issues/49