### PR TITLE
Use ClassLoaderSafeConnectorMetadata for Phoenix connector

### DIFF
--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConnector.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConnector.java
@@ -35,7 +35,7 @@ public class PhoenixConnector
     private static final Logger log = Logger.get(PhoenixConnector.class);
 
     private final LifeCycleManager lifeCycleManager;
-    private final PhoenixMetadata metadata;
+    private final ConnectorMetadata metadata;
     private final ConnectorSplitManager splitManager;
     private final ConnectorRecordSetProvider recordSetProvider;
     private final ConnectorPageSinkProvider pageSinkProvider;
@@ -44,7 +44,7 @@ public class PhoenixConnector
 
     public PhoenixConnector(
             LifeCycleManager lifeCycleManager,
-            PhoenixMetadata metadata,
+            ConnectorMetadata metadata,
             ConnectorSplitManager splitManager,
             ConnectorRecordSetProvider recordSetProvider,
             ConnectorPageSinkProvider pageSinkProvider,

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConnectorFactory.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorRecordSetProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorMetadata;
 import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorPageSinkProvider;
 import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
 
@@ -80,7 +81,7 @@ public class PhoenixConnectorFactory
 
             return new PhoenixConnector(
                     lifeCycleManager,
-                    metadata,
+                    new ClassLoaderSafeConnectorMetadata(metadata, classLoader),
                     new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),
                     recordSetProvider,
                     new ClassLoaderSafeConnectorPageSinkProvider(pageSinkProvider, classLoader),


### PR DESCRIPTION
Forthcoming version 4.15 of Phoenix uses META-INF/services for a particular class , which needs this change to get picked up properly.