### PR TITLE
CLI: Enable function and table completion even if catalog and schema are not specified

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -344,7 +344,6 @@ public class Console
                         .withCatalog(query.getSetCatalog().orElse(session.getCatalog()))
                         .withSchema(query.getSetSchema().orElse(session.getSchema()))
                         .build();
-                schemaChanged.run();
             }
 
             // update transaction ID if necessary
@@ -388,6 +387,11 @@ public class Console
 
             session = builder.build();
             queryRunner.setSession(session);
+
+            // refresh completion caches if catalog or schema was changed
+            if (query.getSetCatalog().isPresent() || query.getSetSchema().isPresent()) {
+                schemaChanged.run();
+            }
 
             return success;
         }

--- a/presto-cli/src/main/java/io/prestosql/cli/TableNameCompleter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/TableNameCompleter.java
@@ -227,7 +227,7 @@ public class TableNameCompleter
         String[] fragments = splitTableName(prefix);
         if (fragments.length > 1) {
             List<String> catalogs = catalogCache.getIfPresent("");
-            if (catalogs.contains(fragments[0])) {
+            if (catalogs != null && catalogs.contains(fragments[0])) {
                 return fragments[0];
             }
         }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestTableNameCompleter.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestTableNameCompleter.java
@@ -13,9 +13,10 @@
  */
 package io.prestosql.cli;
 
-import com.google.common.collect.ImmutableList;
 import io.prestosql.client.ClientSession;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
 
 import static io.prestosql.cli.TestQueryRunner.createQueryRunner;
 import static org.testng.Assert.assertEquals;
@@ -29,6 +30,6 @@ public class TestTableNameCompleter
         QueryRunner runner = createQueryRunner(session);
 
         TableNameCompleter completer = new TableNameCompleter(runner);
-        assertEquals(completer.complete("SELECT is_infi", 14, ImmutableList.of()), 7);
+        assertEquals(completer.complete("SELECT is_infi", 14, new ArrayList<>()), 7);
     }
 }


### PR DESCRIPTION
Currently, function name completion and table name completion are work only if both `--catalog` and `--schema` are specified as command line options. This pull request improves query completion as follows:

- Enable table name completion even if catalog and schema are not specified
- Enable function name completion even if catalog and schema are not specified
- Fix a bug that updating completion cache doesn't work when catalog or schema is changed