### PR TITLE
Pushdown dereference expression to Parquet reader

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveColumnHandle.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.type.TypeManager;
@@ -60,6 +61,7 @@ public class HiveColumnHandle
     private final int hiveColumnIndex;
     private final ColumnType columnType;
     private final Optional<String> comment;
+    private final Optional<NestedColumn> nestedColumn;
 
     @JsonCreator
     public HiveColumnHandle(
@@ -68,7 +70,8 @@ public class HiveColumnHandle
             @JsonProperty("typeSignature") TypeSignature typeSignature,
             @JsonProperty("hiveColumnIndex") int hiveColumnIndex,
             @JsonProperty("columnType") ColumnType columnType,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("nestedColumn") Optional<NestedColumn> nestedColumn)
     {
         this.name = requireNonNull(name, "name is null");
         checkArgument(hiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == SYNTHESIZED, "hiveColumnIndex is negative");
@@ -77,6 +80,7 @@ public class HiveColumnHandle
         this.typeName = requireNonNull(typeSignature, "type is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.comment = requireNonNull(comment, "comment is null");
+        this.nestedColumn = requireNonNull(nestedColumn, "nestedColumn is null");
     }
 
     @JsonProperty
@@ -95,6 +99,12 @@ public class HiveColumnHandle
     public int getHiveColumnIndex()
     {
         return hiveColumnIndex;
+    }
+
+    @JsonProperty
+    public Optional<NestedColumn> getNestedColumn()
+    {
+        return nestedColumn;
     }
 
     public boolean isPartitionKey()
@@ -133,7 +143,7 @@ public class HiveColumnHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, hiveColumnIndex, hiveType, columnType, comment);
+        return Objects.hash(name, hiveColumnIndex, hiveType, columnType, comment, nestedColumn);
     }
 
     @Override
@@ -150,7 +160,8 @@ public class HiveColumnHandle
                 Objects.equals(this.hiveColumnIndex, other.hiveColumnIndex) &&
                 Objects.equals(this.hiveType, other.hiveType) &&
                 Objects.equals(this.columnType, other.columnType) &&
-                Objects.equals(this.comment, other.comment);
+                Objects.equals(this.comment, other.comment) &&
+                Objects.equals(this.nestedColumn, other.nestedColumn);
     }
 
     @Override
@@ -167,12 +178,12 @@ public class HiveColumnHandle
         // plan-time support for row-by-row delete so that planning doesn't fail. This is why we need
         // rowid handle. Note that in Hive connector, rowid handle is not implemented beyond plan-time.
 
-        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, SYNTHESIZED, Optional.empty(), Optional.empty());
     }
 
     public static HiveColumnHandle pathColumnHandle()
     {
-        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -182,7 +193,7 @@ public class HiveColumnHandle
      */
     public static HiveColumnHandle bucketColumnHandle()
     {
-        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty(), Optional.empty());
     }
 
     public static boolean isPathColumnHandle(HiveColumnHandle column)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUtil.java
@@ -818,7 +818,7 @@ public final class HiveUtil
             // ignore unsupported types rather than failing
             HiveType hiveType = field.getType();
             if (hiveType.isSupportedType()) {
-                columns.add(new HiveColumnHandle(field.getName(), hiveType, hiveType.getTypeSignature(), hiveColumnIndex, REGULAR, field.getComment()));
+                columns.add(new HiveColumnHandle(field.getName(), hiveType, hiveType.getTypeSignature(), hiveColumnIndex, REGULAR, field.getComment(), Optional.empty()));
             }
             hiveColumnIndex++;
         }
@@ -836,7 +836,7 @@ public final class HiveUtil
             if (!hiveType.isSupportedType()) {
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
             }
-            columns.add(new HiveColumnHandle(field.getName(), hiveType, hiveType.getTypeSignature(), -1, PARTITION_KEY, field.getComment()));
+            columns.add(new HiveColumnHandle(field.getName(), hiveType, hiveType.getTypeSignature(), -1, PARTITION_KEY, field.getComment(), Optional.empty()));
         }
 
         return columns.build();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
@@ -261,7 +261,7 @@ public class OrcPageSourceFactory
                 physicalOrdinal = nextMissingColumnIndex;
                 nextMissingColumnIndex++;
             }
-            physicalColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), physicalOrdinal, column.getColumnType(), column.getComment()));
+            physicalColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), physicalOrdinal, column.getColumnType(), column.getComment(), column.getNestedColumn()));
         }
         return physicalColumns.build();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -63,6 +63,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.parquet.ParquetTypeUtils.getColumnIO;
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
+import static io.prestosql.parquet.ParquetTypeUtils.getNestedColumnType;
 import static io.prestosql.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static io.prestosql.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.prestosql.parquet.predicate.PredicateUtils.predicateMatches;
@@ -77,7 +78,6 @@ import static io.prestosql.plugin.hive.HiveUtil.getDeserializerClassName;
 import static io.prestosql.plugin.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 
 public class ParquetPageSourceFactory
@@ -163,13 +163,14 @@ public class ParquetPageSourceFactory
             MessageType fileSchema = fileMetaData.getSchema();
             dataSource = buildHdfsParquetDataSource(inputStream, path, fileSize, stats);
 
-            List<org.apache.parquet.schema.Type> fields = columns.stream()
+            Optional<MessageType> optionalRequestedSchema = columns.stream()
                     .filter(column -> column.getColumnType() == REGULAR)
-                    .map(column -> getParquetType(column, fileSchema, useParquetColumnNames))
+                    .map(column -> getColumnType(column, fileSchema, useParquetColumnNames))
                     .filter(Objects::nonNull)
-                    .collect(toList());
+                    .map(type -> new MessageType(fileSchema.getName(), type))
+                    .reduce(MessageType::union);
 
-            MessageType requestedSchema = new MessageType(fileSchema.getName(), fields);
+            MessageType requestedSchema = optionalRequestedSchema.orElseGet(() -> new MessageType(fileSchema.getName(), ImmutableList.of()));
 
             ImmutableList.Builder<BlockMetaData> footerBlocks = ImmutableList.builder();
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
@@ -265,5 +266,13 @@ public class ParquetPageSourceFactory
             return messageType.getType(column.getHiveColumnIndex());
         }
         return null;
+    }
+
+    public static org.apache.parquet.schema.Type getColumnType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
+    {
+        if (useParquetColumnNames && column.getNestedColumn().isPresent()) {
+            return getNestedColumnType(messageType, column.getNestedColumn().get());
+        }
+        return getParquetType(column, messageType, useParquetColumnNames);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -624,11 +624,11 @@ public abstract class AbstractTestHive
                 Optional.empty(),
                 Optional.empty());
 
-        dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty());
-        fileFormatColumn = new HiveColumnHandle("file_format", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty());
-        dummyColumn = new HiveColumnHandle("dummy", HIVE_INT, parseTypeSignature(StandardTypes.INTEGER), -1, PARTITION_KEY, Optional.empty());
-        intColumn = new HiveColumnHandle("t_int", HIVE_INT, parseTypeSignature(StandardTypes.INTEGER), -1, PARTITION_KEY, Optional.empty());
-        invalidColumnHandle = new HiveColumnHandle(INVALID_COLUMN, HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), 0, REGULAR, Optional.empty());
+        dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty(), Optional.empty());
+        fileFormatColumn = new HiveColumnHandle("file_format", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty(), Optional.empty());
+        dummyColumn = new HiveColumnHandle("dummy", HIVE_INT, parseTypeSignature(StandardTypes.INTEGER), -1, PARTITION_KEY, Optional.empty(), Optional.empty());
+        intColumn = new HiveColumnHandle("t_int", HIVE_INT, parseTypeSignature(StandardTypes.INTEGER), -1, PARTITION_KEY, Optional.empty(), Optional.empty());
+        invalidColumnHandle = new HiveColumnHandle(INVALID_COLUMN, HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), 0, REGULAR, Optional.empty(), Optional.empty());
 
         List<ColumnHandle> partitionColumns = ImmutableList.of(dsColumn, fileFormatColumn, dummyColumn);
         List<HivePartition> partitions = ImmutableList.<HivePartition>builder()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -483,7 +483,7 @@ public abstract class AbstractTestHiveFileFormats
             int columnIndex = testColumn.isPartitionKey() ? -1 : nextHiveColumnIndex++;
 
             HiveType hiveType = HiveType.valueOf(testColumn.getObjectInspector().getTypeName());
