### PR TITLE
Compute estimated size directly from Slice for parseJson function

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/JsonFunctions.java
@@ -143,8 +143,7 @@ public final class JsonFunctions
         // If you make changes to this function (e.g. use parse JSON string into some internal representation),
         // make sure `$internal$json_string_to_array/map/row_cast` is changed accordingly.
         try (JsonParser parser = createJsonParser(JSON_FACTORY, slice)) {
-            byte[] in = slice.getBytes();
-            SliceOutput dynamicSliceOutput = new DynamicSliceOutput(in.length);
+            SliceOutput dynamicSliceOutput = new DynamicSliceOutput(slice.length());
             SORTED_MAPPER.writeValue((OutputStream) dynamicSliceOutput, SORTED_MAPPER.readValue(parser, Object.class));
             // nextToken() returns null if the input is parsed correctly,
             // but will throw an exception if there are trailing characters.


### PR DESCRIPTION
When parsing a JSON using Presto's parseJson we compute estimated size of output by populating byte[] from Slice which is not required as we could fetch the same from the length of the Slice.