### PR TITLE
Use enforced constraint in EffectivePredicateExtractor

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
@@ -208,7 +208,7 @@ public class EffectivePredicateExtractor
         {
             Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
-            TupleDomain<ColumnHandle> predicate = metadata.getTableProperties(session, node.getTable()).getPredicate();
+            TupleDomain<ColumnHandle> predicate = node.getEnforcedConstraint();
             return domainTranslator.toPredicate(predicate.simplify().transform(assignments::get));
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
@@ -208,6 +208,7 @@ public class EffectivePredicateExtractor
         {
             Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
+            // TODO: replace with metadata.getTableProperties() when table layouts are fully removed
             TupleDomain<ColumnHandle> predicate = node.getEnforcedConstraint();
             return domainTranslator.toPredicate(predicate.simplify().transform(assignments::get));
         }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
@@ -356,27 +356,29 @@ public class TestEffectivePredicateExtractor
                 makeTableHandle(TupleDomain.none()),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
-                TupleDomain.all());
+                TupleDomain.none());
         effectivePredicate = effectivePredicateExtractor.extract(SESSION, node);
         assertEquals(effectivePredicate, FALSE_LITERAL);
 
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L)));
         node = new TableScanNode(
                 newId(),
-                makeTableHandle(TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L)))),
+                makeTableHandle(predicate),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
-                TupleDomain.all());
+                predicate);
         effectivePredicate = effectivePredicateExtractor.extract(SESSION, node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(1L), AE)));
 
+        predicate = TupleDomain.withColumnDomains(ImmutableMap.of(
+                scanAssignments.get(A), Domain.singleValue(BIGINT, 1L),
+                scanAssignments.get(B), Domain.singleValue(BIGINT, 2L)));
         node = new TableScanNode(
                 newId(),
-                makeTableHandle(TupleDomain.withColumnDomains(ImmutableMap.of(
-                        scanAssignments.get(A), Domain.singleValue(BIGINT, 1L),
-                        scanAssignments.get(B), Domain.singleValue(BIGINT, 2L)))),
+                makeTableHandle(predicate),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
-                TupleDomain.all());
+                predicate);
         effectivePredicate = effectivePredicateExtractor.extract(SESSION, node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHivePartitionsTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHivePartitionsTable.java
@@ -143,6 +143,9 @@ public class TestHivePartitionsTable
         assertThat(partitionListResult).containsExactly(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
         assertColumnNames(partitionListResult, "part_col");
 
+        partitionListResult = query(format("SELECT a.part_col FROM (SELECT * FROM %s WHERE part_col = 1) a, (SELECT * FROM %s WHERE part_col = 1) b WHERE a.col = b.col", tableName, tableName));
+        assertThat(partitionListResult).containsExactly(row(1));
+
         partitionListResult = query(format("SELECT * FROM %s WHERE part_col < -10", partitionsTable));
         assertThat(partitionListResult).hasNoRows();
 


### PR DESCRIPTION
Existing `metadata.getTableProperties(session, node.getTable())` calls `partitionManager.getPartitions` with TupleDomain{ALL}. If the table partition has more than hive.max-partitions-per-scan, it throws HIVE_EXCEEDED_PARTITION_LIMIT.

Fixes https://github.com/prestosql/presto/issues/619