### PR TITLE
Fix PagesSpatialIndexFactory reference counting

### DIFF
--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinOperator.java
@@ -30,6 +30,7 @@ import io.prestosql.operator.OperatorFactory;
 import io.prestosql.operator.PagesIndex.TestingFactory;
 import io.prestosql.operator.PagesSpatialIndex;
 import io.prestosql.operator.PagesSpatialIndexFactory;
+import io.prestosql.operator.PipelineContext;
 import io.prestosql.operator.SpatialIndexBuilderOperator.SpatialIndexBuilderOperatorFactory;
 import io.prestosql.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import io.prestosql.operator.SpatialJoinOperator.SpatialJoinOperatorFactory;
@@ -45,6 +46,7 @@ import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.TestingTaskContext;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -61,6 +63,7 @@ import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.geospatial.KdbTree.Node.newInternal;
 import static io.prestosql.geospatial.KdbTree.Node.newLeaf;
 import static io.prestosql.operator.OperatorAssertion.assertOperatorEquals;
+import static io.prestosql.operator.OperatorAssertion.toPages;
 import static io.prestosql.plugin.geospatial.GeoFunctions.stGeometryFromText;
 import static io.prestosql.plugin.geospatial.GeoFunctions.stPoint;
 import static io.prestosql.plugin.geospatial.GeometryType.GEOMETRY;
@@ -70,6 +73,7 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.sql.planner.plan.SpatialJoinNode.Type.INNER;
 import static io.prestosql.sql.planner.plan.SpatialJoinNode.Type.LEFT;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
+import static java.util.Collections.emptyIterator;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -318,6 +322,49 @@ public class TestSpatialJoinOperator
 
         // make sure we have 40 matches
         assertEquals(output.getPositionCount(), 40);
+    }
+
+    @Test(dataProvider = "testDuplicateProbeFactoryDataProvider")
+    public void testDuplicateProbeFactory(boolean createSecondaryOperators)
+            throws Exception
+    {
+        TaskContext taskContext = createTaskContext();
+        PipelineContext pipelineContext = taskContext.addPipelineContext(0, true, true, false);
+        DriverContext probeDriver = pipelineContext.addDriverContext();
+        DriverContext buildDriver = pipelineContext.addDriverContext();
+
+        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, DOUBLE))
+                .row(stPoint(0, 0), "0_0", 1.5);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(buildDriver, (build, probe, r) -> build.distance(probe) <= r.getAsDouble(), Optional.of(2), Optional.empty(), buildPages);
+
+        RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
+                .row(stPoint(0, 1), "0_1");
+        OperatorFactory firstFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), INNER, probePages.getTypes(), Ints.asList(1), 0, Optional.empty(), pagesSpatialIndexFactory);
+
+        for (int i = 0; i < 3; i++) {
+            DriverContext secondDriver = pipelineContext.addDriverContext();
+            OperatorFactory secondFactory = firstFactory.duplicate();
+            if (createSecondaryOperators) {
+                try (Operator secondOperator = secondFactory.createOperator(secondDriver)) {
+                    assertEquals(toPages(secondOperator, emptyIterator()), ImmutableList.of());
+                }
+            }
+            secondFactory.noMoreOperators();
+        }
+
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
+                .row("0_1", "0_0")
+                .build();
+        assertOperatorEquals(firstFactory, probeDriver, probePages.build(), expected);
+    }
+
+    @DataProvider
+    public Object[][] testDuplicateProbeFactoryDataProvider()
+    {
+        return new Object[][] {
+                {true},
+                {false},
+        };
     }
 
     @Test

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinOperator.java
@@ -114,7 +114,7 @@ public class TestSpatialJoinOperator
                 Integer.MAX_VALUE,
                 60L,
                 SECONDS,
