### PR TITLE
Handle race in QueryStateTimer

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateTimer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateTimer.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.airlift.units.Duration.succinctNanos;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -271,7 +272,7 @@ class QueryStateTimer
 
     private static Duration nanosSince(long start, long now)
     {
-        return succinctNanos(now - start);
+        return succinctNanos(max(0, now - start));
     }
 
     private Duration getDuration(AtomicReference<Duration> finalDuration, AtomicReference<Long> start)


### PR DESCRIPTION
In rare cases two threads can attemtp to update the timing states with
different "now" times, and this can result is a negative duration.