### PR TITLE
Resolve tables/schemas case-insensitively in JDBC connectors

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -14,6 +14,8 @@
 package io.prestosql.plugin.jdbc;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -43,6 +45,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,9 +54,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
@@ -88,6 +94,7 @@ import static java.sql.DatabaseMetaData.columnNoNulls;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.function.Function.identity;
 
 public class BaseJdbcClient
@@ -109,12 +116,21 @@ public class BaseJdbcClient
 
     protected final ConnectionFactory connectionFactory;
     protected final String identifierQuote;
+    protected final boolean caseInsensitiveNameMatching;
+    protected final Cache<JdbcIdentity, Map<String, String>> remoteSchemaNames;
+    protected final Cache<RemoteTableNameCacheKey, Map<String, String>> remoteTableNames;
 
     public BaseJdbcClient(BaseJdbcConfig config, String identifierQuote, ConnectionFactory connectionFactory)
     {
         requireNonNull(config, "config is null"); // currently unused, retained as parameter for future extensions
         this.identifierQuote = requireNonNull(identifierQuote, "identifierQuote is null");
         this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory is null");
+
+        this.caseInsensitiveNameMatching = config.isCaseInsensitiveNameMatching();
+        CacheBuilder<Object, Object> remoteNamesCacheBuilder = CacheBuilder.newBuilder()
+                .expireAfterWrite(config.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS);
+        this.remoteSchemaNames = remoteNamesCacheBuilder.build();
+        this.remoteTableNames = remoteNamesCacheBuilder.build();
     }
 
     @PreDestroy
@@ -125,15 +141,26 @@ public class BaseJdbcClient
     }
 
     @Override