-                new SynchronousQueue<Runnable>(),
+                new SynchronousQueue<>(),
                 daemonThreadsNamed("test-executor-%s"),
                 new ThreadPoolExecutor.DiscardPolicy());
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -354,4 +354,14 @@ public class TestSpatialJoins
                         "ON a.name > b.name AND ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt))",
                 "VALUES (null, 'c'), (null, 'd'), ('c', 'a'), ('c', 'b'), (null, 'empty'), (null, 'null')");
     }
+
+    @Test
+    public void testSpatialJoinOverRightJoin()
+    {
+        assertQuery("SELECT a.name, b.name, c.name " +
+                        "FROM (" + POINTS_SQL + ") AS a (latitude, longitude, name, id) " +
+                        "RIGHT JOIN (" + POINTS_SQL + ") AS b (latitude, longitude, name, id) ON a.latitude = b.latitude AND a.longitude = b.longitude AND a.latitude > 0 " +
+                        "JOIN (" + POINTS_SQL + ") AS c (latitude, longitude, name, id) ON ST_Distance(ST_Point(a.latitude, b.longitude), ST_Point(c.latitude, c.longitude)) < 1 ",
+                "VALUES ('y', 'y', 'y'), ('z', 'z', 'z')");
+    }
 }

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -118,33 +118,33 @@ public class TestSpatialJoins
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POINTS_SQL + ") AS a (latitude, longitude, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(wkt), ST_Point(longitude, latitude))",
-                "SELECT * FROM (VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z'))");
+                "VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z')");
 
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POINTS_SQL + ") AS a (latitude, longitude, name, id) JOIN (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "ON ST_Contains(ST_GeometryFromText(wkt), ST_Point(longitude, latitude))",
-                "SELECT * FROM (VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z'))");
+                "VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z')");
 
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt))",
-                "SELECT * FROM (VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('c', 'b'))");
+                "VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('c', 'b')");
 
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id) JOIN (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "ON ST_Contains(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt))",
-                "SELECT * FROM (VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('c', 'b'))");
+                "VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('c', 'b')");
 
         // Test ST_Contains(probe, build)
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS b (wkt, name, id), (" + POINTS_SQL + ") AS a (latitude, longitude, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(wkt), ST_Point(longitude, latitude))",
-                "SELECT * FROM (VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z'))");
+                "VALUES ('a', 'x'), ('b', 'y'), ('c', 'y'), ('d', 'z')");
 
         assertQuery(session, "SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(a.wkt), ST_GeometryFromText(b.wkt))",
-                "SELECT * FROM (VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('b', 'c'))");
+                "VALUES ('a', 'a'), ('b', 'b'), ('c', 'c'), ('d', 'd'), ('b', 'c')");
     }
 
     @Test
@@ -153,12 +153,12 @@ public class TestSpatialJoins
         assertQuery("SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt)) AND a.name != b.name",
-                "SELECT * FROM (VALUES ('c', 'b'))");
+                "VALUES ('c', 'b')");
 
         assertQuery("SELECT b.name, a.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id) JOIN (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "ON ST_Contains(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt)) AND a.name != b.name",
-                "SELECT * FROM (VALUES ('c', 'b'))");
+                "VALUES ('c', 'b')");
     }
 
     @Test
