### PR TITLE
Allow simplified OFFSET syntax

### DIFF
--- a/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
@@ -149,7 +149,7 @@ property
 queryNoWith:
       queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
-      (OFFSET offset=INTEGER_VALUE (ROW | ROWS))?
+      (OFFSET offset=INTEGER_VALUE (ROW | ROWS)?)?
       ((LIMIT limit=(INTEGER_VALUE | ALL)) | (FETCH (FIRST | NEXT) (fetchFirst=INTEGER_VALUE)? (ROW | ROWS) ONLY))?
     ;
 

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
@@ -946,11 +946,37 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty()));
 
+        assertStatement("SELECT * FROM table1 OFFSET 2",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(new Offset("2")),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
         Query valuesQuery = query(values(
                 row(new LongLiteral("1"), new StringLiteral("1")),
                 row(new LongLiteral("2"), new StringLiteral("2"))));
 
         assertStatement("SELECT * FROM (VALUES (1, '1'), (2, '2')) OFFSET 2 ROWS",
+                simpleQuery(selectList(new AllColumns()),
+                        subquery(valuesQuery),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new Offset("2")),
+                        Optional.empty()));
+
+        assertStatement("SELECT * FROM (VALUES (1, '1'), (2, '2')) OFFSET 2",
                 simpleQuery(selectList(new AllColumns()),
                         subquery(valuesQuery),
                         Optional.empty(),


### PR DESCRIPTION
This change allows using simplified syntax
`OFFSET x`
instead of
`OFFSET x ROW/ROWS`