### PR TITLE
Fix incorrect plan for implicit GROUP BY with HAVING

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -1654,7 +1654,7 @@ class StatementAnalyzer
                 return expressions;
             }
 
-            if (hasAggregates(node)) {
+            if (hasAggregates(node) || node.getHaving().isPresent()) {
                 analysis.setGroupByExpressions(node, ImmutableList.of());
             }
 
@@ -1911,8 +1911,6 @@ class StatementAnalyzer
                     .collect(toImmutableList()));
 
             toExtractBuilder.addAll(getSortItemsFromOrderBy(node.getOrderBy()));
-
-            node.getHaving().ifPresent(toExtractBuilder::add);
 
             List<FunctionCall> aggregates = extractAggregateFunctions(toExtractBuilder.build(), metadata.getFunctionRegistry());
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestHaving.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestHaving.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.assertions.BasePlanTest;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.globalAggregation;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestHaving
+        extends BasePlanTest
+{
+    @Test
+    public void testImplicitGroupBy()
+    {
+        assertPlan(
+                "SELECT 'a' FROM (VALUES 1, 1, 2) t(a) HAVING true",
+                anyTree(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                AggregationNode.Step.SINGLE,
+                                values())));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestHaving.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestHaving.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.query;
+
+import org.testng.annotations.Test;
+
+public class TestHaving
+{
+    @Test
+    public void testImplicitGroupBy()
+    {
+        try (QueryAssertions queryAssertions = new QueryAssertions()) {
+            queryAssertions
+                    .assertQuery(
+                            "SELECT 'x' FROM (VALUES 1, 1, 2) t(a) HAVING true",
+                            "VALUES 'x'");
+        }
+    }
+}


### PR DESCRIPTION
Per the SQL spec,

  1) Let HC be the <having clause>. Let TE be the <table expression> that immediately
     contains HC. If TE does not immediately contain a <group by clause>, then “GROUP BY ()”
     is implicit.