@@ -172,14 +172,21 @@ public class TestSpatialJoins
         assertQuery("SELECT b.name, a.name " +
                         "FROM (" + pointsX + " UNION ALL " + pointsY + ") AS a (latitude, longitude, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Contains(ST_GeometryFromText(wkt), ST_Point(longitude, latitude)) AND stateful_sleeping_sum(0.001, 100, a.id, b.id) <= 3",
-                "SELECT * FROM (VALUES ('a', 'x1'), ('a', 'x2'), ('b', 'y1'))");
+                "VALUES ('a', 'x1'), ('a', 'x2'), ('b', 'y1')");
     }
 
     private static String generatePointsSql(double minX, double minY, double maxX, double maxY, int pointCount, String prefix)
     {
-        return format("SELECT %s + n * %f, %s + n * %f, '%s' || CAST (n AS VARCHAR), n " +
-                "FROM (SELECT sequence(1, %s) as numbers) " +
-                "CROSS JOIN UNNEST (numbers) AS t(n)", minX, (maxX - minX) / pointCount, minY, (maxY - minY) / pointCount, prefix, pointCount);
+        return format(
+                "SELECT %s + n * %f, %s + n * %f, '%s' || CAST (n AS VARCHAR), n " +
+                        "FROM (SELECT sequence(1, %s) as numbers) " +
+                        "CROSS JOIN UNNEST (numbers) AS t(n)",
+                minX,
+                (maxX - minX) / pointCount,
+                minY,
+                (maxY - minY) / pointCount,
+                prefix,
+                pointCount);
     }
 
     @Test
@@ -247,19 +254,19 @@ public class TestSpatialJoins
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt)) " +
                         "   AND a.name != b.name",
-                "SELECT * FROM VALUES ('a', 'c'), ('c', 'a'), ('c', 'b'), ('b', 'c')");
+                "VALUES ('a', 'c'), ('c', 'a'), ('c', 'b'), ('b', 'c')");
 
         assertQuery("SELECT a.name, b.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id) JOIN (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "ON ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt)) " +
                         "   AND a.name != b.name",
-                "SELECT * FROM VALUES ('a', 'c'), ('c', 'a'), ('c', 'b'), ('b', 'c')");
+                "VALUES ('a', 'c'), ('c', 'a'), ('c', 'b'), ('b', 'c')");
 
         assertQuery("SELECT a.name, b.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id), (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "WHERE ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt)) " +
                         "   AND a.name < b.name",
-                "SELECT * FROM VALUES ('a', 'c'), ('b', 'c')");
+                "VALUES ('a', 'c'), ('b', 'c')");
     }
 
     @Test
@@ -271,8 +278,8 @@ public class TestSpatialJoins
     @Test
     public void testDistributedDistanceQuery()
     {
-        assertUpdate(format("CREATE TABLE distance_partitioning AS SELECT spatial_partitioning(ST_Point(x, y)) as v " +
-                "FROM (VALUES (0, 0, '0_0'), (1, 0, '1_0'), (3, 0, '3_0'), (10, 0, '10_0')) as a (x, y, name)"), 1);
+        assertUpdate("CREATE TABLE distance_partitioning AS SELECT spatial_partitioning(ST_Point(x, y)) as v " +
+                "FROM (VALUES (0, 0, '0_0'), (1, 0, '1_0'), (3, 0, '3_0'), (10, 0, '10_0')) as a (x, y, name)", 1);
 
         Session session = Session.builder(getSession())
                 .setSystemProperty(SPATIAL_PARTITIONING_TABLE_NAME, "distance_partitioning")
@@ -287,20 +294,20 @@ public class TestSpatialJoins
                         "FROM (VALUES (0, 0, '0_0'), (1, 0, '1_0'), (3, 0, '3_0'), (10, 0, '10_0')) as a (x, y, name), " +
                         "(VALUES (0, 1, '0_1'), (1, 1, '1_1'), (3, 1, '3_1'), (10, 1, '10_1')) as b (x, y, name) " +
                         "WHERE ST_Distance(ST_Point(a.x, a.y), ST_Point(b.x, b.y)) <= 1.5",
-                "SELECT * FROM VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('1_0', '0_1'), ('1_0', '1_1'), ('3_0', '3_1'), ('10_0', '10_1')");
+                "VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('1_0', '0_1'), ('1_0', '1_1'), ('3_0', '3_1'), ('10_0', '10_1')");
 
         // ST_Distance(build, probe)
         assertQuery(session, "SELECT a.name, b.name " +
                         "FROM (VALUES (0, 0, '0_0'), (1, 0, '1_0'), (3, 0, '3_0'), (10, 0, '10_0')) as a (x, y, name), " +
                         "(VALUES (0, 1, '0_1'), (1, 1, '1_1'), (3, 1, '3_1'), (10, 1, '10_1')) as b (x, y, name) " +
                         "WHERE ST_Distance(ST_Point(b.x, b.y), ST_Point(a.x, a.y)) <= 1.5",
-                "SELECT * FROM VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('1_0', '0_1'), ('1_0', '1_1'), ('3_0', '3_1'), ('10_0', '10_1')");
+                "VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('1_0', '0_1'), ('1_0', '1_1'), ('3_0', '3_1'), ('10_0', '10_1')");
 
         // radius expression
         assertQuery(session, "SELECT a.name, b.name " + "FROM (VALUES (0, 0, '0_0'), (1, 0, '1_0'), (3, 0, '3_0'), (10, 0, '10_0')) as a (x, y, name), " +
                         "(VALUES (0, 1, '0_1'), (1, 1, '1_1'), (3, 1, '3_1'), (10, 1, '10_1')) as b (x, y, name) " +
                         "WHERE ST_Distance(ST_Point(a.x, a.y), ST_Point(b.x, b.y)) <= sqrt(b.x * b.x + b.y * b.y)",
-                "SELECT * FROM VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('0_0', '3_1'), ('0_0', '10_1'), ('1_0', '1_1'), ('1_0', '3_1'), ('1_0', '10_1'), ('3_0', '3_1'), ('3_0', '10_1'), ('10_0', '10_1')");
+                "VALUES ('0_0', '0_1'), ('0_0', '1_1'), ('0_0', '3_1'), ('0_0', '10_1'), ('1_0', '1_1'), ('1_0', '3_1'), ('1_0', '10_1'), ('3_0', '3_1'), ('3_0', '10_1'), ('10_0', '10_1')");
     }
 
     @Test