-    public Set<String> getSchemaNames(JdbcIdentity identity)
+    public final Set<String> getSchemaNames(JdbcIdentity identity)
     {
-        try (Connection connection = connectionFactory.openConnection(identity);
-                ResultSet resultSet = connection.getMetaData().getSchemas()) {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            return listSchemas(connection).stream()
+                    .map(schemaName -> schemaName.toLowerCase(ENGLISH))
+                    .collect(toImmutableSet());
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    protected Collection<String> listSchemas(Connection connection)
+    {
+        try (ResultSet resultSet = connection.getMetaData().getSchemas()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
             while (resultSet.next()) {
-                String schemaName = resultSet.getString("TABLE_SCHEM").toLowerCase(ENGLISH);
+                String schemaName = resultSet.getString("TABLE_SCHEM");
                 // skip internal schemas
-                if (!schemaName.equals("information_schema")) {
+                if (!schemaName.equalsIgnoreCase("information_schema")) {
                     schemaNames.add(schemaName);
                 }
             }
@@ -148,7 +175,7 @@ public class BaseJdbcClient
     public List<SchemaTableName> getTableNames(JdbcIdentity identity, Optional<String> schema)
     {
         try (Connection connection = connectionFactory.openConnection(identity)) {
-            Optional<String> remoteSchema = schema.map(schemaName -> toRemoteSchemaName(connection, schemaName));
+            Optional<String> remoteSchema = schema.map(schemaName -> toRemoteSchemaName(identity, connection, schemaName));
             try (ResultSet resultSet = getTables(connection, remoteSchema, Optional.empty())) {
                 ImmutableList.Builder<SchemaTableName> list = ImmutableList.builder();
                 while (resultSet.next()) {
@@ -168,8 +195,8 @@ public class BaseJdbcClient
     public Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName)
     {
         try (Connection connection = connectionFactory.openConnection(identity)) {
-            String remoteSchema = toRemoteSchemaName(connection, schemaTableName.getSchemaName());
-            String remoteTable = toRemoteTableName(connection, remoteSchema, schemaTableName.getTableName());
+            String remoteSchema = toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
+            String remoteTable = toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
             try (ResultSet resultSet = getTables(connection, Optional.of(remoteSchema), Optional.of(remoteTable))) {
                 List<JdbcTableHandle> tableHandles = new ArrayList<>();
                 while (resultSet.next()) {
@@ -314,8 +341,8 @@ public class BaseJdbcClient
 
         try (Connection connection = connectionFactory.openConnection(identity)) {
             boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
-            String remoteSchema = toRemoteSchemaName(connection, schemaTableName.getSchemaName());
-            String remoteTable = toRemoteTableName(connection, remoteSchema, schemaTableName.getTableName());
+            String remoteSchema = toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
+            String remoteTable = toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
             if (uppercase) {
                 tableName = tableName.toUpperCase(ENGLISH);
             }
@@ -545,10 +572,31 @@ public class BaseJdbcClient
         return resultSet.getString("TABLE_SCHEM");
     }
 
-    protected String toRemoteSchemaName(Connection connection, String schemaName)
+    protected String toRemoteSchemaName(JdbcIdentity identity, Connection connection, String schemaName)
     {
         requireNonNull(schemaName, "schemaName is null");
         verify(CharMatcher.forPredicate(Character::isUpperCase).matchesNoneOf(schemaName), "Expected schema name from internal metadata to be lowercase: %s", schemaName);
+
+        if (caseInsensitiveNameMatching) {
+            try {
+                Map<String, String> mapping = remoteSchemaNames.getIfPresent(identity);
+                if (mapping != null && !mapping.containsKey(schemaName)) {
+                    // This might be a schema that has just been created. Force reload.
+                    mapping = null;
+                }
+                if (mapping == null) {
+                    mapping = listSchemasByLowerCase(connection);
+                    remoteSchemaNames.put(identity, mapping);
+                }
+                String remoteSchema = mapping.get(schemaName);
+                if (remoteSchema != null) {
+                    return remoteSchema;
+                }
+            }
+            catch (RuntimeException e) {
+                throw new PrestoException(JDBC_ERROR, "Failed to find remote schema name: " + firstNonNull(e.getMessage(), e), e);
+            }
+        }
 
         try {
             DatabaseMetaData metadata = connection.getMetaData();
@@ -562,11 +610,39 @@ public class BaseJdbcClient
         }
     }
 
-    protected String toRemoteTableName(Connection connection, String remoteSchema, String tableName)
+    protected Map<String, String> listSchemasByLowerCase(Connection connection)
+    {
+        return listSchemas(connection).stream()
+                .collect(toImmutableMap(schemaName -> schemaName.toLowerCase(ENGLISH), schemaName -> schemaName));
+    }
+
+    protected String toRemoteTableName(JdbcIdentity identity, Connection connection, String remoteSchema, String tableName)
     {
         requireNonNull(remoteSchema, "remoteSchema is null");
         requireNonNull(tableName, "tableName is null");
         verify(CharMatcher.forPredicate(Character::isUpperCase).matchesNoneOf(tableName), "Expected table name from internal metadata to be lowercase: %s", tableName);
+
+        if (caseInsensitiveNameMatching) {
+            try {
+                RemoteTableNameCacheKey cacheKey = new RemoteTableNameCacheKey(identity, remoteSchema);
+                Map<String, String> mapping = remoteTableNames.getIfPresent(cacheKey);
+                if (mapping != null && !mapping.containsKey(tableName)) {
+                    // This might be a table that has just been created. Force reload.
+                    mapping = null;
+                }
+                if (mapping == null) {
+                    mapping = listTablesByLowerCase(connection, remoteSchema);
+                    remoteTableNames.put(cacheKey, mapping);
+                }
+                String remoteTable = mapping.get(tableName);
+                if (remoteTable != null) {
+                    return remoteTable;
+                }
+            }
+            catch (RuntimeException e) {
+                throw new PrestoException(JDBC_ERROR, "Failed to find remote table name: " + firstNonNull(e.getMessage(), e), e);
+            }
+        }
 
         try {
             DatabaseMetaData metadata = connection.getMetaData();
@@ -574,6 +650,21 @@ public class BaseJdbcClient
                 return tableName.toUpperCase(ENGLISH);
             }
             return tableName;
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    protected Map<String, String> listTablesByLowerCase(Connection connection, String remoteSchema)
+    {
+        try (ResultSet resultSet = getTables(connection, Optional.of(remoteSchema), Optional.empty())) {
+            ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
+            while (resultSet.next()) {
+                String tableName = resultSet.getString("TABLE_NAME");
+                map.put(tableName.toLowerCase(ENGLISH), tableName);
+            }
+            return map.build();
         }
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -152,7 +152,9 @@ public class BaseJdbcClient
             try (ResultSet resultSet = getTables(connection, remoteSchema, Optional.empty())) {
                 ImmutableList.Builder<SchemaTableName> list = ImmutableList.builder();
                 while (resultSet.next()) {
-                    list.add(getSchemaTableName(resultSet));
+                    String tableSchema = getTableSchemaName(resultSet);
+                    String tableName = resultSet.getString("TABLE_NAME");
+                    list.add(new SchemaTableName(tableSchema.toLowerCase(ENGLISH), tableName.toLowerCase(ENGLISH)));
                 }
                 return list.build();
             }
@@ -537,12 +539,10 @@ public class BaseJdbcClient
                 new String[] {"TABLE", "VIEW"});
     }
 
-    protected SchemaTableName getSchemaTableName(ResultSet resultSet)
+    protected String getTableSchemaName(ResultSet resultSet)
             throws SQLException
     {
-        return new SchemaTableName(
-                resultSet.getString("TABLE_SCHEM").toLowerCase(ENGLISH),
-                resultSet.getString("TABLE_NAME").toLowerCase(ENGLISH));
+        return resultSet.getString("TABLE_SCHEM");
     }
 
     protected String toRemoteSchemaName(Connection connection, String schemaName)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -15,9 +15,13 @@ package io.prestosql.plugin.jdbc;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class BaseJdbcConfig
 {
@@ -26,6 +30,8 @@ public class BaseJdbcConfig
     private String connectionPassword;
     private String userCredentialName;
     private String passwordCredentialName;
+    private boolean caseInsensitiveNameMatching;
+    private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
 
     @NotNull
     public String getConnectionUrl()
@@ -90,6 +96,32 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setPasswordCredentialName(String passwordCredentialName)
     {
         this.passwordCredentialName = passwordCredentialName;
+        return this;
+    }
+
+    public boolean isCaseInsensitiveNameMatching()
+    {
+        return caseInsensitiveNameMatching;
+    }
+
+    @Config("case-insensitive-name-matching")
+    public BaseJdbcConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
+    {
+        this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getCaseInsensitiveNameMatchingCacheTtl()
+    {
+        return caseInsensitiveNameMatchingCacheTtl;
+    }
+
+    @Config("case-insensitive-name-matching.cache-ttl")
+    public BaseJdbcConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
+    {
+        this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcTableHandle.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcTableHandle.java
@@ -32,6 +32,8 @@ public final class JdbcTableHandle
         implements ConnectorTableHandle
 {
     private final SchemaTableName schemaTableName;
+
+    // catalog, schema and table names are reported by the remote database
     private final String catalogName;
     private final String schemaName;
     private final String tableName;

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableNameCacheKey.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableNameCacheKey.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+final class RemoteTableNameCacheKey
+{
+    private final JdbcIdentity identity;
+    private final String schema;
+
+    RemoteTableNameCacheKey(JdbcIdentity identity, String schema)
+    {
+        this.identity = requireNonNull(identity, "identity is null");
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    JdbcIdentity getIdentity()
+    {
+        return identity;
+    }
+
+    String getSchema()
+    {
+        return schema;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RemoteTableNameCacheKey that = (RemoteTableNameCacheKey) o;
+        return Objects.equals(identity, that.identity) &&
+                Objects.equals(schema, that.schema);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(identity, schema);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("identity", identity)
+                .add("schema", schema)
+                .toString();
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -15,9 +15,13 @@ package io.prestosql.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestBaseJdbcConfig
 {
@@ -29,7 +33,9 @@ public class TestBaseJdbcConfig
                 .setConnectionUser(null)
                 .setConnectionPassword(null)
                 .setUserCredentialName(null)
-                .setPasswordCredentialName(null));
+                .setPasswordCredentialName(null)
+                .setCaseInsensitiveNameMatching(false)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
     }
 
     @Test
@@ -41,6 +47,8 @@ public class TestBaseJdbcConfig
                 .put("connection-password", "password")
                 .put("user-credential-name", "foo")
                 .put("password-credential-name", "bar")
+                .put("case-insensitive-name-matching", "true")
+                .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
@@ -48,7 +56,9 @@ public class TestBaseJdbcConfig
                 .setConnectionUser("user")
                 .setConnectionPassword("password")
                 .setUserCredentialName("foo")
-                .setPasswordCredentialName("bar");
+                .setPasswordCredentialName("bar")
+                .setCaseInsensitiveNameMatching(true)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -85,6 +85,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
@@ -123,6 +129,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing-mysql-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-testing-docker</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -154,13 +154,11 @@ public class MySqlClient
     }
 
     @Override
-    protected SchemaTableName getSchemaTableName(ResultSet resultSet)
+    protected String getTableSchemaName(ResultSet resultSet)
             throws SQLException
     {
         // MySQL uses catalogs instead of schemas
-        return new SchemaTableName(
-                resultSet.getString("TABLE_CAT").toLowerCase(ENGLISH),
-                resultSet.getString("TABLE_NAME").toLowerCase(ENGLISH));
+        return resultSet.getString("TABLE_CAT");
     }
 
     @Override

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -38,9 +38,9 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -99,16 +99,15 @@ public class MySqlClient
     }
 
     @Override
-    public Set<String> getSchemaNames(JdbcIdentity identity)
+    protected Collection<String> listSchemas(Connection connection)
     {
         // for MySQL, we need to list catalogs instead of schemas
-        try (Connection connection = connectionFactory.openConnection(identity);
-                ResultSet resultSet = connection.getMetaData().getCatalogs()) {
+        try (ResultSet resultSet = connection.getMetaData().getCatalogs()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
             while (resultSet.next()) {
-                String schemaName = resultSet.getString("TABLE_CAT").toLowerCase(ENGLISH);
+                String schemaName = resultSet.getString("TABLE_CAT");
                 // skip internal schemas
-                if (!schemaName.equals("information_schema") && !schemaName.equals("mysql")) {
+                if (!schemaName.equalsIgnoreCase("information_schema") && !schemaName.equalsIgnoreCase("mysql")) {
                     schemaNames.add(schemaName);
                 }
             }

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/DockerizedMySqlServer.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/DockerizedMySqlServer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mysql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.docker.DockerContainer;
+import io.prestosql.testing.docker.DockerContainer.HostPortProvider;
+
+import java.io.Closeable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.lang.String.format;
+
+public class DockerizedMySqlServer
+        implements Closeable
+{
+    private static final int MYSQL_PORT = 3306;
+
+    private static final String MYSQL_ROOT_USER = "root";
+    private static final String MYSQL_ROOT_PASSWORD = "mysqlrootpassword";
+    private static final String MYSQL_USER = "testuser";
+    private static final String MYSQL_PASSWORD = "testpassword";
+
+    private final DockerContainer dockerContainer;
+
+    public DockerizedMySqlServer()
+    {
+        this.dockerContainer = new DockerContainer(
+                "mysql:8.0.15",
+                ImmutableList.of(MYSQL_PORT),
+                ImmutableMap.of(
+                        "MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD,
+                        "MYSQL_USER", MYSQL_USER,
+                        "MYSQL_PASSWORD", MYSQL_PASSWORD,
+                        "MYSQL_DATABASE", "tpch"),
+                DockerizedMySqlServer::healthCheck);
+    }
+
+    private static void healthCheck(HostPortProvider hostPortProvider)
+            throws SQLException
+    {
+        String jdbcUrl = getJdbcUrl(hostPortProvider, MYSQL_ROOT_USER, MYSQL_ROOT_PASSWORD);
+        try (Connection conn = DriverManager.getConnection(jdbcUrl);
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("SELECT 1");
+        }
+    }
+
+    public void init()
+            throws SQLException
+    {
+        String jdbcUrl = getJdbcUrl(dockerContainer::getHostPort, MYSQL_ROOT_USER, MYSQL_ROOT_PASSWORD);
+        try (Connection conn = DriverManager.getConnection(jdbcUrl);
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", MYSQL_USER));
+        }
+    }
+
+    public String getJdbcUrl()
+    {
+        return getJdbcUrl(dockerContainer::getHostPort, MYSQL_USER, MYSQL_PASSWORD);
+    }
+
+    private static String getJdbcUrl(HostPortProvider hostPortProvider, String user, String password)
+    {
+        return format("jdbc:mysql://localhost:%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true", hostPortProvider.getHostPort(MYSQL_PORT), user, password);
+    }
+
+    @Override
+    public void close()
+    {
+        dockerContainer.close();
+    }
+}

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/MySqlQueryRunner.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/MySqlQueryRunner.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.tpch.TpchPlugin;
 import io.prestosql.testing.QueryRunner;
 import io.prestosql.tests.DistributedQueryRunner;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -40,10 +41,22 @@ public final class MySqlQueryRunner
     public static QueryRunner createMySqlQueryRunner(TestingMySqlServer server, TpchTable<?>... tables)
             throws Exception
     {
-        return createMySqlQueryRunner(server, ImmutableList.copyOf(tables));
+        return createMySqlQueryRunner(server, ImmutableMap.of(), ImmutableList.copyOf(tables));
     }
 
-    public static QueryRunner createMySqlQueryRunner(TestingMySqlServer server, Iterable<TpchTable<?>> tables)
+    public static QueryRunner createMySqlQueryRunner(TestingMySqlServer server, Map<String, String> connectorProperties, Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        try {
+            return createMySqlQueryRunner(server.getJdbcUrl(), connectorProperties, tables);
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, server);
+            throw e;
+        }
+    }
+
+    public static QueryRunner createMySqlQueryRunner(String jdbcUrl, Map<String, String> connectorProperties, Iterable<TpchTable<?>> tables)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;
@@ -53,20 +66,19 @@ public final class MySqlQueryRunner
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");
 
-            Map<String, String> properties = ImmutableMap.<String, String>builder()
-                    .put("connection-url", server.getJdbcUrl())
-                    .put("allow-drop-table", "true")
-                    .build();
+            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+            connectorProperties.putIfAbsent("connection-url", jdbcUrl);
+            connectorProperties.putIfAbsent("allow-drop-table", "true");
 
             queryRunner.installPlugin(new MySqlPlugin());
-            queryRunner.createCatalog("mysql", "mysql", properties);
+            queryRunner.createCatalog("mysql", "mysql", connectorProperties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
 
             return queryRunner;
         }
         catch (Throwable e) {
-            closeAllSuppress(e, queryRunner, server);
+            closeAllSuppress(e, queryRunner);
             throw e;
         }
     }

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mysql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.tpch.TpchTable;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.prestosql.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestMySqlCaseInsensitiveMapping
+        extends AbstractTestQueryFramework
+{
+    private final DockerizedMySqlServer mySqlServer;
+
+    public TestMySqlCaseInsensitiveMapping()
+    {
+        // Using dockerized MySQL server instead of TestingMySqlServer because TestingMySqlServer depends on host's file system.
+        // Because host file system may be case insensitive, it would not be possible to create schemas/tables with names differing in case only.
+        this(new DockerizedMySqlServer());
+    }
+
+    public TestMySqlCaseInsensitiveMapping(DockerizedMySqlServer mySqlServer)
+    {
+        super(() -> createMySqlQueryRunner(
+                mySqlServer,
+                ImmutableMap.of("case-insensitive-name-matching", "true"),
+                ImmutableList.of()));
+        this.mySqlServer = mySqlServer;
+    }
+
+    private static QueryRunner createMySqlQueryRunner(DockerizedMySqlServer mySqlServer, Map<String, String> connectorProperties, Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        try {
+            mySqlServer.init();
+            return MySqlQueryRunner.createMySqlQueryRunner(mySqlServer.getJdbcUrl(), connectorProperties, tables);
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, mySqlServer);
+            throw e;
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        mySqlServer.close();
+    }
+
+    @Test
+    public void testNonLowerCaseSchemaName()
+            throws Exception
+    {
+        try (AutoCloseable ignore1 = withSchema("NonLowerCaseSchema");
+                AutoCloseable ignore2 = withTable("NonLowerCaseSchema.lower_case_name", "(c varchar(5))");
+                AutoCloseable ignore3 = withTable("NonLowerCaseSchema.Mixed_Case_Name", "(c varchar(5))");
+                AutoCloseable ignore4 = withTable("NonLowerCaseSchema.UPPER_CASE_NAME", "(c varchar(5))")) {
+            assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn()).contains("nonlowercaseschema");
+            assertQuery("SHOW SCHEMAS LIKE 'nonlowerc%'", "VALUES 'nonlowercaseschema'");
+            assertQuery("SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '%nonlowercaseschema'", "VALUES 'nonlowercaseschema'");
+            assertQuery("SHOW TABLES FROM nonlowercaseschema", "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = 'nonlowercaseschema'", "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQueryReturnsEmptyResult("SELECT * FROM nonlowercaseschema.lower_case_name");
+        }
+    }
+
+    @Test
+    public void testNonLowerCaseTableName()
+            throws Exception
+    {
+        try (AutoCloseable ignore1 = withSchema("SomeSchema");
+                AutoCloseable ignore2 = withTable(
+                        "SomeSchema.NonLowerCaseTable", "(lower_case_name varchar(10), Mixed_Case_Name varchar(10), UPPER_CASE_NAME varchar(10))")) {
+            execute("INSERT INTO SomeSchema.NonLowerCaseTable VALUES ('a', 'b', 'c')");
+
+            assertQuery(
+                    "SELECT column_name FROM information_schema.columns WHERE table_schema = 'someschema' AND table_name = 'nonlowercasetable'",
+                    "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQuery(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name = 'nonlowercasetable'",
+                    "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertEquals(
+                    computeActual("SHOW COLUMNS FROM someschema.nonlowercasetable").getMaterializedRows().stream()
+                            .map(row -> row.getField(0))
+                            .collect(toImmutableSet()),
+                    ImmutableSet.of("lower_case_name", "mixed_case_name", "upper_case_name"));
+
+            // Note: until https://github.com/prestodb/presto/issues/2863 is resolved, this is *the* way to access the tables.
+
+            assertQuery("SELECT lower_case_name FROM someschema.nonlowercasetable", "VALUES 'a'");
+            assertQuery("SELECT mixed_case_name FROM someschema.nonlowercasetable", "VALUES 'b'");
+            assertQuery("SELECT upper_case_name FROM someschema.nonlowercasetable", "VALUES 'c'");
+            assertQuery("SELECT upper_case_name FROM SomeSchema.NonLowerCaseTable", "VALUES 'c'");
+            assertQuery("SELECT upper_case_name FROM \"SomeSchema\".\"NonLowerCaseTable\"", "VALUES 'c'");
+
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (lower_case_name) VALUES ('lower')", 1);
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (mixed_case_name) VALUES ('mixed')", 1);
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (upper_case_name) VALUES ('upper')", 1);
+            assertQuery(
+                    "SELECT * FROM someschema.nonlowercasetable",
+                    "VALUES ('a', 'b', 'c')," +
+                            "('lower', NULL, NULL)," +
+                            "(NULL, 'mixed', NULL)," +
+                            "(NULL, NULL, 'upper')");
+        }
+    }
+
+    @Test
+    public void testSchemaNameClash()
+            throws Exception
+    {
+        String[] nameVariants = {"casesensitivename", "CaseSensitiveName", "CASESENSITIVENAME"};
+        assertThat(Stream.of(nameVariants)
+                .map(name -> name.toLowerCase(ENGLISH))
+                .collect(toImmutableSet()))
+                .hasSize(1);
+
+        for (int i = 0; i < nameVariants.length; i++) {
+            for (int j = i + 1; j < nameVariants.length; j++) {
+                String schemaName = nameVariants[i];
+                String otherSchemaName = nameVariants[j];
+                try (AutoCloseable ignore1 = withSchema(schemaName);
+                        AutoCloseable ignore2 = withSchema(otherSchemaName);
+                        AutoCloseable ignore3 = withTable(schemaName + ".some_table_name", "(c varchar(5))")) {
+                    assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn()).contains("casesensitivename");
+                    assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn().filter("casesensitivename"::equals)).hasSize(1); // TODO change io.prestosql.plugin.jdbc.JdbcClient.getSchemaNames to return a List
+                    assertQueryFails("SHOW TABLES FROM casesensitivename", "Failed to find remote schema name:.*Multiple entries with same key.*");
+                    assertQueryFails("SELECT * FROM casesensitivename.some_table_name", "Failed to find remote schema name:.*Multiple entries with same key.*");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTableNameClash()
+            throws Exception
+    {
+        String[] nameVariants = {"casesensitivename", "CaseSensitiveName", "CASESENSITIVENAME"};
+        assertThat(Stream.of(nameVariants)
+                .map(name -> name.toLowerCase(ENGLISH))
+                .collect(toImmutableSet()))
+                .hasSize(1);
+
+        for (int i = 0; i < nameVariants.length; i++) {
+            for (int j = i + 1; j < nameVariants.length; j++) {
+                try (AutoCloseable ignore1 = withTable("tpch." + nameVariants[i], "(c varchar(5))");
+                        AutoCloseable ignore2 = withTable("tpch." + nameVariants[j], "(d varchar(5))")) {
+                    assertThat(computeActual("SHOW TABLES").getOnlyColumn()).contains("casesensitivename");
+                    assertThat(computeActual("SHOW TABLES").getOnlyColumn().filter("casesensitivename"::equals)).hasSize(1); // TODO, should be 2
+                    assertQueryFails("SHOW COLUMNS FROM casesensitivename", "Failed to find remote table name:.*Multiple entries with same key.*");
+                    assertQueryFails("SELECT * FROM casesensitivename", "Failed to find remote table name:.*Multiple entries with same key.*");
+                }
+            }
+        }
+    }
+
+    private AutoCloseable withSchema(String schemaName)
+    {
+        execute(format("CREATE SCHEMA `%s`", schemaName));
+        return () -> execute(format("DROP SCHEMA `%s`", schemaName));
+    }
+
+    private AutoCloseable withTable(String tableName, String tableDefinition)
+    {
+        execute(format("CREATE TABLE %s %s", tableName, tableDefinition));
+        return () -> execute(format("DROP TABLE %s", tableName));
+    }
+
+    private void execute(String sql)
+    {
+        try (Connection connection = DriverManager.getConnection(mySqlServer.getJdbcUrl());
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to execute statement: " + sql, e);
+        }
+    }
+}

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.mysql;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.testing.MaterializedResult;
@@ -39,7 +40,7 @@ public class TestMySqlDistributedQueries
 
     public TestMySqlDistributedQueries(TestingMySqlServer mysqlServer)
     {
-        super(() -> createMySqlQueryRunner(mysqlServer, TpchTable.getTables()));
+        super(() -> createMySqlQueryRunner(mysqlServer, ImmutableMap.of(), TpchTable.getTables()));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.mysql;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import io.prestosql.Session;
 import io.prestosql.spi.type.TimeZoneKey;
@@ -51,7 +52,6 @@ import static io.prestosql.tests.datatype.DataType.stringDataType;
 import static io.prestosql.tests.datatype.DataType.tinyintDataType;
 import static io.prestosql.tests.datatype.DataType.varcharDataType;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 
 @Test
 public class TestMySqlTypeMapping
@@ -69,7 +69,7 @@ public class TestMySqlTypeMapping
 
     private TestMySqlTypeMapping(TestingMySqlServer mysqlServer)
     {
-        super(() -> createMySqlQueryRunner(mysqlServer, emptyList()));
+        super(() -> createMySqlQueryRunner(mysqlServer, ImmutableMap.of(), ImmutableList.of()));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -44,10 +45,10 @@ public final class PostgreSqlQueryRunner
     public static QueryRunner createPostgreSqlQueryRunner(TestingPostgreSqlServer server, TpchTable<?>... tables)
             throws Exception
     {
-        return createPostgreSqlQueryRunner(server, ImmutableList.copyOf(tables));
+        return createPostgreSqlQueryRunner(server, ImmutableMap.of(), ImmutableList.copyOf(tables));
     }
 
-    public static QueryRunner createPostgreSqlQueryRunner(TestingPostgreSqlServer server, Iterable<TpchTable<?>> tables)
+    public static QueryRunner createPostgreSqlQueryRunner(TestingPostgreSqlServer server, Map<String, String> connectorProperties, Iterable<TpchTable<?>> tables)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;
@@ -57,15 +58,14 @@ public final class PostgreSqlQueryRunner
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");
 
-            Map<String, String> properties = ImmutableMap.<String, String>builder()
-                    .put("connection-url", server.getJdbcUrl())
-                    .put("allow-drop-table", "true")
-                    .build();
+            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+            connectorProperties.putIfAbsent("connection-url", server.getJdbcUrl());
+            connectorProperties.putIfAbsent("allow-drop-table", "true");
 
             createSchema(server.getJdbcUrl(), "tpch");
 
             queryRunner.installPlugin(new PostgreSqlPlugin());
-            queryRunner.createCatalog("postgresql", "postgresql", properties);
+            queryRunner.createCatalog("postgresql", "postgresql", connectorProperties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.postgresql;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.testing.postgresql.TestingPostgreSqlServer;
+import io.prestosql.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestPostgreSqlCaseInsensitiveMapping
+        extends AbstractTestQueryFramework
+{
+    private final TestingPostgreSqlServer postgreSqlServer;
+
+    public TestPostgreSqlCaseInsensitiveMapping()
+            throws Exception
+    {
+        this(new TestingPostgreSqlServer("testuser", "tpch"));
+    }
+
+    public TestPostgreSqlCaseInsensitiveMapping(TestingPostgreSqlServer postgreSqlServer)
+    {
+        super(() -> PostgreSqlQueryRunner.createPostgreSqlQueryRunner(
+                postgreSqlServer,
+                ImmutableMap.of("case-insensitive-name-matching", "true"),
+                ImmutableSet.of()));
+        this.postgreSqlServer = postgreSqlServer;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        postgreSqlServer.close();
+    }
+
+    @Test
+    public void testNonLowerCaseSchemaName()
+            throws Exception
+    {
+        try (AutoCloseable ignore1 = withSchema("\"NonLowerCaseSchema\"");
+                AutoCloseable ignore2 = withTable("\"NonLowerCaseSchema\".lower_case_name", "(c varchar(5))");
+                AutoCloseable ignore3 = withTable("\"NonLowerCaseSchema\".\"Mixed_Case_Name\"", "(c varchar(5))");
+                AutoCloseable ignore4 = withTable("\"NonLowerCaseSchema\".\"UPPER_CASE_NAME\"", "(c varchar(5))")) {
+            assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn()).contains("nonlowercaseschema");
+            assertQuery("SHOW SCHEMAS LIKE 'nonlowerc%'", "VALUES 'nonlowercaseschema'");
+            assertQuery("SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE '%nonlowercaseschema'", "VALUES 'nonlowercaseschema'");
+            assertQuery("SHOW TABLES FROM nonlowercaseschema", "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = 'nonlowercaseschema'", "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQueryReturnsEmptyResult("SELECT * FROM nonlowercaseschema.lower_case_name");
+        }
+    }
+
+    @Test
+    public void testNonLowerCaseTableName()
+            throws Exception
+    {
+        try (AutoCloseable ignore1 = withSchema("\"SomeSchema\"");
+                AutoCloseable ignore2 = withTable(
+                        "\"SomeSchema\".\"NonLowerCaseTable\"", "AS SELECT * FROM (VALUES ('a', 'b', 'c')) t(lower_case_name, \"Mixed_Case_Name\", \"UPPER_CASE_NAME\")")) {
+            assertQuery(
+                    "SELECT column_name FROM information_schema.columns WHERE table_schema = 'someschema' AND table_name = 'nonlowercasetable'",
+                    "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertQuery(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name = 'nonlowercasetable'",
+                    "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
+            assertEquals(
+                    computeActual("SHOW COLUMNS FROM someschema.nonlowercasetable").getMaterializedRows().stream()
+                            .map(row -> row.getField(0))
+                            .collect(toImmutableSet()),
+                    ImmutableSet.of("lower_case_name", "mixed_case_name", "upper_case_name"));
+
+            // Note: until https://github.com/prestodb/presto/issues/2863 is resolved, this is *the* way to access the tables.
+
+            assertQuery("SELECT lower_case_name FROM someschema.nonlowercasetable", "VALUES 'a'");
+            assertQuery("SELECT mixed_case_name FROM someschema.nonlowercasetable", "VALUES 'b'");
+            assertQuery("SELECT upper_case_name FROM someschema.nonlowercasetable", "VALUES 'c'");
+            assertQuery("SELECT upper_case_name FROM SomeSchema.NonLowerCaseTable", "VALUES 'c'");
+            assertQuery("SELECT upper_case_name FROM \"SomeSchema\".\"NonLowerCaseTable\"", "VALUES 'c'");
+
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (lower_case_name) VALUES ('lower')", 1);
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (mixed_case_name) VALUES ('mixed')", 1);
+            assertUpdate("INSERT INTO someschema.nonlowercasetable (upper_case_name) VALUES ('upper')", 1);
+            assertQuery(
+                    "SELECT * FROM someschema.nonlowercasetable",
+                    "VALUES ('a', 'b', 'c')," +
+                            "('lower', NULL, NULL)," +
+                            "(NULL, 'mixed', NULL)," +
+                            "(NULL, NULL, 'upper')");
+        }
+    }
+
+    @Test
+    public void testSchemaNameClash()
+            throws Exception
+    {
+        String[] nameVariants = {"casesensitivename", "\"CaseSensitiveName\"", "\"CASESENSITIVENAME\""};
+        assertThat(Stream.of(nameVariants)
+                .map(name -> name.replace("\"", "").toLowerCase(ENGLISH))
+                .collect(toImmutableSet()))
+                .hasSize(1);
+
+        for (int i = 0; i < nameVariants.length; i++) {
+            for (int j = i + 1; j < nameVariants.length; j++) {
+                String schemaName = nameVariants[i];
+                String otherSchemaName = nameVariants[j];
+                try (AutoCloseable ignore1 = withSchema(schemaName);
+                        AutoCloseable ignore2 = withSchema(otherSchemaName);
+                        AutoCloseable ignore3 = withTable(schemaName + ".some_table_name", "(c varchar(5))")) {
+                    assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn()).contains("casesensitivename");
+                    assertThat(computeActual("SHOW SCHEMAS").getOnlyColumn().filter("casesensitivename"::equals)).hasSize(1); // TODO change io.prestosql.plugin.jdbc.JdbcClient.getSchemaNames to return a List
+                    assertQueryFails("SHOW TABLES FROM casesensitivename", "Failed to find remote schema name:.*Multiple entries with same key.*");
+                    assertQueryFails("SELECT * FROM casesensitivename.some_table_name", "Failed to find remote schema name:.*Multiple entries with same key.*");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTableNameClash()
+            throws Exception
+    {
+        String[] nameVariants = {"casesensitivename", "\"CaseSensitiveName\"", "\"CASESENSITIVENAME\""};
+        assertThat(Stream.of(nameVariants)
+                .map(name -> name.replace("\"", "").toLowerCase(ENGLISH))
+                .collect(toImmutableSet()))
+                .hasSize(1);
+
+        for (int i = 0; i < nameVariants.length; i++) {
+            for (int j = i + 1; j < nameVariants.length; j++) {
+                try (AutoCloseable ignore1 = withTable("tpch." + nameVariants[i], "(c varchar(5))");
+                        AutoCloseable ignore2 = withTable("tpch." + nameVariants[j], "(d varchar(5))")) {
+                    assertThat(computeActual("SHOW TABLES").getOnlyColumn()).contains("casesensitivename");
+                    assertThat(computeActual("SHOW TABLES").getOnlyColumn().filter("casesensitivename"::equals)).hasSize(1); // TODO, should be 2
+                    assertQueryFails("SHOW COLUMNS FROM casesensitivename", "Failed to find remote table name:.*Multiple entries with same key.*");
+                    assertQueryFails("SELECT * FROM casesensitivename", "Failed to find remote table name:.*Multiple entries with same key.*");
+                }
+            }
+        }
+    }
+
+    private AutoCloseable withSchema(String schemaName)
+    {
+        execute("CREATE SCHEMA " + schemaName);
+        return () -> execute("DROP SCHEMA " + schemaName);
+    }
+
+    private AutoCloseable withTable(String tableName, String tableDefinition)
+    {
+        execute(format("CREATE TABLE %s %s", tableName, tableDefinition));
+        return () -> execute(format("DROP TABLE %s", tableName));
+    }
+
+    private void execute(String sql)
+    {
+        try (Connection connection = DriverManager.getConnection(postgreSqlServer.getJdbcUrl());
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to execute statement: " + sql, e);
+        }
+    }
+}

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.postgresql;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.tests.AbstractTestDistributedQueries;
@@ -37,7 +38,7 @@ public class TestPostgreSqlDistributedQueries
 
     public TestPostgreSqlDistributedQueries(TestingPostgreSqlServer postgreSqlServer)
     {
-        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, TpchTable.getTables()));
+        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of(), TpchTable.getTables()));
         this.postgreSqlServer = postgreSqlServer;
     }
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.prestosql.Session;
 import io.prestosql.spi.type.TimeZoneKey;
@@ -62,7 +63,6 @@ import static io.prestosql.type.JsonType.JSON;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
 
 @Test
@@ -79,7 +79,7 @@ public class TestPostgreSqlTypeMapping
 
     private TestPostgreSqlTypeMapping(TestingPostgreSqlServer postgreSqlServer)
     {
-        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, emptyList()));
+        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of(), ImmutableList.of()));
         this.postgreSqlServer = postgreSqlServer;
     }
 

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -22,6 +22,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
In https://github.com/prestosql/presto/pull/354 will need support for case-insensitive name matching by default. For now, this is an opt-in feature.
Fixes https://github.com/prestodb/presto/issues/3470