### PR TITLE
Update Hadoop Linux-amd64 libraries to use glibc 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
             <dependency>
                 <groupId>io.prestosql.hadoop</groupId>
                 <artifactId>hadoop-apache</artifactId>
-                <version>3.2.0-1</version>
+                <version>3.2.0-2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Depends on https://github.com/prestosql/presto-hadoop-apache/pull/6