@@ -317,12 +324,12 @@ public class TestSpatialJoins
         assertQuery("SELECT a.name, b.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id) LEFT JOIN (VALUES (null, 'null', 1)) AS b (wkt, name, id) " +
                         "ON ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt))",
-                "SELECT * FROM VALUES ('a', null), ('b', null), ('c', null), ('d', null), ('empty', null), ('null', null)");
+                "VALUES ('a', null), ('b', null), ('c', null), ('d', null), ('empty', null), ('null', null)");
 
         // Extra condition
         assertQuery("SELECT a.name, b.name " +
                         "FROM (" + POLYGONS_SQL + ") AS a (wkt, name, id) LEFT JOIN (" + POLYGONS_SQL + ") AS b (wkt, name, id) " +
                         "ON a.name > b.name AND ST_Intersects(ST_GeometryFromText(b.wkt), ST_GeometryFromText(a.wkt))",
-                "SELECT * FROM VALUES ('a', null), ('b', null), ('c', 'a'), ('c', 'b'), ('d', null), ('empty', null), ('null', null)");
+                "VALUES ('a', null), ('b', null), ('c', 'a'), ('c', 'b'), ('d', null), ('empty', null), ('null', null)");
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/SpatialJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SpatialJoinOperator.java
@@ -66,13 +66,13 @@ public class SpatialJoinOperator
         {
             checkArgument(joinType == INNER || joinType == LEFT, "unsupported join type: %s", joinType);
             this.operatorId = operatorId;
-            this.planNodeId = planNodeId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.joinType = joinType;
             this.probeTypes = ImmutableList.copyOf(probeTypes);
             this.probeOutputChannels = ImmutableList.copyOf(probeOutputChannels);
             this.probeGeometryChannel = probeGeometryChannel;
             this.partitionChannel = requireNonNull(partitionChannel, "partitionChannel is null");
-            this.pagesSpatialIndexFactory = pagesSpatialIndexFactory;
+            this.pagesSpatialIndexFactory = requireNonNull(pagesSpatialIndexFactory, "pagesSpatialIndexFactory is null");
         }
 
         @Override
