### PR TITLE
Use precomputed hash in probe side of HashSemiJoinOperator when available

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/ChannelSet.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ChannelSet.java
@@ -71,6 +71,11 @@ public class ChannelSet
         return hash.contains(position, page, hashChannels);
     }
 
+    public boolean contains(int position, Page page, long rawHash)
+    {
+        return hash.contains(position, page, hashChannels, rawHash);
+    }
+
     public static class ChannelSetBuilder
     {
         private static final int[] HASH_CHANNELS = {0};

--- a/presto-main/src/main/java/io/prestosql/operator/GroupByHash.java
+++ b/presto-main/src/main/java/io/prestosql/operator/GroupByHash.java
@@ -73,6 +73,11 @@ public interface GroupByHash
 
     boolean contains(int position, Page page, int[] hashChannels);
 
+    default boolean contains(int position, Page page, int[] hashChannels, long rawHash)
+    {
+        return contains(position, page, hashChannels);
+    }
+
     long getRawHash(int groupyId);
 
     @VisibleForTesting

--- a/presto-main/src/main/java/io/prestosql/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/io/prestosql/operator/MultiChannelGroupByHash.java
@@ -242,6 +242,12 @@ public class MultiChannelGroupByHash
     public boolean contains(int position, Page page, int[] hashChannels)
     {
         long rawHash = hashStrategy.hashRow(position, page);
+        return contains(position, page, hashChannels, rawHash);
+    }
+
+    @Override
+    public boolean contains(int position, Page page, int[] hashChannels, long rawHash)
+    {
         int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for a slot containing this key

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -2091,6 +2091,7 @@ public class LocalExecutionPlanner
             int buildChannel = buildSource.getLayout().get(node.getFilteringSourceJoinSymbol());
 
             Optional<Integer> buildHashChannel = node.getFilteringSourceHashSymbol().map(channelGetter(buildSource));
+            Optional<Integer> probeHashChannel = node.getSourceHashSymbol().map(channelGetter(probeSource));
 
             SetBuilderOperatorFactory setBuilderOperatorFactory = new SetBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),
@@ -2117,7 +2118,7 @@ public class LocalExecutionPlanner
                     .put(node.getSemiJoinOutput(), probeSource.getLayout().size())
                     .build();
 
-            HashSemiJoinOperatorFactory operator = new HashSemiJoinOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel);
+            HashSemiJoinOperatorFactory operator = new HashSemiJoinOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel, probeHashChannel);
             return new PhysicalOperation(operator, outputMappings, context, probeSource);
         }
 

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
@@ -126,12 +126,14 @@ public class TestHashSemiJoinOperator
         List<Page> probeInput = rowPagesBuilderProbe
                 .addSequencePage(10, 30, 0)
                 .build();
+        Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
         HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
                 rowPagesBuilderProbe.getTypes(),
-                0);
+                0,
+                probeHashChannel);
 
         // expected
         MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
@@ -145,6 +147,70 @@ public class TestHashSemiJoinOperator
                 .row(37L, 7L, true)
                 .row(38L, 8L, false)
                 .row(39L, 9L, false)
+                .build();
+
+        OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
+    }
+
+    @Test(dataProvider = "hashEnabledValues")
+    public void testSemiJoinOnVarcharType(boolean hashEnabled)
+    {
+        DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+
+        // build
+        OperatorContext operatorContext = driverContext.addOperatorContext(0, new PlanNodeId("test"), ValuesOperator.class.getSimpleName());
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, Ints.asList(0), VARCHAR);
+        Operator buildOperator = new ValuesOperator(operatorContext, rowPagesBuilder
+                .row("10")
+                .row("30")
+                .row("30")
+                .row("35")
+                .row("36")
+                .row("37")
+                .row("50")
+                .build());
+        SetBuilderOperatorFactory setBuilderOperatorFactory = new SetBuilderOperatorFactory(
+                1,
+                new PlanNodeId("test"),
+                rowPagesBuilder.getTypes().get(0),
+                0,
+                rowPagesBuilder.getHashChannel(),
+                10,
+                new JoinCompiler(createTestMetadataManager()));
+        Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
+
+        Driver driver = Driver.createDriver(driverContext, buildOperator, setBuilderOperator);
+        while (!driver.isFinished()) {
+            driver.process();
+        }
+
+        // probe
+        List<Type> probeTypes = ImmutableList.of(VARCHAR, BIGINT);
+        RowPagesBuilder rowPagesBuilderProbe = rowPagesBuilder(hashEnabled, Ints.asList(0), VARCHAR, BIGINT);
+        List<Page> probeInput = rowPagesBuilderProbe
+                .addSequencePage(10, 30, 0)
+                .build();
+        Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
+        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+                2,
+                new PlanNodeId("test"),
+                setBuilderOperatorFactory.getSetProvider(),
+                rowPagesBuilderProbe.getTypes(),
+                0,
+                probeHashChannel);
+
+        // expected
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+                .row("30", 0L, true)
+                .row("31", 1L, false)
+                .row("32", 2L, false)
+                .row("33", 3L, false)
+                .row("34", 4L, false)
+                .row("35", 5L, true)
+                .row("36", 6L, true)
+                .row("37", 7L, true)
+                .row("38", 8L, false)
+                .row("39", 9L, false)
                 .build();
 
         OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
@@ -217,12 +283,14 @@ public class TestHashSemiJoinOperator
         List<Page> probeInput = rowPagesBuilderProbe
                 .addSequencePage(4, 1)
                 .build();
+        Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
         HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
                 rowPagesBuilderProbe.getTypes(),
-                0);
+                0,
+                probeHashChannel);
 
         // expected
         MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
@@ -273,12 +341,14 @@ public class TestHashSemiJoinOperator
                 .row(1L)
                 .row(2L)
                 .build();
+        Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
         HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
                 rowPagesBuilderProbe.getTypes(),
-                0);
+                0,
+                probeHashChannel);
 
         // expected
         MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
@@ -330,12 +400,14 @@ public class TestHashSemiJoinOperator
                 .row(1L)
                 .row(2L)
                 .build();
+        Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
         HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
                 rowPagesBuilderProbe.getTypes(),
-                0);
+                0,
+                probeHashChannel);
 
         // expected
         MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))


### PR DESCRIPTION
fixes #766 