### PR TITLE
Fix SHOW GRANTS when fewer than ~100 tables in Metastore

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -111,6 +111,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -1104,7 +1105,6 @@ public class MetadataManager
     public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
-        SchemaTablePrefix tablePrefix = prefix.asSchemaTablePrefix();
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
 
@@ -1112,9 +1112,13 @@ public class MetadataManager
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
             ConnectorSession connectorSession = session.toConnectorSession(catalogMetadata.getCatalogName());
-            for (CatalogName catalogName : catalogMetadata.listConnectorIds()) {
+
+            List<CatalogName> connectorIds = prefix.asQualifiedObjectName()
+                    .map(qualifiedTableName -> singletonList(catalogMetadata.getConnectorId(session, qualifiedTableName)))
+                    .orElseGet(catalogMetadata::listConnectorIds);
+            for (CatalogName catalogName : connectorIds) {
                 ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
-                grantInfos.addAll(metadata.listTablePrivileges(connectorSession, tablePrefix));
+                grantInfos.addAll(metadata.listTablePrivileges(connectorSession, prefix.asSchemaTablePrefix()));
             }
         }
         return ImmutableList.copyOf(grantInfos.build());

--- a/presto-main/src/main/java/io/prestosql/metadata/QualifiedTablePrefix.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/QualifiedTablePrefix.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.Verify.verify;
 import static io.prestosql.metadata.MetadataUtil.checkCatalogName;
 import static io.prestosql.metadata.MetadataUtil.checkSchemaName;
 import static io.prestosql.metadata.MetadataUtil.checkTableName;
@@ -105,6 +106,16 @@ public class QualifiedTablePrefix
         else {
             return new SchemaTablePrefix(schemaName.get(), tableName.get());
         }
+    }
+
+    public Optional<QualifiedObjectName> asQualifiedObjectName()
+    {
+        if (tableName.isPresent()) {
+            verify(schemaName.isPresent());
+            return Optional.of(new QualifiedObjectName(catalogName, schemaName.get(), tableName.get()));
+        }
+
+        return Optional.empty();
     }
 
     public boolean matches(QualifiedObjectName objectName)


### PR DESCRIPTION
Before the change, `SHOW GRANTS` without specifying a table could fail
with

```
io.prestosql.spi.PrestoException: information_schema.schemata table not found
	at io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore.listTablePrivileges(ThriftHiveMetastore.java:1281)
	at io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore.listTablePrivileges(BridgingHiveMetastore.java:364)
        ...
	at io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore.listTablePrivileges(SemiTransactionalHiveMetastore.java:831)
	at io.prestosql.plugin.hive.HiveMetadata.buildGrants(HiveMetadata.java:2039)
	at io.prestosql.plugin.hive.HiveMetadata.listTablePrivileges(HiveMetadata.java:2029)
	at io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listTablePrivileges(ClassLoaderSafeConnectorMetadata.java:551)
	at io.prestosql.metadata.MetadataManager.listTablePrivileges(MetadataManager.java:1117)
	at io.prestosql.metadata.MetadataListing.listTablePrivileges(MetadataListing.java:80)
	at io.prestosql.connector.informationschema.InformationSchemaPageSourceProvider.buildTablePrivileges(InformationSchemaPageSourceProvider.java:201)
	at io.prestosql.connector.informationschema.InformationSchemaPageSourceProvider.getInformationSchemaTable(InformationSchemaPageSourceProvider.java:131)
	at io.prestosql.connector.informationschema.InformationSchemaPageSourceProvider.getInternalTable(InformationSchemaPageSourceProvider.java:113)
	at io.prestosql.connector.informationschema.InformationSchemaPageSourceProvider.createPageSource(InformationSchemaPageSourceProvider.java:87)
        ...
	at io.prestosql.$gen.Presto_311_29_gc02198c____20190520_104145_1.run(Unknown Source)
        ...
Caused by: org.apache.hadoop.hive.metastore.api.NoSuchObjectException: information_schema.schemata table not found
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result$get_table_resultStandardScheme.read(ThriftHiveMetastore.java)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result$get_table_resultStandardScheme.read(ThriftHiveMetastore.java)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$get_table_result.read(ThriftHiveMetastore.java)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:86)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_get_table(ThriftHiveMetastore.java:1993)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.get_table(ThriftHiveMetastore.java:1979)
	at io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient.getTable(ThriftHiveMetastoreClient.java:141)
	at io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore.lambda$listTablePrivileges$51(ThriftHiveMetastore.java:1253)
	at io.prestosql.plugin.hive.metastore.thrift.HiveMetastoreApiStats.lambda$wrap$0(HiveMetastoreApiStats.java:42)
	at io.prestosql.plugin.hive.util.RetryDriver.run(RetryDriver.java:130)
	at io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore.listTablePrivileges(ThriftHiveMetastore.java:1251)
	... 52 more
```

This also fixes reading `information_schema.table_privileges`.