### PR TITLE
Update to Airlift 0.181

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.180</dep.airlift.version>
+        <dep.airlift.version>0.181</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.36</dep.slice.version>
         <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>

--- a/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
@@ -96,7 +96,7 @@ public class PrestoServer
                 new DiscoveryModule(),
                 new HttpServerModule(),
                 new JsonModule(),
-                new JaxrsModule(true),
+                new JaxrsModule(),
                 new MBeanModule(),
                 new PrefixObjectNameGeneratorModule("io.prestosql"),
                 new JmxModule(),

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -217,7 +217,7 @@ public class TestingPrestoServer
                 .add(new TestingNodeModule(Optional.ofNullable(environment)))
                 .add(new TestingHttpServerModule(parseInt(coordinator ? coordinatorPort : "0")))
                 .add(new JsonModule())
-                .add(new JaxrsModule(true))
+                .add(new JaxrsModule())
                 .add(new MBeanModule())
                 .add(new TestingJmxModule())
                 .add(new EventModule())

--- a/presto-main/src/test/java/io/prestosql/failuredetector/TestHeartbeatFailureDetector.java
+++ b/presto-main/src/test/java/io/prestosql/failuredetector/TestHeartbeatFailureDetector.java
@@ -61,7 +61,7 @@ public class TestHeartbeatFailureDetector
                 new TestingHttpServerModule(),
                 new TraceTokenModule(),
                 new JsonModule(),
-                new JaxrsModule(true),
+                new JaxrsModule(),
                 new FailureDetectorModule(),
                 new Module()
                 {

--- a/presto-proxy/src/main/java/io/prestosql/proxy/PrestoProxy.java
+++ b/presto-proxy/src/main/java/io/prestosql/proxy/PrestoProxy.java
@@ -37,7 +37,7 @@ public final class PrestoProxy
                 .add(new NodeModule())
                 .add(new HttpServerModule())
                 .add(new JsonModule())
-                .add(new JaxrsModule(true))
+                .add(new JaxrsModule())
                 .add(new MBeanModule())
                 .add(new JmxModule())
                 .add(new LogJmxModule())

--- a/presto-proxy/src/test/java/io/prestosql/proxy/TestProxyServer.java
+++ b/presto-proxy/src/test/java/io/prestosql/proxy/TestProxyServer.java
@@ -85,7 +85,7 @@ public class TestProxyServer
                 new TestingNodeModule("test"),
                 new TestingHttpServerModule(),
                 new JsonModule(),
-                new JaxrsModule(true),
+                new JaxrsModule(),
                 new TestingJmxModule(),
                 new ProxyModule());
 

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/backup/TestHttpBackupStore.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/backup/TestHttpBackupStore.java
@@ -63,7 +63,7 @@ public class TestHttpBackupStore
                 new TestingNodeModule(),
                 new TestingHttpServerModule(),
                 new JsonModule(),
-                new JaxrsModule(true),
+                new JaxrsModule(),
                 binder -> jaxrsBinder(binder).bind(TestingHttpBackupResource.class),
                 binder -> binder.bind(NodeManager.class).toInstance(new TestingNodeManager()),
                 override(new HttpBackupModule()).with(new TestingModule()));


### PR DESCRIPTION
This fixes JAX-RS warnings on Java 9 and allows configuring the HTTP
max response header size which is needed for large prepared statements.