### PR TITLE
Skip PostgreSQL arrays declared using internal name

### DIFF
--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -235,6 +235,9 @@ public class PostgreSqlClient
             return Optional.of(timestampColumnMapping(session));
         }
         if (typeHandle.getJdbcType() == Types.ARRAY) {
+            if (!typeHandle.getArrayDimensions().isPresent()) {
+                return Optional.empty();
+            }
             JdbcTypeHandle elementTypeHandle = getArrayElementTypeHandle(session, typeHandle);
             if (elementTypeHandle.getJdbcType() == Types.VARBINARY) {
                 // PostgreSQL jdbc driver doesn't currently support array of varbinary (bytea[])
@@ -244,8 +247,7 @@ public class PostgreSqlClient
             return toPrestoType(session, elementTypeHandle)
                     .map(elementMapping -> {
                         ArrayType prestoArrayType = new ArrayType(elementMapping.getType());
-                        int arrayDimensions = typeHandle.getArrayDimensions()
-                                .orElseThrow(() -> new PrestoException(JDBC_ERROR, "No array dimensions for ARRAY type: " + typeHandle));
+                        int arrayDimensions = typeHandle.getArrayDimensions().get();
                         for (int i = 1; i < arrayDimensions; i++) {
                             prestoArrayType = new ArrayType(prestoArrayType);
                         }

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -282,6 +282,14 @@ public class TestPostgreSqlTypeMapping
     }
 
     @Test
+    public void testInternalArray()
+    {
+        // One can declare column using internal type name for an array. Such a column is not recognized
+        // as array in Presto, because it does not have correct value in pg_attribute.attndims.
+        testUnsupportedDataType("_int4");
+    }
+
+    @Test
     public void testArrayEmptyOrNulls()
     {
         DataTypeTest.create()


### PR DESCRIPTION
Before the change, Presto would fail to list columns of a table
containing such a column.

Alternative to https://github.com/prestosql/presto/pull/659

cc @guyco33 @vincentpoon 