-            columns.add(new HiveColumnHandle(testColumn.getName(), hiveType, hiveType.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
+            columns.add(new HiveColumnHandle(testColumn.getName(), hiveType, hiveType.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty(), Optional.empty()));
         }
         return columns;
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -102,7 +102,7 @@ public class TestBackgroundHiveSplitLoader
     private static final List<Column> PARTITION_COLUMNS = ImmutableList.of(
             new Column("partitionColumn", HIVE_INT, Optional.empty()));
     private static final List<HiveColumnHandle> BUCKET_COLUMN_HANDLES = ImmutableList.of(
-            new HiveColumnHandle("col1", HIVE_INT, INTEGER.getTypeSignature(), 0, ColumnType.REGULAR, Optional.empty()));
+            new HiveColumnHandle("col1", HIVE_INT, INTEGER.getTypeSignature(), 0, ColumnType.REGULAR, Optional.empty(), Optional.empty()));
 
     private static final Optional<HiveBucketProperty> BUCKET_PROPERTY = Optional.of(
             new HiveBucketProperty(ImmutableList.of("col1"), BUCKET_COUNT, ImmutableList.of()));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveColumnHandle.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveColumnHandle.java
@@ -38,14 +38,14 @@ public class TestHiveColumnHandle
     @Test
     public void testRegularColumn()
     {
-        HiveColumnHandle expectedPartitionColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), 88, PARTITION_KEY, Optional.empty());
+        HiveColumnHandle expectedPartitionColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), 88, PARTITION_KEY, Optional.empty(), Optional.empty());
         testRoundTrip(expectedPartitionColumn);
     }
 
     @Test
     public void testPartitionKeyColumn()
     {
-        HiveColumnHandle expectedRegularColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), 88, REGULAR, Optional.empty());
+        HiveColumnHandle expectedRegularColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), 88, REGULAR, Optional.empty(), Optional.empty());
         testRoundTrip(expectedRegularColumn);
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveMetadata.java
@@ -34,6 +34,7 @@ public class TestHiveMetadata
             TypeSignature.parseTypeSignature("varchar"),
             0,
             HiveColumnHandle.ColumnType.PARTITION_KEY,
+            Optional.empty(),
             Optional.empty());
 
     @Test(timeOut = 5000)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -282,7 +282,7 @@ public class TestHivePageSink
         for (int i = 0; i < columns.size(); i++) {
             LineItemColumn column = columns.get(i);
             HiveType hiveType = getHiveType(column.getType());
-            handles.add(new HiveColumnHandle(column.getColumnName(), hiveType, hiveType.getTypeSignature(), i, REGULAR, Optional.empty()));
+            handles.add(new HiveColumnHandle(column.getColumnName(), hiveType, hiveType.getTypeSignature(), i, REGULAR, Optional.empty(), Optional.empty()));
         }
         return handles.build();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
@@ -61,7 +61,7 @@ public class TestHiveSplit
                 Optional.of(new HiveSplit.BucketConversion(
                         32,
                         16,
-                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))),
+                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"), Optional.empty())))),
                 false);
 
         String json = codec.toJson(expected);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
@@ -56,9 +56,9 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("n_nationkey", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("n_name", HIVE_STRING, parseTypeSignature(VARCHAR), 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("n_regionkey", HIVE_INT, parseTypeSignature(INTEGER), 2, REGULAR, Optional.empty()));
+                new HiveColumnHandle("n_nationkey", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("n_name", HIVE_STRING, parseTypeSignature(VARCHAR), 1, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("n_regionkey", HIVE_INT, parseTypeSignature(INTEGER), 2, REGULAR, Optional.empty(), Optional.empty()));
 
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s",
                 queryBuilder.buildSql(columns, TupleDomain.all()));
@@ -81,9 +81,9 @@ public class TestIonSqlQueryBuilder
         TypeManager typeManager = new TypeRegistry();
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("quantity", HiveType.valueOf("decimal(20,0)"), parseTypeSignature(DECIMAL), 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("extendedprice", HiveType.valueOf("decimal(20,2)"), parseTypeSignature(DECIMAL), 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("discount", HiveType.valueOf("decimal(10,2)"), parseTypeSignature(DECIMAL), 2, REGULAR, Optional.empty()));
+                new HiveColumnHandle("quantity", HiveType.valueOf("decimal(20,0)"), parseTypeSignature(DECIMAL), 0, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("extendedprice", HiveType.valueOf("decimal(20,2)"), parseTypeSignature(DECIMAL), 1, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("discount", HiveType.valueOf("decimal(10,2)"), parseTypeSignature(DECIMAL), 2, REGULAR, Optional.empty(), Optional.empty()));
         DecimalType decimalType = DecimalType.createDecimalType(10, 2);
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
                 ImmutableMap.of(
@@ -101,8 +101,8 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("t1", HIVE_TIMESTAMP, parseTypeSignature(TIMESTAMP), 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("t2", HIVE_DATE, parseTypeSignature(StandardTypes.DATE), 1, REGULAR, Optional.empty()));
+                new HiveColumnHandle("t1", HIVE_TIMESTAMP, parseTypeSignature(TIMESTAMP), 0, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("t2", HIVE_DATE, parseTypeSignature(StandardTypes.DATE), 1, REGULAR, Optional.empty(), Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 columns.get(1), Domain.create(SortedRangeSet.copyOf(DATE, ImmutableList.of(Range.equal(DATE, (long) DateTimeUtils.parseDate("2001-08-22")))), false)));
 
@@ -114,9 +114,9 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("quantity", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("extendedprice", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("discount", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 2, REGULAR, Optional.empty()));
+                new HiveColumnHandle("quantity", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("extendedprice", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 1, REGULAR, Optional.empty(), Optional.empty()),
+                new HiveColumnHandle("discount", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 2, REGULAR, Optional.empty(), Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
                 ImmutableMap.of(
                         columns.get(0), Domain.create(ofRanges(Range.lessThan(BIGINT, 50L)), false),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestJsonHiveHandles.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestJsonHiveHandles.java
@@ -77,7 +77,7 @@ public class TestJsonHiveHandles
     public void testColumnHandleSerialize()
             throws Exception
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("column", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), -1, PARTITION_KEY, Optional.of("comment"));
+        HiveColumnHandle columnHandle = new HiveColumnHandle("column", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), -1, PARTITION_KEY, Optional.of("comment"), Optional.empty());
 
         assertTrue(objectMapper.canSerialize(HiveColumnHandle.class));
         String json = objectMapper.writeValueAsString(columnHandle);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -445,8 +445,7 @@ public class TestOrcPageSourceMemoryTracking
                 ObjectInspector inspector = testColumn.getObjectInspector();
                 HiveType hiveType = HiveType.valueOf(inspector.getTypeName());
                 Type type = hiveType.getType(TYPE_MANAGER);
-
-                columnsBuilder.add(new HiveColumnHandle(testColumn.getName(), hiveType, type.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
+                columnsBuilder.add(new HiveColumnHandle(testColumn.getName(), hiveType, type.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty(), Optional.empty()));
                 typesBuilder.add(type);
             }
             columns = columnsBuilder.build();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
@@ -31,6 +31,7 @@ import io.prestosql.plugin.hive.parquet.write.MapKeyValuesSchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.SingleLevelArrayMapKeyValuesSchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.SingleLevelArraySchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.TestMapredParquetOutputFormat;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSource;
@@ -79,6 +80,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Functions.constant;
 import static com.google.common.base.Verify.verify;
@@ -190,6 +192,19 @@ public class ParquetTester
         }
     }
 
+    public void testNestedColumnRoundTrip(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues, List<NestedColumn> nestedColumns, List<Type> columnTypes, Optional<MessageType> parquetSchema, boolean singleLevelArray)
+            throws Exception
+    {
+        List<String> columnNames = nestedColumns.stream().map(NestedColumn::getName).collect(Collectors.toList());
+        List<String> rootNames = nestedColumns.stream().map(NestedColumn::getBase).collect(Collectors.toList());
+
+        // just the values
+        testRoundTripType(objectInspectors, writeValues, readValues, columnNames, columnTypes, Optional.of(rootNames), parquetSchema, singleLevelArray);
+
+        // all nulls
+        assertRoundTrip(objectInspectors, transformToNulls(writeValues), transformToNulls(readValues), columnNames, columnTypes, Optional.of(rootNames), parquetSchema, singleLevelArray);
+    }
+
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
             throws Exception
     {
@@ -248,17 +263,31 @@ public class ParquetTester
             boolean singleLevelArray)
             throws Exception
     {
+        testRoundTripType(objectInspectors, writeValues, readValues, columnNames, columnTypes, Optional.empty(), parquetSchema, singleLevelArray);
+    }
+
+    private void testRoundTripType(
+            List<ObjectInspector> objectInspectors,
+            Iterable<?>[] writeValues,
+            Iterable<?>[] readValues,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            Optional<List<String>> rootColumns,
+            Optional<MessageType> parquetSchema,
+            boolean singleLevelArray)
+            throws Exception
+    {
         // forward order
-        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, singleLevelArray);
+        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, rootColumns, parquetSchema, singleLevelArray);
 
         // reverse order
-        assertRoundTrip(objectInspectors, reverse(writeValues), reverse(readValues), columnNames, columnTypes, parquetSchema, singleLevelArray);
+        assertRoundTrip(objectInspectors, reverse(writeValues), reverse(readValues), columnNames, columnTypes, rootColumns, parquetSchema, singleLevelArray);
 
         // forward order with nulls
-        assertRoundTrip(objectInspectors, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), columnNames, columnTypes, parquetSchema, singleLevelArray);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), columnNames, columnTypes, rootColumns, parquetSchema, singleLevelArray);
 
         // reverse order with nulls
-        assertRoundTrip(objectInspectors, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), columnNames, columnTypes, parquetSchema, singleLevelArray);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), columnNames, columnTypes, rootColumns, parquetSchema, singleLevelArray);
     }
 
     void assertRoundTrip(
@@ -283,6 +312,19 @@ public class ParquetTester
             boolean singleLevelArray)
             throws Exception
     {
+        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, Optional.empty(), parquetSchema, singleLevelArray);
+    }
+
+    void assertRoundTrip(List<ObjectInspector> objectInspectors,
+            Iterable<?>[] writeValues,
+            Iterable<?>[] readValues,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            Optional<List<String>> rootColumns,
+            Optional<MessageType> parquetSchema,
+            boolean singleLevelArray)
+            throws Exception
+    {
         for (WriterVersion version : versions) {
             for (CompressionCodecName compressionCodecName : compressions) {
                 for (ConnectorSession session : sessions) {
@@ -291,12 +333,13 @@ public class ParquetTester
                         jobConf.setEnum(COMPRESSION, compressionCodecName);
                         jobConf.setBoolean(ENABLE_DICTIONARY, true);
                         jobConf.setEnum(WRITER_VERSION, version);
+                        List<String> writeColumns = rootColumns.isPresent() ? rootColumns.get() : columnNames;
                         writeParquetColumn(
                                 jobConf,
                                 tempFile.getFile(),
                                 compressionCodecName,
-                                createTableProperties(columnNames, objectInspectors),
-                                getStandardStructObjectInspector(columnNames, objectInspectors),
+                                createTableProperties(writeColumns, objectInspectors),
+                                getStandardStructObjectInspector(writeColumns, objectInspectors),
                                 getIterators(writeValues),
                                 parquetSchema,
                                 singleLevelArray);
@@ -605,7 +648,7 @@ public class ParquetTester
     private static Iterable<?>[] reverse(Iterable<?>[] iterables)
     {
         return stream(iterables)
-                .map(ImmutableList::copyOf)
+                .map(Lists::newArrayList)
                 .map(Lists::reverse)
                 .toArray(Iterable<?>[]::new);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -56,7 +56,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainPrimitiveArray()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array", HiveType.valueOf("array<int>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array", HiveType.valueOf("array<int>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty(), Optional.empty());
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(INTEGER))));
 
         MessageType fileSchema = new MessageType("hive_schema",
@@ -71,7 +71,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainStructArray()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array_struct", HiveType.valueOf("array<struct<a:int>>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array_struct", HiveType.valueOf("array<struct<a:int>>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty(), Optional.empty());
         RowType.Field rowField = new RowType.Field(Optional.of("a"), INTEGER);
         RowType rowType = RowType.from(ImmutableList.of(rowField));
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(rowType))));
@@ -89,7 +89,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainPrimitive()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_primitive", HiveType.valueOf("bigint"), parseTypeSignature(StandardTypes.BIGINT), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_primitive", HiveType.valueOf("bigint"), parseTypeSignature(StandardTypes.BIGINT), 0, REGULAR, Optional.empty(), Optional.empty());
         Domain singleValueDomain = Domain.singleValue(BIGINT, 123L);
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, singleValueDomain));
 
