### PR TITLE
Enable JMX on recent JDKs

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -82,6 +82,7 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:+UseGCOverheadLimit
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:ReservedCodeCacheSize=512M
+    -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
 
 Because an ``OutOfMemoryError`` will typically leave the JVM in an

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -15,6 +15,7 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
+-Djdk.attach.allowAttachSelf=true
 # jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
 -Djdk.nio.maxCachedBufferSize=0
 -DHADOOP_USER_NAME=hive

--- a/presto-product-tests/conf/presto/etc/multinode-master-jvm.config
+++ b/presto-product-tests/conf/presto/etc/multinode-master-jvm.config
@@ -16,6 +16,7 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
+-Djdk.attach.allowAttachSelf=true
 # jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
 -Djdk.nio.maxCachedBufferSize=0
 -DHADOOP_USER_NAME=hive

--- a/presto-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/presto-server-rpm/src/main/resources/dist/config/jvm.config
@@ -8,4 +8,5 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=512M
+-Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000


### PR DESCRIPTION
We already have `-Djdk.attach.allowAttachSelf=true` in Presto docker image's `jvm.config`.