### PR TITLE
Fix minor issues in the elasticsearch connector documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -263,11 +263,31 @@ Optionally, column metadata can be described in the same table description JSON 
 ===================== ========= ============== =============================
 Field                 Required  Type           Description
 ===================== ========= ============== =============================
-``name``              optional  string         Column name of Elasticsearch field.
-``type``              optional  string         Column type of Elasticsearch `field`_.
-``jsonPath``          optional  string         Json path of Elasticsearch field.
-``jsonType``          optional  string         Json type of Elasticsearch field.
+``name``              required  string         Column name of Elasticsearch field.
+``type``              required  string         Column type of Elasticsearch field (see second column of `data type mapping`_).
+``jsonPath``          required  string         Json path of Elasticsearch field (when in doubt set to the same as ``name``).
+``jsonType``          required  string         Json type of Elasticsearch field (when in doubt set to the same as ``type``).
 ``ordinalPosition``   optional  integer        Ordinal position of the column.
 ===================== ========= ============== =============================
 
-.. _field: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
+.. _data type mapping: #data-types
+
+Data Types
+----------
+
+The data type mappings are as follows:
+
+============= ======
+Elasticsearch Presto
+============= ======
+``binary``    ``VARBINARY``
+``boolean``   ``BOOLEAN``
+``double``    ``DOUBLE``
+``float``     ``DOUBLE``
+``integer``   ``INTEGER``
+``keyword``   ``VARCHAR``
+``long``      ``BIGINT``
+``string``    ``VARCHAR``
+``text``      ``VARCHAR``
+(all others)  (unsupported)
+============= ======

--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -222,7 +222,7 @@ A table definition file describes a table in JSON format.
     {
         "tableName": ...,
         "schemaName": ...,
-        "hostAddress": ...,
+        "host": ...,
         "port": ...,
         "clusterName": ...,
         "index": ...,
@@ -249,7 +249,7 @@ Field               Required  Type           Description
 ``clusterName``     required  string         Elasticsearch cluster name.
 ``index``           required  string         Elasticsearch index that is backing this table.
 ``indexExactMatch`` optional  boolean        If set to true, the index specified with the ``index`` property is used. Otherwise, all indices starting with the prefix specified by the ``index`` property are used.
-``type``            required  string         Elasticsearch `mapping type`_, which determines how the document are indexed.
+``type``            required  string         Elasticsearch `mapping type`_, which determines how the document are indexed (like "_doc").
 ``columns``         optional  list           List of column metadata information.
 =================== ========= ============== =============================
 


### PR DESCRIPTION
For prior discussion see also [this issue](https://github.com/prestodb/presto/issues/12880) in prestodb.  This PR is to fix points 2, 4 and 5 therein.

Further improvements may be of use to the description / explanation of `JSONtype` and `JSONpath` but unfortunately I'm out of depth there :( (as of yet anyway).