### PR TITLE
Add support for fractional weights in approx_percentile

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -182,29 +182,29 @@ Approximate Aggregate Functions
 .. function:: approx_percentile(x, w, percentage) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
-    using the per-item weight ``w`` at the percentage ``p``. The weight must be
-    an integer value of at least one. It is effectively a replication count for
-    the value ``x`` in the percentile set. The value of ``p`` must be between
-    zero and one and must be constant for all input rows.
+    using the per-item weight ``w`` at the percentage ``p``. Weights must be
+    strictly positive. Integer-value weights can be thought of as a replication
+    count for the value ``x`` in the percentile set. The value of ``p`` must be
+    between zero and one and must be constant for all input rows.
 
 .. function:: approx_percentile(x, w, percentage, accuracy) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
     using the per-item weight ``w`` at the percentage ``p``, with a maximum rank
-    error of ``accuracy``. The weight must be an integer value of at least one.
-    It is effectively a replication count for the value ``x`` in the percentile
-    set. The value of ``p`` must be between zero and one and must be constant
-    for all input rows. ``accuracy`` must be a value greater than zero and less
-    than one, and it must be constant for all input rows.
+    error of ``accuracy``. Weights must be strictly positive. Integer-value
+    weights can be thought of as a replication count for the value ``x`` in the
+    percentile set. The value of ``p`` must be between zero and one and must be
+    constant for all input rows. ``accuracy`` must be a value greater than zero
+    and less than one, and it must be constant for all input rows.
 
 .. function:: approx_percentile(x, w, percentages) -> array<[same as x]>
 
     Returns the approximate weighed percentile for all input values of ``x``
     using the per-item weight ``w`` at each of the given percentages specified
-    in the array. The weight must be an integer value of at least one. It is
-    effectively a replication count for the value ``x`` in the percentile set.
-    Each element of the array must be between zero and one, and the array must
-    be constant for all input rows.
+    in the array. Weights must be strictly positive. Integer-value weights can
+    be thought of as a replication count for the value ``x`` in the percentile
+    set. Each element of the array must be between zero and one, and the array
+    must be constant for all input rows.
 
 .. function:: approx_set(x) -> HyperLogLog
     :noindex:

--- a/presto-docs/src/main/sphinx/release/release-310.rst
+++ b/presto-docs/src/main/sphinx/release/release-310.rst
@@ -16,6 +16,7 @@ General Changes
   Simple select queries of type ``SELECT ... FROM table ORDER BY cols LIMIT n`` can
   experience significant CPU and performance improvement. (:issue:`602`)
 * Add support for ``FETCH FIRST`` syntax. (:issue:`666`)
+* Add support for fractional weights in ``approx_percentile``. (:issue:`758`)
 
 CLI Changes
 -----------

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -54,6 +54,19 @@ public final class ApproximateDoublePercentileAggregations
         ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile, accuracy);
     }
 
+    // #758 -- weight can be double as well as long
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile);
+    }
+
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile, accuracy);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileState state, DigestAndPercentileState otherState)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -48,6 +48,13 @@ public final class ApproximateDoublePercentileArrayAggregations
         ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
     }
 
+    // #758 -- fractional weights
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -62,6 +62,19 @@ public final class ApproximateLongPercentileArrayAggregations
         state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
     }
 
+    // #758 -- fractional weights
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        initializePercentilesArray(state, percentilesArrayBlock);
+        initializeDigest(state);
+
+        QuantileDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value, weight);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileAggregations.java
@@ -56,6 +56,19 @@ public class ApproximateRealPercentileAggregations
         ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile, accuracy);
     }
 
+    // #758 -- weight can be double as well as long
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile);
+    }
+
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile, accuracy);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileState state, @AggregationState DigestAndPercentileState otherState)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -50,6 +50,13 @@ public class ApproximateRealPercentileArrayAggregations
         ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
     }
 
+    // #758 -- fractional weights
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileArrayState state, @AggregationState DigestAndPercentileArrayState otherState)
     {

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -43,6 +43,8 @@ public class TestApproximatePercentileAggregation
             new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
 
@@ -50,6 +52,8 @@ public class TestApproximatePercentileAggregation
             new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+    private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
 
@@ -69,6 +73,9 @@ public class TestApproximatePercentileAggregation
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
                     ImmutableList.of(REAL.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature())));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
