### PR TITLE
Support JSON CLI output format

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>okhttp</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -125,7 +125,7 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
-    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, CSV_UNQUOTED, CSV_HEADER_UNQUOTED, NULL] (default: CSV)")
+    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, JSON, CSV, TSV, CSV_HEADER, TSV_HEADER, CSV_UNQUOTED, CSV_HEADER_UNQUOTED, NULL] (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 
     @Option(name = "--resource-estimate", title = "resource-estimate", description = "Resource estimate (property can be used multiple times; format is key=value)")
@@ -159,6 +159,7 @@ public class ClientOptions
         CSV_HEADER,
         CSV_UNQUOTED,
         CSV_HEADER_UNQUOTED,
+        JSON,
         NULL
     }
 

--- a/presto-cli/src/main/java/io/prestosql/cli/JsonPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/JsonPrinter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cli;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+import static io.prestosql.cli.AlignedTablePrinter.formatHexDump;
+import static java.util.Objects.requireNonNull;
+
+public class JsonPrinter
+        implements OutputPrinter
+{
+    private final List<String> fieldNames;
+    private final Writer writer;
+
+    public JsonPrinter(List<String> fieldNames, Writer writer)
+    {
+        this.fieldNames = ImmutableList.copyOf(requireNonNull(fieldNames, "fieldNames is null"));
+        this.writer = requireNonNull(writer, "writer is null");
+    }
+
+    @Override
+    public void printRows(List<List<?>> rows, boolean complete)
+            throws IOException
+    {
+        JsonFactory jsonFactory = new JsonFactory();
+        for (List<?> row : rows) {
+            JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
+            jsonGenerator.writeStartObject();
+            for (int position = 0; position < row.size(); position++) {
+                String columnName = fieldNames.get(position);
+                jsonGenerator.writeObjectField(columnName, formatValue(row.get(position)));
+            }
+            jsonGenerator.writeEndObject();
+            jsonGenerator.writeRaw('\n');
+            jsonGenerator.flush();
+        }
+    }
+
+    @Override
+    public void finish()
+            throws IOException
+    {
+        writer.flush();
+    }
+
+    private static Object formatValue(Object o)
+    {
+        if (o instanceof byte[]) {
+            return formatHexDump((byte[]) o);
+        }
+        return o;
+    }
+}

--- a/presto-cli/src/main/java/io/prestosql/cli/Query.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Query.java
@@ -321,6 +321,8 @@ public class Query
                 return new TsvPrinter(fieldNames, writer, false);
             case TSV_HEADER:
                 return new TsvPrinter(fieldNames, writer, true);
+            case JSON:
+                return new JsonPrinter(fieldNames, writer);
             case NULL:
                 return new NullPrinter();
         }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestJsonPrinter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestJsonPrinter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cli;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+import static io.prestosql.cli.TestAlignedTablePrinter.row;
+import static io.prestosql.cli.TestAlignedTablePrinter.rows;
+import static org.testng.Assert.assertEquals;
+
+public class TestJsonPrinter
+{
+    @Test
+    public void testJsonPrinting()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.printRows(rows(
+                row("hello", "world", 123),
+                row("a", null, 4.5),
+                row("some long\ntext\tdone", "more\ntext", 4567),
+                row("bye", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "{\"first\":\"hello\",\"last\":\"world\",\"quantity\":123}\n" +
+                "{\"first\":\"a\",\"last\":null,\"quantity\":4.5}\n" +
+                "{\"first\":\"some long\\ntext\\tdone\",\"last\":\"more\\ntext\",\"quantity\":4567}\n" +
+                "{\"first\":\"bye\",\"last\":\"done\",\"quantity\":-15}\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testJsonPrintingNoRows()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.finish();
+
+        assertEquals(writer.getBuffer().toString(), "");
+    }
+
+    @Test
+    public void testJsonVarbinaryPrinting()
+            throws IOException
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
+        printer.finish();
+
+        String expected = "{\"first\":\"68 65 6c 6c 6f\",\"last\":null,\"quantity\":123}\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+}

--- a/presto-cli/src/test/java/io/prestosql/cli/TestTsvPrinter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestTsvPrinter.java
@@ -89,7 +89,7 @@ public class TestTsvPrinter
     }
 
     @Test
-    public void testCsvVarbinaryPrinting()
+    public void testTsvVarbinaryPrinting()
             throws IOException
     {
         StringWriter writer = new StringWriter();


### PR DESCRIPTION
Fix #867 

Example
```shell
$ presto --output-format JSON --execute "select * from tpch.sf1.customer limit 2" | jq
[
  {
    "custkey": 37501,
    "name": "Customer#000037501",
    "address": "Ftb6T5ImHuJ",
    "nationkey": 2,
    "phone": "12-397-688-6719",
    "acctbal": -324.85,
    "mktsegment": "HOUSEHOLD",
    "comment": "pending ideas use carefully. express, ironic platelets use among the furiously regular instructions. "
  },
  {
    "custkey": 37502,
    "name": "Customer#000037502",
    "address": "ppCVXCFV,4JJ97IibbcMB5,aPByjYL07vmOLO 3m",
    "nationkey": 18,
    "phone": "28-515-931-4624",
    "acctbal": 5179.2,
    "mktsegment": "BUILDING",
    "comment": "express deposits. pending, regular deposits wake furiously bold deposits. regular "
  }
]

$ presto --output-format JSON --execute "select * from tpch.sf1.customer limit 2" | jq '.[0].name'
"Customer#000112501"
```