### PR TITLE
Update to aircompressor 0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.14</version>
+                <version>0.15</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes a rare bug when compressing data that generates
a large RLE literal block.