@@ -110,7 +110,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainStruct()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_struct", HiveType.valueOf("struct<a:int,b:int>"), parseTypeSignature(StandardTypes.ROW), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_struct", HiveType.valueOf("struct<a:int,b:int>"), parseTypeSignature(StandardTypes.ROW), 0, REGULAR, Optional.empty(), Optional.empty());
         RowType.Field rowField = new RowType.Field(Optional.of("my_struct"), INTEGER);
         RowType rowType = RowType.from(ImmutableList.of(rowField));
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(rowType)));
@@ -127,7 +127,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainMap()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_map", HiveType.valueOf("map<int,int>"), parseTypeSignature(StandardTypes.MAP), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_map", HiveType.valueOf("map<int,int>"), parseTypeSignature(StandardTypes.MAP), 0, REGULAR, Optional.empty(), Optional.empty());
 
         MapType mapType = new MapType(
                 INTEGER,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -94,8 +94,8 @@ public class TestMetastoreHiveStatisticsProvider
     private static final String COLUMN = "column";
     private static final DecimalType DECIMAL = createDecimalType(5, 3);
 
-    private static final HiveColumnHandle PARTITION_COLUMN_1 = new HiveColumnHandle("p1", HIVE_STRING, VARCHAR.getTypeSignature(), 0, PARTITION_KEY, Optional.empty());
-    private static final HiveColumnHandle PARTITION_COLUMN_2 = new HiveColumnHandle("p2", HIVE_LONG, BIGINT.getTypeSignature(), 1, PARTITION_KEY, Optional.empty());
+    private static final HiveColumnHandle PARTITION_COLUMN_1 = new HiveColumnHandle("p1", HIVE_STRING, VARCHAR.getTypeSignature(), 0, PARTITION_KEY, Optional.empty(), Optional.empty());
+    private static final HiveColumnHandle PARTITION_COLUMN_2 = new HiveColumnHandle("p2", HIVE_LONG, BIGINT.getTypeSignature(), 1, PARTITION_KEY, Optional.empty(), Optional.empty());
 
     @Test
     public void testGetPartitionsSample()
@@ -611,7 +611,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .build();
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((table, hivePartitions) -> ImmutableMap.of(partitionName, statistics));
         TestingConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
-        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT.getTypeSignature(), 2, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT.getTypeSignature(), 2, REGULAR, Optional.empty(), Optional.empty());
         TableStatistics expected = TableStatistics.builder()
                 .setRowCount(Estimate.of(1000))
                 .setColumnStatistics(
@@ -661,7 +661,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .build();
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((table, hivePartitions) -> ImmutableMap.of(UNPARTITIONED_ID, statistics));
         TestingConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
-        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT.getTypeSignature(), 2, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT.getTypeSignature(), 2, REGULAR, Optional.empty(), Optional.empty());
         TableStatistics expected = TableStatistics.builder()
                 .setRowCount(Estimate.of(1000))
                 .setColumnStatistics(

--- a/presto-main/etc/catalog/hive.properties
+++ b/presto-main/etc/catalog/hive.properties
@@ -7,3 +7,5 @@
 
 connector.name=hive-hadoop2
 hive.metastore.uri=thrift://localhost:9083
+
+hive.parquet.use-column-names=true

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -16,6 +16,7 @@ package io.prestosql.metadata;
 import io.airlift.slice.Slice;
 import io.prestosql.Session;
 import io.prestosql.connector.CatalogName;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.BlockEncodingSerde;
 import io.prestosql.spi.connector.CatalogSchemaName;
@@ -121,6 +122,13 @@ public interface Metadata
      * @throws RuntimeException if table handle is no longer valid
      */
     Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle);
