### PR TITLE
Remove a not used variable

### DIFF
--- a/presto-local-file/src/main/java/io/prestosql/plugin/localfile/LocalFileSplitManager.java
+++ b/presto-local-file/src/main/java/io/prestosql/plugin/localfile/LocalFileSplitManager.java
@@ -45,7 +45,6 @@ public class LocalFileSplitManager
     public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
     {
         LocalFileTableLayoutHandle layoutHandle = (LocalFileTableLayoutHandle) layout;
-        LocalFileTableHandle tableHandle = layoutHandle.getTable();
 
         TupleDomain<LocalFileColumnHandle> effectivePredicate = layoutHandle.getConstraint()
                 .transform(LocalFileColumnHandle.class::cast);


### PR DESCRIPTION
This has not been used since 02803849787af59a4b4a0e01e7115c0084a30df3.