### PR TITLE
Remove redundant hash computation

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -25,7 +25,6 @@ import io.prestosql.Session;
 import io.prestosql.SystemSessionProperties;
 import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.metadata.Signature;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.type.StandardTypes;
 import io.prestosql.sql.planner.FunctionCallBuilder;
@@ -80,7 +79,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.prestosql.metadata.FunctionKind.SCALAR;
 import static io.prestosql.metadata.Signature.mangleOperatorName;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
@@ -97,11 +95,6 @@ public class HashGenerationOptimizer
 {
     public static final int INITIAL_HASH_VALUE = 0;
     private static final String HASH_CODE = mangleOperatorName(OperatorType.HASH_CODE);
-    private static final Signature COMBINE_HASH = new Signature(
-            "combine_hash",
-            SCALAR,
-            BIGINT.getTypeSignature(),
-            ImmutableList.of(BIGINT.getTypeSignature(), BIGINT.getTypeSignature()));
 
     private final Metadata metadata;
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/IdentityProjectionMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/IdentityProjectionMatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import io.prestosql.Session;
+import io.prestosql.cost.StatsProvider;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.ProjectNode;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
+import static io.prestosql.sql.planner.assertions.MatchResult.match;
+
+public class IdentityProjectionMatcher
+        implements Matcher
+{
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof ProjectNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        ProjectNode projectNode = (ProjectNode) node;
+
+        if (projectNode.isIdentity()) {
+            return match();
+        }
+        return NO_MATCH;
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -337,6 +337,11 @@ public final class PlanMatchPattern
         return result;
     }
 
+    public static PlanMatchPattern identityProject(PlanMatchPattern source)
+    {
+        return node(ProjectNode.class, source).with(new IdentityProjectionMatcher());
+    }
+
     public static PlanMatchPattern strictProject(Map<String, ExpressionMatcher> assignments, PlanMatchPattern source)
     {
         /*


### PR DESCRIPTION
Currently hash value is recomputed for aggregation node for queries with Union when optimize_hash_generation session is enabled.