### PR TITLE
Add semantic error information to analyze an error query in detail

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/QueryError.java
+++ b/presto-client/src/main/java/io/prestosql/client/QueryError.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Optional;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 @Immutable
@@ -28,6 +30,7 @@ public class QueryError
     private final String sqlState;
     private final int errorCode;
     private final String errorName;
+    private final Optional<String> semanticErrorName;
     private final String errorType;
     private final ErrorLocation errorLocation;
     private final FailureInfo failureInfo;
@@ -38,6 +41,7 @@ public class QueryError
             @JsonProperty("sqlState") String sqlState,
             @JsonProperty("errorCode") int errorCode,
             @JsonProperty("errorName") String errorName,
+            @JsonProperty("semanticErrorName") Optional<String> semanticErrorName,
             @JsonProperty("errorType") String errorType,
             @JsonProperty("errorLocation") ErrorLocation errorLocation,
             @JsonProperty("failureInfo") FailureInfo failureInfo)
@@ -46,6 +50,7 @@ public class QueryError
         this.sqlState = sqlState;
         this.errorCode = errorCode;
         this.errorName = errorName;
+        this.semanticErrorName = semanticErrorName;
         this.errorType = errorType;
         this.errorLocation = errorLocation;
         this.failureInfo = failureInfo;
@@ -77,6 +82,12 @@ public class QueryError
     }
 
     @JsonProperty
+    public Optional<String> getSemanticErrorName()
+    {
+        return semanticErrorName;
+    }
+
+    @JsonProperty
     public String getErrorType()
     {
         return errorType;
@@ -104,6 +115,7 @@ public class QueryError
                 .add("sqlState", sqlState)
                 .add("errorCode", errorCode)
                 .add("errorName", errorName)
+                .add("semanticErrorName", semanticErrorName.orElse(null))
                 .add("errorType", errorType)
                 .add("errorLocation", errorLocation)
                 .add("failureInfo", failureInfo)

--- a/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
@@ -29,6 +29,7 @@ import io.prestosql.server.HttpRequestSessionContext;
 import io.prestosql.server.SessionContext;
 import io.prestosql.spi.ErrorCode;
 import io.prestosql.spi.QueryId;
+import io.prestosql.sql.analyzer.SemanticErrorCode;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
@@ -428,6 +429,7 @@ public class QueuedStatementResource
                     null,
                     errorCode.getCode(),
                     errorCode.getName(),
+                    executionFailureInfo.getSemanticErrorCode().map(SemanticErrorCode::name),
                     errorCode.getType().toString(),
                     executionFailureInfo.getErrorLocation(),
                     executionFailureInfo.toFailureInfo());

--- a/presto-main/src/main/java/io/prestosql/execution/ExecutionFailureInfo.java
+++ b/presto-main/src/main/java/io/prestosql/execution/ExecutionFailureInfo.java
@@ -20,11 +20,13 @@ import io.prestosql.client.ErrorLocation;
 import io.prestosql.client.FailureInfo;
 import io.prestosql.spi.ErrorCode;
 import io.prestosql.spi.HostAddress;
+import io.prestosql.sql.analyzer.SemanticErrorCode;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,6 +45,7 @@ public class ExecutionFailureInfo
     private final List<String> stack;
     private final ErrorLocation errorLocation;
     private final ErrorCode errorCode;
+    private final Optional<SemanticErrorCode> semanticErrorCode;
     // use for transport errors
     private final HostAddress remoteHost;
 
@@ -55,6 +58,7 @@ public class ExecutionFailureInfo
             @JsonProperty("stack") List<String> stack,
             @JsonProperty("errorLocation") @Nullable ErrorLocation errorLocation,
             @JsonProperty("errorCode") @Nullable ErrorCode errorCode,
+            @JsonProperty("semanticErrorCode") Optional<SemanticErrorCode> semanticErrorCode,
             @JsonProperty("remoteHost") @Nullable HostAddress remoteHost)
     {
         requireNonNull(type, "type is null");
@@ -68,6 +72,7 @@ public class ExecutionFailureInfo
         this.stack = ImmutableList.copyOf(stack);
         this.errorLocation = errorLocation;
         this.errorCode = errorCode;
+        this.semanticErrorCode = semanticErrorCode;
         this.remoteHost = remoteHost;
     }
 
@@ -115,6 +120,12 @@ public class ExecutionFailureInfo
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    @JsonProperty
+    public Optional<SemanticErrorCode> getSemanticErrorCode()
+    {
+        return semanticErrorCode;
     }
 
     @Nullable

--- a/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
@@ -542,6 +542,7 @@ public final class SqlStageExecution
                 executionFailureInfo.getStack(),
                 executionFailureInfo.getErrorLocation(),
                 REMOTE_HOST_GONE.toErrorCode(),
+                executionFailureInfo.getSemanticErrorCode(),
                 executionFailureInfo.getRemoteHost());
     }
 


### PR DESCRIPTION
# Motivation
We want to analyze an error query which a user submits.
For example, when a user submits ```select aaa```, ```line 1:8: Column 'aaa' cannot be resolved``` returns.
In this case, we only know error code ```SYNTAX_ERROR``` and the above message.
But if we would know ```SemanticErrorCode``` from QueryError in presto client, we could investigate an error-proneness SQL query
https://github.com/prestosql/presto/blob/4d6325b661635ef61e52d420ea1bcf5006389c2f/presto-main/src/main/java/io/prestosql/sql/analyzer/SemanticErrorCode.java