### PR TITLE
Provide possible values when conversion to enum fails

### DIFF
--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/conf/AccumuloSessionProperties.java
@@ -55,63 +55,53 @@ public final class AccumuloSessionProperties
     @Inject
     public AccumuloSessionProperties()
     {
-        PropertyMetadata<Boolean> s1 = booleanProperty(
-                OPTIMIZE_LOCALITY_ENABLED,
-                "Set to true to enable data locality for non-indexed scans. Default true.", true,
-                false);
-
-        PropertyMetadata<Boolean> s2 = booleanProperty(
-                OPTIMIZE_SPLIT_RANGES_ENABLED,
-                "Set to true to split non-indexed queries by tablet splits. Should generally be true.",
-                true, false);
-
-        PropertyMetadata<String> s3 = stringProperty(
-                SCAN_USERNAME,
-                "User to impersonate when scanning the tables. This property trumps the scan_auths table property. Default is the user in the configuration file.", null, false);
-
-        PropertyMetadata<Boolean> s4 = booleanProperty(
-                OPTIMIZE_INDEX_ENABLED,
-                "Set to true to enable usage of the secondary index on query. Default true.",
-                true,
-                false);
-
-        PropertyMetadata<Integer> s5 = integerProperty(
-                INDEX_ROWS_PER_SPLIT,
-                "The number of Accumulo row IDs that are packed into a single Presto split. Default 10000",
-                10000,
-                false);
-
-        PropertyMetadata<Double> s6 = doubleProperty(
-                INDEX_THRESHOLD,
-                "The ratio between number of rows to be scanned based on the index over the total number of rows. If the ratio is below this threshold, the index will be used. Default .2",
-                0.2,
-                false);
-
-        PropertyMetadata<Double> s7 = doubleProperty(
-                INDEX_LOWEST_CARDINALITY_THRESHOLD,
-                "The threshold where the column with the lowest cardinality will be used instead of computing an intersection of ranges in the secondary index. Secondary index must be enabled. Default .01",
-                0.01,
-                false);
-
-        PropertyMetadata<Boolean> s8 = booleanProperty(
-                INDEX_METRICS_ENABLED,
-                "Set to true to enable usage of the metrics table to optimize usage of the index. Default true",
-                true,
-                false);
-
-        PropertyMetadata<Boolean> s9 = booleanProperty(
-                INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH,
-                "Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold. Default true",
-                true,
-                false);
-
-        PropertyMetadata<Duration> s10 = durationProperty(
-                INDEX_CARDINALITY_CACHE_POLLING_DURATION,
-                "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
-                new Duration(10, MILLISECONDS),
-                false);
-
-        sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10);
+        sessionProperties = ImmutableList.of(
+                booleanProperty(
+                        OPTIMIZE_LOCALITY_ENABLED,
+                        "Set to true to enable data locality for non-indexed scans. Default true.", true,
+                        false),
+                booleanProperty(
+                        OPTIMIZE_SPLIT_RANGES_ENABLED,
+                        "Set to true to split non-indexed queries by tablet splits. Should generally be true.",
+                        true, false),
+                stringProperty(
+                        SCAN_USERNAME,
+                        "User to impersonate when scanning the tables. This property trumps the scan_auths table property. Default is the user in the configuration file.", null, false),
+                booleanProperty(
+                        OPTIMIZE_INDEX_ENABLED,
+                        "Set to true to enable usage of the secondary index on query. Default true.",
+                        true,
+                        false),
+                integerProperty(
+                        INDEX_ROWS_PER_SPLIT,
+                        "The number of Accumulo row IDs that are packed into a single Presto split. Default 10000",
+                        10000,
+                        false),
+                doubleProperty(
+                        INDEX_THRESHOLD,
+                        "The ratio between number of rows to be scanned based on the index over the total number of rows. If the ratio is below this threshold, the index will be used. Default .2",
+                        0.2,
+                        false),
+                doubleProperty(
+                        INDEX_LOWEST_CARDINALITY_THRESHOLD,
+                        "The threshold where the column with the lowest cardinality will be used instead of computing an intersection of ranges in the secondary index. Secondary index must be enabled. Default .01",
+                        0.01,
+                        false),
+                booleanProperty(
+                        INDEX_METRICS_ENABLED,
+                        "Set to true to enable usage of the metrics table to optimize usage of the index. Default true",
+                        true,
+                        false),
+                booleanProperty(
+                        INDEX_SHORT_CIRCUIT_CARDINALITY_FETCH,
+                        "Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold. Default true",
+                        true,
+                        false),
+                durationProperty(
+                        INDEX_CARDINALITY_CACHE_POLLING_DURATION,
+                        "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
+                        new Duration(10, MILLISECONDS),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/conf/AccumuloSessionProperties.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/conf/AccumuloSessionProperties.java
@@ -24,9 +24,10 @@ import java.util.List;
 
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
+import static io.prestosql.spi.session.PropertyMetadata.durationProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
-import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Class contains all session-based properties for the Accumulo connector.
@@ -104,14 +105,11 @@ public final class AccumuloSessionProperties
                 true,
                 false);
 
-        PropertyMetadata<String> s10 = new PropertyMetadata<>(
+        PropertyMetadata<Duration> s10 = durationProperty(
                 INDEX_CARDINALITY_CACHE_POLLING_DURATION,
                 "Sets the cardinality cache polling duration for short circuit retrieval of index metrics. Default 10ms",
-                VARCHAR, String.class,
-                "10ms",
-                false,
-                duration -> Duration.valueOf(duration.toString()).toString(),
-                object -> object);
+                new Duration(10, MILLISECONDS),
+                false);
 
         sessionProperties = ImmutableList.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10);
     }
