### PR TITLE
Hide support for PostgreSQL arrays behind a config switch

### DIFF
--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>joda-time</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlConfig.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlConfig.java
@@ -13,22 +13,30 @@
  */
 package io.prestosql.plugin.postgresql;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.Scopes;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig;
-import io.prestosql.plugin.jdbc.JdbcClient;
+import io.airlift.configuration.Config;
 
-import static io.airlift.configuration.ConfigBinder.configBinder;
+import javax.validation.constraints.NotNull;
 
-public class PostgreSqlClientModule
-        implements Module
+public class PostgreSqlConfig
 {
-    @Override
-    public void configure(Binder binder)
+    private ArrayMapping arrayMapping = ArrayMapping.DISABLED;
+
+    public enum ArrayMapping {
+        DISABLED,
+        @Deprecated // TODO https://github.com/prestosql/presto/issues/682
+        AS_ARRAY,
+    }
+
+    @NotNull
+    public ArrayMapping getArrayMapping()
     {
-        binder.bind(JdbcClient.class).to(PostgreSqlClient.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(BaseJdbcConfig.class);
-        configBinder(binder).bindConfig(PostgreSqlConfig.class);
+        return arrayMapping;
+    }
+
+    @Config("postgresql.experimental.array-mapping")
+    public PostgreSqlConfig setArrayMapping(ArrayMapping arrayMapping)
+    {
+        this.arrayMapping = arrayMapping;
+        return this;
     }
 }

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.postgresql;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestPostgreSqlConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(PostgreSqlConfig.class)
+                .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("postgresql.experimental.array-mapping", "AS_ARRAY")
+                .build();
+
+        PostgreSqlConfig expected = new PostgreSqlConfig()
+                .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -56,6 +56,13 @@ public class TestPostgreSqlDistributedQueries
     }
 
     @Override
+    protected boolean supportsArrays()
+    {
+        // Arrays are supported conditionally. Check the defaults.
+        return new PostgreSqlConfig().getArrayMapping() != PostgreSqlConfig.ArrayMapping.DISABLED;
+    }
+
+    @Override
     public void testCommentTable()
     {
         // PostgreSQL connector currently does not support comment on table

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -85,7 +85,7 @@ public class TestPostgreSqlTypeMapping
 
     private TestPostgreSqlTypeMapping(TestingPostgreSqlServer postgreSqlServer)
     {
-        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of(), ImmutableList.of()));
+        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of("postgresql.experimental.array-mapping", "AS_ARRAY"), ImmutableList.of()));
         this.postgreSqlServer = postgreSqlServer;
     }
 


### PR DESCRIPTION
As we want to replace existing mapping with something more suitable (https://github.com/prestosql/presto/issues/682), the
first step is to provide a config toggle that will help during
transition period.