### PR TITLE
Remove invalid dynamic filters in JoinNode flipChildren

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
@@ -145,7 +145,7 @@ public class JoinNode
                 leftHashSymbol,
                 distributionType,
                 spillable,
-                dynamicFilters);
+                ImmutableMap.of()); // dynamicFilters are invalid after flipping children
     }
 
     private static Type flipType(Type type)


### PR DESCRIPTION
When left and right children of JoinNode are flipped in ReorderJoins or DetermineJoinDistributionType, existing dynamic filters in JoinNode can become invalid and need to be removed.
