### PR TITLE
Fix skipped test executions

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractCostBasedPlanTest
         return queryResourcePath.replaceAll("\\.sql$", ".plan.txt");
     }
 
-    public void generate()
+    protected void generate()
             throws Exception
     {
         initPlanTest();

--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationIntegerColumns.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationIntegerColumns.java
@@ -61,7 +61,7 @@ public class TestKuduIntegrationIntegerColumns
         }
     }
 
-    public void doTestCreateTableWithIntegerColumn(TestInt test)
+    private void doTestCreateTableWithIntegerColumn(TestInt test)
     {
         String dropTable = "DROP TABLE IF EXISTS test_int";
         String createTable = "CREATE TABLE test_int (\n";

--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationRangePartitioning.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationRangePartitioning.java
@@ -97,7 +97,7 @@ public class TestKuduIntegrationRangePartitioning
         }
     }
 
-    public void doTestCreateAndChangeTableWithRangePartition(TestRanges ranges)
+    private void doTestCreateAndChangeTableWithRangePartition(TestRanges ranges)
     {
         String[] types = ranges.types;
         String name = join("_", ranges.types);

--- a/presto-main/src/test/java/io/prestosql/tests/ReportUnannotatedMethods.java
+++ b/presto-main/src/test/java/io/prestosql/tests/ReportUnannotatedMethods.java
@@ -43,12 +43,16 @@ public class ReportUnannotatedMethods
                 .collect(toImmutableList());
 
         if (!unannotatedMethods.isEmpty()) {
-            throw new RuntimeException(format(
-                    "Test class %s has methods which are public but not explicitly annotated. Are they missing @Test?%s",
+            // TestNG may or may not propagate listener's exception as test execution exception.
+            // Therefore, instead of throwing, we terminate the JVM.
+            System.err.println(format(
+                    "FATAL: Test class %s has methods which are public but not explicitly annotated. Are they missing @Test?%s",
                     testClass.getRealClass().getName(),
                     unannotatedMethods.stream()
                             .map(Method::toString)
                             .collect(joining("\n\t\t", "\n\t\t", ""))));
+            System.err.println("JVM will be terminated");
+            System.exit(1);
         }
     }
 


### PR DESCRIPTION
Certain tests were skipped on Travis (e.g. `TestTpchCostBasedPlan`) since 6e860541025728510a509f088ef71139f7d025b7.

Travis output after the change (but without fixing the test class):
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
2019-06-10T08:34:42.542-0500 SEVERE Test class io.prestosql.sql.planner.TestTpchCostBasedPlan has methods which are public but not explicitly annotated. Are they missing @Test?
		public void io.prestosql.sql.planner.AbstractCostBasedPlanTest.generate() throws java.lang.Exception
2019-06-10T08:34:42.567-0500 SEVERE JVM will be terminated
2019-06-10T08:34:42.546-0500 SEVERE Test class io.prestosql.sql.planner.TestTpcdsCostBasedPlan has methods which are public but not explicitly annotated. Are they missing @Test?
		public void io.prestosql.sql.planner.AbstractCostBasedPlanTest.generate() throws java.lang.Exception
2019-06-10T08:34:42.570-0500 SEVERE JVM will be terminated
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] presto-root ........................................ SUCCESS [  2.801 s]
[INFO] presto-spi ......................................... SUCCESS [  7.070 s]
[INFO] presto-plugin-toolkit .............................. SUCCESS [  3.635 s]
[INFO] presto-client ...................................... SUCCESS [  2.887 s]
[INFO] presto-parser ...................................... SUCCESS [  5.641 s]
[INFO] presto-geospatial-toolkit .......................... SUCCESS [  3.328 s]
[INFO] presto-array ....................................... SUCCESS [  2.668 s]
[INFO] presto-matching .................................... SUCCESS [  1.901 s]
[INFO] presto-memory-context .............................. SUCCESS [  1.788 s]
[INFO] presto-tpch ........................................ SUCCESS [  2.829 s]
[INFO] presto-resource-group-managers ..................... SUCCESS [  8.304 s]
[INFO] presto-atop ........................................ SUCCESS [ 11.113 s]
[INFO] presto-jmx ......................................... SUCCESS [ 47.548 s]
[INFO] presto-record-decoder .............................. SUCCESS [  5.540 s]
[INFO] presto-kafka ....................................... SUCCESS [08:35 min]
[INFO] presto-blackhole ................................... SUCCESS [ 47.781 s]
[INFO] presto-memory ...................................... SUCCESS [01:22 min]
[INFO] presto-benchmark ................................... SUCCESS [ 34.164 s]
[INFO] presto-rcfile ...................................... SUCCESS [01:26 min]
[INFO] presto-hive-hadoop2 ................................ SUCCESS [  1.556 s]
[INFO] presto-teradata-functions .......................... SUCCESS [ 10.834 s]
[INFO] presto-example-http ................................ SUCCESS [  4.964 s]
[INFO] presto-local-file .................................. SUCCESS [  3.327 s]
[INFO] presto-tpcds ....................................... SUCCESS [02:13 min]
[INFO] presto-base-jdbc ................................... SUCCESS [05:12 min]
[INFO] presto-testing-docker .............................. SUCCESS [  1.037 s]
[INFO] presto-redshift .................................... SUCCESS [  5.827 s]
[INFO] presto-ml .......................................... SUCCESS [ 21.804 s]
[INFO] presto-geospatial .................................. SUCCESS [01:59 min]
[INFO] presto-jdbc ........................................ SUCCESS [02:45 min]
[INFO] presto-cli ......................................... SUCCESS [  3.321 s]
[INFO] presto-product-tests ............................... SUCCESS [  3.517 s]
[INFO] presto-benchmark-driver ............................ SUCCESS [  1.772 s]
[INFO] presto-thrift-api .................................. SUCCESS [ 12.234 s]
[INFO] presto-verifier .................................... SUCCESS [  6.265 s]
[INFO] presto-testing-server-launcher ..................... SUCCESS [  1.051 s]
[INFO] presto-password-authenticators ..................... SUCCESS [  2.371 s]
[INFO] presto-session-property-managers ................... SUCCESS [  3.208 s]
[INFO] presto-benchto-benchmarks .......................... FAILURE [  2.331 s]
[INFO] presto-thrift-testing-server ....................... SKIPPED
[INFO] presto-thrift ...................................... SKIPPED
[INFO] presto-proxy ....................................... SKIPPED
[INFO] presto-elasticsearch ............................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:11 min
[INFO] Finished at: 2019-06-10T13:34:42Z
[INFO] Final Memory: 162M/420M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.0:test (default-test) on project presto-benchto-benchmarks: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/travis/build/prestosql/presto/presto-benchto-benchmarks/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /home/travis/build/prestosql/presto/presto-benchto-benchmarks && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Dfile.encoding=UTF-8 -Xmx2g -Xms2g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -jar /home/travis/build/prestosql/presto/presto-benchto-benchmarks/target/surefire/surefirebooter8321762598671820864.jar /home/travis/build/prestosql/presto/presto-benchto-benchmarks/target/surefire 2019-06-10T13-06-39_626-jvmRun1 surefire29640636017816578tmp surefire_34558604964106061527tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 1
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /home/travis/build/prestosql/presto/presto-benchto-benchmarks && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Dfile.encoding=UTF-8 -Xmx2g -Xms2g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow -jar /home/travis/build/prestosql/presto/presto-benchto-benchmarks/target/surefire/surefirebooter8321762598671820864.jar /home/travis/build/prestosql/presto/presto-benchto-benchmarks/target/surefire 2019-06-10T13-06-39_626-jvmRun1 surefire29640636017816578tmp surefire_34558604964106061527tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 1
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:671)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:533)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:278)
[ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:244)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1194)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1022)
[ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:868)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:309)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:194)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:107)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:993)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:345)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:191)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.lang.reflect.Method.invoke(Method.java:498)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.lang.reflect.Method.invoke(Method.java:498)
[ERROR] 	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
[ERROR] 	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
[ERROR] 	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:50)
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :presto-benchto-benchmarks
travis_time:end:040187b6:start=1560171989320851157,finish=1560173683536682095,duration=1694215830938
[0K[31;1mThe command "if [[ -v TEST_OTHER_MODULES ]]; then
  ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B -pl "${TEST_OTHER_MODULES}"
fi
" exited with 1.[0m
```

Thanks @kasiafi for finding that.