### PR TITLE
Add query diagnosis warning

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -118,6 +118,7 @@ public final class SystemSessionProperties
     public static final String SKIP_REDUNDANT_SORT = "skip_redundant_sort";
     public static final String WORK_PROCESSOR_PIPELINES = "work_processor_pipelines";
     public static final String ENABLE_DYNAMIC_FILTERING = "enable_dynamic_filtering";
+    public static final String ENABLE_QUERY_DIAGNOSIS_WARNING = "enable_query_diagnosis_warning";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -509,6 +510,11 @@ public final class SystemSessionProperties
                         ENABLE_DYNAMIC_FILTERING,
                         "Enable dynamic filtering",
                         featuresConfig.isEnableDynamicFiltering(),
+                        false),
+                booleanProperty(
+                        ENABLE_QUERY_DIAGNOSIS_WARNING,
+                        "Enable query diagnosis warning",
+                            featuresConfig.getQueryDiagnosisWarningEnable(),
                         false));
     }
 
@@ -905,5 +911,10 @@ public final class SystemSessionProperties
     public static boolean isEnableDynamicFiltering(Session session)
     {
         return session.getSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.class);
+    }
+
+    public static boolean isEnableQueryDiagnosisWarning(Session session)
+    {
+        return session.getSystemProperty(ENABLE_QUERY_DIAGNOSIS_WARNING, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -122,6 +122,7 @@ public class FeaturesConfig
     private boolean optimizeTopNRowNumber = true;
     private boolean workProcessorPipelines;
     private boolean skipRedundantSort = true;
+    private boolean enableQueryDiagnosisWarning;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private boolean enableDynamicFiltering;
@@ -892,6 +893,18 @@ public class FeaturesConfig
     public FeaturesConfig setMaxGroupingSets(int maxGroupingSets)
     {
         this.maxGroupingSets = maxGroupingSets;
+        return this;
+    }
+
+    public boolean getQueryDiagnosisWarningEnable()
+    {
+        return enableQueryDiagnosisWarning;
+    }
+
+    @Config("analyzer.query-diagnosis-warning-enabled")
+    public FeaturesConfig setQueryDiagnosisWarningEnable(boolean queryDiagnosisWarning)
+    {
+        this.enableQueryDiagnosisWarning = queryDiagnosisWarning;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/sanity/warnings/DeprecatedFunctionWarning.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/sanity/warnings/DeprecatedFunctionWarning.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.sanity.warnings;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.PrestoWarning;
+import io.prestosql.sql.planner.ExpressionExtractor;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.sanity.PlanSanityChecker;
+import io.prestosql.sql.tree.DefaultTraversalVisitor;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.FunctionCall;
+
+import java.util.List;
+
+import static io.prestosql.spi.connector.StandardWarningCode.DREPRCATED_FUNCTION;
+
+public final class DeprecatedFunctionWarning
+        implements PlanSanityChecker.Checker
+{
+    private List<String> deprecatedFunctions = ImmutableList.of("json_array_get");
+
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, TypeAnalyzer typeAnalyzer, TypeProvider types, WarningCollector warningCollector)
+    {
+        for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitFunctionCall(FunctionCall node, Void context)
+                {
+                    if (node.getName().getParts().stream().anyMatch(deprecatedFunctions::contains)) {
+                        warningCollector.add(new PrestoWarning(DREPRCATED_FUNCTION, "Detected use of deprecated function: json_array_get()"));
+                    }
+                    return null;
+                }
+            }.process(expression, null);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/sanity/warnings/IntegerDivisionWarning.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/sanity/warnings/IntegerDivisionWarning.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.sanity.warnings;
+
+import io.prestosql.Session;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.PrestoWarning;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.ExpressionExtractor;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.sanity.PlanSanityChecker;
+import io.prestosql.sql.tree.ArithmeticBinaryExpression;
+import io.prestosql.sql.tree.DefaultTraversalVisitor;
+import io.prestosql.sql.tree.Expression;
+
+import static io.prestosql.spi.connector.StandardWarningCode.INTEGER_DIVISION;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.sql.tree.ArithmeticBinaryExpression.Operator.DIVIDE;
+
+public final class IntegerDivisionWarning
+        implements PlanSanityChecker.Checker
+{
+    public IntegerDivisionWarning() {}
+
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, TypeAnalyzer typeAnalyzer, TypeProvider types, WarningCollector warningCollector)
+    {
+        for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitArithmeticBinary(ArithmeticBinaryExpression node, Void context)
+                {
+                    if (node.getOperator().equals(DIVIDE)) {
+                        Type leftType = typeAnalyzer.getType(session, types, node.getLeft());
+                        Type rightType = typeAnalyzer.getType(session, types, node.getRight());
+                        if (leftType.equals(INTEGER) && rightType.equals(INTEGER)) {
+                            warningCollector.add(new PrestoWarning(INTEGER_DIVISION, "Detected integer division. Possible loss of precision."));
+                        }
+                    }
+                    return null;
+                }
+            }.process(expression, null);
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -105,6 +105,7 @@ public class TestFeaturesConfig
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.NEW)
                 .setDistributedSortEnabled(true)
                 .setMaxGroupingSets(2048)
+                .setQueryDiagnosisWarningEnable(false)
                 .setWorkProcessorPipelines(false)
                 .setSkipRedundantSort(true)
                 .setEnableDynamicFiltering(false));
@@ -172,6 +173,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-top-n-row-number", "false")
                 .put("distributed-sort", "false")
                 .put("analyzer.max-grouping-sets", "2047")
+                .put("analyzer.query-diagnosis-warning-enabled", "true")
                 .put("experimental.work-processor-pipelines", "true")
                 .put("optimizer.skip-redundant-sort", "false")
                 .put("experimental.enable-dynamic-filtering", "true")
@@ -235,6 +237,7 @@ public class TestFeaturesConfig
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.LEGACY)
                 .setDistributedSortEnabled(false)
                 .setMaxGroupingSets(2047)
