### PR TITLE
Fix up PageBuilderStatus::toString

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/block/PageBuilderStatus.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/PageBuilderStatus.java
@@ -67,8 +67,8 @@ public class PageBuilderStatus
     @Override
     public String toString()
     {
-        StringBuilder buffer = new StringBuilder("BlockBuilderStatus{");
-        buffer.append("maxSizeInBytes=").append(maxPageSizeInBytes);
+        StringBuilder buffer = new StringBuilder("PageBuilderStatus{");
+        buffer.append("maxPageSizeInBytes=").append(maxPageSizeInBytes);
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();


### PR DESCRIPTION
PageBuilderStatus::toString prints its name as "BlockBuilderStatus" instead of "PageBuilderStatus". It also uses the wrong name for a variable