+
+    /**
+     * Gets all of the columns on the specified table, or an empty map if the columns can not be enumerated.
+     *
+     * @throws RuntimeException if table handle is no longer valid
+     */
+    Map<NestedColumn, ColumnHandle> getNestedColumnHandles(Session session, TableHandle tableHandle, Collection<NestedColumn> dereferences);
 
     /**
      * Gets the metadata for the specified table column.

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -27,6 +27,7 @@ import io.airlift.slice.Slice;
 import io.prestosql.Session;
 import io.prestosql.block.BlockEncodingManager;
 import io.prestosql.connector.CatalogName;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.block.BlockEncodingSerde;
@@ -522,6 +523,14 @@ public class MetadataManager
             map.put(mapEntry.getKey().toLowerCase(ENGLISH), mapEntry.getValue());
         }
         return map.build();
+    }
+
+    @Override
+    public Map<NestedColumn, ColumnHandle> getNestedColumnHandles(Session session, TableHandle tableHandle, Collection<NestedColumn> dereferences)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        return metadata.getNestedColumnHandles(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), dereferences);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/InlineProjections.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/InlineProjections.java
@@ -156,6 +156,7 @@ public class InlineProjections
                 .filter(entry -> entry.getValue() == 1) // reference appears just once across all expressions in parent project node
                 .filter(entry -> !tryArguments.contains(entry.getKey())) // they are not inputs to TRY. Otherwise, inlining might change semantics
                 .filter(entry -> !child.getAssignments().isIdentity(entry.getKey())) // skip identities, otherwise, this rule will keep firing forever
+                //.filter(entry -> !(child.getAssignments().get(entry.getKey()) instanceof DereferenceExpression)) // skip dereference expression
                 .map(Map.Entry::getKey)
                 .collect(toSet());
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/MergeNestedColumn.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/MergeNestedColumn.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.optimizations;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.spi.NestedColumn;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.PlanNodeIdAllocator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.SymbolAllocator;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.SimplePlanRewriter;
+import io.prestosql.sql.planner.plan.TableScanNode;
+import io.prestosql.sql.tree.DefaultExpressionTraversalVisitor;
+import io.prestosql.sql.tree.DereferenceExpression;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.ExpressionRewriter;
+import io.prestosql.sql.tree.ExpressionTreeRewriter;
+import io.prestosql.sql.tree.Identifier;
+import io.prestosql.sql.tree.SubscriptExpression;
+import io.prestosql.sql.tree.SymbolReference;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class MergeNestedColumn
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+    private final TypeAnalyzer typeAnalyzer;
+
+    public MergeNestedColumn(Metadata metadata, TypeAnalyzer typeAnalyzer)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        return SimplePlanRewriter.rewriteWith(new Optimizer(session, symbolAllocator, idAllocator, metadata, typeAnalyzer, warningCollector), plan);
+    }
+
+    public static boolean prefixExist(Expression expression, final Set<Expression> allDereferences)
+    {
+        int[] referenceCount = {0};
+        new DefaultExpressionTraversalVisitor<Void, int[]>()
+        {
+            @Override
+            protected Void visitDereferenceExpression(DereferenceExpression node, int[] referenceCount)
+            {
+                if (allDereferences.contains(node)) {
+                    referenceCount[0] += 1;
+                }
+                process(node.getBase(), referenceCount);
+                return null;
+            }
+
+            @Override
+            protected Void visitSymbolReference(SymbolReference node, int[] context)
+            {
+                if (allDereferences.contains(node)) {
+                    referenceCount[0] += 1;
+                }
+                return null;
+            }
+        }.process(expression, referenceCount);
+        return referenceCount[0] > 1;
+    }
+
+    private static class Optimizer
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final SymbolAllocator symbolAllocator;
+        private final PlanNodeIdAllocator idAllocator;
+        private final Metadata metadata;
+        private final TypeAnalyzer typeAnalyzer;
+
+        public Optimizer(Session session, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Metadata metadata, TypeAnalyzer typeAnalyzer, WarningCollector warningCollector)
+        {
+            this.session = requireNonNull(session);
+            this.symbolAllocator = requireNonNull(symbolAllocator);
+            this.idAllocator = requireNonNull(idAllocator);
+            this.metadata = requireNonNull(metadata);
+            this.typeAnalyzer = requireNonNull(typeAnalyzer);
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            if (node.getSource() instanceof TableScanNode) {
+                TableScanNode tableScanNode = (TableScanNode) node.getSource();
+                return mergeProjectWithTableScan(node, tableScanNode, context);
+            }
+            return context.defaultRewrite(node);
+        }
+
+        private Type extractType(Expression expression)
+        {
+            Type type = typeAnalyzer.getType(session, symbolAllocator.getTypes(), expression);
+            return type;
+        }
+
+        public PlanNode mergeProjectWithTableScan(ProjectNode node, TableScanNode tableScanNode, RewriteContext<Void> context)
+        {
+            Set<Expression> allExpressions = node.getAssignments().getExpressions().stream().map(MergeNestedColumn::validDereferenceExpression).filter(Objects::nonNull).collect(toImmutableSet());
+            Set<Expression> dereferences = allExpressions.stream()
+                    .filter(expression -> !prefixExist(expression, allExpressions))
+                    .filter(expression -> expression instanceof DereferenceExpression)
+                    .collect(toImmutableSet());
+
+            if (dereferences.isEmpty()) {
+                return context.defaultRewrite(node);
+            }
+
+            NestedColumnTranslator nestedColumnTranslator = new NestedColumnTranslator(tableScanNode.getAssignments(), tableScanNode.getTable());
+            Map<Expression, NestedColumn> nestedColumns = dereferences.stream().collect(Collectors.toMap(Function.identity(), nestedColumnTranslator::toNestedColumn));
+
+            Map<NestedColumn, ColumnHandle> nestedColumnHandles =
+                    metadata.getNestedColumnHandles(session, tableScanNode.getTable(), nestedColumns.values())
+                            .entrySet().stream()
+                            .filter(entry -> !nestedColumnTranslator.columnHandleExists(entry.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (nestedColumnHandles.isEmpty()) {
+                return context.defaultRewrite(node);
+            }
+
+            ImmutableMap.Builder<Symbol, ColumnHandle> columnHandleBuilder = ImmutableMap.builder();
+            columnHandleBuilder.putAll(tableScanNode.getAssignments());
+
+            // Use to replace expression in original dereference expression
+            ImmutableMap.Builder<Expression, Symbol> symbolExpressionBuilder = ImmutableMap.builder();
+            for (Map.Entry<NestedColumn, ColumnHandle> entry : nestedColumnHandles.entrySet()) {
+                NestedColumn nestedColumn = entry.getKey();
+                Expression expression = nestedColumnTranslator.toExpression(nestedColumn);
+                Symbol symbol = symbolAllocator.newSymbol(nestedColumn.getName(), extractType(expression));
+                symbolExpressionBuilder.put(expression, symbol);
+                columnHandleBuilder.put(symbol, entry.getValue());
+            }
+            ImmutableMap<Symbol, ColumnHandle> nestedColumnsMap = columnHandleBuilder.build();
+
+            TableScanNode newTableScan = new TableScanNode(
+                    idAllocator.getNextId(),
+                    tableScanNode.getTable(),
+                    ImmutableList.copyOf(nestedColumnsMap.keySet()),
+                    nestedColumnsMap,
+                    tableScanNode.getEnforcedConstraint());
+
+            Rewriter rewriter = new Rewriter(symbolExpressionBuilder.build());
+            Map<Symbol, Expression> assignments = node.getAssignments().entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, entry -> ExpressionTreeRewriter.rewriteWith(rewriter, entry.getValue())));
+            return new ProjectNode(idAllocator.getNextId(), newTableScan, Assignments.copyOf(assignments));
+        }
+
+        private class NestedColumnTranslator
+        {
+            private final Map<Symbol, String> symbolToColumnName;
+            private final Map<String, Symbol> columnNameToSymbol;
+
+            NestedColumnTranslator(Map<Symbol, ColumnHandle> columnHandleMap, TableHandle tableHandle)
+            {
+                BiMap<Symbol, String> symbolToColumnName = HashBiMap.create(columnHandleMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> metadata.getColumnMetadata(session, tableHandle, entry.getValue()).getName())));
+                this.symbolToColumnName = symbolToColumnName;
+                this.columnNameToSymbol = symbolToColumnName.inverse();
+            }
+
+            boolean columnHandleExists(NestedColumn nestedColumn)
+            {
+                return columnNameToSymbol.containsKey(nestedColumn.getName());
+            }
+
+            NestedColumn toNestedColumn(Expression expression)
+            {
+                ImmutableList.Builder<String> builder = ImmutableList.builder();
+                new DefaultExpressionTraversalVisitor<Void, Void>()
+                {
+                    @Override
+                    protected Void visitSubscriptExpression(SubscriptExpression node, Void context)
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+                    {
+                        process(node.getBase(), context);
+                        builder.add(node.getField().getValue());
+                        return null;
+                    }
+
+                    @Override
+                    protected Void visitSymbolReference(SymbolReference node, Void context)
+                    {
+                        Symbol baseName = Symbol.from(node);
+                        Preconditions.checkArgument(symbolToColumnName.containsKey(baseName), "base [%s] doesn't exist in assignments [%s]", baseName, symbolToColumnName);
+                        builder.add(symbolToColumnName.get(baseName));
+                        return null;
+                    }
+                }.process(expression, null);
+                List<String> names = builder.build();
+                Preconditions.checkArgument(names.size() > 1, "names size is less than 0", names);
+                return new NestedColumn(names);
+            }
+
+            Expression toExpression(NestedColumn nestedColumn)
+            {
+                Expression result = null;
+                for (String part : nestedColumn.getNames()) {
+                    if (result == null) {
+                        Preconditions.checkArgument(columnNameToSymbol.containsKey(part), "element %s doesn't exist in map %s", part, columnNameToSymbol);
+                        result = columnNameToSymbol.get(part).toSymbolReference();
+                    }
+                    else {
+                        result = new DereferenceExpression(result, new Identifier(part));
+                    }
+                }
+                return result;
+            }
+        }
+    }
+
+    // expression: msg_12.foo -> nestedColumn: msg.foo -> expression: msg_12.foo
+
+    private static class Rewriter
+            extends ExpressionRewriter<Void>
+    {
+        private final Map<Expression, Symbol> map;
+
+        Rewriter(Map<Expression, Symbol> map)
+        {
+            this.map = map;
+        }
+
+        @Override
+        public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (map.containsKey(node)) {
+                return map.get(node).toSymbolReference();
+            }
+            return treeRewriter.defaultRewrite(node, context);
+        }
+
+        @Override
+        public Expression rewriteSymbolReference(SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (map.containsKey(node)) {
+                return map.get(node).toSymbolReference();
+            }
+            return super.rewriteSymbolReference(node, context, treeRewriter);
+        }
+    }
+
+    public static Expression validDereferenceExpression(Expression expression)
+    {
+        //Preconditions.checkArgument(expression instanceof DereferenceExpression, "express must be dereference expression first");
+        SubscriptExpression[] shortestSubscriptExp = new SubscriptExpression[1];
+        boolean[] valid = new boolean[1];
+        valid[0] = true;
+        new DefaultExpressionTraversalVisitor<Void, Void>()
+        {
+            @Override
+            protected Void visitSubscriptExpression(SubscriptExpression node, Void context)
+            {
+                shortestSubscriptExp[0] = node;
+                process(node.getBase(), context);
+                return null;
+            }
+
+            @Override
+            protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+            {
+                valid[0] &= (node.getBase() instanceof SymbolReference || node.getBase() instanceof DereferenceExpression || node.getBase() instanceof SubscriptExpression);
+                process(node.getBase(), context);
+                return null;
+            }
+        }.process(expression, null);
+        if (valid[0]) {
+            return shortestSubscriptExp[0] == null ? expression : shortestSubscriptExp[0].getBase();
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PushDownDereferenceExpression.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PushDownDereferenceExpression.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.prestosql.Session;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.ExpressionExtractor;
+import io.prestosql.sql.planner.PlanNodeIdAllocator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.SymbolAllocator;
+import io.prestosql.sql.planner.SymbolsExtractor;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.FilterNode;
+import io.prestosql.sql.planner.plan.JoinNode;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.SimplePlanRewriter;
+import io.prestosql.sql.planner.plan.TableScanNode;
+import io.prestosql.sql.planner.plan.UnnestNode;
+import io.prestosql.sql.planner.plan.ValuesNode;
+import io.prestosql.sql.tree.ComparisonExpression;
+import io.prestosql.sql.tree.DefaultExpressionTraversalVisitor;
+import io.prestosql.sql.tree.DereferenceExpression;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.ExpressionRewriter;
+import io.prestosql.sql.tree.ExpressionTreeRewriter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.sql.planner.optimizations.MergeNestedColumn.prefixExist;
+import static java.util.Objects.requireNonNull;
+
+public class PushDownDereferenceExpression
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+    private final TypeAnalyzer typeAnalyzer;
+
+    public PushDownDereferenceExpression(Metadata metadata, TypeAnalyzer typeAnalyzer)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        Map<Expression, DereferenceInfo> expressionInfoMap = new HashMap<>();
+        return SimplePlanRewriter.rewriteWith(new Optimizer(session, metadata, typeAnalyzer, symbolAllocator, idAllocator, warningCollector), plan, expressionInfoMap);
+    }
+
+    private static class DereferenceReplacer
+            extends ExpressionRewriter<Void>
+    {
+        private final Map<Expression, DereferenceInfo> map;
+
+        DereferenceReplacer(Map<Expression, DereferenceInfo> map)
+        {
+            this.map = map;
+        }
+
+        @Override
+        public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (map.containsKey(node) && map.get(node).isFromValidSource()) {
+                return map.get(node).getSymbol().toSymbolReference();
+            }
+            return treeRewriter.defaultRewrite(node, context);
+        }
+    }
+
+    private static class Optimizer
+            extends SimplePlanRewriter<Map<Expression, DereferenceInfo>>
+    {
+        private final Session session;
+        private final SymbolAllocator symbolAllocator;
+        private final TypeAnalyzer typeAnalyzer;
+        private final PlanNodeIdAllocator idAllocator;
+        private final Metadata metadata;
+        private final WarningCollector warningCollector;
+
+        private Optimizer(Session session, Metadata metadata, TypeAnalyzer typeAnalyzer, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+        {
+            this.session = session;
+            this.typeAnalyzer = typeAnalyzer;
+            this.metadata = metadata;
+            this.symbolAllocator = symbolAllocator;
+            this.idAllocator = idAllocator;
+            this.warningCollector = warningCollector;
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            extractDereferenceInfos(node).forEach(expressionInfoMap::putIfAbsent);
+
+            PlanNode child = context.rewrite(node.getSource(), expressionInfoMap);
+
+            Map<Symbol, AggregationNode.Aggregation> aggregations = new HashMap<>();
+            for (Map.Entry<Symbol, AggregationNode.Aggregation> symbolAggregationEntry : node.getAggregations().entrySet()) {
+                Symbol symbol = symbolAggregationEntry.getKey();
+                AggregationNode.Aggregation oldAggregation = symbolAggregationEntry.getValue();
+                AggregationNode.Aggregation newAggregation = new AggregationNode.Aggregation(ExpressionTreeRewriter.rewriteWith(new DereferenceReplacer(expressionInfoMap), oldAggregation.getCall()), oldAggregation.getSignature(), oldAggregation.getMask());
+                aggregations.put(symbol, newAggregation);
+            }
+            return new AggregationNode(
+                    idAllocator.getNextId(),
+                    child,
+                    aggregations,
+                    node.getGroupingSets(),
+                    node.getPreGroupedSymbols(),
+                    node.getStep(),
+                    node.getHashSymbol(),
+                    node.getGroupIdSymbol());
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            extractDereferenceInfos(node).forEach(expressionInfoMap::putIfAbsent);
+
+            PlanNode child = context.rewrite(node.getSource(), expressionInfoMap);
+
+            Expression predicate = ExpressionTreeRewriter.rewriteWith(new DereferenceReplacer(expressionInfoMap), node.getPredicate());
+            return new FilterNode(idAllocator.getNextId(), child, predicate);
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            //  parentDereferenceInfos is used to find out passThroughSymbol. we will only pass those symbols that are needed by upstream
+            List<DereferenceInfo> parentDereferenceInfos = expressionInfoMap.entrySet().stream().map(Map.Entry::getValue).collect(Collectors.toList());
+            Map<Expression, DereferenceInfo> newDereferences = extractDereferenceInfos(node);
+            newDereferences.forEach(expressionInfoMap::putIfAbsent);
+
+            PlanNode child = context.rewrite(node.getSource(), expressionInfoMap);
+
+            List<Symbol> passThroughSymbols = getUsedDereferenceInfo(node.getOutputSymbols(), parentDereferenceInfos).stream().filter(DereferenceInfo::isFromValidSource).map(DereferenceInfo::getSymbol).collect(Collectors.toList());
+
+            Assignments.Builder assignmentsBuilder = Assignments.builder();
+            for (Map.Entry<Symbol, Expression> entry : node.getAssignments().entrySet()) {
+                assignmentsBuilder.put(entry.getKey(), ExpressionTreeRewriter.rewriteWith(new DereferenceReplacer(expressionInfoMap), entry.getValue()));
+            }
+            assignmentsBuilder.putIdentities(passThroughSymbols);
+            ProjectNode newProjectNode = new ProjectNode(idAllocator.getNextId(), child, assignmentsBuilder.build());
+            newDereferences.forEach(expressionInfoMap::remove);
+            return newProjectNode;
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            List<DereferenceInfo> usedDereferenceInfo = getUsedDereferenceInfo(node.getOutputSymbols(), expressionInfoMap.values());
+            if (!usedDereferenceInfo.isEmpty()) {
+                usedDereferenceInfo.forEach(DereferenceInfo::doesFromValidSource);
+                Map<Symbol, Expression> assignmentMap = usedDereferenceInfo.stream().collect(Collectors.toMap(DereferenceInfo::getSymbol, DereferenceInfo::getDereference));
+                return new ProjectNode(idAllocator.getNextId(), node, Assignments.builder().putAll(assignmentMap).putIdentities(node.getOutputSymbols()).build());
+            }
+            return node;
+        }
+
+        @Override
+        public PlanNode visitValues(ValuesNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            List<DereferenceInfo> usedDereferenceInfo = getUsedDereferenceInfo(node.getOutputSymbols(), expressionInfoMap.values());
+            if (!usedDereferenceInfo.isEmpty()) {
+                usedDereferenceInfo.forEach(DereferenceInfo::doesFromValidSource);
+                Map<Symbol, Expression> assignmentMap = usedDereferenceInfo.stream().collect(Collectors.toMap(DereferenceInfo::getSymbol, DereferenceInfo::getDereference));
+                return new ProjectNode(idAllocator.getNextId(), node, Assignments.builder().putAll(assignmentMap).putIdentities(node.getOutputSymbols()).build());
+            }
+            return node;
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode joinNode, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            extractDereferenceInfos(joinNode).forEach(expressionInfoMap::putIfAbsent);
+
+            PlanNode leftNode = context.rewrite(joinNode.getLeft(), expressionInfoMap);
+            PlanNode rightNode = context.rewrite(joinNode.getRight(), expressionInfoMap);
+
+            List<JoinNode.EquiJoinClause> equiJoinClauses = joinNode.getCriteria().stream()
+                    .map(JoinNode.EquiJoinClause::toExpression)
+                    .map(expr -> ExpressionTreeRewriter.rewriteWith(new DereferenceReplacer(expressionInfoMap), expr))
+                    .map(this::getEquiJoinClause)
+                    .collect(Collectors.toList());
+
+            Optional<Expression> joinFilter = joinNode.getFilter().map(expression -> ExpressionTreeRewriter.rewriteWith(new DereferenceReplacer(expressionInfoMap), expression));
+
+            return new JoinNode(
+                    joinNode.getId(),
+                    joinNode.getType(),
+                    leftNode,
+                    rightNode,
+                    equiJoinClauses,
+                    ImmutableList.<Symbol>builder().addAll(leftNode.getOutputSymbols()).addAll(rightNode.getOutputSymbols()).build(),
+                    joinFilter,
+                    joinNode.getLeftHashSymbol(),
+                    joinNode.getRightHashSymbol(),
+                    joinNode.getDistributionType(),
+                    joinNode.isSpillable());
+        }
+
+        @Override
+        public PlanNode visitUnnest(UnnestNode node, RewriteContext<Map<Expression, DereferenceInfo>> context)
+        {
+            Map<Expression, DereferenceInfo> expressionInfoMap = context.get();
+            List<DereferenceInfo> parentDereferenceInfos = expressionInfoMap.entrySet().stream().map(Map.Entry::getValue).collect(Collectors.toList());
+
+            PlanNode child = context.rewrite(node.getSource(), expressionInfoMap);
+
+            List<Symbol> passThroughSymbols = getUsedDereferenceInfo(child.getOutputSymbols(), parentDereferenceInfos).stream().filter(DereferenceInfo::isFromValidSource).map(DereferenceInfo::getSymbol).collect(Collectors.toList());
+            UnnestNode unnestNode = new UnnestNode(idAllocator.getNextId(), child, ImmutableList.<Symbol>builder().addAll(node.getReplicateSymbols()).addAll(passThroughSymbols).build(), node.getUnnestSymbols(), node.getOrdinalitySymbol());
+
+            List<Symbol> unnestSymbols = unnestNode.getUnnestSymbols().entrySet().stream().flatMap(entry -> entry.getValue().stream()).collect(Collectors.toList());
+            List<DereferenceInfo> dereferenceExpressionInfos = getUsedDereferenceInfo(unnestSymbols, expressionInfoMap.values());
+            if (!dereferenceExpressionInfos.isEmpty()) {
+                dereferenceExpressionInfos.forEach(DereferenceInfo::doesFromValidSource);
+                Map<Symbol, Expression> assignmentMap = dereferenceExpressionInfos.stream().collect(Collectors.toMap(DereferenceInfo::getSymbol, DereferenceInfo::getDereference));
+                return new ProjectNode(idAllocator.getNextId(), unnestNode, Assignments.builder().putAll(assignmentMap).putIdentities(unnestNode.getOutputSymbols()).build());
+            }
+            return unnestNode;
+        }
+
+        private List<DereferenceInfo> getUsedDereferenceInfo(List<Symbol> symbols, Collection<DereferenceInfo> dereferenceExpressionInfos)
+        {
+            Set<Symbol> symbolSet = symbols.stream().collect(Collectors.toSet());
+            return dereferenceExpressionInfos.stream().filter(dereferenceExpressionInfo -> symbolSet.contains(dereferenceExpressionInfo.getBaseSymbol())).collect(Collectors.toList());
+        }
+
+        private JoinNode.EquiJoinClause getEquiJoinClause(Expression expression)
+        {
+            checkArgument(expression instanceof ComparisonExpression, "expression [%s] is not equal expression", expression);
+            ComparisonExpression comparisonExpression = (ComparisonExpression) expression;
+            return new JoinNode.EquiJoinClause(Symbol.from(comparisonExpression.getLeft()), Symbol.from(comparisonExpression.getRight()));
+        }
+
+        private Type extractType(Expression expression)
+        {
+            Type type = typeAnalyzer.getType(session, symbolAllocator.getTypes(), expression);
+            return type;
+        }
+
+        private DereferenceInfo getDereferenceInfo(Expression expression)
+        {
+            Symbol symbol = symbolAllocator.newSymbol(expression, extractType(expression));
+            Symbol base = Iterables.getOnlyElement(SymbolsExtractor.extractAll(expression));
+            return new DereferenceInfo(expression, symbol, base);
+        }
+
+        private List<Expression> extractDereference(Expression expression)
+        {
+            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+            new DefaultExpressionTraversalVisitor<Void, ImmutableList.Builder<Expression>>()
+            {
+                @Override
+                protected Void visitDereferenceExpression(DereferenceExpression node, ImmutableList.Builder<Expression> context)
+                {
+                    context.add(node);
+                    return null;
+                }
+            }.process(expression, builder);
+            return builder.build();
+        }
+
+        private Map<Expression, DereferenceInfo> extractDereferenceInfos(PlanNode node)
+        {
+            Set<Expression> allExpressions = ExpressionExtractor.extractExpressionsNonRecursive(node).stream()
+                    .flatMap(expression -> extractDereference(expression).stream())
+                    .map(MergeNestedColumn::validDereferenceExpression).filter(Objects::nonNull).collect(toImmutableSet());
+
+            return allExpressions.stream()
+                    .filter(expression -> !prefixExist(expression, allExpressions))
+                    .filter(expression -> expression instanceof DereferenceExpression)
+                    .distinct()
+                    .map(this::getDereferenceInfo)
+                    .collect(Collectors.toMap(DereferenceInfo::getDereference, Function.identity()));
+        }
+    }
+
+    private static class DereferenceInfo
+    {
+        // e.g. for dereference expression msg.foo[1].bar, base is "msg", newSymbol is new assigned symbol to replace this dereference expression
+        private final Expression dereferenceExpression;
+        private final Symbol symbol;
+        private final Symbol baseSymbol;
+
+        // fromValidSource is used to check whether the dereference expression is from either TableScan or Unnest
+        // it will be false for following node therefore we won't rewrite:
+        // Project[expr_1 := "max_by"."field1"]
+        // - Aggregate[max_by := "max_by"("expr", "app_rating")] => [max_by:row(field0 varchar, field1 varchar)]
+        private boolean fromValidSource;
+
+        public DereferenceInfo(Expression dereferenceExpression, Symbol symbol, Symbol baseSymbol)
+        {
+            this.dereferenceExpression = requireNonNull(dereferenceExpression);
+            this.symbol = requireNonNull(symbol);
+            this.baseSymbol = requireNonNull(baseSymbol);
+            this.fromValidSource = false;
+        }
+
+        public Symbol getSymbol()
+        {
+            return symbol;
+        }
+
+        public Symbol getBaseSymbol()
+        {
+            return baseSymbol;
+        }
+
+        public Expression getDereference()
+        {
+            return dereferenceExpression;
+        }
+
+        public boolean isFromValidSource()
+        {
+            return fromValidSource;
+        }
+
+        public void doesFromValidSource()
+        {
+            fromValidSource = true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("(%s, %s, %s)", dereferenceExpression, symbol, baseSymbol);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingMetadata.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
 import static java.util.Objects.requireNonNull;
@@ -60,6 +61,16 @@ public class TestingMetadata
 {
     private final ConcurrentMap<SchemaTableName, ConnectorTableMetadata> tables = new ConcurrentHashMap<>();
     private final ConcurrentMap<SchemaTableName, String> views = new ConcurrentHashMap<>();
+
+    protected ConcurrentMap<SchemaTableName, ConnectorTableMetadata> getTables()
+    {
+        return tables;
+    }
+
+    protected ConcurrentMap<SchemaTableName, String> getViews()
+    {
+        return views;
+    }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
@@ -287,7 +298,7 @@ public class TestingMetadata
         tables.clear();
     }
 
-    private static SchemaTableName getTableName(ConnectorTableHandle tableHandle)
+    protected static SchemaTableName getTableName(ConnectorTableHandle tableHandle)
     {
         requireNonNull(tableHandle, "tableHandle is null");
         checkArgument(tableHandle instanceof TestingTableHandle, "tableHandle is not an instance of TestingTableHandle");
@@ -393,6 +404,12 @@ public class TestingMetadata
         public int hashCode()
         {
             return Objects.hash(name, ordinalPosition, type);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this).add("name", name).add("position", ordinalPosition).add("type", type).toString();
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -16,6 +16,7 @@ package io.prestosql.metadata;
 import io.airlift.slice.Slice;
 import io.prestosql.Session;
 import io.prestosql.connector.CatalogName;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.block.BlockEncodingSerde;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -167,6 +168,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<NestedColumn, ColumnHandle> getNestedColumnHandles(Session session, TableHandle tableHandle, Collection<NestedColumn> dereferences)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDereferencePushDown.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDereferencePushDown.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.output;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+
+public class TestDereferencePushDown
+        extends BasePlanTest
+{
+    private static final String VALUES = "(values ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))";
+
+    @Test
+    public void testPushDownDereferencesThroughJoin()
+    {
+        assertPlan(" with t1 as ( select * from " + VALUES + " as t (msg) ) select b.msg.x from t1 a, t1 b where a.msg.y = b.msg.y",
+                output(ImmutableList.of("x"),
+                        join(INNER, ImmutableList.of(equiJoinClause("left_y", "right_y")),
+                                anyTree(
+                                        project(ImmutableMap.of("left_y", expression("field.y")),
+                                                values("field"))
+                                ), anyTree(
+                                        project(ImmutableMap.of("right_y", expression("field1.y"), "x", expression("field1.x")),
+                                                values("field1"))))));
+    }
+
+    @Test
+    public void testPushDownDereferencesInCase()
+    {
+        // Test dereferences in then clause will not be eagerly evaluated.
+        String statement = "with t as (select * from (values cast(array[CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE)),ROW(1, 2.0)] as array<ROW(x BIGINT, y DOUBLE)>)) as t (arr) ) " +
+                "select case when cardinality(arr) > cast(0 as bigint) then arr[cast(1 as bigint)].x end from t";
+        assertPlan(statement,
+                output(ImmutableList.of("x"),
+                        project(ImmutableMap.of("x", expression("case when cardinality(field) > bigint '0' then field[bigint '1'].x end")), values("field"))));
+    }
+
+    @Test
+    public void testPushDownDereferencesThroughFilter()
+    {
+        assertPlan(" with t1 as ( select * from " + VALUES + " as t (msg) ) select a.msg.y from t1 a join t1 b on a.msg.y = b.msg.y where a.msg.x > bigint '5'",
+                output(ImmutableList.of("left_y"),
+                        join(INNER, ImmutableList.of(equiJoinClause("left_y", "right_y")),
+                                anyTree(
+                                        project(ImmutableMap.of("left_y", expression("field.y")),
+                                                filter("field.x > bigint '5'", values("field")))
+                                ), anyTree(
+                                        project(ImmutableMap.of("right_y", expression("field1.y")),
+                                                values("field1"))))));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestMergeNestedColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestMergeNestedColumns.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.NestedColumn;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.Connector;
+import io.prestosql.spi.connector.ConnectorContext;
+import io.prestosql.spi.connector.ConnectorFactory;
+import io.prestosql.spi.connector.ConnectorHandleResolver;
+import io.prestosql.spi.connector.ConnectorMetadata;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorPageSourceProvider;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorSplit;
+import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.FixedPageSource;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.transaction.IsolationLevel;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
+import io.prestosql.sql.planner.assertions.BasePlanTest;
+import io.prestosql.testing.LocalQueryRunner;
+import io.prestosql.testing.TestingHandleResolver;
+import io.prestosql.testing.TestingMetadata;
+import io.prestosql.testing.TestingPageSinkProvider;
+import io.prestosql.testing.TestingSplitManager;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.output;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public class TestMergeNestedColumns
+        extends BasePlanTest
+{
+    private static final Type MSG_TYPE = RowType.from(ImmutableList.of(field("x", VarcharType.VARCHAR), field("y", VarcharType.VARCHAR)));
+
+    public TestMergeNestedColumns()
+    {
+        super(TestMergeNestedColumns::createQueryRunner);
+    }
+
+    @Test
+    public void testSelectDereference()
+    {
+        assertPlan("select foo.x, foo.y, bar.x, bar.y from nested_column_table",
+                output(ImmutableList.of("foo_x", "foo_y", "bar_x", "bar_y"),
+                        project(ImmutableMap.of("foo_x", expression("foo_x"), "foo_y", expression("foo_y"), "bar_x", expression("bar.x"), "bar_y", expression("bar.y")),
+                                tableScan("nested_column_table", ImmutableMap.of("foo_x", "foo.x", "foo_y", "foo.y", "bar", "bar")))));
+    }
+
+    @Test
+    public void testSelectDereferenceAndParentDoesNotFire()
+    {
+        assertPlan("select foo.x, foo.y, foo from nested_column_table",
+                output(ImmutableList.of("foo_x", "foo_y", "foo"),
+                        project(ImmutableMap.of("foo_x", expression("foo.x"), "foo_y", expression("foo.y"), "foo", expression("foo")),
+                                tableScan("nested_column_table", ImmutableMap.of("foo", "foo")))));
+    }
+
+    private static LocalQueryRunner createQueryRunner()
+    {
+        String schemaName = "test-schema";
+        String catalogName = "test";
+        TableInfo regularTable = new TableInfo(new SchemaTableName(schemaName, "regular_table"),
+                ImmutableList.of(new ColumnMetadata("dummy_column", VarcharType.VARCHAR)), ImmutableMap.of());
+
+        TableInfo nestedColumnTable = new TableInfo(new SchemaTableName(schemaName, "nested_column_table"),
+                ImmutableList.of(new ColumnMetadata("foo", MSG_TYPE), new ColumnMetadata("bar", MSG_TYPE)), ImmutableMap.of(
+                new NestedColumn(ImmutableList.of("foo", "x")), 0,
+                new NestedColumn(ImmutableList.of("foo", "y")), 0));
+
+        ImmutableList<TableInfo> tableInfos = ImmutableList.of(regularTable, nestedColumnTable);
+
+        LocalQueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog(catalogName)
+                .setSchema(schemaName)
+                .build());
+        queryRunner.createCatalog(catalogName, new TestConnectorFactory(new TestMetadata(tableInfos)), ImmutableMap.of());
+        return queryRunner;
+    }
+
+    private static class TestConnectorFactory
+            implements ConnectorFactory
+    {
+        private final TestMetadata metadata;
+
+        public TestConnectorFactory(TestMetadata metadata)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public String getName()
+        {
+            return "test";
+        }
+
+        @Override
+        public ConnectorHandleResolver getHandleResolver()
+        {
+            return new TestingHandleResolver();
+        }
+
+        @Override
+        public Connector create(String connectorId, Map<String, String> config, ConnectorContext context)
+        {
+            return new TestConnector(metadata);
+        }
+    }
+
+    private enum TransactionInstance
+            implements ConnectorTransactionHandle
+    {
+        INSTANCE
+    }
+
+    private static class TestConnector
+            implements Connector
+    {
+        private final ConnectorMetadata metadata;
+
+        private TestConnector(ConnectorMetadata metadata)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+        {
+            return TransactionInstance.INSTANCE;
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+        {
+            return metadata;
+        }
+
+        @Override
+        public ConnectorSplitManager getSplitManager()
+        {
+            return new TestingSplitManager(ImmutableList.of());
+        }
+
+        @Override
+        public ConnectorPageSourceProvider getPageSourceProvider()
+        {
+            return new ConnectorPageSourceProvider()
+            {
+                @Override
+                public ConnectorPageSource createPageSource(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<ColumnHandle> columns)
+                {
+                    return new FixedPageSource(ImmutableList.of());
+                }
+            };
+        }
+
+        @Override
+        public ConnectorPageSinkProvider getPageSinkProvider()
+        {
+            return new TestingPageSinkProvider();
+        }
+    }
+
+    private static class TestMetadata
+            extends TestingMetadata
+    {
+        private final List<TableInfo> tableInfos;
+
+        TestMetadata(List<TableInfo> tableInfos)
+        {
+            this.tableInfos = requireNonNull(tableInfos, "tableinfos is null");
+            insertTables();
+        }
+
+        private void insertTables()
+        {
+            for (TableInfo tableInfo : tableInfos) {
+                getTables().put(tableInfo.getSchemaTableName(), tableInfo.getTableMetadata());
+            }
+        }
+
+        @Override
+        public Map<NestedColumn, ColumnHandle> getNestedColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<NestedColumn> dereferences)
+        {
+            requireNonNull(tableHandle, "tableHandle is null");
+            SchemaTableName tableName = getTableName(tableHandle);
+            return tableInfos.stream().filter(tableInfo -> tableInfo.getSchemaTableName().equals(tableName)).map(TableInfo::getNestedColumnHandle).findFirst().orElse(ImmutableMap.of());
+        }
+    }
+
+    private static class TableInfo
+    {
+        private final SchemaTableName schemaTableName;
+        private final List<ColumnMetadata> columnMetadatas;
+        private final Map<NestedColumn, Integer> nestedColumns;
+
+        public TableInfo(SchemaTableName schemaTableName, List<ColumnMetadata> columnMetadata, Map<NestedColumn, Integer> nestedColumns)
+        {
+            this.schemaTableName = schemaTableName;
+            this.columnMetadatas = columnMetadata;
+            this.nestedColumns = nestedColumns;
+        }
+
+        SchemaTableName getSchemaTableName()
+        {
+            return schemaTableName;
+        }
+
+        ConnectorTableMetadata getTableMetadata()
+        {
+            return new ConnectorTableMetadata(schemaTableName, columnMetadatas);
+        }
+
+        Map<NestedColumn, ColumnHandle> getNestedColumnHandle()
+        {
+            return nestedColumns.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                Preconditions.checkArgument(entry.getValue() >= 0 && entry.getValue() < columnMetadatas.size(), "index is not valid");
+                NestedColumn nestedColumn = entry.getKey();
+                return new TestingMetadata.TestingColumnHandle(nestedColumn.getName(), entry.getValue(), VarcharType.VARCHAR);
+            }));
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ColumnReference.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ColumnReference.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.sql.planner.assertions;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import io.prestosql.Session;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.TableHandle;
@@ -23,6 +25,7 @@ import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.TableScanNode;
 
+import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -91,8 +94,8 @@ public class ColumnReference
 
     private Optional<ColumnHandle> getColumnHandle(TableHandle tableHandle, Session session, Metadata metadata)
     {
-        return metadata.getColumnHandles(session, tableHandle).entrySet()
-                .stream()
+        return Streams.concat(metadata.getColumnHandles(session, tableHandle).entrySet().stream(),
+                metadata.getNestedColumnHandles(session, tableHandle, ImmutableList.of()).entrySet().stream().map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey().getName(), entry.getValue())))
                 .filter(entry -> columnName.equals(entry.getKey()))
                 .map(Map.Entry::getValue)
                 .findFirst();

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionVerifier.java
@@ -21,6 +21,7 @@ import io.prestosql.sql.tree.Cast;
 import io.prestosql.sql.tree.CoalesceExpression;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.DecimalLiteral;
+import io.prestosql.sql.tree.DereferenceExpression;
 import io.prestosql.sql.tree.DoubleLiteral;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FunctionCall;
@@ -34,8 +35,10 @@ import io.prestosql.sql.tree.LongLiteral;
 import io.prestosql.sql.tree.Node;
 import io.prestosql.sql.tree.NotExpression;
 import io.prestosql.sql.tree.NullLiteral;
+import io.prestosql.sql.tree.SearchedCaseExpression;
 import io.prestosql.sql.tree.SimpleCaseExpression;
 import io.prestosql.sql.tree.StringLiteral;
+import io.prestosql.sql.tree.SubscriptExpression;
 import io.prestosql.sql.tree.SymbolReference;
 import io.prestosql.sql.tree.TryExpression;
 import io.prestosql.sql.tree.WhenClause;
@@ -98,6 +101,20 @@ final class ExpressionVerifier
     }
 
     @Override
+    protected Boolean visitDereferenceExpression(DereferenceExpression actual, Node expectedExpression)
+    {
+        if (!(expectedExpression instanceof DereferenceExpression)) {
+            return false;
+        }
+
+        DereferenceExpression expected = (DereferenceExpression) expectedExpression;
+        if (actual.getField().equals(expected.getField())) {
+            return process(actual.getBase(), expected.getBase());
+        }
+        return false;
+    }
+
+    @Override
     protected Boolean visitCast(Cast actual, Node expectedExpression)
     {
         if (!(expectedExpression instanceof Cast)) {
@@ -123,6 +140,18 @@ final class ExpressionVerifier
         IsNullPredicate expected = (IsNullPredicate) expectedExpression;
 
         return process(actual.getValue(), expected.getValue());
+    }
+
+    @Override
+    protected Boolean visitSubscriptExpression(SubscriptExpression actual, Node expectedExpression)
+    {
+        if (!(expectedExpression instanceof SubscriptExpression)) {
+            return false;
+        }
+
+        SubscriptExpression expected = (SubscriptExpression) expectedExpression;
+
+        return process(actual.getBase(), expected.getBase()) && process(actual.getIndex(), expected.getIndex());
     }
 
     @Override
@@ -304,6 +333,17 @@ final class ExpressionVerifier
             return process(actual.getValue(), ((NotExpression) expected).getValue());
         }
         return false;
+    }
+
+    @Override
+    protected Boolean visitSearchedCaseExpression(SearchedCaseExpression actual, Node expectedExpression)
+    {
+        if (!(expectedExpression instanceof SearchedCaseExpression)) {
+            return false;
+        }
+
+        SearchedCaseExpression expected = (SearchedCaseExpression) expectedExpression;
+        return process(actual.getDefaultValue(), expected.getDefaultValue()) && process(actual.getWhenClauses(), expected.getWhenClauses());
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -324,6 +324,11 @@ public final class PlanMatchPattern
         return output(outputs, source).withExactOutputs(outputs);
     }
 
+    public static PlanMatchPattern unnest(List<String> replicateSymbols, Map<String, List<String>> unnestSymbols, Optional<String> ordinalitySymbol, PlanMatchPattern source)
+    {
+        return unnest(source).with(new UnnestMatcher(replicateSymbols, unnestSymbols, ordinalitySymbol));
+    }
+
     public static PlanMatchPattern project(PlanMatchPattern source)
     {
         return node(ProjectNode.class, source);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/UnnestMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/UnnestMatcher.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.prestosql.Session;
+import io.prestosql.cost.StatsProvider;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.UnnestNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.prestosql.sql.planner.assertions.MatchResult.match;
+import static java.util.Objects.requireNonNull;
+
+public class UnnestMatcher
+        implements Matcher
+{
+    private final List<String> replicateSymbols;
+    private final Map<String, List<String>> unnestSymbols;
+    private final Optional<String> ordinalitySymbol;
+
+    public UnnestMatcher(List<String> replicateSymbols, Map<String, List<String>> unnestSymbols, Optional<String> ordinalitySymbol)
+    {
+        this.replicateSymbols = requireNonNull(replicateSymbols, "replicateSymbols is null");
+        this.unnestSymbols = requireNonNull(unnestSymbols);
+        this.ordinalitySymbol = requireNonNull(ordinalitySymbol);
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof UnnestNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        UnnestNode unnestNode = (UnnestNode) node;
+
+        ImmutableList.Builder<String> aliasBuilder = ImmutableList.<String>builder().addAll(replicateSymbols).addAll(Iterables.concat(unnestSymbols.values()));
+        ordinalitySymbol.ifPresent(aliasBuilder::add);
+        List<String> alias = aliasBuilder.build();
+
+        if (alias.size() != unnestNode.getOutputSymbols().size()) {
+            return MatchResult.NO_MATCH;
+        }
+
+        SymbolAliases.Builder builder = SymbolAliases.builder().putAll(symbolAliases);
+        IntStream.range(0, alias.size()).forEach(i -> builder.put(alias.get(i), unnestNode.getOutputSymbols().get(i).toSymbolReference()));
+        return match(builder.build());
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
@@ -43,6 +43,12 @@ public class RuleTester
 
     private final Metadata metadata;
     private final Session session;
+
+    public LocalQueryRunner getQueryRunner()
+    {
+        return queryRunner;
+    }
+
     private final LocalQueryRunner queryRunner;
     private final TransactionManager transactionManager;
     private final SplitManager splitManager;

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/DereferenceExpression.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
 
 public class DereferenceExpression
         extends Expression
@@ -118,12 +119,12 @@ public class DereferenceExpression
         }
         DereferenceExpression that = (DereferenceExpression) o;
         return Objects.equals(base, that.base) &&
-                Objects.equals(field, that.field);
+                Objects.equals(field.getValue().toLowerCase(ENGLISH), that.field.getValue().toLowerCase(ENGLISH));
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(base, field);
+        return Objects.hash(base, field.getValue().toLowerCase(ENGLISH));
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/NestedColumn.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/NestedColumn.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class NestedColumn
+{
+    private final List<String> names;
+
+    @JsonCreator
+    public NestedColumn(@JsonProperty("names") List<String> names)
+    {
+        this.names = requireNonNull(names);
+    }
+
+    @JsonProperty
+    public List<String> getNames()
+    {
+        return names;
+    }
+
+    public String getBase()
+    {
+        return names.get(0);
+    }
+
+    public List<String> getRest()
+    {
+        // TODO assert size > 1;
+        return names.subList(1, names.size());
+    }
+
+    public String getName()
+    {
+        return names.stream().collect(Collectors.joining("."));
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(names);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        NestedColumn other = (NestedColumn) obj;
+        return Objects.equals(this.names, other.names);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("NestedColumns{");
+        sb.append("name='").append(getName()).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.connector;
 
 import io.airlift.slice.Slice;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.GrantInfo;
@@ -27,6 +28,7 @@ import io.prestosql.spi.statistics.TableStatisticsMetadata;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -645,5 +647,10 @@ public interface ConnectorMetadata
     default Optional<ConnectorTableHandle> applySample(ConnectorSession session, ConnectorTableHandle handle, SampleType sampleType, double sampleRatio)
     {
         return Optional.empty();
+    }
+
+    default Map<NestedColumn, ColumnHandle> getNestedColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<NestedColumn> dereferences)
+    {
+        return new HashMap<>();
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.connector.classloader;
 
 import io.airlift.slice.Slice;
+import io.prestosql.spi.NestedColumn;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
@@ -590,6 +591,13 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applySample(session, table, sampleType, sampleRatio);
+        }
+    }
+
+    public Map<NestedColumn, ColumnHandle> getNestedColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<NestedColumn> dereferences)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getNestedColumnHandles(session, tableHandle, dereferences);
         }
     }
 }


### PR DESCRIPTION
Rebased @qqibrow [patch](https://github.com/prestosql/presto/pull/187) to Presto master. When querying nested data, this patch improved our performance 40x (120 seconds -> 3 seconds). Great work, @qqibrow!