### PR TITLE
Remove derivation of FULL join properties

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushTopNThroughOuterJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushTopNThroughOuterJoin.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 import static io.prestosql.matching.Capture.newCapture;
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.extractCardinality;
-import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.RIGHT;
 import static io.prestosql.sql.planner.plan.Patterns.Join.type;
@@ -44,18 +43,22 @@ import static io.prestosql.sql.planner.plan.TopNNode.Step.PARTIAL;
  * Transforms:
  * <pre>
  * - TopN (partial)
- *    - Join (left, right or full)
+ *    - Join (left, right)
  *       - left source
  *       - right source
  * </pre>
  * Into:
  * <pre>
  * - Join
- *    - TopN (present if Join is left or outer, not already limited, and orderBy symbols come from left source)
+ *    - TopN (present if Join is left, not already limited, and orderBy symbols come from left source)
  *       - left source
- *    - TopN (present if Join is right or outer, not already limited, and orderBy symbols come from right source)
+ *    - TopN (present if Join is right, not already limited, and orderBy symbols come from right source)
  *       - right source
  * </pre>
+ * <p>
+ * <p>
+ * TODO: this Rule violates the expectation that Rule transformations must preserve the semantics of the
+ * expression subtree. It works only because it's a PARTIAL TopN, so there will be a FINAL TopN that "fixes" it.
  */
 public class PushTopNThroughOuterJoin
         implements Rule<TopNNode>
@@ -65,7 +68,7 @@ public class PushTopNThroughOuterJoin
     private static final Pattern<TopNNode> PATTERN =
             topN().with(step().equalTo(PARTIAL))
                     .with(source().matching(
-                            join().capturedAs(JOIN_CHILD).with(type().matching(type -> type == LEFT || type == RIGHT || type == FULL))));
+                            join().capturedAs(JOIN_CHILD).with(type().matching(type -> type == LEFT || type == RIGHT))));
 
     @Override
     public Pattern<TopNNode> getPattern()
@@ -84,7 +87,7 @@ public class PushTopNThroughOuterJoin
         PlanNode right = joinNode.getRight();
         JoinNode.Type type = joinNode.getType();
 
-        if ((type == LEFT || type == FULL)
+        if ((type == LEFT)
                 && ImmutableSet.copyOf(left.getOutputSymbols()).containsAll(orderBySymbols)
                 && !isLimited(left, context.getLookup(), parent.getCount())) {
             return Result.ofPlanNode(
@@ -93,7 +96,7 @@ public class PushTopNThroughOuterJoin
                             right)));
         }
 
-        if ((type == RIGHT || type == FULL)
+        if ((type == RIGHT)
                 && ImmutableSet.copyOf(right.getOutputSymbols()).containsAll(orderBySymbols)
                 && !isLimited(right, context.getLookup(), parent.getCount())) {
             return Result.ofPlanNode(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
@@ -25,6 +25,7 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.limit;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.RIGHT;
 
 public class TestPushLimitThroughOuterJoin
         extends BaseRuleTest
@@ -53,6 +54,29 @@ public class TestPushLimitThroughOuterJoin
     }
 
     @Test
+    public void testPushLimitThroughRightJoin()
+    {
+        tester().assertThat(new PushLimitThroughOuterJoin())
+                .on(p -> {
+                    Symbol leftKey = p.symbol("leftKey");
+                    Symbol rightKey = p.symbol("rightKey");
+                    return p.limit(1,
+                            p.join(
+                                    RIGHT,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new EquiJoinClause(leftKey, rightKey)));
+                })
+                .matches(
+                        limit(1,
+                                join(
+                                        RIGHT,
+                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                        values("leftKey"),
+                                        limit(1, true, values("rightKey")))));
+    }
+
+    @Test
     public void testPushLimitThroughFullOuterJoin()
     {
         tester().assertThat(new PushLimitThroughOuterJoin())
@@ -66,13 +90,7 @@ public class TestPushLimitThroughOuterJoin
                                     p.values(5, rightKey),
                                     new EquiJoinClause(leftKey, rightKey)));
                 })
-                .matches(
-                        limit(1,
-                                join(
-                                        FULL,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        limit(1, true, values("leftKey")),
-                                        limit(1, true, values("rightKey")))));
+                .doesNotFire();
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
@@ -36,7 +36,7 @@ import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
 public class TestFullOuterJoinWithCoalesce
         extends BasePlanTest
 {
-    @Test
+    @Test(enabled = false) // TODO: re-enable once FULL join property derivations are re-introduced
     public void testFullOuterJoinWithCoalesce()
     {
         assertDistributedPlan(
@@ -64,7 +64,7 @@ public class TestFullOuterJoinWithCoalesce
                                         exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r"))))))));
     }
 
-    @Test
+    @Test(enabled = false) // TODO: re-enable once FULL join property derivations are re-introduced
     public void testArgumentsInDifferentOrder()
     {
         // ensure properties for full outer join are derived properly regardless of the order of arguments to coalesce, since they

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestFullJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestFullJoin.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.query;
+
+import io.prestosql.testing.MaterializedResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.query.QueryAssertions.assertContains;
+import static org.testng.Assert.assertEquals;
+
+public class TestFullJoin
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testFullJoinWithLimit()
+    {
+        MaterializedResult actual = assertions.execute(
+                "SELECT * FROM (VALUES 1, 2) AS l(v) FULL OUTER JOIN (VALUES 2, 1) AS r(v) ON l.v = r.v LIMIT 1");
+
+        assertEquals(actual.getMaterializedRows().size(), 1);
+        assertContains(assertions.execute("VALUES (1,1), (2,2)"), actual);
+
+        assertions.assertQuery(
+                "SELECT * FROM (VALUES 1, 2) AS l(v) FULL OUTER JOIN (VALUES 2) AS r(v) ON l.v = r.v " +
+                        "ORDER BY l.v NULLS FIRST " +
+                        "LIMIT 1",
+                "VALUES (1, CAST(NULL AS INTEGER))");
+
+        assertions.assertQuery(
+                "SELECT * FROM (VALUES 2) AS l(v) FULL OUTER JOIN (VALUES 1, 2) AS r(v) ON l.v = r.v " +
+                        "ORDER BY r.v NULLS FIRST " +
+                        "LIMIT 1",
+                "VALUES (CAST(NULL AS INTEGER), 1)");
+
+        assertEquals(actual.getMaterializedRows().size(), 1);
+        assertContains(assertions.execute("VALUES (1,1), (2,2)"), actual);
+    }
+}


### PR DESCRIPTION
Certain combinations of FULL OUTER JOIN queries involving coalesce()
where some of the fields in either side of the join are inferred tos
 be constants can produce bad plans due to incompatible partitionings.

Fixes https://github.com/prestosql/presto/issues/622