### PR TITLE
Add instruction for presto benchto driver data bootstrapping 

### DIFF
--- a/presto-benchto-benchmarks/README.md
+++ b/presto-benchto-benchmarks/README.md
@@ -63,7 +63,7 @@ macros:
 ```
 
 ### Bootstrapping benchmark data
-* Configure Presto [TCP-H connector](https://prestodb.github.io/docs/current/connector/tpch.html), if you haven't.
+* Configure Presto [TCP-H connector](https://prestosql.io/docs/current/connector/tpch.html), if you haven't.
 * Generate SQL file:
 ```bash
 python presto-benchto-benchmarks/generate_schemas/generate-tpch.py tpch.sql

--- a/presto-benchto-benchmarks/README.md
+++ b/presto-benchto-benchmarks/README.md
@@ -62,6 +62,17 @@ macros:
       
 ```
 
+### Bootstrapping benchmark data
+* Configure Presto [TCP-H connector](https://prestodb.github.io/docs/current/connector/tpch.html), if you haven't.
+* Generate SQL file:
+```bash
+python presto-benchto-benchmarks/generate_schemas/generate-tpch.py tpch.sql
+```
+* Bootstrap benchmark data:
+```bash
+presto-cli-[version]-executable.jar --server [presto_coordinator-url]:[port] --file tpch.sql 
+```
+
 ### Configuring overrides file
 
 It is possible to override benchmark variables with benchto-driver overrides feature.

--- a/presto-benchto-benchmarks/README.md
+++ b/presto-benchto-benchmarks/README.md
@@ -63,14 +63,10 @@ macros:
 ```
 
 ### Bootstrapping benchmark data
-* Configure Presto [TCP-H connector](https://prestosql.io/docs/current/connector/tpch.html), if you haven't.
-* Generate SQL file:
-```bash
-python presto-benchto-benchmarks/generate_schemas/generate-tpch.py tpch.sql
-```
+* Make sure you have configured [Presto TCP-H connector](https://prestosql.io/docs/current/connector/tpch.html).
 * Bootstrap benchmark data:
 ```bash
-presto-cli-[version]-executable.jar --server [presto_coordinator-url]:[port] --file tpch.sql 
+python presto-benchto-benchmarks/generate_schemas/generate-tpch.py | presto-cli-[version]-executable.jar --server [presto_coordinator-url]:[port]
 ```
 
 ### Configuring overrides file


### PR DESCRIPTION
Adding more instruction for presto benchto driver data bootstrapping to clarify what needs to be done before the benchmark driver can be run.