@@ -145,14 +145,14 @@ public class SpatialJoinOperator
             Optional<Integer> partitionChannel,
             PagesSpatialIndexFactory pagesSpatialIndexFactory)
     {
-        this.operatorContext = operatorContext;
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
-        this.joinType = joinType;
+        this.joinType = requireNonNull(joinType, "joinType is null");
         this.probeTypes = ImmutableList.copyOf(probeTypes);
         this.probeOutputChannels = ImmutableList.copyOf(probeOutputChannels);
         this.probeGeometryChannel = probeGeometryChannel;
         this.partitionChannel = requireNonNull(partitionChannel, "partitionChannel is null");
-        this.pagesSpatialIndexFactory = pagesSpatialIndexFactory;
+        this.pagesSpatialIndexFactory = requireNonNull(pagesSpatialIndexFactory, "pagesSpatialIndexFactory is null");
         this.pagesSpatialIndexFuture = pagesSpatialIndexFactory.createPagesSpatialIndex();
         this.pageBuilder = new PageBuilder(ImmutableList.<Type>builder()
                 .addAll(probeOutputChannels.stream()
@@ -291,14 +291,14 @@ public class SpatialJoinOperator
     }
 
     @Override
-    public void close()
-    {
-        pagesSpatialIndexFuture = null;
-    }
-
-    @Override
     public boolean isFinished()
     {
         return finished;
+    }
+
+    @Override
+    public void close()
+    {
+        pagesSpatialIndexFuture = null;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/SpatialJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SpatialJoinOperator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getDone;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.prestosql.sql.planner.plan.SpatialJoinNode.Type.INNER;
@@ -51,6 +52,7 @@ public class SpatialJoinOperator
         private final int probeGeometryChannel;
         private final Optional<Integer> partitionChannel;
         private final PagesSpatialIndexFactory pagesSpatialIndexFactory;
+        private final ReferenceCount referenceCount;
 
         private boolean closed;
 
@@ -73,6 +75,23 @@ public class SpatialJoinOperator
             this.probeGeometryChannel = probeGeometryChannel;
             this.partitionChannel = requireNonNull(partitionChannel, "partitionChannel is null");
             this.pagesSpatialIndexFactory = requireNonNull(pagesSpatialIndexFactory, "pagesSpatialIndexFactory is null");
+            this.referenceCount = new ReferenceCount(1);
+            this.referenceCount.getFreeFuture().addListener(pagesSpatialIndexFactory::destroy, directExecutor());
+        }
+
+        private SpatialJoinOperatorFactory(SpatialJoinOperatorFactory other)
+        {
+            this.operatorId = other.operatorId;
+            this.planNodeId = other.planNodeId;
+            this.joinType = other.joinType;
+            this.probeTypes = other.probeTypes;
+            this.probeOutputChannels = other.probeOutputChannels;
+            this.probeGeometryChannel = other.probeGeometryChannel;
+            this.partitionChannel = other.partitionChannel;
+            this.pagesSpatialIndexFactory = other.pagesSpatialIndexFactory;
+            this.referenceCount = other.referenceCount;
+            this.closed = false;
+            referenceCount.retain();
         }
 
         @Override
@@ -83,6 +102,7 @@ public class SpatialJoinOperator
                     operatorId,
                     planNodeId,
                     SpatialJoinOperator.class.getSimpleName());
+            referenceCount.retain();
             return new SpatialJoinOperator(
                     operatorContext,
                     joinType,
@@ -90,7 +110,8 @@ public class SpatialJoinOperator
                     probeOutputChannels,
                     probeGeometryChannel,
                     partitionChannel,
-                    pagesSpatialIndexFactory);
+                    pagesSpatialIndexFactory,
+                    referenceCount::release);
         }
 
         @Override
