### PR TITLE
Add support for Database based SessionPropertyConfigurationManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,13 @@
 
             <dependency>
                 <groupId>io.prestosql</groupId>
+                <artifactId>presto-session-property-managers</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestosql</groupId>
                 <artifactId>presto-array</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -60,6 +60,7 @@ import io.prestosql.security.AccessControlManager;
 import io.prestosql.server.GracefulShutdownHandler;
 import io.prestosql.server.PluginManager;
 import io.prestosql.server.ServerMainModule;
+import io.prestosql.server.SessionPropertyDefaults;
 import io.prestosql.server.ShutdownAction;
 import io.prestosql.server.security.ServerSecurityModule;
 import io.prestosql.spi.Plugin;
@@ -120,6 +121,7 @@ public class TestingPrestoServer
     private final TestingAccessControlManager accessControl;
     private final ProcedureTester procedureTester;
     private final Optional<InternalResourceGroupManager<?>> resourceGroupManager;
+    private final SessionPropertyDefaults sessionPropertyDefaults;
     private final SplitManager splitManager;
     private final PageSourceManager pageSourceManager;
     private final NodePartitioningManager nodePartitioningManager;
@@ -279,6 +281,7 @@ public class TestingPrestoServer
             dispatchManager = injector.getInstance(DispatchManager.class);
             queryManager = (SqlQueryManager) injector.getInstance(QueryManager.class);
             resourceGroupManager = Optional.of(injector.getInstance(InternalResourceGroupManager.class));
+            sessionPropertyDefaults = injector.getInstance(SessionPropertyDefaults.class);
             nodePartitioningManager = injector.getInstance(NodePartitioningManager.class);
             clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);
             statsCalculator = injector.getInstance(StatsCalculator.class);
@@ -287,6 +290,7 @@ public class TestingPrestoServer
             dispatchManager = null;
             queryManager = null;
             resourceGroupManager = Optional.empty();
+            sessionPropertyDefaults = null;
             nodePartitioningManager = null;
             clusterMemoryManager = null;
             statsCalculator = null;
@@ -427,6 +431,11 @@ public class TestingPrestoServer
     public Optional<InternalResourceGroupManager<?>> getResourceGroupManager()
     {
         return resourceGroupManager;
+    }
+
+    public SessionPropertyDefaults getSessionPropertyDefaults()
+    {
+        return sessionPropertyDefaults;
     }
 
     public NodePartitioningManager getNodePartitioningManager()

--- a/presto-session-property-managers/pom.xml
+++ b/presto-session-property-managers/pom.xml
@@ -24,12 +24,38 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -40,6 +66,11 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
 
         <dependency>
@@ -62,6 +93,26 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>
@@ -72,6 +123,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -99,5 +156,12 @@
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing-mysql-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionMatchSpec.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionMatchSpec.java
@@ -15,17 +15,24 @@ package io.prestosql.plugin.session;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.spi.session.SessionConfigurationContext;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class SessionMatchSpec
@@ -119,5 +126,46 @@ public class SessionMatchSpec
     public Map<String, String> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static class Mapper
