### PR TITLE
Fix parsing of largest negative bigint value

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -1507,8 +1507,9 @@ public class TestExpressionInterpreter
     private static void assertRoundTrip(String expression)
     {
         ParsingOptions parsingOptions = createParsingOptions(TEST_SESSION);
-        assertEquals(SQL_PARSER.createExpression(expression, parsingOptions),
-                SQL_PARSER.createExpression(formatExpression(SQL_PARSER.createExpression(expression, parsingOptions), Optional.empty()), parsingOptions));
+        Expression parsed = SQL_PARSER.createExpression(expression, parsingOptions);
+        String formatted = formatExpression(parsed, Optional.empty());
+        assertEquals(parsed, SQL_PARSER.createExpression(formatted, parsingOptions));
     }
 
     private static Object evaluate(Expression expression)

--- a/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
@@ -481,9 +481,9 @@ identifier
     ;
 
 number
-    : DECIMAL_VALUE  #decimalLiteral
-    | DOUBLE_VALUE   #doubleLiteral
-    | INTEGER_VALUE  #integerLiteral
+    : MINUS? DECIMAL_VALUE  #decimalLiteral
+    | MINUS? DOUBLE_VALUE   #doubleLiteral
+    | MINUS? INTEGER_VALUE  #integerLiteral
     ;
 
 nonReserved

--- a/presto-parser/src/main/java/io/prestosql/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/ExpressionFormatter.java
@@ -484,9 +484,9 @@ public final class ExpressionFormatter
 
             switch (node.getSign()) {
                 case MINUS:
-                    // this is to avoid turning a sequence of "-" into a comment (i.e., "-- comment")
-                    String separator = value.startsWith("-") ? " " : "";
-                    return "-" + separator + value;
+                    // Unary is ambiguous with respect to negative numbers. "-1" parses as a number, but "-(1)" parses as "unaryMinus(number)"
+                    // The parentheses are needed to ensure the parsing roundtrips properly.
+                    return "-(" + value + ")";
                 case PLUS:
                     return "+" + value;
                 default:

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
@@ -74,7 +74,7 @@ public class TestSqlParserErrorHandling
                 {"select CAST(12223222232535343423232435343 AS BIGINT)",
                         "line 1:1: Invalid numeric literal: 12223222232535343423232435343"},
                 {"select CAST(-12223222232535343423232435343 AS BIGINT)",
-                        "line 1:1: Invalid numeric literal: 12223222232535343423232435343"},
+                        "line 1:1: Invalid numeric literal: -12223222232535343423232435343"},
                 {"select foo(,1)",
                         "line 1:12: mismatched input ','. Expecting: <expression>"},
                 {"select foo(DISTINCT)",


### PR DESCRIPTION
The largest negative bigint value (i.e., Long.MIN_VALUE) was previously being parsed as
-(9223372036854775808), which is a number too big to fit in a java long (the range is
[-9223372036854775808, 9223372036854775807]).  This change makes the sign part of the
number, so it is now parsed and stored properly in the syntax tree.

We also update parsing of decimal and double numbers to avoid tokens such as -123E45
or -123.45 from being interpreted as an integer (-123) with another token trailing
behind it.

Before:
```
presto> SELECT -9223372036854775808;
Query 20190522_012223_00016_zcjux failed: line 1:1: Invalid numeric literal: 9223372036854775808
```
After:

```
presto> SELECT -9223372036854775808;
        _col0
----------------------
 -9223372036854775808
(1 row)
```