### PR TITLE
Push limit through union

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -85,6 +85,7 @@ import io.prestosql.sql.planner.iterative.rule.PushLimitThroughOffset;
 import io.prestosql.sql.planner.iterative.rule.PushLimitThroughOuterJoin;
 import io.prestosql.sql.planner.iterative.rule.PushLimitThroughProject;
 import io.prestosql.sql.planner.iterative.rule.PushLimitThroughSemiJoin;
+import io.prestosql.sql.planner.iterative.rule.PushLimitThroughUnion;
 import io.prestosql.sql.planner.iterative.rule.PushOffsetThroughProject;
 import io.prestosql.sql.planner.iterative.rule.PushPartialAggregationThroughExchange;
 import io.prestosql.sql.planner.iterative.rule.PushPartialAggregationThroughJoin;
@@ -314,6 +315,7 @@ public class PlanOptimizers
                                         new PushLimitThroughMarkDistinct(),
                                         new PushLimitThroughOuterJoin(),
                                         new PushLimitThroughSemiJoin(),
+                                        new PushLimitThroughUnion(),
                                         new PushLimitIntoTableScan(metadata),
                                         new PushPredicateIntoTableScan(metadata, typeAnalyzer),
                                         new RemoveTrivialFilters(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushLimitThroughUnion.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushLimitThroughUnion.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.LimitNode;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.UnionNode;
+
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isAtMost;
+import static io.prestosql.sql.planner.plan.Patterns.limit;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static io.prestosql.sql.planner.plan.Patterns.union;
+
+/**
+ * Transforms:
+ * <pre>
+ * - Limit
+ *    - Union
+ *       - relation1
+ *       - relation2
+ *       ..
+ * </pre>
+ * Into:
+ * <pre>
+ * - Limit
+ *    - Union
+ *       - Limit
+ *          - relation1
+ *       - Limit
+ *          - relation2
+ *       ..
+ * </pre>
+ */
+public class PushLimitThroughUnion
+        implements Rule<LimitNode>
+{
+    private static final Capture<UnionNode> CHILD = newCapture();
+
+    private static final Pattern<LimitNode> PATTERN =
+            limit().with(source().matching(union().capturedAs(CHILD)));
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(LimitNode parent, Captures captures, Context context)
+    {
+        UnionNode unionNode = captures.get(CHILD);
+        ImmutableList.Builder<PlanNode> builder = ImmutableList.builder();
+        boolean shouldApply = false;
+        for (PlanNode source : unionNode.getSources()) {
+            // This check is to ensure that we don't fire the optimizer if it was previously applied.
+            if (isAtMost(source, context.getLookup(), parent.getCount())) {
+                builder.add(source);
+            }
+            else {
+                shouldApply = true;
+                builder.add(new LimitNode(context.getIdAllocator().getNextId(), source, parent.getCount(), true));
+            }
+        }
+
+        if (!shouldApply) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(
+                parent.replaceChildren(ImmutableList.of(
+                        unionNode.replaceChildren(builder.build()))));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushLimitThroughUnion.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushLimitThroughUnion.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.union;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPushLimitThroughUnion
+        extends BaseRuleTest
+{
+    @Test
+    public void testPushLimitThroughUnion()
+    {
+        tester().assertThat(new PushLimitThroughUnion())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.limit(1,
+                            p.union(
+                                    ImmutableListMultimap.<Symbol, Symbol>builder()
+                                            .put(c, a)
+                                            .put(c, b)
+                                            .build(),
+                                    ImmutableList.of(
+                                            p.values(10, a),
+                                            p.values(10, b))));
+                })
+                .matches(
+                        limit(1,
+                                union(
+                                        limit(1, true, values("a")),
+                                        limit(1, true, values("b")))));
+    }
+
+    @Test
+    public void doesNotFire()
+    {
+        tester().assertThat(new PushLimitThroughUnion())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.limit(1,
+                            p.union(
+                                    ImmutableListMultimap.<Symbol, Symbol>builder()
+                                            .put(c, a)
+                                            .put(c, b)
+                                            .build(),
+                                    ImmutableList.of(
+                                            p.limit(1, p.values(5, a)),
+                                            p.limit(1, p.values(5, b)))));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Enables migrating legacy `LimitPushDownOptimizer` to rule based optimizer for `UnionNode`(#811)