@@ -153,7 +151,7 @@ public final class AccumuloSessionProperties
 
     public static Duration getIndexCardinalityCachePollingDuration(ConnectorSession session)
     {
-        return Duration.valueOf(session.getProperty(INDEX_CARDINALITY_CACHE_POLLING_DURATION, String.class));
+        return session.getProperty(INDEX_CARDINALITY_CACHE_POLLING_DURATION, Duration.class);
     }
 
     public static boolean isIndexMetricsEnabled(ConnectorSession session)

--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleConnector.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleConnector.java
@@ -30,9 +30,9 @@ import io.prestosql.spi.type.TypeSignatureParameter;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import static io.prestosql.spi.session.PropertyMetadata.durationProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.type.StandardTypes.ARRAY;
-import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -146,15 +146,11 @@ public class BlackHoleConnector
                                 .map(name -> name.toLowerCase(ENGLISH))
                                 .collect(toList())),
                         List.class::cast),
-                new PropertyMetadata<>(
+                durationProperty(
                         PAGE_PROCESSING_DELAY,
                         "Sleep duration before processing each page",
-                        VARCHAR,
-                        Duration.class,
                         new Duration(0, SECONDS),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString));
+                        false));
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -30,11 +30,11 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingParti
 import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.ERROR;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.dataSizeProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -126,27 +126,27 @@ public final class HiveSessionProperties
                         "ORC: Enable bloom filters for predicate pushdown",
                         hiveConfig.isOrcBloomFiltersEnabled(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_MAX_MERGE_DISTANCE,
                         "ORC: Maximum size of gap between two reads to merge into a single read",
                         hiveConfig.getOrcMaxMergeDistance(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_MAX_BUFFER_SIZE,
                         "ORC: Maximum size of a single read",
                         hiveConfig.getOrcMaxBufferSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_STREAM_BUFFER_SIZE,
                         "ORC: Size of buffer for streaming reads",
                         hiveConfig.getOrcStreamBufferSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_TINY_STRIPE_THRESHOLD,
                         "ORC: Threshold below which an ORC stripe or file will read in its entirety",
                         hiveConfig.getOrcTinyStripeThreshold(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_MAX_READ_BLOCK_SIZE,
                         "ORC: Soft max size of Presto blocks produced by ORC reader",
                         hiveConfig.getOrcMaxReadBlockSize(),
@@ -156,7 +156,7 @@ public final class HiveSessionProperties
                         "Experimental: ORC: Read small file segments lazily",
                         hiveConfig.isOrcLazyReadSmallRanges(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_STRING_STATISTICS_LIMIT,
                         "ORC: Maximum size of string statistics; drop if exceeding",
                         orcFileWriterConfig.getStringStatisticsLimit(),
@@ -188,12 +188,12 @@ public final class HiveSessionProperties
                         "Experimental: ORC: Level of detail in ORC validation",
                         hiveConfig.getOrcWriterValidationMode().toString(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_OPTIMIZED_WRITER_MIN_STRIPE_SIZE,
                         "Experimental: ORC: Min stripe size",
                         orcFileWriterConfig.getStripeMinSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_OPTIMIZED_WRITER_MAX_STRIPE_SIZE,
                         "Experimental: ORC: Max stripe size",
                         orcFileWriterConfig.getStripeMaxSize(),
@@ -203,7 +203,7 @@ public final class HiveSessionProperties
                         "Experimental: ORC: Max stripe row count",
                         orcFileWriterConfig.getStripeMaxRowCount(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY,
                         "Experimental: ORC: Max dictionary memory",
                         orcFileWriterConfig.getDictionaryMaxMemory(),
@@ -228,27 +228,27 @@ public final class HiveSessionProperties
                         "Parquet: Fail when scanning Parquet files with corrupted statistics",
                         hiveConfig.isFailOnCorruptedParquetStatistics(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         PARQUET_MAX_READ_BLOCK_SIZE,
                         "Parquet: Maximum size of a block to read",
                         hiveConfig.getParquetMaxReadBlockSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
                         "Parquet: Writer block size",
                         parquetFileWriterConfig.getBlockSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
                         parquetFileWriterConfig.getPageSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         MAX_SPLIT_SIZE,
                         "Max split size",
                         hiveConfig.getMaxSplitSize(),
                         true),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         MAX_INITIAL_SPLIT_SIZE,
                         "Max initial split size",
                         hiveConfig.getMaxInitialSplitSize(),
@@ -504,18 +504,5 @@ public final class HiveSessionProperties
     public static String getTemporaryStagingDirectoryPath(ConnectorSession session)
     {
         return session.getProperty(TEMPORARY_STAGING_DIRECTORY_PATH, String.class);
-    }
-
-    public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)
-    {
-        return new PropertyMetadata<>(
-                name,
-                description,
-                createUnboundedVarcharType(),
-                DataSize.class,
-                defaultValue,
-                hidden,
-                value -> DataSize.valueOf((String) value),
-                DataSize::toString);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
@@ -32,10 +32,10 @@ import static io.prestosql.plugin.hive.metastore.SortingColumn.Order.ASCENDING;
 import static io.prestosql.plugin.hive.metastore.SortingColumn.Order.DESCENDING;
 import static io.prestosql.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
+import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.TypeSignature.parseTypeSignature;
-import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -62,15 +62,12 @@ public class HiveTableProperties
                         "File system location URI for external table",
                         null,
                         false),
-                new PropertyMetadata<>(
+                enumProperty(
                         STORAGE_FORMAT_PROPERTY,
                         "Hive storage format for the table",
-                        createUnboundedVarcharType(),
                         HiveStorageFormat.class,
                         config.getHiveStorageFormat(),
-                        false,
-                        value -> HiveStorageFormat.valueOf(((String) value).toUpperCase(ENGLISH)),
-                        HiveStorageFormat::toString),
+                        false),
                 new PropertyMetadata<>(
                         PARTITIONED_BY_PROPERTY,
                         "Partition columns",

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3332,7 +3332,7 @@ public class TestHiveIntegrationSmokeTest
 
         // Test invalid property
         assertQueryFails(format("ANALYZE %s WITH (error = 1)", tableName), ".*'hive' does not support analyze property 'error'.*");
-        assertQueryFails(format("ANALYZE %s WITH (partitions = 1)", tableName), ".*Cannot convert '1' to \\Qarray(array(varchar))\\E.*");
+        assertQueryFails(format("ANALYZE %s WITH (partitions = 1)", tableName), ".*\\QCannot convert [1] to array(array(varchar))\\E.*");
         assertQueryFails(format("ANALYZE %s WITH (partitions = NULL)", tableName), ".*Invalid null value for analyze property.*");
         assertQueryFails(format("ANALYZE %s WITH (partitions = ARRAY[NULL])", tableName), ".*Invalid null value in analyze partitions property.*");
 

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -34,13 +34,14 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.dataSizeProperty;
+import static io.prestosql.spi.session.PropertyMetadata.durationProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static io.prestosql.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static java.lang.Math.min;
@@ -147,15 +148,11 @@ public final class SystemSessionProperties
                         JoinDistributionType.class,
                         featuresConfig.getJoinDistributionType(),
                         false),
-                new PropertyMetadata<>(
+                dataSizeProperty(
                         JOIN_MAX_BROADCAST_TABLE_SIZE,
                         "Maximum estimated size of a table that can be broadcast when using automatic join type selection",
-                        VARCHAR,
-                        DataSize.class,
                         featuresConfig.getJoinMaxBroadcastTableSize(),
-                        false,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
+                        false),
                 booleanProperty(
                         DISTRIBUTED_INDEX_JOIN,
                         "Distribute index joins on join keys instead of executing inline",
@@ -200,15 +197,11 @@ public final class SystemSessionProperties
                         "Scale out writers based on throughput (use minimum necessary)",
                         featuresConfig.isScaleWriters(),
                         false),
-                new PropertyMetadata<>(
+                dataSizeProperty(
                         WRITER_MIN_SIZE,
                         "Target minimum size of writer output when scaling writers",
-                        VARCHAR,
-                        DataSize.class,
                         featuresConfig.getWriterMinSize(),
-                        false,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
+                        false),
                 booleanProperty(
                         PUSH_TABLE_WRITE_THROUGH_UNION,
                         "Parallelize writes when using UNION ALL in queries that write data",
@@ -228,51 +221,31 @@ public final class SystemSessionProperties
                         "Share index join lookups and caching within a task",
                         taskManagerConfig.isShareIndexLoading(),
                         false),
-                new PropertyMetadata<>(
+                durationProperty(
                         QUERY_MAX_RUN_TIME,
                         "Maximum run time of a query (includes the queueing time)",
-                        VARCHAR,
-                        Duration.class,
                         queryManagerConfig.getQueryMaxRunTime(),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString),
-                new PropertyMetadata<>(
+                        false),
+                durationProperty(
                         QUERY_MAX_EXECUTION_TIME,
                         "Maximum execution time of a query",
-                        VARCHAR,
-                        Duration.class,
                         queryManagerConfig.getQueryMaxExecutionTime(),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString),
-                new PropertyMetadata<>(
+                        false),
+                durationProperty(
                         QUERY_MAX_CPU_TIME,
                         "Maximum CPU time of a query",
-                        VARCHAR,
-                        Duration.class,
                         queryManagerConfig.getQueryMaxCpuTime(),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString),
-                new PropertyMetadata<>(
+                        false),
+                dataSizeProperty(
                         QUERY_MAX_MEMORY,
                         "Maximum amount of distributed memory a query can use",
-                        VARCHAR,
-                        DataSize.class,
                         memoryManagerConfig.getMaxQueryMemory(),
-                        true,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
-                new PropertyMetadata<>(
+                        true),
+                dataSizeProperty(
                         QUERY_MAX_TOTAL_MEMORY,
                         "Maximum amount of distributed total memory a query can use",
-                        VARCHAR,
-                        DataSize.class,
                         memoryManagerConfig.getMaxQueryTotalMemory(),
-                        true,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
+                        true),
                 booleanProperty(
                         RESOURCE_OVERCOMMIT,
                         "Use resources which are not guaranteed to be available to the query",
@@ -293,15 +266,11 @@ public final class SystemSessionProperties
                         "The number of splits each node will run per task, initially",
                         taskManagerConfig.getInitialSplitsPerNode(),
                         false),
-                new PropertyMetadata<>(
+                durationProperty(
                         SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL,
                         "Experimental: Interval between changes to the number of concurrent splits per node",
-                        VARCHAR,
-                        Duration.class,
                         taskManagerConfig.getSplitConcurrencyAdjustmentInterval(),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString),
+                        false),
                 booleanProperty(
                         OPTIMIZE_METADATA_QUERIES,
                         "Enable optimization for metadata queries",
@@ -395,15 +364,11 @@ public final class SystemSessionProperties
                         "Spill in WindowOperator if spill_enabled is also set",
                         featuresConfig.isSpillWindowOperator(),
                         false),
-                new PropertyMetadata<>(
+                dataSizeProperty(
                         AGGREGATION_OPERATOR_UNSPILL_MEMORY_LIMIT,
                         "Experimental: How much memory can should be allocated per aggragation operator in unspilling process",
-                        VARCHAR,
-                        DataSize.class,
                         featuresConfig.getAggregationOperatorUnspillMemoryLimit(),
-                        false,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
+                        false),
                 booleanProperty(
                         OPTIMIZE_DISTINCT_AGGREGATIONS,
                         "Optimize mixed non-distinct and distinct aggregations",
@@ -414,15 +379,11 @@ public final class SystemSessionProperties
                         "Experimental: enable iterative optimizer",
                         featuresConfig.isIterativeOptimizerEnabled(),
                         false),
-                new PropertyMetadata<>(
+                durationProperty(
                         ITERATIVE_OPTIMIZER_TIMEOUT,
                         "Timeout for plan optimization in iterative optimizer",
-                        VARCHAR,
-                        Duration.class,
                         featuresConfig.getIterativeOptimizerTimeout(),
-                        false,
-                        value -> Duration.valueOf((String) value),
-                        Duration::toString),
+                        false),
                 booleanProperty(
                         ENABLE_FORCED_EXCHANGE_BELOW_GROUP_ID,
                         "Enable a stats-based rule adding exchanges below GroupId",
@@ -463,15 +424,11 @@ public final class SystemSessionProperties
                         "Force single node output",
                         featuresConfig.isForceSingleNodeOutput(),
                         true),
-                new PropertyMetadata<>(
+                dataSizeProperty(
                         FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
                         "Experimental: Minimum output page size for filter and project operators",
-                        VARCHAR,
-                        DataSize.class,
                         featuresConfig.getFilterAndProjectMinOutputPageSize(),
-                        false,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString),
+                        false),
                 integerProperty(
                         FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT,
                         "Experimental: Minimum output page row count for filter and project operators",

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -30,11 +30,11 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -46,7 +46,6 @@ import static io.prestosql.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NO
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 
 public final class SystemSessionProperties
 {
@@ -142,18 +141,12 @@ public final class SystemSessionProperties
                         "Compute hash codes for distribution, joins, and aggregations early in query plan",
                         featuresConfig.isOptimizeHashGeneration(),
                         false),
-                new PropertyMetadata<>(
+                enumProperty(
                         JOIN_DISTRIBUTION_TYPE,
-                        format("The join method to use. Options are %s",
-                                Stream.of(JoinDistributionType.values())
-                                        .map(JoinDistributionType::name)
-                                        .collect(joining(","))),
-                        VARCHAR,
+                        "Join distribution type",
                         JoinDistributionType.class,
                         featuresConfig.getJoinDistributionType(),
-                        false,
-                        value -> JoinDistributionType.valueOf(((String) value).toUpperCase()),
-                        JoinDistributionType::name),
+                        false),
                 new PropertyMetadata<>(
                         JOIN_MAX_BROADCAST_TABLE_SIZE,
                         "Maximum estimated size of a table that can be broadcast when using automatic join type selection",
@@ -329,18 +322,12 @@ public final class SystemSessionProperties
                         "(DEPRECATED) Reorder joins to remove unnecessary cross joins. If this is set, join_reordering_strategy will be ignored",
                         null,
                         false),
-                new PropertyMetadata<>(
+                enumProperty(
                         JOIN_REORDERING_STRATEGY,
-                        format("The join reordering strategy to use. Options are %s",
-                                Stream.of(JoinReorderingStrategy.values())
-                                        .map(JoinReorderingStrategy::name)
-                                        .collect(joining(","))),
-                        VARCHAR,
+                        "Join reordering strategy",
                         JoinReorderingStrategy.class,
                         featuresConfig.getJoinReorderingStrategy(),
-                        false,
-                        value -> JoinReorderingStrategy.valueOf(((String) value).toUpperCase()),
-                        JoinReorderingStrategy::name),
+                        false),
                 new PropertyMetadata<>(
                         MAX_REORDERED_JOINS,
                         "The maximum number of joins to reorder as one group in cost-based join reordering",

--- a/presto-main/src/main/java/io/prestosql/metadata/AbstractPropertyManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/AbstractPropertyManager.java
@@ -101,7 +101,7 @@ abstract class AbstractPropertyManager
             }
             catch (SemanticException e) {
                 throw new PrestoException(propertyError,
-                        format("Invalid value for %s property '%s': Cannot convert '%s' to %s",
+                        format("Invalid value for %s property '%s': Cannot convert [%s] to %s",
                                 propertyType,
                                 property.getName(),
                                 sqlProperty.getValue(),
@@ -114,7 +114,7 @@ abstract class AbstractPropertyManager
             }
             catch (Exception e) {
                 throw new PrestoException(propertyError,
-                        format("Unable to set %s property '%s' to '%s': %s",
+                        format("Unable to set %s property '%s' to [%s]: %s",
                                 propertyType,
                                 property.getName(),
                                 sqlProperty.getValue(),

--- a/presto-main/src/main/java/io/prestosql/metadata/AbstractPropertyManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/AbstractPropertyManager.java
@@ -88,7 +88,8 @@ abstract class AbstractPropertyManager
             String propertyName = sqlProperty.getKey().toLowerCase(ENGLISH);
             PropertyMetadata<?> property = supportedProperties.get(propertyName);
             if (property == null) {
-                throw new PrestoException(propertyError,
+                throw new PrestoException(
+                        propertyError,
                         format("Catalog '%s' does not support %s property '%s'",
                                 catalog,
                                 propertyType,
@@ -100,12 +101,14 @@ abstract class AbstractPropertyManager
                 sqlObjectValue = evaluatePropertyValue(sqlProperty.getValue(), property.getSqlType(), session, metadata, parameters);
             }
             catch (SemanticException e) {
-                throw new PrestoException(propertyError,
+                throw new PrestoException(
+                        propertyError,
                         format("Invalid value for %s property '%s': Cannot convert [%s] to %s",
                                 propertyType,
                                 property.getName(),
                                 sqlProperty.getValue(),
-                                property.getSqlType()), e);
+                                property.getSqlType()),
+                        e);
             }
 
             Object value;
@@ -113,12 +116,15 @@ abstract class AbstractPropertyManager
                 value = property.decode(sqlObjectValue);
             }
             catch (Exception e) {
-                throw new PrestoException(propertyError,
-                        format("Unable to set %s property '%s' to [%s]: %s",
+                throw new PrestoException(
+                        propertyError,
+                        format(
+                                "Unable to set %s property '%s' to [%s]: %s",
                                 propertyType,
                                 property.getName(),
                                 sqlProperty.getValue(),
-                                e.getMessage()), e);
+                                e.getMessage()),
+                        e);
             }
 
             properties.put(property.getName(), value);

--- a/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliTests.java
@@ -213,14 +213,14 @@ public class PrestoCliTests
 
         presto.getProcessInput().println("show session;");
         assertThat(squeezeLines(presto.readLinesUntilPrompt()))
-                .contains("join_distribution_type|PARTITIONED|PARTITIONED|varchar|The join method to use. Options are BROADCAST,PARTITIONED,AUTOMATIC");
+                .contains("join_distribution_type|PARTITIONED|PARTITIONED|varchar|Join distribution type. Possible values: [BROADCAST, PARTITIONED, AUTOMATIC]");
 
         presto.getProcessInput().println("set session join_distribution_type = 'BROADCAST';");
         assertThat(presto.readLinesUntilPrompt()).contains("SET SESSION");
 
         presto.getProcessInput().println("show session;");
         assertThat(squeezeLines(presto.readLinesUntilPrompt()))
-                .contains("join_distribution_type|BROADCAST|PARTITIONED|varchar|The join method to use. Options are BROADCAST,PARTITIONED,AUTOMATIC");
+                .contains("join_distribution_type|BROADCAST|PARTITIONED|varchar|Join distribution type. Possible values: [BROADCAST, PARTITIONED, AUTOMATIC]");
     }
 
     @Test(groups = CLI, timeOut = TIMEOUT)

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorSessionProperties.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorSessionProperties.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.dataSizeProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
-import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 
 public class RaptorSessionProperties
 {
@@ -51,22 +51,22 @@ public class RaptorSessionProperties
                         "Two-phase commit batch ID",
                         null,
                         true),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         READER_MAX_MERGE_DISTANCE,
                         "Reader: Maximum size of gap between two reads to merge into a single read",
                         config.getOrcMaxMergeDistance(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         READER_MAX_READ_SIZE,
                         "Reader: Maximum size of a single read",
                         config.getOrcMaxReadSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         READER_STREAM_BUFFER_SIZE,
                         "Reader: Size of buffer for streaming reads",
                         config.getOrcStreamBufferSize(),
                         false),
-                dataSizeSessionProperty(
+                dataSizeProperty(
                         READER_TINY_STRIPE_THRESHOLD,
                         "Reader: Threshold below which an ORC stripe or file will read in its entirety",
                         config.getOrcTinyStripeThreshold(),
@@ -121,18 +121,5 @@ public class RaptorSessionProperties
     public static int getOneSplitPerBucketThreshold(ConnectorSession session)
     {
         return session.getProperty(ONE_SPLIT_PER_BUCKET_THRESHOLD, Integer.class);
-    }
-
-    public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)
-    {
-        return new PropertyMetadata<>(
-                name,
-                description,
-                createUnboundedVarcharType(),
-                DataSize.class,
-                defaultValue,
-                hidden,
-                value -> DataSize.valueOf((String) value),
-                DataSize::toString);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/session/PropertyMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/session/PropertyMetadata.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.session;
 
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.prestosql.spi.type.Type;
 
 import java.util.EnumSet;
@@ -224,5 +226,31 @@ public final class PropertyMetadata<T>
                     }
                 },
                 Enum::name);
+    }
+
+    public static PropertyMetadata<DataSize> dataSizeProperty(String name, String description, DataSize defaultValue, boolean hidden)
+    {
+        return new PropertyMetadata<>(
+                name,
+                description,
+                createUnboundedVarcharType(),
+                DataSize.class,
+                defaultValue,
+                hidden,
+                value -> DataSize.valueOf((String) value),
+                DataSize::toString);
+    }
+
+    public static PropertyMetadata<Duration> durationProperty(String name, String description, Duration defaultValue, boolean hidden)
+    {
+        return new PropertyMetadata<>(
+                name,
+                description,
+                createUnboundedVarcharType(),
+                Duration.class,
+                defaultValue,
+                hidden,
+                value -> Duration.valueOf((String) value),
+                Duration::toString);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/session/PropertyMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/session/PropertyMetadata.java
@@ -15,6 +15,7 @@ package io.prestosql.spi.session;
 
 import io.prestosql.spi.type.Type;
 
+import java.util.EnumSet;
 import java.util.function.Function;
 
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -22,9 +23,11 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public final class PropertyMetadata<T>
 {
@@ -198,5 +201,28 @@ public final class PropertyMetadata<T>
                 hidden,
                 String.class::cast,
                 object -> object);
+    }
+
+    public static <T extends Enum<T>> PropertyMetadata<T> enumProperty(String name, String descriptionPrefix, Class<T> type, T defaultValue, boolean hidden)
+    {
+        String allValues = EnumSet.allOf(type).stream()
+                .map(Enum::name)
+                .collect(joining(", ", "[", "]"));
+        return new PropertyMetadata<>(
+                name,
+                format("%s. Possible values: %s", descriptionPrefix, allValues),
+                createUnboundedVarcharType(),
+                type,
+                defaultValue,
+                hidden,
+                value -> {
+                    try {
+                        return Enum.valueOf(type, ((String) value).toUpperCase(ENGLISH));
+                    }
+                    catch (IllegalArgumentException e) {
+                        throw new IllegalArgumentException(format("Invalid value [%s]. Valid values: %s", value, allValues), e);
+                    }
+                },
+                Enum::name);
     }
 }


### PR DESCRIPTION
Before the change:

    presto:default> create table t (c int) with (format='TEXT');
    Query 20190520_142007_00003_43vmp failed: Unable to set table
    property 'format' to ''TEXT'': No enum constant
    io.prestosql.plugin.hive.HiveStorageFormat.TEXT

After the change:

    presto:default> create table t (c int) with (format='TEXT');
    Query 20190520_142238_00003_ezyq4 failed: Unable to set table
    property 'format' to ['TEXT']: Invalid value [TEXT]. Valid values:
    [ORC, PARQUET, AVRO, RCBINARY, RCTEXT, SEQUENCEFILE, JSON, TEXTFILE]