### PR TITLE
Correctly Identify S3 Usage for EmrFs

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -176,6 +176,7 @@ import static io.prestosql.plugin.hive.HiveUtil.toPartitionValues;
 import static io.prestosql.plugin.hive.HiveUtil.verifyPartitionTypeSupported;
 import static io.prestosql.plugin.hive.HiveWriteUtils.checkTableIsWritable;
 import static io.prestosql.plugin.hive.HiveWriteUtils.initializeSerializer;
+import static io.prestosql.plugin.hive.HiveWriteUtils.isS3FileSystem;
 import static io.prestosql.plugin.hive.HiveWriteUtils.isWritableType;
 import static io.prestosql.plugin.hive.HiveWriterFactory.computeBucketedFileName;
 import static io.prestosql.plugin.hive.PartitionUpdate.UpdateMode.APPEND;
@@ -767,8 +768,10 @@ public class HiveMetadata
     {
         try {
             Path path = new Path(location);
-            if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
-                throw new PrestoException(INVALID_TABLE_PROPERTY, "External location must be a directory");
+            if (!isS3FileSystem(context, hdfsEnvironment, path)) {
+                if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
+                    throw new PrestoException(INVALID_TABLE_PROPERTY, "External location must be a directory");
+                }
             }
             return path;
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
@@ -23,7 +23,6 @@ import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Storage;
 import io.prestosql.plugin.hive.metastore.Table;
-import io.prestosql.plugin.hive.s3.HiveS3Module;
 import io.prestosql.plugin.hive.s3.PrestoS3FileSystem;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
@@ -118,6 +117,7 @@ import static io.prestosql.plugin.hive.HiveUtil.isRowType;
 import static io.prestosql.plugin.hive.ParquetRecordWriterUtil.createParquetWriter;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getProtectMode;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.verifyOnline;
+import static io.prestosql.plugin.hive.s3.HiveS3Module.EMR_FS_CLASS_NAME;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.Chars.isCharType;
 import static java.lang.Float.intBitsToFloat;
@@ -460,7 +460,7 @@ public final class HiveWriteUtils
     {
         try {
             FileSystem fileSystem = getRawFileSystem(hdfsEnvironment.getFileSystem(context, path));
-            return fileSystem instanceof PrestoS3FileSystem || fileSystem.getClass().getName().equals(HiveS3Module.EMR_FS_CLASS_NAME);
+            return fileSystem instanceof PrestoS3FileSystem || fileSystem.getClass().getName().equals(EMR_FS_CLASS_NAME);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Storage;
 import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.plugin.hive.s3.HiveS3Module;
 import io.prestosql.plugin.hive.s3.PrestoS3FileSystem;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
@@ -458,7 +459,8 @@ public final class HiveWriteUtils
     public static boolean isS3FileSystem(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return getRawFileSystem(hdfsEnvironment.getFileSystem(context, path)) instanceof PrestoS3FileSystem;
+            FileSystem fileSystem = getRawFileSystem(hdfsEnvironment.getFileSystem(context, path));
+            return fileSystem instanceof PrestoS3FileSystem || fileSystem.getClass().getName().equals(HiveS3Module.EMR_FS_CLASS_NAME);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
@@ -27,7 +27,7 @@ import static org.weakref.jmx.guice.ExportBinder.newExporter;
 public class HiveS3Module
         extends AbstractConfigurationAwareModule
 {
-    private static final String EMR_FS_CLASS_NAME = "com.amazon.ws.emr.hadoop.fs.EmrFileSystem";
+    public static final String EMR_FS_CLASS_NAME = "com.amazon.ws.emr.hadoop.fs.EmrFileSystem";
 
     @Override
     protected void setup(Binder binder)


### PR DESCRIPTION
Fixes #699

This PR modifies the way that Presto checks for the S3 file system class. The file system checks if it is an instance of `PrestoS3` or the class name matches the EmrFs class name. The EmrFs class name was modified to be `public static` from the HiveS3Module class so it did not have to be redefined. 

During testing, it was also discovered that when creating a new table, there was another check done to ensure that the directory exists before creating the table. In S3, the directory does not necessarily need to exist before data is written so I have added a condition to see if it is an S3 filesystem before doing the check that the external location exists. 

\- Chris