### PR TITLE
Fix misleading test data

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
@@ -875,7 +875,7 @@ public abstract class TestDateTimeFunctionsBase
         assertInvalidFunction("date_parse('', '%X')", "%X not supported in date format string");
 
         assertInvalidFunction("date_parse('3.0123456789', '%s.%f')", "Invalid format: \"3.0123456789\" is malformed at \"9\"");
-        assertInvalidFunction("date_parse('%Y-%M-%d', '')", "Both printing and parsing not supported");
+        assertInvalidFunction("date_parse('1970-01-01', '')", "Both printing and parsing not supported");
     }
 
     @Test


### PR DESCRIPTION
The test was providing pattern-like varchar value for timestamp
argument, whereas it was actually testing behavior with empty pattern
argument.