+            implements RowMapper<SessionMatchSpec>
+    {
+        @Override
+        public SessionMatchSpec map(ResultSet resultSet, StatementContext context)
+                throws SQLException
+        {
+            Map<String, String> sessionProperties = getProperties(
+                    Optional.ofNullable(resultSet.getString("session_property_names")),
+                    Optional.ofNullable(resultSet.getString("session_property_values")));
+
+            return new SessionMatchSpec(
+                    Optional.ofNullable(resultSet.getString("user_regex")).map(Pattern::compile),
+                    Optional.ofNullable(resultSet.getString("source_regex")).map(Pattern::compile),
+                    Optional.ofNullable(resultSet.getString("client_tags")).map(tag -> Splitter.on(",").splitToList(tag)),
+                    Optional.ofNullable(resultSet.getString("query_type")),
+                    Optional.ofNullable(resultSet.getString("group_regex")).map(Pattern::compile),
+                    sessionProperties);
+        }
+
+        private static Map<String, String> getProperties(Optional<String> names, Optional<String> values)
+        {
+            if (!names.isPresent()) {
+                return ImmutableMap.of();
+            }
+
+            checkArgument(values.isPresent(), "names are present, but values are not");
+            List<String> sessionPropertyNames = Splitter.on(",").splitToList(names.get());
+            List<String> sessionPropertyValues = Splitter.on(",").splitToList(values.get());
+            checkArgument(sessionPropertyNames.size() == sessionPropertyValues.size(),
+                    "The number of property names and values should be the same");
+
+            Map<String, String> sessionProperties = new HashMap<>();
+            for (int i = 0; i < sessionPropertyNames.size(); i++) {
+                sessionProperties.put(sessionPropertyNames.get(i), sessionPropertyValues.get(i));
+            }
+
+            return sessionProperties;
+        }
     }
 }

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionPropertyConfigurationManagerPlugin.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionPropertyConfigurationManagerPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.session.db.DbSessionPropertyManagerFactory;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.session.SessionPropertyConfigurationManagerFactory;
+
+public class SessionPropertyConfigurationManagerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<SessionPropertyConfigurationManagerFactory> getSessionPropertyConfigurationManagerFactories()
+    {
+        return ImmutableList.of(
+                new FileSessionPropertyManagerFactory(),
+                new DbSessionPropertyManagerFactory());
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionPropertyConfigurationManagerPlugin.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionPropertyConfigurationManagerPlugin.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.session;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.session.db.DbSessionPropertyManagerFactory;
+import io.prestosql.plugin.session.file.FileSessionPropertyManagerFactory;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.session.SessionPropertyConfigurationManagerFactory;
 

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.plugin.session.SessionMatchSpec;
+import io.prestosql.spi.session.SessionConfigurationContext;
+import io.prestosql.spi.session.SessionPropertyConfigurationManager;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link SessionPropertyConfigurationManager} implementation that connects to a database for fetching information
+ * about session property overrides given {@link SessionConfigurationContext}.
+ */
+public class DbSessionPropertyManager
+        implements SessionPropertyConfigurationManager
+{
+    private final DbSpecsProvider specsProvider;
+
+    @Inject
+    public DbSessionPropertyManager(DbSpecsProvider specsProvider)
+    {
+        this.specsProvider = requireNonNull(specsProvider, "specsProvider is null");
+    }
+
+    @Override
+    public Map<String, String> getSystemSessionProperties(SessionConfigurationContext context)
+    {
+        List<SessionMatchSpec> sessionMatchSpecs = specsProvider.get();
+
+        // later properties override earlier properties
+        Map<String, String> combinedProperties = new HashMap<>();
+        for (SessionMatchSpec sessionMatchSpec : sessionMatchSpecs) {
+            combinedProperties.putAll(sessionMatchSpec.match(context));
+        }
+
+        return ImmutableMap.copyOf(combinedProperties);
+    }
+
+    @Override
+    public Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context)
+    {
+        // NOT IMPLEMENTED YET
+        return ImmutableMap.of();
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerConfig.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class DbSessionPropertyManagerConfig
+{
+    private String configDbUrl;
+    private String username;
+    private String password;
+    private Duration specsRefreshPeriod = new Duration(10, SECONDS);
+
+    @NotNull
+    public String getConfigDbUrl()
+    {
+        return configDbUrl;
+    }
+
+    @Config("session-property-manager.db.url")
+    public DbSessionPropertyManagerConfig setConfigDbUrl(String configDbUrl)
+    {
+        this.configDbUrl = configDbUrl;
+        return this;
+    }
+
+    @Nullable
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("session-property-manager.db.username")
+    public DbSessionPropertyManagerConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    @Nullable
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("session-property-manager.db.password")
+    @ConfigSecuritySensitive
+    public DbSessionPropertyManagerConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1ms")
+    public Duration getSpecsRefreshPeriod()
+    {
+        return specsRefreshPeriod;
+    }
+
+    @Config("session-property-manager.db.refresh-period")
+    public DbSessionPropertyManagerConfig setSpecsRefreshPeriod(Duration specsRefreshPeriod)
+    {
+        this.specsRefreshPeriod = specsRefreshPeriod;
+        return this;
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerFactory.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.prestosql.plugin.base.jmx.MBeanServerModule;
+import io.prestosql.spi.resourcegroups.SessionPropertyConfigurationManagerContext;
+import io.prestosql.spi.session.SessionPropertyConfigurationManager;
+import io.prestosql.spi.session.SessionPropertyConfigurationManagerFactory;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class DbSessionPropertyManagerFactory
+        implements SessionPropertyConfigurationManagerFactory
+{
+    @Override
+    public String getName()
+    {
+        return "db";
+    }
+
+    @Override
+    public SessionPropertyConfigurationManager create(Map<String, String> config, SessionPropertyConfigurationManagerContext context)
+    {
+        try {
+            Bootstrap app = new Bootstrap(
+                    new MBeanModule(),
+                    new MBeanServerModule(),
+                    new JsonModule(),
+                    new DbSessionPropertyManagerModule());
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(DbSessionPropertyManager.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerModule.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManagerModule.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class DbSessionPropertyManagerModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(DbSessionPropertyManagerConfig.class);
+        binder.bind(DbSessionPropertyManager.class).in(Scopes.SINGLETON);
+        binder.bind(SessionPropertiesDao.class).toProvider(SessionPropertiesDaoProvider.class).in(Scopes.SINGLETON);
+        binder.bind(DbSpecsProvider.class).to(RefreshingDbSpecsProvider.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(DbSpecsProvider.class).withGeneratedName();
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSpecsProvider.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSpecsProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import io.prestosql.plugin.session.SessionMatchSpec;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * This interface was created to separate the scheduling logic for {@link SessionMatchSpec} loading. This also helps
+ * us test the core logic of {@link DbSessionPropertyManager} in a modular fashion by letting us use a test
+ * implementation of this interface.
+ */
+public interface DbSpecsProvider
+        extends Supplier<List<SessionMatchSpec>>
+{
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/RefreshingDbSpecsProvider.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/RefreshingDbSpecsProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.stats.CounterStat;
+import io.prestosql.plugin.session.SessionMatchSpec;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+/**
+ * Periodically schedules the loading of specs from the database during initialization. Returns the most recent successfully
+ * loaded specs on every get() invocation.
+ */
+public class RefreshingDbSpecsProvider
+        implements DbSpecsProvider
+{
+    private static final Logger log = Logger.get(RefreshingDbSpecsProvider.class);
+
+    private final AtomicReference<List<SessionMatchSpec>> sessionMatchSpecs = new AtomicReference<>(ImmutableList.of());
+    private final SessionPropertiesDao dao;
+
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("RefreshingDbSpecsProvider"));
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final long refreshPeriodMillis;
+    private final CounterStat dbLoadFailures = new CounterStat();
+
+    @Inject
+    public RefreshingDbSpecsProvider(DbSessionPropertyManagerConfig config, SessionPropertiesDao dao)
+    {
+        requireNonNull(config, "config is null");
+        this.dao = requireNonNull(dao, "dao is null");
+        this.refreshPeriodMillis = config.getSpecsRefreshPeriod().toMillis();
+
+        dao.createSessionSpecsTable();
+        dao.createSessionClientTagsTable();
+        dao.createSessionPropertiesTable();
+    }
+
+    @PostConstruct
+    public void initialize()
+    {
+        if (!started.getAndSet(true)) {
+            executor.scheduleWithFixedDelay(this::refresh, 0, refreshPeriodMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @VisibleForTesting
+    void refresh()
+    {
+        requireNonNull(dao, "dao is null");
+
+        try {
+            sessionMatchSpecs.set(ImmutableList.copyOf(dao.getSessionMatchSpecs()));
+        }
+        catch (Throwable e) {
+            // Catch all exceptions here since throwing an exception from executor#scheduleWithFixedDelay method
+            // suppresses all future scheduled invocations
+            dbLoadFailures.update(1);
+            log.error(e, "Error loading configuration from database");
+        }
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        executor.shutdownNow();
+    }
+
+    @Override
+    public List<SessionMatchSpec> get()
+    {
+        return sessionMatchSpecs.get();
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getDbLoadFailures()
+    {
+        return dbLoadFailures;
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/SessionPropertiesDao.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/SessionPropertiesDao.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.prestosql.plugin.session.SessionMatchSpec;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+
+import java.util.List;
+
+import static io.prestosql.plugin.session.db.util.SessionPropertiesDaoUtil.CLIENT_TAGS_TABLE;
+import static io.prestosql.plugin.session.db.util.SessionPropertiesDaoUtil.PROPERTIES_TABLE;
+import static io.prestosql.plugin.session.db.util.SessionPropertiesDaoUtil.SESSION_SPECS_TABLE;
+
+/**
+ * Dao should guarantee that the list of SessionMatchSpecs is returned in increasing order of priority. i.e. if two
+ * rows in the ResultSet specify different values for the same property, the row coming in later will override the
+ * value set by the row coming in earlier.
+ */
+public interface SessionPropertiesDao
+{
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + SESSION_SPECS_TABLE + "(\n" +
+            "spec_id BIGINT NOT NULL AUTO_INCREMENT,\n" +
+            "user_regex VARCHAR(512),\n" +
+            "source_regex VARCHAR(512),\n" +
+            "query_type VARCHAR(512),\n" +
+            "group_regex VARCHAR(512),\n" +
+            "priority INT NOT NULL,\n" +
+            "PRIMARY KEY (spec_id)\n" +
+            ")")
+    void createSessionSpecsTable();
+
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + CLIENT_TAGS_TABLE + "(\n" +
+            "tag_spec_id BIGINT NOT NULL,\n" +
+            "client_tag VARCHAR(512) NOT NULL,\n" +
+            "PRIMARY KEY (tag_spec_id, client_tag),\n" +
+            "FOREIGN KEY (tag_spec_id) REFERENCES session_specs (spec_id)\n" +
+            ")")
+    void createSessionClientTagsTable();
+
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + PROPERTIES_TABLE + "(\n" +
+            "property_spec_id BIGINT NOT NULL,\n" +
+            "session_property_name VARCHAR(512),\n" +
+            "session_property_value VARCHAR(512),\n" +
+            "PRIMARY KEY (property_spec_id, session_property_name),\n" +
+            "FOREIGN KEY (property_spec_id) REFERENCES session_specs (spec_id)\n" +
+            ")")
+    void createSessionPropertiesTable();
+
+    @SqlUpdate("DROP TABLE IF EXISTS " + SESSION_SPECS_TABLE)
+    void dropSessionSpecsTable();
+
+    @SqlUpdate("DROP TABLE IF EXISTS " + CLIENT_TAGS_TABLE)
+    void dropSessionClientTagsTable();
+
+    @SqlUpdate("DROP TABLE IF EXISTS " + PROPERTIES_TABLE)
+    void dropSessionPropertiesTable();
+
+    @SqlQuery("SELECT " +
+            "S.spec_id,\n" +
+            "S.user_regex,\n" +
+            "S.source_regex,\n" +
+            "S.query_type,\n" +
+            "S.group_regex,\n" +
+            "S.client_tags,\n" +
+            "GROUP_CONCAT(P.session_property_name ORDER BY P.session_property_name) session_property_names,\n" +
+            "GROUP_CONCAT(P.session_property_value ORDER BY P.session_property_name) session_property_values\n" +
+            "FROM\n" +
+            "(SELECT\n" +
+            "A.spec_id, A.user_regex, A.source_regex, A.query_type, A.group_regex, A.priority,\n" +
+            "GROUP_CONCAT(DISTINCT B.client_tag) client_tags\n" +
+            "FROM " + SESSION_SPECS_TABLE + " A\n" +
+            "LEFT JOIN " + CLIENT_TAGS_TABLE + " B\n" +
+            "ON A.spec_id = B.tag_spec_id\n" +
+            "GROUP BY A.spec_id, A.user_regex, A.source_regex, A.query_type, A.group_regex, A.priority)\n" +
+            " S JOIN\n" +
+            PROPERTIES_TABLE + " P\n" +
+            "ON S.spec_id = P.property_spec_id\n" +
+            "GROUP BY S.spec_id, S.user_regex, S.source_regex, S.query_type, S.group_regex, S.priority, S.client_tags\n" +
+            "ORDER BY S.priority asc")
+    @UseRowMapper(SessionMatchSpec.Mapper.class)
+    List<SessionMatchSpec> getSessionMatchSpecs();
+
+    @VisibleForTesting
+    @SqlUpdate("INSERT INTO " + SESSION_SPECS_TABLE + " (spec_id, user_regex, source_regex, query_type, group_regex, priority)\n" +
+            "VALUES (:spec_id, :user_regex, :source_regex, :query_type, :group_regex, :priority)")
+    void insertSpecRow(
+            @Bind("spec_id") long specId,
+            @Bind("user_regex") String userRegex,
+            @Bind("source_regex") String sourceRegex,
+            @Bind("query_type") String queryType,
+            @Bind("group_regex") String groupRegex,
+            @Bind("priority") int priority);
+
+    @VisibleForTesting
+    @SqlUpdate("INSERT INTO " + CLIENT_TAGS_TABLE + " (tag_spec_id, client_tag) VALUES (:spec_id, :client_tag)")
+    void insertClientTag(@Bind("spec_id") long specId, @Bind("client_tag") String clientTag);
+
+    @VisibleForTesting
+    @SqlUpdate("INSERT INTO " + PROPERTIES_TABLE + " (property_spec_id, session_property_name, session_property_value)\n" +
+            "VALUES (:property_spec_id, :session_property_name, :session_property_value)")
+    void insertSessionProperty(
+            @Bind("property_spec_id") long propertySpecId,
+            @Bind("session_property_name") String sessionPropertyName,
+            @Bind("session_property_value") String sessionPropertyValue);
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/SessionPropertiesDaoProvider.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/SessionPropertiesDaoProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class SessionPropertiesDaoProvider
+        implements Provider<SessionPropertiesDao>
+{
+    private final SessionPropertiesDao dao;
+
+    @Inject
+    public SessionPropertiesDaoProvider(DbSessionPropertyManagerConfig config)
+    {
+        requireNonNull(config, "config is null");
+        String url = requireNonNull(config.getConfigDbUrl(), "db url is null");
+
+        MysqlDataSource dataSource = new MysqlDataSource();
+        dataSource.setURL(url);
+
+        Optional<String> username = Optional.ofNullable(config.getUsername());
+        username.ifPresent(dataSource::setUser);
+
+        Optional<String> password = Optional.ofNullable(config.getPassword());
+        password.ifPresent(dataSource::setPassword);
+
+        this.dao = Jdbi.create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .onDemand(SessionPropertiesDao.class);
+    }
+
+    @Override
+    public SessionPropertiesDao get()
+    {
+        return dao;
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/util/SessionPropertiesDaoUtil.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/util/SessionPropertiesDaoUtil.java
@@ -11,18 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.db.util;
 
-import com.google.common.collect.ImmutableList;
-import io.prestosql.spi.Plugin;
-import io.prestosql.spi.session.SessionPropertyConfigurationManagerFactory;
-
-public class FileSessionPropertyManagerPlugin
-        implements Plugin
+public final class SessionPropertiesDaoUtil
 {
-    @Override
-    public Iterable<SessionPropertyConfigurationManagerFactory> getSessionPropertyConfigurationManagerFactories()
-    {
-        return ImmutableList.of(new FileSessionPropertyManagerFactory());
-    }
+    private SessionPropertiesDaoUtil() {}
+
+    public static final String SESSION_SPECS_TABLE = "session_specs";
+    public static final String CLIENT_TAGS_TABLE = "session_client_tags";
+    public static final String PROPERTIES_TABLE = "session_property_values";
 }

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManager.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
+import io.prestosql.plugin.session.SessionMatchSpec;
 import io.prestosql.spi.session.SessionConfigurationContext;
 import io.prestosql.spi.session.SessionPropertyConfigurationManager;
 

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerConfig.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerConfig.java
@@ -11,21 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.Scopes;
+import io.airlift.configuration.Config;
 
-import static io.airlift.configuration.ConfigBinder.configBinder;
+import javax.validation.constraints.NotNull;
 
-public class FileSessionPropertyManagerModule
-        implements Module
+import java.io.File;
+
+public class FileSessionPropertyManagerConfig
 {
-    @Override
-    public void configure(Binder binder)
+    private File configFile;
+
+    @NotNull
+    public File getConfigFile()
     {
-        configBinder(binder).bindConfig(FileSessionPropertyManagerConfig.class);
-        binder.bind(FileSessionPropertyManager.class).in(Scopes.SINGLETON);
+        return configFile;
+    }
+
+    @Config("session-property-manager.config-file")
+    public FileSessionPropertyManagerConfig setConfigFile(File configFile)
+    {
+        this.configFile = configFile;
+        return this;
     }
 }

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerFactory.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerModule.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManagerModule.java
@@ -11,28 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
-import io.airlift.configuration.Config;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 
-import javax.validation.constraints.NotNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
-import java.io.File;
-
-public class FileSessionPropertyManagerConfig
+public class FileSessionPropertyManagerModule
+        implements Module
 {
-    private File configFile;
-
-    @NotNull
-    public File getConfigFile()
+    @Override
+    public void configure(Binder binder)
     {
-        return configFile;
-    }
-
-    @Config("session-property-manager.config-file")
-    public FileSessionPropertyManagerConfig setConfigFile(File configFile)
-    {
-        this.configFile = configFile;
-        return this;
+        configBinder(binder).bindConfig(FileSessionPropertyManagerConfig.class);
+        binder.bind(FileSessionPropertyManager.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.spi.resourcegroups.QueryType;
+import io.prestosql.spi.resourcegroups.ResourceGroupId;
+import io.prestosql.spi.session.SessionConfigurationContext;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Test
+public abstract class AbstractTestSessionPropertyManager
+{
+    protected static final SessionConfigurationContext CONTEXT = new SessionConfigurationContext(
+            "user",
+            Optional.of("source"),
+            ImmutableSet.of("tag1", "tag2"),
+            Optional.of(QueryType.DATA_DEFINITION.toString()),
+            new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar")));
+
+    protected abstract void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+            throws Exception;
+
+    @Test
+    public void testResourceGroupMatch()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2");
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("global.pipeline.user_.*")),
+                properties);
+
+        assertProperties(properties, spec);
+    }
+
+    @Test
+    public void testClientTagMatch()
+            throws Exception
+    {
+        ImmutableMap<String, String> properties = ImmutableMap.of("PROPERTY", "VALUE");
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(ImmutableList.of("tag2")),
+                Optional.empty(),
+                Optional.empty(),
+                properties);
+
+        assertProperties(properties, spec);
+    }
+
+    @Test
+    public void testMultipleMatch()
+            throws Exception
+    {
+        SessionMatchSpec spec1 = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(ImmutableList.of("tag2")),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY3", "VALUE3"));
+        SessionMatchSpec spec2 = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(ImmutableList.of("tag1", "tag2")),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2"));
+
+        assertProperties(ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2", "PROPERTY3", "VALUE3"), spec1, spec2);
+    }
+
+    @Test
+    public void testNoMatch()
+            throws Exception
+    {
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("global.interactive.user_.*")),
+                ImmutableMap.of("PROPERTY", "VALUE"));
+
+        assertProperties(ImmutableMap.of(), spec);
+    }
+}

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/TestFileSessionPropertyManager.java
@@ -14,106 +14,23 @@
 
 package io.prestosql.plugin.session;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.testing.TempFile;
-import io.prestosql.spi.resourcegroups.QueryType;
-import io.prestosql.spi.resourcegroups.ResourceGroupId;
-import io.prestosql.spi.session.SessionConfigurationContext;
 import io.prestosql.spi.session.SessionPropertyConfigurationManager;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
-import java.util.regex.Pattern;
 
 import static io.prestosql.plugin.session.FileSessionPropertyManager.CODEC;
 import static org.testng.Assert.assertEquals;
 
 public class TestFileSessionPropertyManager
+        extends AbstractTestSessionPropertyManager
 {
-    private static final SessionConfigurationContext CONTEXT = new SessionConfigurationContext(
-            "user",
-            Optional.of("source"),
-            ImmutableSet.of("tag1", "tag2"),
-            Optional.of(QueryType.DATA_DEFINITION.toString()),
-            new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar")));
-
-    @Test
-    public void testResourceGroupMatch()
-            throws IOException
-    {
-        Map<String, String> properties = ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2");
-        SessionMatchSpec spec = new SessionMatchSpec(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(Pattern.compile("global.pipeline.user_.*")),
-                properties);
-
-        assertProperties(properties, spec);
-    }
-
-    @Test
-    public void testClientTagMatch()
-            throws IOException
-    {
-        ImmutableMap<String, String> properties = ImmutableMap.of("PROPERTY", "VALUE");
-        SessionMatchSpec spec = new SessionMatchSpec(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(ImmutableList.of("tag2")),
-                Optional.empty(),
-                Optional.empty(),
-                properties);
-
-        assertProperties(properties, spec);
-    }
-
-    @Test
-    public void testMultipleMatch()
-            throws IOException
-    {
-        SessionMatchSpec spec1 = new SessionMatchSpec(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(ImmutableList.of("tag2")),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of("PROPERTY1", "VALUE1"));
-        SessionMatchSpec spec2 = new SessionMatchSpec(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(ImmutableList.of("tag1", "tag2")),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2"));
-
-        assertProperties(ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2"), spec1, spec2);
-    }
-
-    @Test
-    public void testNoMatch()
-            throws IOException
-    {
-        SessionMatchSpec spec = new SessionMatchSpec(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(Pattern.compile("global.interactive.user_.*")),
-                ImmutableMap.of("PROPERTY", "VALUE"));
-
-        assertProperties(ImmutableMap.of(), spec);
-    }
-
-    private static void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+    @Override
+    protected void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
             throws IOException
     {
         try (TempFile tempFile = new TempFile()) {

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManager.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.testing.mysql.TestingMySqlServer;
+import io.prestosql.plugin.session.AbstractTestSessionPropertyManager;
+import io.prestosql.plugin.session.SessionMatchSpec;
+import io.prestosql.spi.resourcegroups.ResourceGroupId;
+import io.prestosql.spi.session.SessionConfigurationContext;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+@Test(singleThreaded = true)
+public class TestDbSessionPropertyManager
+        extends AbstractTestSessionPropertyManager
+{
+    private DbSessionPropertyManagerConfig config;
+    private SessionPropertiesDao dao;
+    private DbSessionPropertyManager manager;
+    private RefreshingDbSpecsProvider specsProvider;
+
+    private TestingMySqlServer testingMySqlServer;
+    private static final String MYSQL_TEST_USER = "testuser";
+    private static final String MYSQL_TEST_PASSWORD = "testpassword";
+    private static final String MYSQL_TEST_DATABASE = "test_database";
+
+    private static final ResourceGroupId TEST_RG = new ResourceGroupId("rg1");
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        testingMySqlServer = new TestingMySqlServer(MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_TEST_DATABASE);
+
+        config = new DbSessionPropertyManagerConfig()
+                .setConfigDbUrl(testingMySqlServer.getJdbcUrl(MYSQL_TEST_DATABASE));
+
+        SessionPropertiesDaoProvider daoProvider = new SessionPropertiesDaoProvider(config);
+        dao = daoProvider.get();
+    }
+
+    @BeforeMethod
+    public void setupTest()
+    {
+        specsProvider = new RefreshingDbSpecsProvider(config, dao);
+        manager = new DbSessionPropertyManager(specsProvider);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown()
+    {
+        dao.dropSessionPropertiesTable();
+        dao.dropSessionClientTagsTable();
+        dao.dropSessionSpecsTable();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        specsProvider.destroy();
+        testingMySqlServer.close();
+    }
+
+    @Override
+    protected void assertProperties(Map<String, String> properties, SessionMatchSpec... specs)
+            throws IOException
+    {
+        insertSpecs(specs);
+        long failureCountBefore = specsProvider.getDbLoadFailures().getTotalCount();
+        specsProvider.refresh();
+        long failureCountAfter = specsProvider.getDbLoadFailures().getTotalCount();
+        assertEquals(failureCountAfter, failureCountBefore, "specs refresh should not fail");
+        assertEquals(manager.getSystemSessionProperties(CONTEXT), properties);
+    }
+
+    private void insertSpecs(SessionMatchSpec[] specs)
+    {
+        for (int i = 1; i <= specs.length; i++) {
+            SessionMatchSpec spec = specs[i - 1];
+            String userRegex = spec.getUserRegex().map(Pattern::pattern).orElse(null);
+            String sourceRegex = spec.getSourceRegex().map(Pattern::pattern).orElse(null);
+            String queryType = spec.getQueryType().orElse(null);
+            String resourceGroupRegex = spec.getResourceGroupRegex().map(Pattern::pattern).orElse(null);
+
+            dao.insertSpecRow(i, userRegex, sourceRegex, queryType, resourceGroupRegex, 0);
+
+            for (String tag : spec.getClientTags()) {
+                dao.insertClientTag(i, tag);
+            }
+
+            int propertyId = i;
+            spec.getSessionProperties().forEach((key, value) -> dao.insertSessionProperty(propertyId, key, value));
+        }
+    }
+
+    /**
+     * A basic test for session property overrides with the {@link DbSessionPropertyManager}
+     */
+    @Test
+    public void testSessionProperties()
+    {
+        dao.insertSpecRow(1, "foo.*", null, null, null, 0);
+        dao.insertSessionProperty(1, "prop_1", "val_1");
+
+        dao.insertSpecRow(2, ".*", "bar.*", null, null, 0);
+        dao.insertSessionProperty(2, "prop_2", "val_2");
+
+        specsProvider.refresh();
+        SessionConfigurationContext context1 = new SessionConfigurationContext("foo123", Optional.of("src1"),
+                ImmutableSet.of(), Optional.empty(), TEST_RG);
+        Map<String, String> sessionProperties1 = manager.getSystemSessionProperties(context1);
+        assertEquals(sessionProperties1.get("prop_1"), "val_1");
+        assertFalse(sessionProperties1.containsKey("prop_2"));
+
+        specsProvider.refresh();
+        SessionConfigurationContext context2 = new SessionConfigurationContext("bar123", Optional.of("bar123"),
+                ImmutableSet.of(), Optional.empty(), TEST_RG);
+        Map<String, String> sessionProperties2 = manager.getSystemSessionProperties(context2);
+        assertEquals(sessionProperties2.get("prop_2"), "val_2");
+        assertFalse(sessionProperties2.containsKey("prop_1"));
+
+        specsProvider.refresh();
+        SessionConfigurationContext context3 = new SessionConfigurationContext("foo123", Optional.of("bar123"),
+                ImmutableSet.of(), Optional.empty(), TEST_RG);
+        Map<String, String> sessionProperties3 = manager.getSystemSessionProperties(context3);
+        assertEquals(sessionProperties3.get("prop_1"), "val_1");
+        assertEquals(sessionProperties3.get("prop_2"), "val_2");
+
+        specsProvider.refresh();
+        SessionConfigurationContext context4 = new SessionConfigurationContext("abc", Optional.empty(), ImmutableSet.of(), Optional.empty(), TEST_RG);
+        Map<String, String> sessionProperties4 = manager.getSystemSessionProperties(context4);
+        assertFalse(sessionProperties4.containsKey("prop_1"));
+        assertFalse(sessionProperties4.containsKey("prop_2"));
+    }
+
+    /**
+     * Test {@link DbSessionPropertyManager#getSystemSessionProperties} after unsuccessful reloading
+     */
+    @Test
+    public void testReloads()
+    {
+        SessionConfigurationContext context1 = new SessionConfigurationContext("foo123", Optional.of("src1"), ImmutableSet.of(), Optional.empty(), TEST_RG);
+
+        dao.insertSpecRow(1, "foo.*", null, null, null, 0);
+        dao.insertSessionProperty(1, "prop_1", "val_1");
+        dao.insertSpecRow(2, ".*", "bar.*", null, null, 0);
+        dao.insertSessionProperty(2, "prop_2", "val_2");
+
+        specsProvider.refresh();
+        long failuresBefore = specsProvider.getDbLoadFailures().getTotalCount();
+
+        dao.insertSpecRow(3, "bar", null, null, null, 0);
+        dao.insertSessionProperty(3, "prop_3", "val_3");
+
+        // Simulating bad database operation
+        dao.dropSessionPropertiesTable();
+
+        specsProvider.refresh();
+        long failuresAfter = specsProvider.getDbLoadFailures().getTotalCount();
+
+        // Failed reloading, use cached configurations
+        assertEquals(failuresAfter - failuresBefore, 1);
+        Map<String, String> sessionProperties1 = manager.getSystemSessionProperties(context1);
+        assertEquals(sessionProperties1.get("prop_1"), "val_1");
+        assertEquals(sessionProperties1.get("prop_3"), null);
+    }
+
+    /**
+     * A test for conflicting values for the same session property
+     */
+    @Test
+    public void testOrderingOfSpecs()
+    {
+        dao.insertSpecRow(1, "foo", null, null, null, 2);
+        dao.insertSessionProperty(1, "prop_1", "val_1_2");
+        dao.insertSessionProperty(1, "prop_2", "val_2_2");
+
+        dao.insertSpecRow(2, "foo", null, null, null, 1);
+        dao.insertSessionProperty(2, "prop_1", "val_1_1");
+        dao.insertSessionProperty(2, "prop_2", "val_2_1");
+        dao.insertSessionProperty(2, "prop_3", "val_3_1");
+
+        dao.insertSpecRow(3, "foo", null, null, null, 3);
+        dao.insertSessionProperty(3, "prop_1", "val_1_3");
+
+        specsProvider.refresh();
+
+        SessionConfigurationContext context = new SessionConfigurationContext("foo", Optional.of("bar"), ImmutableSet.of(), Optional.empty(), TEST_RG);
+        Map<String, String> sessionProperties = manager.getSystemSessionProperties(context);
+        assertEquals(sessionProperties.get("prop_1"), "val_1_3");
+        assertEquals(sessionProperties.get("prop_2"), "val_2_2");
+        assertEquals(sessionProperties.get("prop_3"), "val_3_1");
+        assertEquals(sessionProperties.size(), 3);
+    }
+}

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManagerConfig.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManagerConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestDbSessionPropertyManagerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DbSessionPropertyManagerConfig.class)
+                .setConfigDbUrl(null)
+                .setUsername(null)
+                .setPassword(null)
+                .setSpecsRefreshPeriod(new Duration(10, SECONDS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("session-property-manager.db.url", "foo")
+                .put("session-property-manager.db.username", "bar")
+                .put("session-property-manager.db.password", "pass")
+                .put("session-property-manager.db.refresh-period", "50s")
+                .build();
+
+        DbSessionPropertyManagerConfig expected = new DbSessionPropertyManagerConfig()
+                .setConfigDbUrl("foo")
+                .setUsername("bar")
+                .setPassword("pass")
+                .setSpecsRefreshPeriod(new Duration(50, TimeUnit.SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestingDbSpecsProvider.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestingDbSpecsProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session.db;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.prestosql.plugin.session.SessionMatchSpec;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Test implementation of DbSpecsProvider.
+ * {@link SessionPropertiesDao#getSessionMatchSpecs} is invoked every time the get() method is called.
+ */
+public class TestingDbSpecsProvider
+        implements DbSpecsProvider
+{
+    private static final Logger log = Logger.get(TestingDbSpecsProvider.class);
+
+    private final AtomicReference<List<SessionMatchSpec>> sessionMatchSpecs = new AtomicReference<>(ImmutableList.of());
+    private final AtomicBoolean destroyed = new AtomicBoolean(false);
+
+    private final SessionPropertiesDao dao;
+
+    @Inject
+    public TestingDbSpecsProvider(SessionPropertiesDao dao)
+    {
+        requireNonNull(dao, "dao is null");
+        this.dao = dao;
+
+        dao.createSessionSpecsTable();
+        dao.createSessionClientTagsTable();
+        dao.createSessionPropertiesTable();
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        destroyed.compareAndSet(false, true);
+    }
+
+    @Override
+    public List<SessionMatchSpec> get()
+    {
+        checkState(!destroyed.get(), "provider already destroyed");
+
+        try {
+            sessionMatchSpecs.set(dao.getSessionMatchSpecs());
+        }
+        catch (RuntimeException e) {
+            // Swallow exceptions
+            log.error(e, "Error reloading configuration");
+        }
+        return ImmutableList.copyOf(this.sessionMatchSpecs.get());
+    }
+}

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
 import io.airlift.testing.TempFile;
+import io.prestosql.plugin.session.AbstractTestSessionPropertyManager;
+import io.prestosql.plugin.session.SessionMatchSpec;
 import io.prestosql.spi.session.SessionPropertyConfigurationManager;
 
 import java.io.IOException;
@@ -23,7 +25,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
 
-import static io.prestosql.plugin.session.FileSessionPropertyManager.CODEC;
+import static io.prestosql.plugin.session.file.FileSessionPropertyManager.CODEC;
 import static org.testng.Assert.assertEquals;
 
 public class TestFileSessionPropertyManager

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManagerConfig.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManagerConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.session;
+package io.prestosql.plugin.session.file;
 
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -143,6 +143,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>
@@ -192,6 +202,25 @@
             <groupId>io.prestosql</groupId>
             <artifactId>presto-resource-group-managers</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-session-property-managers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-session-property-managers</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing-mysql-server</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-tests/src/test/java/io/prestosql/execution/sessionpropertymanagers/TestDbSessionPropertyManagerIntegration.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/sessionpropertymanagers/TestDbSessionPropertyManagerIntegration.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution.sessionpropertymanagers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.airlift.testing.mysql.TestingMySqlServer;
+import io.airlift.units.Duration;
+import io.prestosql.Session;
+import io.prestosql.SystemSessionProperties;
+import io.prestosql.execution.QueryIdGenerator;
+import io.prestosql.execution.QueryManagerConfig;
+import io.prestosql.metadata.SessionPropertyManager;
+import io.prestosql.plugin.session.db.DbSessionPropertyManager;
+import io.prestosql.plugin.session.db.DbSessionPropertyManagerConfig;
+import io.prestosql.plugin.session.db.DbSpecsProvider;
+import io.prestosql.plugin.session.db.SessionPropertiesDao;
+import io.prestosql.plugin.session.db.SessionPropertiesDaoProvider;
+import io.prestosql.plugin.session.db.TestingDbSpecsProvider;
+import io.prestosql.server.SessionPropertyDefaults;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.resourcegroups.SessionPropertyConfigurationManagerContext;
+import io.prestosql.spi.security.Identity;
+import io.prestosql.spi.session.SessionPropertyConfigurationManager;
+import io.prestosql.spi.session.SessionPropertyConfigurationManagerFactory;
+import io.prestosql.sql.SqlPath;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.tests.DistributedQueryRunner;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.prestosql.testing.TestingSession.DEFAULT_TIME_ZONE_KEY;
+import static java.util.Collections.emptyMap;
+import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class TestDbSessionPropertyManagerIntegration
+{
+    private DistributedQueryRunner queryRunner;
+
+    private static final String EXAMPLE_PROPERTY = SystemSessionProperties.QUERY_MAX_CPU_TIME;
+    private static final Duration EXAMPLE_VALUE_DEFAULT = new QueryManagerConfig().getQueryMaxCpuTime();
+    private static final Duration EXAMPLE_VALUE_CONFIGURED = new Duration(50000, DAYS);
+
+    TestingMySqlServer testingMySqlServer;
+    private SessionPropertiesDao dao;
+    private static final String MYSQL_TEST_USER = "testuser";
+    private static final String MYSQL_TEST_PASSWORD = "testpassword";
+    private static final String MYSQL_TEST_DATABASE = "test_database";
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().build();
+        assertEquals(session.getSystemProperties(), emptyMap());
+
+        Duration sessionValue = session.getSystemProperty(EXAMPLE_PROPERTY, Duration.class);
+        assertEquals(EXAMPLE_VALUE_DEFAULT, sessionValue, "sessionValue is not equal to EXAMPLE_VALUE_DEFAULT");
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        queryRunner.installPlugin(new TestSessionPropertyConfigurationManagerPlugin());
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        testingMySqlServer = new TestingMySqlServer(MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_TEST_DATABASE);
+        assertFalse(EXAMPLE_VALUE_CONFIGURED.equals(EXAMPLE_VALUE_DEFAULT));
+        queryRunner = createQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        testingMySqlServer.close();
+        queryRunner.close();
+    }
+
+    @BeforeMethod
+    public void setupTest()
+    {
+        SessionPropertyDefaults sessionDefaults = queryRunner.getCoordinator().getSessionPropertyDefaults();
+        Map<String, String> configs = ImmutableMap.of("session-property-manager.db.url", testingMySqlServer.getJdbcUrl(MYSQL_TEST_DATABASE));
+        sessionDefaults.setConfigurationManager("db-test", configs);
+
+        MysqlDataSource dataSource = new MysqlDataSource();
+        dataSource.setURL(testingMySqlServer.getJdbcUrl(MYSQL_TEST_DATABASE));
+        dao = Jdbi.create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .onDemand(SessionPropertiesDao.class);
+    }
+
+    @Test(description = "Test successful and unsuccessful reloading of SessionMatchSpecs from the database")
+    public void testOperation()
+    {
+        // Configure the session property for users with user regex user1.*
+        dao.insertSpecRow(1, "user1.*", null, null, null, 0);
+        dao.insertSessionProperty(1, EXAMPLE_PROPERTY, EXAMPLE_VALUE_CONFIGURED.toString());
+
+        // All queries with matching session should have overridden session properties
+        assertSessionPropertyValue("user123", EXAMPLE_VALUE_CONFIGURED);
+
+        // Add a spec and simulate a bad database operation to intentionally fail further queries
+        dao.insertSpecRow(2, "user3.*", null, null, null, 0);
+        dao.insertSessionProperty(2, EXAMPLE_PROPERTY, EXAMPLE_VALUE_CONFIGURED.toString());
+        dao.dropSessionPropertiesTable();
+
+        // Reloading should fail now, old values should still be in use.
+        assertSessionPropertyValue("user123", EXAMPLE_VALUE_CONFIGURED);
+        assertSessionPropertyValue("user345", EXAMPLE_VALUE_DEFAULT);
+
+        // Fix the database by re-constructing the dropped table
+        dao.createSessionPropertiesTable();
+        dao.insertSessionProperty(1, EXAMPLE_PROPERTY, EXAMPLE_VALUE_CONFIGURED.toString());
+        dao.insertSessionProperty(2, EXAMPLE_PROPERTY, EXAMPLE_VALUE_CONFIGURED.toString());
+
+        // Fixing the database should enable successful reloading again.
+        assertSessionPropertyValue("user123", EXAMPLE_VALUE_CONFIGURED);
+        assertSessionPropertyValue("user312", EXAMPLE_VALUE_CONFIGURED);
+    }
+
+    private void assertSessionPropertyValue(String user, Duration expectedValue)
+    {
+        Session session = testSessionBuilder()
+                .setIdentity(new Identity(user, Optional.empty()))
+                .build();
+
+        MaterializedResult result = queryRunner.execute(session, "SHOW SESSION");
+        String actualValueString = (String) result.getMaterializedRows().stream()
+                .filter(row -> (row.getField(0).equals(EXAMPLE_PROPERTY)))
+                .collect(onlyElement())
+                .getField(1);
+
+        assertEquals(Duration.valueOf(actualValueString), expectedValue);
+    }
+
+    /**
+     * Generates a test {@link Session.SessionBuilder} ensuring that no system properties are set within the builder.
+     */
+    private static Session.SessionBuilder testSessionBuilder()
+    {
+        return Session.builder(new SessionPropertyManager())
+                .setQueryId(new QueryIdGenerator().createNextQueryId())
+                .setIdentity(new Identity("user", Optional.empty()))
+                .setSource("test")
+                .setCatalog("catalog")
+                .setSchema("schema")
+                .setPath(new SqlPath(Optional.of("path")))
+                .setTimeZoneKey(DEFAULT_TIME_ZONE_KEY)
+                .setLocale(ENGLISH)
+                .setRemoteUserAddress("address")
+                .setUserAgent("agent");
+    }
+
+    static class TestSessionPropertyConfigurationManagerPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<SessionPropertyConfigurationManagerFactory> getSessionPropertyConfigurationManagerFactories()
+        {
+            return ImmutableList.of(new TestDbSessionPropertyManagerFactory());
+        }
+    }
+
+    static class TestDbSessionPropertyManagerModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(DbSessionPropertyManagerConfig.class);
+            binder.bind(DbSessionPropertyManager.class).in(Scopes.SINGLETON);
+            binder.bind(DbSpecsProvider.class).to(TestingDbSpecsProvider.class).in(Scopes.SINGLETON);
+            binder.bind(SessionPropertiesDao.class).toProvider(SessionPropertiesDaoProvider.class).in(Scopes.SINGLETON);
+            newExporter(binder).export(DbSessionPropertyManager.class).withGeneratedName();
+        }
+    }
+
+    static class TestDbSessionPropertyManagerFactory
+            implements SessionPropertyConfigurationManagerFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "db-test";
+        }
+
+        @Override
+        public SessionPropertyConfigurationManager create(Map<String, String> config, SessionPropertyConfigurationManagerContext context)
+        {
+            try {
+                Bootstrap app = new Bootstrap(
+                        new JsonModule(),
+                        new TestDbSessionPropertyManagerModule());
+
+                Injector injector = app
+                        .strictConfig()
+                        .doNotInitializeLogging()
+                        .setRequiredConfigurationProperties(config)
+                        .quiet()
+                        .initialize();
+                return injector.getInstance(DbSessionPropertyManager.class);
+            }
+            catch (Exception e) {
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of `SessionPropertyConfigurationManager`, that can keep refreshing session property override information periodically from a relational database. 