### PR TITLE
Indicate progress only if limit is applied

### DIFF
--- a/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
@@ -356,10 +356,12 @@ public class MemoryMetadata
     {
         MemoryTableHandle table = (MemoryTableHandle) handle;
 
-        if (!table.getLimit().isPresent() || limit < table.getLimit().getAsLong()) {
-            table = new MemoryTableHandle(table.getId(), OptionalLong.of(limit));
+        if (table.getLimit().isPresent() && table.getLimit().getAsLong() <= limit) {
+            return Optional.empty();
         }
 
-        return Optional.of(new LimitApplicationResult<>(table, true));
+        return Optional.of(new LimitApplicationResult<>(
+                new MemoryTableHandle(table.getId(), OptionalLong.of(limit)),
+                true));
     }
 }


### PR DESCRIPTION
The code was always returning an indication that it could benefit
from the limit pushdown even if that wasn't the case. This could
cause the optimizer to loop indefinitely in some cases.