@@ -100,14 +121,15 @@ public class SpatialJoinOperator
                 return;
             }
 
-            pagesSpatialIndexFactory.noMoreProbeOperators();
+            referenceCount.release();
             closed = true;
         }
 
         @Override
         public OperatorFactory duplicate()
         {
-            return new SpatialJoinOperatorFactory(operatorId, planNodeId, joinType, probeTypes, probeOutputChannels, probeGeometryChannel, partitionChannel, pagesSpatialIndexFactory);
+            checkState(!closed, "Factory is already closed");
+            return new SpatialJoinOperatorFactory(this);
         }
     }
 
@@ -119,6 +141,7 @@ public class SpatialJoinOperator
     private final int probeGeometryChannel;
     private final Optional<Integer> partitionChannel;
     private final PagesSpatialIndexFactory pagesSpatialIndexFactory;
+    private final Runnable onClose;
 
     private ListenableFuture<PagesSpatialIndex> pagesSpatialIndexFuture;
     private final PageBuilder pageBuilder;
@@ -135,6 +158,7 @@ public class SpatialJoinOperator
 
     private boolean finishing;
     private boolean finished;
+    private boolean closed;
 
     public SpatialJoinOperator(
             OperatorContext operatorContext,
@@ -143,7 +167,8 @@ public class SpatialJoinOperator
             List<Integer> probeOutputChannels,
             int probeGeometryChannel,
             Optional<Integer> partitionChannel,
-            PagesSpatialIndexFactory pagesSpatialIndexFactory)
+            PagesSpatialIndexFactory pagesSpatialIndexFactory,
+            Runnable onClose)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
@@ -153,6 +178,7 @@ public class SpatialJoinOperator
         this.probeGeometryChannel = probeGeometryChannel;
         this.partitionChannel = requireNonNull(partitionChannel, "partitionChannel is null");
         this.pagesSpatialIndexFactory = requireNonNull(pagesSpatialIndexFactory, "pagesSpatialIndexFactory is null");
+        this.onClose = requireNonNull(onClose, "onClose is null");
         this.pagesSpatialIndexFuture = pagesSpatialIndexFactory.createPagesSpatialIndex();
         this.pageBuilder = new PageBuilder(ImmutableList.<Type>builder()
                 .addAll(probeOutputChannels.stream()
@@ -204,9 +230,8 @@ public class SpatialJoinOperator
                 page = pageBuilder.build();
                 pageBuilder.reset();
             }
-            pagesSpatialIndexFactory.probeOperatorFinished();
-            pagesSpatialIndexFuture = null;
             finished = true;
+            close();
             return page;
         }
 
@@ -299,6 +324,12 @@ public class SpatialJoinOperator
     @Override
     public void close()
     {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
         pagesSpatialIndexFuture = null;
+        onClose.run();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/io/prestosql/operator/OperatorAssertion.java
@@ -163,6 +163,7 @@ public final class OperatorAssertion
     public static List<Page> toPages(OperatorFactory operatorFactory, DriverContext driverContext, List<Page> input, boolean revokeMemoryWhenAddingPages)
     {
         try (Operator operator = operatorFactory.createOperator(driverContext)) {
+            operatorFactory.noMoreOperators();
             return toPages(operator, input.iterator(), revokeMemoryWhenAddingPages);
         }
         catch (Exception e) {


### PR DESCRIPTION
Before the change, the reference accounting didn't consider the fact an
operator factory can be duplicated.

For example, after creating a new factory
`SpatialJoinOperatorFactory#duplicate` and closing one of the factories
with `noMoreOperators()` (either the original one or the new one), the
`PagesSpatialIndexFactory` would be disposed even though there can be
`SpatialJoinOperator` yet to be created.

Inspired by https://github.com/prestodb/presto/pull/12673. A different implementation though.
Fixes https://github.com/prestodb/presto/issues/12672