### PR TITLE
Fix LATERAL example query in document

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -871,8 +871,8 @@ This is repeated for set of rows from the column source tables.
 computing the rows to be joined::
 
     SELECT name, x, y
-    FROM nation,
-    CROSS JOIN LATERAL (SELECT name || ' :-' AS x),
+    FROM nation
+    CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
     CROSS JOIN LATERAL (SELECT x || ')' AS y)
 
 Qualifying Column Names


### PR DESCRIPTION
```
presto> SELECT name, x, y
     -> FROM nation,
     -> CROSS JOIN LATERAL (SELECT name || ' :-' AS x),
     -> CROSS JOIN LATERAL (SELECT x || ')' AS y)
     -> ;
Query 20190616_135100_00026_b26r4 failed: line 3:1: mismatched input 'CROSS'. Expecting: '(', 'LATERAL', 'UNNEST', <identifier>
```
↓
```
presto:sf1> SELECT name, x, y
         -> FROM nation
         -> CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
         -> CROSS JOIN LATERAL (SELECT x || ')' AS y)
         -> ;
      name      |         x         |         y          
----------------+-------------------+--------------------
 ALGERIA        | ALGERIA :-        | ALGERIA :-)        
 ARGENTINA      | ARGENTINA :-      | ARGENTINA :-)  
```