### PR TITLE
Simplify startup of product tests containers

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -81,11 +81,8 @@ function cleanup() {
   # In most cases after the docker containers are stopped, logs processes must be terminated.
   # However when the `LEAVE_CONTAINERS_ALIVE_ON_EXIT` is set, docker containers are not being terminated.
   # Redirection of system error is supposed to hide the `process does not exist` and `process terminated` messages
-  if test ! -z ${HADOOP_LOGS_PID:-}; then
-    kill ${HADOOP_LOGS_PID} 2>/dev/null || true
-  fi
-  if test ! -z ${PRESTO_LOGS_PID:-}; then
-    kill ${PRESTO_LOGS_PID} 2>/dev/null || true
+  if test ! -z ${DOCKER_COMPOSE_LOGS_PID:-}; then
+    kill ${DOCKER_COMPOSE_LOGS_PID} 2>/dev/null || true
   fi
 
   # docker logs processes are being terminated as soon as docker container are stopped
@@ -117,15 +114,6 @@ if [[ ! -f "$DOCKER_CONF_LOCATION/$ENVIRONMENT/compose.sh" ]]; then
   usage
 fi
 
-PRESTO_SERVICES="presto-master"
-if [[ "$ENVIRONMENT" == "multinode" ]]; then
-   PRESTO_SERVICES="${PRESTO_SERVICES} presto-worker"
-elif [[ "$ENVIRONMENT" == "multinode-tls" ]]; then
-   PRESTO_SERVICES="${PRESTO_SERVICES} presto-worker-1 presto-worker-2"
-elif [[ "$ENVIRONMENT" == "multinode-tls-kerberos" ]]; then
-   PRESTO_SERVICES="${PRESTO_SERVICES} presto-worker-1 presto-worker-2"
-fi
-
 # check docker and docker compose installation
 docker-compose version
 docker version
@@ -143,38 +131,12 @@ fi
 # catch terminate signals
 trap terminate INT TERM EXIT
 
-if [[ "$ENVIRONMENT" == "singlenode-sqlserver" ]]; then
-  EXTERNAL_SERVICES="hadoop-master sqlserver"
-elif [[ "$ENVIRONMENT" == "singlenode-ldap" ]]; then
-  EXTERNAL_SERVICES="hadoop-master ldapserver"
-elif [[ "$ENVIRONMENT" == "singlenode-mysql" ]]; then
-  EXTERNAL_SERVICES="hadoop-master mysql"
-elif [[ "$ENVIRONMENT" == "singlenode-postgresql" ]]; then
-  EXTERNAL_SERVICES="hadoop-master postgres"
-elif [[ "$ENVIRONMENT" == "singlenode-cassandra" ]]; then
-  EXTERNAL_SERVICES="hadoop-master cassandra"
-elif [[ "$ENVIRONMENT" == "singlenode-kafka" ]]; then
-  EXTERNAL_SERVICES="hadoop-master kafka"
-else
-  EXTERNAL_SERVICES="hadoop-master"
-fi
-
 # display how test environment is configured
 environment_compose config
 
-environment_compose up -d ${EXTERNAL_SERVICES}
-
-# start docker logs for the external services
-environment_compose logs --no-color -f ${EXTERNAL_SERVICES} &
-
-HADOOP_LOGS_PID=$!
-
-# start presto containers
-environment_compose up -d ${PRESTO_SERVICES}
-
-# start docker logs for presto containers
-environment_compose logs --no-color -f ${PRESTO_SERVICES} &
-PRESTO_LOGS_PID=$!
+environment_compose up -d
+environment_compose logs --no-color -f &
+DOCKER_COMPOSE_LOGS_PID=$!
 
 # wait until hadoop processes are started
 retry check_hadoop


### PR DESCRIPTION
Previously we would start the services in two batches:
- `EXTERNAL_SERVICES`
- `PRESTO_SERVICES`

It requires knowledge what exactly are the services in the
`run_on_docker.sh` script. Moreover, this is unnecessary.