### PR TITLE
Support PostgreSQL array created using array internal type name

### DIFF
--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -219,13 +219,14 @@ public class PostgreSqlClient
             return ImmutableMap.of();
         }
         String sql = "" +
-                "SELECT att.attname, att.attndims " +
+                "SELECT att.attname, greatest(att.attndims, 1) AS attndims " +
                 "FROM pg_attribute att " +
+                "  JOIN pg_type attyp ON att.atttypid = attyp.oid" +
                 "  JOIN pg_class tbl ON tbl.oid = att.attrelid " +
                 "  JOIN pg_namespace ns ON tbl.relnamespace = ns.oid " +
                 "WHERE ns.nspname = ? " +
                 "AND tbl.relname = ? " +
-                "AND att.attndims > 0 ";
+                "AND attyp.typcategory = 'A' ";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, tableHandle.getSchemaName());
             statement.setString(2, tableHandle.getTableName());

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -336,9 +336,10 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testInternalArray()
     {
-        // One can declare column using internal type name for an array. Such a column is not recognized
-        // as array in Presto, because it does not have correct value in pg_attribute.attndims.
-        testUnsupportedDataType("_int4");
+        DataTypeTest.create()
+                .addRoundTrip(arrayDataType(integerDataType(), "_int4"), asList(1, 2, 3))
+                .addRoundTrip(arrayDataType(varcharDataType(), "_text"), asList("a", "b"))
+                .execute(getQueryRunner(), postgresCreateAndInsert("tpch.test_array_with_native_name"));
     }
 
     @Test


### PR DESCRIPTION
Fixing failure when selecting Postgres Array column that was created with native type name (eg: _int4)

Postgres: ```create table t (a _int4);```
Presto: ```select a from t;```
```
io.prestosql.spi.PrestoException: No array dimensions for ARRAY type: JdbcTypeHandle{jdbcType=2003, jdbcTypeName=_int4, columnSize=10, decimalDigits=0}
	at io.prestosql.plugin.postgresql.PostgreSqlClient.lambda$null$0(PostgreSqlClient.java:248)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at io.prestosql.plugin.postgresql.PostgreSqlClient.lambda$toPrestoType$1(PostgreSqlClient.java:248)
```
Explanation:
```pg_attribute.attndims``` is 0  when creating columns with the native type names 

```create table t (a _int4); --> pg_attribute.attndims = 0 for column a```
```create table t (a int[]); --> pg_attribute.attndims = 1 for column a```

Fix potential issue for https://github.com/prestosql/presto/pull/317