### PR TITLE
CLI: Refresh completion caches properly when catalog or schema is changed

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -344,7 +344,6 @@ public class Console
                         .withCatalog(query.getSetCatalog().orElse(session.getCatalog()))
                         .withSchema(query.getSetSchema().orElse(session.getSchema()))
                         .build();
-                schemaChanged.run();
             }
 
             // update transaction ID if necessary
@@ -388,6 +387,10 @@ public class Console
 
             session = builder.build();
             queryRunner.setSession(session);
+
+            if (query.getSetCatalog().isPresent() || query.getSetSchema().isPresent()) {
+                schemaChanged.run();
+            }
 
             return success;
         }


### PR DESCRIPTION
Currently, presto-cli's table name completion caches aren't refreshed when catalog or schema is changed by `USE` statement. This pull request fixes it by calling the refresh function after new session is set to QueryRunner.