+                    ImmutableList.of(REAL.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
                     ImmutableList.of(REAL.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
@@ -178,11 +185,27 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(1L, 1L, 1L),
                 createRLEBlock(0.5, 3));
 
+        // #758 -- fractional weights
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION,
+                2L,
+                createLongsBlock(1L, 2L, 3L),
+                createDoublesBlock(0.1, 0.1, 0.1),
+                createRLEBlock(0.5, 3));
+
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 3L,
                 createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 17));
+
+        // #758 -- fractional weights
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION,
+                3L,
+                createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 17));
 
         assertAggregation(
@@ -321,6 +344,14 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
                 createRLEBlock(0.5, 17));
 
+        // #758 -- fractional weights
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION,
+                3.0f,
+                createBlockOfReals(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
+                createRLEBlock(0.5, 17));
+
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY,
                 9900.0f,
@@ -443,6 +474,13 @@ public class TestApproximatePercentileAggregation
                 3.0,
                 createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 17));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_FRACTIONAL_WEIGHTED_AGGREGATION,
+                3.0,
+                createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 17));
 
         assertAggregation(

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -714,7 +714,9 @@ public abstract class AbstractTestQueries
                 "   approx_percentile(orderkey, 0.5), " +
                 "   approx_percentile(totalprice, 0.5)," +
                 "   approx_percentile(orderkey, 2, 0.5)," +
-                "   approx_percentile(totalprice, 2, 0.5)\n" +
+                "   approx_percentile(totalprice, 2, 0.5)," +
+                "   approx_percentile(orderkey, .2, 0.5)," +
+                "   approx_percentile(totalprice, .2, 0.5)\n" +
                 "FROM orders\n" +
                 "GROUP BY orderstatus");
 
@@ -724,6 +726,8 @@ public abstract class AbstractTestQueries
             Double totalPrice = (Double) row.getField(2);
             Long orderKeyWeighted = ((Number) row.getField(3)).longValue();
             Double totalPriceWeighted = (Double) row.getField(4);
+            Long orderKeyFractionalWeighted = ((Number) row.getField(5)).longValue();
+            Double totalPriceFractionalWeighted = (Double) row.getField(6);
 
             List<Long> orderKeys = Ordering.natural().sortedCopy(orderKeyByStatus.get(status));
             List<Double> totalPrices = Ordering.natural().sortedCopy(totalPriceByStatus.get(status));
@@ -735,11 +739,17 @@ public abstract class AbstractTestQueries
             assertTrue(orderKeyWeighted >= orderKeys.get((int) (0.49 * orderKeys.size())));
             assertTrue(orderKeyWeighted <= orderKeys.get((int) (0.51 * orderKeys.size())));
 
+            assertTrue(orderKeyFractionalWeighted >= orderKeys.get((int) (0.49 * orderKeys.size())));
+            assertTrue(orderKeyFractionalWeighted <= orderKeys.get((int) (0.51 * orderKeys.size())));
+
             assertTrue(totalPrice >= totalPrices.get((int) (0.49 * totalPrices.size())));
             assertTrue(totalPrice <= totalPrices.get((int) (0.51 * totalPrices.size())));
 
             assertTrue(totalPriceWeighted >= totalPrices.get((int) (0.49 * totalPrices.size())));
             assertTrue(totalPriceWeighted <= totalPrices.get((int) (0.51 * totalPrices.size())));
+
+            assertTrue(totalPriceFractionalWeighted >= totalPrices.get((int) (0.49 * totalPrices.size())));
+            assertTrue(totalPriceFractionalWeighted <= totalPrices.get((int) (0.51 * totalPrices.size())));
         }
     }
 


### PR DESCRIPTION
Closes #758 

A lot to change, I may have missed some things, thank you in advance for your guidance.

In particular I didn't know what/if anything needs to be updated in `./presto-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result` which currently has lines like `approx_percentile | bigint | bigint, bigint, double | aggregate | true | |`. (PS it looks like these lines should rather be in `testcases/aggregate`?)