### PR TITLE
Set default Metastore recording duration to 10m

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -150,7 +150,7 @@ public class HiveConfig
 
     private String recordingPath;
     private boolean replay;
-    private Duration recordingDuration = new Duration(0, MINUTES);
+    private Duration recordingDuration = new Duration(10, MINUTES);
     private boolean s3SelectPushdownEnabled;
     private int s3SelectPushdownMaxConnections = 500;
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -111,7 +111,7 @@ public class TestHiveConfig
                 .setPartitionStatisticsSampleSize(100)
                 .setIgnoreCorruptedStatistics(false)
                 .setRecordingPath(null)
-                .setRecordingDuration(new Duration(0, TimeUnit.MINUTES))
+                .setRecordingDuration(new Duration(10, TimeUnit.MINUTES))
                 .setReplay(false)
                 .setCollectColumnStatisticsOnWrite(false)
                 .setS3SelectPushdownEnabled(false)


### PR DESCRIPTION
Metastore recorder is disabled by default and enabled
only when hive.metastore-recording-path is set
to non-null value. When enablind it should
have a resonable default recording duration set.