### PR TITLE
Convert column names read from ORC files to lower case

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
@@ -49,6 +49,7 @@ import javax.inject.Inject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -280,7 +281,8 @@ public class OrcPageSourceFactory
 
         int ordinal = 0;
         for (String physicalColumnName : reader.getColumnNames()) {
-            physicalNameOrdinalMap.put(physicalColumnName, ordinal);
+            // Convert column names read from ORC files to lower case to be consistent with those stored in Hive Metastore
+            physicalNameOrdinalMap.put(physicalColumnName.toLowerCase(Locale.ENGLISH), ordinal);
             ordinal++;
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -50,6 +50,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
@@ -302,6 +303,24 @@ public class TestHiveFileFormats
                 .withWriteColumns(TEST_COLUMNS)
                 .withRowsCount(rowCount)
                 .withReadColumns(Lists.reverse(TEST_COLUMNS))
+                .withSession(session)
+                .isReadableByPageSource(new OrcPageSourceFactory(TYPE_MANAGER, true, HDFS_ENVIRONMENT, STATS));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testOrcUseColumnNameLowerCaseConversion(int rowCount)
+            throws Exception
+    {
+        TestingConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
+
+        List<TestColumn> testColumnsUpperCase = TEST_COLUMNS.stream()
+                .map(testColumn -> new TestColumn(testColumn.getName().toUpperCase(Locale.ENGLISH), testColumn.getObjectInspector(), testColumn.getWriteValue(), testColumn.getExpectedValue(), testColumn.isPartitionKey()))
+                .collect(toList());
+
+        assertThatFileFormat(ORC)
+                .withWriteColumns(testColumnsUpperCase)
+                .withRowsCount(rowCount)
+                .withReadColumns(TEST_COLUMNS)
                 .withSession(session)
                 .isReadableByPageSource(new OrcPageSourceFactory(TYPE_MANAGER, true, HDFS_ENVIRONMENT, STATS));
     }


### PR DESCRIPTION
Do the conversion so that they are consistent with column names stored in Hive Metastore.

For issue #802 