### PR TITLE
Support multibyte character in data_format function

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
@@ -1177,7 +1177,7 @@ public final class DateTimeFunctions
 
         String formatString = format.toStringUtf8();
         boolean escaped = false;
-        for (int i = 0; i < format.length(); i++) {
+        for (int i = 0; i < formatString.length(); i++) {
             char character = formatString.charAt(i);
 
             if (escaped) {

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
@@ -756,6 +756,7 @@ public abstract class TestDateTimeFunctionsBase
         assertFunction("date_format(" + dateTimeLiteral + ", '%g')", VARCHAR, "g");
         assertFunction("date_format(" + dateTimeLiteral + ", '%4')", VARCHAR, "4");
         assertFunction("date_format(" + dateTimeLiteral + ", '%x %v')", VARCHAR, "2001 02");
+        assertFunction("date_format(" + dateTimeLiteral + ", '%Y年%m月%d日')", VARCHAR, "2001年01月09日");
 
         String weirdDateTimeLiteral = "TIMESTAMP '2001-01-09 13:04:05.321 +07:09'";
 
@@ -788,6 +789,7 @@ public abstract class TestDateTimeFunctionsBase
         assertFunction("date_format(" + weirdDateTimeLiteral + ", '%g')", VARCHAR, "g");
         assertFunction("date_format(" + weirdDateTimeLiteral + ", '%4')", VARCHAR, "4");
         assertFunction("date_format(" + weirdDateTimeLiteral + ", '%x %v')", VARCHAR, "2001 02");
+        assertFunction("date_format(" + weirdDateTimeLiteral + ", '%Y年%m月%d日')", VARCHAR, "2001年01月09日");
 
         assertFunction("date_format(TIMESTAMP '2001-01-09 13:04:05.32', '%f')", VARCHAR, "320000");
         assertFunction("date_format(TIMESTAMP '2001-01-09 00:04:05.32', '%k')", VARCHAR, "0");


### PR DESCRIPTION
Fix https://github.com/prestodb/presto/issues/13022

Japanese keywords I used in tests mean
- 年: Year
- 月: Month
- 日: Day