### PR TITLE
Simplify supporting LIMIT in JDBC connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -63,6 +63,8 @@ public interface JdbcClient
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
             throws SQLException;
 
+    boolean supportsLimit();
+
     boolean isLimitGuaranteed();
 
     void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -109,6 +109,10 @@ public class JdbcMetadata
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
+        if (!jdbcClient.supportsLimit()) {
+            return Optional.empty();
+        }
+
         if (handle.getLimit().isPresent() && handle.getLimit().getAsLong() <= limit) {
             return Optional.empty();
         }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -41,6 +41,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -246,9 +247,9 @@ public class MySqlClient
     }
 
     @Override
-    protected String applyLimit(String sql, long limit)
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return sql + " LIMIT " + limit;
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
     }
 
     @Override

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -52,6 +52,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static com.fasterxml.jackson.core.JsonFactory.Feature.CANONICALIZE_FIELD_NAMES;
 import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
@@ -173,9 +174,9 @@ public class PostgreSqlClient
     }
 
     @Override
-    protected String applyLimit(String sql, long limit)
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return sql + " LIMIT " + limit;
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
     }
 
     @Override

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -71,9 +73,9 @@ public class RedshiftClient
     }
 
     @Override
-    protected String applyLimit(String sql, long limit)
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return sql + " LIMIT " + limit;
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
     }
 
     @Override

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -148,11 +149,13 @@ public class SqlServerClient
     }
 
     @Override
-    protected String applyLimit(String sql, long limit)
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        String start = "SELECT ";
-        checkArgument(sql.startsWith(start));
-        return "SELECT TOP " + limit + " " + sql.substring(start.length());
+        return Optional.of((sql, limit) -> {
+            String start = "SELECT ";
+            checkArgument(sql.startsWith(start));
+            return "SELECT TOP " + limit + " " + sql.substring(start.length());
+        });
     }
 
     @Override


### PR DESCRIPTION
Combines `isLimitGuaranteed` and `applyLimit` into single extension
point.