+                .setQueryDiagnosisWarningEnable(true)
                 .setDefaultFilterFactorEnabled(true)
                 .setWorkProcessorPipelines(true)
                 .setSkipRedundantSort(false)

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/StandardWarningCode.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/StandardWarningCode.java
@@ -21,6 +21,8 @@ public enum StandardWarningCode
 {
     TOO_MANY_STAGES(0x0000_0001),
     REDUNDANT_ORDER_BY(0x0000_0002),
+    INTEGER_DIVISION(0x0000_0003),
+    DREPRCATED_FUNCTION(0x0000_0004),
 
     /**/;
     private final WarningCode warningCode;

--- a/presto-tests/src/test/java/io/prestosql/execution/TestDiagnosisWarning.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestDiagnosisWarning.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.execution.warnings.DefaultWarningCollector;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.execution.warnings.WarningCollectorConfig;
+import io.prestosql.plugin.tpch.TpchConnectorFactory;
+import io.prestosql.spi.PrestoWarning;
+import io.prestosql.spi.WarningCode;
+import io.prestosql.spi.connector.StandardWarningCode;
+import io.prestosql.sql.planner.LogicalPlanner;
+import io.prestosql.testing.LocalQueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.fail;
+
+public class TestDiagnosisWarning
+{
+    private LocalQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .build());
+
+        queryRunner.createCatalog(
+                queryRunner.getDefaultSession().getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+    }
+
+    @Test
+    public void testWarningSession()
+    {
+        WarningCode warningCode = StandardWarningCode.INTEGER_DIVISION.toWarningCode();
+        // sessionProperties = null
+        assertPlannerWarnings(queryRunner,
+                "SELECT 1/2",
+                ImmutableMap.of(),
+                Optional.empty());
+
+        // session enable_query_diagnosis_warning = true
+        assertPlannerWarnings(queryRunner,
+                "SELECT 1/2",
+                Optional.of(warningCode));
+    }
+
+    @Test
+    public void testIntegerDivisionWarning()
+    {
+        WarningCode warningCode = StandardWarningCode.INTEGER_DIVISION.toWarningCode();
+        assertPlannerWarnings(queryRunner,
+                "SELECT 1/2",
+                Optional.of(warningCode));
+        assertPlannerWarnings(queryRunner,
+                "SELECT a/2 FROM (VALUES (1)) as t(a)",
+                Optional.of(warningCode));
+        assertPlannerWarnings(queryRunner,
+                "SELECT 1/2.0",
+                Optional.empty());
+    }
+
+    @Test
+    public void testDeprecatedFunction()
+    {
+        WarningCode warningCode = StandardWarningCode.DREPRCATED_FUNCTION.toWarningCode();
+        assertPlannerWarnings(queryRunner,
+                "SELECT 123",
+                Optional.empty());
+        assertPlannerWarnings(queryRunner,
+                "SELECT json_array_get('[1, 2, 3]', 0)",
+                Optional.of(warningCode));
+        assertPlannerWarnings(queryRunner,
+                "SELECT json_array_get(a, 0) FROM (VALUES ('[1, 2, 3]')) AS t(a)",
+                Optional.of(warningCode));
+    }
+
+    private static void assertPlannerWarnings(LocalQueryRunner queryRunner, @Language("SQL") String sql, Optional<WarningCode> expectedWarning)
+    {
+        assertPlannerWarnings(queryRunner, sql, ImmutableMap.of("enable_query_diagnosis_warning", "true"), expectedWarning);
+    }
+
+    private static void assertPlannerWarnings(LocalQueryRunner queryRunner, @Language("SQL") String sql, Map<String, String> sessionProperties, Optional<WarningCode> expectedWarning)
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog(queryRunner.getDefaultSession().getCatalog().get())
+                .setSchema(queryRunner.getDefaultSession().getSchema().get());
+        sessionProperties.forEach(sessionBuilder::setSystemProperty);
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig());
+        queryRunner.inTransaction(sessionBuilder.build(), transactionSession -> {
+            queryRunner.createPlan(transactionSession, sql, LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, warningCollector);
+            return null;
+        });
+        Set<WarningCode> warnings = warningCollector.getWarnings().stream()
+                .map(PrestoWarning::getWarningCode)
+                .collect(toImmutableSet());
+        if (expectedWarning.isPresent()) {
+            if (!warnings.contains(expectedWarning.get())) {
+                fail("Expected warning: " + expectedWarning);
+            }
+        }
+        else {
+            if (!warnings.isEmpty()) {
+                fail("Expect no warning");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enhance the warning system to report risky or error-prone query. This is similar to the warnings from a language compiler or static code analysis tool.

Current there are two rules:
1. IntegerDivisionWarning
In Hive, `SELECT 1/2` will return 0.5, but in Presto this will return 0.


2. DeprecatedFunctionWarning

---
Some random thoughts that we can do using the warning system:
- Allow Connector to throw warnings on potential bad performance / incompatible type casing query. Such as "Too many partitions" or "unsupported types".
- Allow UDF to be marked as deprecated and issue a warning.
- Warning level.
- "Treat warnings as errors" session property.