### PR TITLE
Adjust getOffset output in Columnar classes for trimmed element blocks

### DIFF
--- a/presto-main/src/test/java/io/prestosql/block/TestColumnarArray.java
+++ b/presto-main/src/test/java/io/prestosql/block/TestColumnarArray.java
@@ -116,6 +116,7 @@ public class TestColumnarArray
             T expectedArray = expectedValues[position];
             assertEquals(columnarArray.isNull(position), expectedArray == null);
             assertEquals(columnarArray.getLength(position), expectedArray == null ? 0 : Array.getLength(expectedArray));
+            assertEquals(elementsPosition, columnarArray.getOffset(position));
 
             for (int i = 0; i < columnarArray.getLength(position); i++) {
                 Object expectedElement = Array.get(expectedArray, i);

--- a/presto-main/src/test/java/io/prestosql/block/TestColumnarMap.java
+++ b/presto-main/src/test/java/io/prestosql/block/TestColumnarMap.java
@@ -120,8 +120,7 @@ public class TestColumnarMap
 
         Block keysBlock = columnarMap.getKeysBlock();
         Block valuesBlock = columnarMap.getValuesBlock();
-        int keysPosition = 0;
-        int valuesPosition = 0;
+        int elementsPosition = 0;
         for (int position = 0; position < expectedValues.length; position++) {
             Slice[][] expectedMap = expectedValues[position];
             assertEquals(columnarMap.isNull(position), expectedMap == null);
@@ -131,16 +130,18 @@ public class TestColumnarMap
             }
 
             assertEquals(columnarMap.getEntryCount(position), expectedMap.length);
+            assertEquals(columnarMap.getOffset(position), elementsPosition);
+
             for (int i = 0; i < columnarMap.getEntryCount(position); i++) {
                 Slice[] expectedEntry = expectedMap[i];
 
                 Slice expectedKey = expectedEntry[0];
-                assertBlockPosition(keysBlock, keysPosition, expectedKey);
-                keysPosition++;
+                assertBlockPosition(keysBlock, elementsPosition, expectedKey);
 
                 Slice expectedValue = expectedEntry[1];
-                assertBlockPosition(valuesBlock, valuesPosition, expectedValue);
-                valuesPosition++;
+                assertBlockPosition(valuesBlock, elementsPosition, expectedValue);
+
+                elementsPosition++;
             }
         }
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ColumnarArray.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ColumnarArray.java
@@ -70,8 +70,7 @@ public class ColumnarArray
             int dictionaryId = dictionaryBlock.getId(position);
             int length = columnarArray.getLength(dictionaryId);
 
-            // adjust to the element block start offset
-            int startOffset = columnarArray.getOffset(dictionaryId) - columnarArray.getOffset(0);
+            int startOffset = columnarArray.getOffset(dictionaryId);
             for (int entryIndex = 0; entryIndex < length; entryIndex++) {
                 dictionaryIds[nextDictionaryIndex] = startOffset + entryIndex;
                 nextDictionaryIndex++;
@@ -133,12 +132,12 @@ public class ColumnarArray
 
     public int getLength(int position)
     {
-        return getOffset(position + 1) - getOffset(position);
+        return (offsets[position + 1 + offsetsOffset] - offsets[position + offsetsOffset]);
     }
 
-    private int getOffset(int position)
+    public int getOffset(int position)
     {
-        return offsets[position + offsetsOffset];
+        return (offsets[position + offsetsOffset] - offsets[offsetsOffset]);
     }
 
     public Block getElementsBlock()

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ColumnarMap.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ColumnarMap.java
@@ -70,8 +70,7 @@ public class ColumnarMap
             int dictionaryId = dictionaryBlock.getId(position);
             int entryCount = columnarMap.getEntryCount(dictionaryId);
 
-            // adjust to the element block start offset
-            int startOffset = columnarMap.getOffset(dictionaryId) - columnarMap.getOffset(0);
+            int startOffset = columnarMap.getOffset(dictionaryId);
             for (int entryIndex = 0; entryIndex < entryCount; entryIndex++) {
                 dictionaryIds[nextDictionaryIndex] = startOffset + entryIndex;
                 nextDictionaryIndex++;
@@ -139,9 +138,9 @@ public class ColumnarMap
         return (offsets[position + 1 + offsetsOffset] - offsets[position + offsetsOffset]);
     }
 
-    private int getOffset(int position)
+    public int getOffset(int position)
     {
-        return offsets[position + offsetsOffset];
+        return (offsets[position + offsetsOffset] - offsets[offsetsOffset]);
     }
 
     public Block getKeysBlock()


### PR DESCRIPTION
`ColumnarArray` constructor stores the underlying element block in `ArrayBlock` after a `getRegion` invocation. `getOffset` method in this class does not account for this, and instead returns indices pointing to original element block (without the trimming). 

We need to access these offsets in #901 ,  and incorrect offset values cause failures in cases where `offsets[offsetsOffset]` is not zero. Another approach is to account for this in accessors of this class.  But I think that making indices from `getOffset` consistent with `getElementsBlock` is a reasonable choice.