### PR TITLE
Mark Hive TPCH q17 as big_query

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch; tables: lineitem,part
+-- database: presto; groups: tpch, big_query; tables: lineitem,part
 SELECT sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
   lineitem,


### PR DESCRIPTION
Mark Hive TPCH q17 as big_query

This query fails on Travis intermittently.
