### PR TITLE
Allow configuring the Glue catalog id

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -30,6 +30,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
+    private Optional<String> catalogId = Optional.empty();
 
     public Optional<String> getGlueRegion()
     {
@@ -121,6 +122,19 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
+        return this;
+    }
+
+    public Optional<String> getCatalogId()
+    {
+        return catalogId;
+    }
+
+    @Config("hive.metastore.glue.catalogid")
+    @ConfigDescription("Hive Glue metastore catalog id")
+    public GlueHiveMetastoreConfig setCatalogId(String catalogId)
+    {
+        this.catalogId = Optional.ofNullable(catalogId);
         return this;
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -34,7 +34,8 @@ public class TestGlueHiveMetastoreConfig
                 .setDefaultWarehouseDir(null)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
-                .setAwsSecretKey(null));
+                .setAwsSecretKey(null)
+                .setCatalogId(null));
     }
 
     @Test
@@ -48,6 +49,7 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
+                .put("hive.metastore.glue.catalogid", "0123456789")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -57,7 +59,8 @@ public class TestGlueHiveMetastoreConfig
                 .setDefaultWarehouseDir("/location")
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
-                .setAwsSecretKey("DEF");
+                .setAwsSecretKey("DEF")
+                .setCatalogId("0123456789");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This setting allows connecting to Glue catalogs in other AWS accounts.

I've named the setting `hive.metastore.glue.catalogid` to be consistent with Amazon's current implementation:  https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-presto-glue.html
