### PR TITLE
Log metastore calls

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>parameternames</artifactId>
+            <version>1.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -14,6 +14,9 @@
 package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.prestosql.plugin.hive.util.LoggingInvocationHandler;
+import io.prestosql.plugin.hive.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -44,18 +47,30 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.reflect.Reflection.newProxy;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftHiveMetastoreClient
         implements ThriftMetastoreClient
 {
+    private static final Logger log = Logger.get(ThriftHiveMetastoreClient.class);
+
     private final TTransport transport;
-    private final ThriftHiveMetastore.Client client;
+    private final ThriftHiveMetastore.Iface client;
 
     public ThriftHiveMetastoreClient(TTransport transport)
     {
         this.transport = requireNonNull(transport, "transport is null");
-        this.client = new ThriftHiveMetastore.Client(new TBinaryProtocol(transport));
+        ThriftHiveMetastore.Client client = new ThriftHiveMetastore.Client(new TBinaryProtocol(transport));
+        if (log.isDebugEnabled()) {
+            this.client = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(
+                    client,
+                    new AirliftParameterNamesProvider(ThriftHiveMetastore.Iface.class, ThriftHiveMetastore.Client.class),
+                    log::debug));
+        }
+        else {
+            this.client = client;
+        }
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/LoggingInvocationHandler.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/LoggingInvocationHandler.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.AbstractInvocationHandler;
+import io.airlift.log.Logger;
+import io.airlift.parameternames.ParameterNames;
+import io.airlift.units.Duration;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.joining;
+
+public class LoggingInvocationHandler
+        extends AbstractInvocationHandler
+{
+    private final Object delegate;
+    private final ParameterNamesProvider parameterNames;
+    private final Consumer<String> logger;
+
+    public LoggingInvocationHandler(Object delegate, ParameterNamesProvider parameterNames, Consumer<String> logger)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.parameterNames = requireNonNull(parameterNames, "parameterNames is null");
+        this.logger = requireNonNull(logger, "logger is null");
+    }
+
+    @Override
+    protected Object handleInvocation(Object proxy, Method method, Object[] args)
+            throws Throwable
+    {
+        Object result;
+        long startNanos = System.nanoTime();
+        try {
+            result = method.invoke(delegate, args);
+        }
+        catch (Exception e) {
+            Duration elapsed = Duration.nanosSince(startNanos);
+            logger.accept(format("%s took %s and failed with %s", invocationDescription(method, args), elapsed, e));
+            throw e;
+        }
+        Duration elapsed = Duration.nanosSince(startNanos);
+        logger.accept(format("%s succeeded in %s", invocationDescription(method, args), elapsed));
+        return result;
+    }
+
+    private String invocationDescription(Method method, Object[] args)
+    {
+        Optional<List<String>> parameterNames = this.parameterNames.getParameterNames(method);
+        return "Invocation of " + method.getName() +
+                IntStream.range(0, args.length)
+                        .mapToObj(i -> {
+                            if (parameterNames.isPresent()) {
+                                return format("%s=%s", parameterNames.get().get(i), formatArgument(args[i]));
+                            }
+                            return formatArgument(args[i]);
+                        })
+                        .collect(joining(", ", "(", ")"));
+    }
+
+    private static String formatArgument(Object arg)
+    {
+        if (arg instanceof String) {
+            return "'" + ((String) arg).replace("'", "''") + "'";
+        }
+        return String.valueOf(arg);
+    }
+
+    public interface ParameterNamesProvider
+    {
+        Optional<List<String>> getParameterNames(Method method);
+    }
+
+    public static class ReflectiveParameterNamesProvider
+            implements ParameterNamesProvider
+    {
+        @Override
+        public Optional<List<String>> getParameterNames(Method method)
+        {
+            Parameter[] parameters = method.getParameters();
+            if (Arrays.stream(parameters).noneMatch(Parameter::isNamePresent)) {
+                return Optional.empty();
+            }
+            return Arrays.stream(parameters)
+                    .map(Parameter::getName)
+                    .collect(collectingAndThen(toImmutableList(), Optional::of));
+        }
+    }
+
+    public static class AirliftParameterNamesProvider
+            implements ParameterNamesProvider
+    {
+        private static final Logger log = Logger.get(AirliftParameterNamesProvider.class);
+
+        private final Map<Method, List<String>> parameterNames;
+
+        public <I, C extends I> AirliftParameterNamesProvider(Class<I> interfaceClass, Class<C> implementationClass)
+        {
+            requireNonNull(interfaceClass, "interfaceClass is null");
+            requireNonNull(implementationClass, "implementationClass is null");
+
+            ImmutableMap.Builder<Method, List<String>> parameterNames = ImmutableMap.builder();
+            for (Method interfaceMethod : interfaceClass.getMethods()) {
+                Optional<List<String>> names = ParameterNames.tryGetParameterNames(interfaceMethod);
+                if (!names.isPresent()) {
+                    Method implementationMethod = null;
+                    try {
+                        implementationMethod = implementationClass.getMethod(interfaceMethod.getName(), interfaceMethod.getParameterTypes());
+                    }
+                    catch (NoSuchMethodException e) {
+                        log.debug(e, "Could not find implementation for %s", interfaceMethod);
+                    }
+                    if (implementationMethod != null) {
+                        names = ParameterNames.tryGetParameterNames(implementationMethod);
+                    }
+                }
+                names.ifPresent(strings -> parameterNames.put(interfaceMethod, strings));
+            }
+            this.parameterNames = parameterNames.build();
+        }
+
+        @Override
+        public Optional<List<String>> getParameterNames(Method method)
+        {
+            return Optional.ofNullable(parameterNames.get(method));
+        }
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestLoggingInvocationHandler.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestLoggingInvocationHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.util;
+
+import io.prestosql.plugin.hive.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
+import io.prestosql.plugin.hive.util.LoggingInvocationHandler.ReflectiveParameterNamesProvider;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.reflect.Reflection.newProxy;
+import static java.lang.reflect.Proxy.newProxyInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggingInvocationHandler
+{
+    private static final String DURATION_PATTERN = "\\d+(\\.\\d+)?\\w{1,2}";
+
+    @Test
+    public void testLogging()
+    {
+        List<String> messages = new ArrayList<>();
+        SomeInterface proxy = newProxy(SomeInterface.class, new LoggingInvocationHandler(new SomeInterface() {}, new ReflectiveParameterNamesProvider(), messages::add));
+        proxy.foo(true, "xyz");
+        assertThat(messages)
+                .hasSize(1)
+                .element(0).matches(message -> message.matches("\\QInvocation of foo(bar=true, s='xyz') succeeded in\\E " + DURATION_PATTERN));
+    }
+
+    @Test
+    public void testWithThriftHiveMetastoreClient()
+            throws Exception
+    {
+        List<String> messages = new ArrayList<>();
+        // LoggingInvocationHandler is used e.g. with ThriftHiveMetastore.Iface. Since the logging is reflection-based,
+        // we test it with this interface as well.
+        ThriftHiveMetastore.Iface proxy = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(
+                dummyThriftHiveMetastoreClient(),
+                new AirliftParameterNamesProvider(ThriftHiveMetastore.Iface.class, ThriftHiveMetastore.Client.class),
+                messages::add));
+        proxy.get_table("some_database", "some_table_name");
+        assertThat(messages)
+                .hasSize(1)
+                .element(0).matches(message -> message.matches("\\QInvocation of get_table(dbname='some_database', tbl_name='some_table_name') succeeded in\\E " + DURATION_PATTERN));
+    }
+
+    private static ThriftHiveMetastore.Iface dummyThriftHiveMetastoreClient()
+    {
+        return (ThriftHiveMetastore.Iface) newProxyInstance(
+                TestLoggingInvocationHandler.class.getClassLoader(),
+                new Class[] {ThriftHiveMetastore.Iface.class},
+                (proxy, method, args) -> null);
+    }
+
+    private interface SomeInterface
+    {
+        default void foo(boolean bar, String s) {}
+    }
+}


### PR DESCRIPTION
Example logging output when doing `SHOW TABLES`

```
DEBUG	Query-1_g8ph3-190	ThriftHiveMetastoreClient	Invocation of get_all_databases() succeeded in 109.21ms
DEBUG	Query-1_g8ph3-190	ThriftHiveMetastoreClient	Invocation of get_all_tables('default') succeeded in 136.49ms
DEBUG	Query-1_g8ph3-190	ThriftHiveMetastoreClient	Invocation of get_database('default') succeeded in 127.34ms
DEBUG	Query-1_g8ph3-190	ThriftHiveMetastoreClient	Invocation of get_table_names_by_filter('default', 'hive_filter_field_params__presto_view = "true"', -1) succeeded in 122.13ms
```