### PR TITLE
Wrap aggregated memory context in InternalAggregatedMemoryContext

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/DriverContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/DriverContext.java
@@ -278,7 +278,7 @@ public class DriverContext
         }
     }
 
-    public long getPphysicalWrittenDataSize()
+    public long getPhysicalWrittenDataSize()
     {
         return operatorContexts.stream()
                 .mapToLong(OperatorContext::getPhysicalWrittenDataSize)

--- a/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorContext.java
@@ -675,7 +675,7 @@ public class OperatorContext
         @Override
         public AggregatedMemoryContext newAggregatedMemoryContext()
         {
-            return delegate.newAggregatedMemoryContext();
+            return new InternalAggregatedMemoryContext(delegate.newAggregatedMemoryContext(), memoryFuture, allocationListener, true);
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
@@ -324,7 +324,7 @@ public class PipelineContext
     public long getPhysicalWrittenDataSize()
     {
         return drivers.stream()
-                .mapToLong(DriverContext::getPphysicalWrittenDataSize)
+                .mapToLong(DriverContext::getPhysicalWrittenDataSize)
                 .sum();
     }
 


### PR DESCRIPTION
Otherwise peak memory accounting could be leaking if child aggregated memory context is used