### PR TITLE
Copy operatorSummaries before merging stats with running drivers

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PipelineContext.java
@@ -376,6 +376,7 @@ public class PipelineContext
 
         List<DriverStats> drivers = new ArrayList<>();
 
+        TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
         Multimap<Integer, OperatorStats> runningOperators = ArrayListMultimap.create();
         for (DriverContext driverContext : driverContexts) {
             DriverStats driverStats = driverContext.getDriverStats();
@@ -412,7 +413,6 @@ public class PipelineContext
         }
 
         // merge the running operator stats into the operator summary
-        TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
         for (Entry<Integer, OperatorStats> entry : runningOperators.entries()) {
             OperatorStats current = operatorSummaries.get(entry.getKey());
             if (current == null) {


### PR DESCRIPTION
PipelineContext contains list of running Driver instances.
All fields in PipelineContext are thread safe. However
getPipelineStats and driverFinished methods modify/read
those fields multiple times, therefore they are racy.
This causes PipelineStats to be consistent only when
there are no running drivers.
When driver is finished its OperatorStats stats are
accumulated in PipelineContext map. Because of that
in previous code version getPipelineStats could double
account for DriverStats (once from accumulated fields
and once from a copy of list of running drivers).

In this PR code is changed so that PipelineContext
can only underaccount for finished driver stats.
This is more natural and less confusing as cumulative OperatorStats
of a pipeline do not exceed accumulated PipelineStats themselves.