### PR TITLE
Make PageProcessor preserve input block laziness

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PageUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PageUtils.java
@@ -19,13 +19,13 @@ import io.prestosql.spi.block.LazyBlock;
 
 import java.util.function.LongConsumer;
 
-final class PageUtils
+public final class PageUtils
 {
     private PageUtils()
     {
     }
 
-    static Page recordMaterializedBytes(Page page, LongConsumer sizeInBytesConsumer)
+    public static Page recordMaterializedBytes(Page page, LongConsumer sizeInBytesConsumer)
     {
         // account processed bytes from lazy blocks only when they are loaded
         Block[] blocks = new Block[page.getChannelCount()];

--- a/presto-main/src/main/java/io/prestosql/operator/PageUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PageUtils.java
@@ -29,6 +29,8 @@ public final class PageUtils
     {
         // account processed bytes from lazy blocks only when they are loaded
         Block[] blocks = new Block[page.getChannelCount()];
+        long loadedBlocksSizeInBytes = 0;
+
         for (int i = 0; i < page.getChannelCount(); ++i) {
             Block block = page.getBlock(i);
             if (block instanceof LazyBlock) {
@@ -40,10 +42,15 @@ public final class PageUtils
                 });
             }
             else {
-                sizeInBytesConsumer.accept(block.getSizeInBytes());
+                loadedBlocksSizeInBytes += block.getSizeInBytes();
                 blocks[i] = block;
             }
         }
+
+        if (loadedBlocksSizeInBytes > 0) {
+            sizeInBytesConsumer.accept(loadedBlocksSizeInBytes);
+        }
+
         return new Page(page.getPositionCount(), blocks);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
@@ -24,6 +24,7 @@ import io.prestosql.metadata.Split;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.operator.WorkProcessor.ProcessState;
 import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.operator.WorkProcessorSourceOperatorAdapter.AdapterWorkProcessorSourceOperatorFactory;
 import io.prestosql.operator.project.CursorProcessor;
 import io.prestosql.operator.project.CursorProcessorOutput;
 import io.prestosql.operator.project.PageProcessor;
@@ -370,7 +371,7 @@ public class ScanFilterAndProjectOperator
     }
 
     public static class ScanFilterAndProjectOperatorFactory
-            implements SourceOperatorFactory, WorkProcessorSourceOperatorFactory
+            implements SourceOperatorFactory, AdapterWorkProcessorSourceOperatorFactory
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;

--- a/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
@@ -424,6 +424,12 @@ public class ScanFilterAndProjectOperator
         }
 
         @Override
+        public PlanNodeId getPlanNodeId()
+        {
+            return planNodeId;
+        }
+
+        @Override
         public String getOperatorType()
         {
             return ScanFilterAndProjectOperator.class.getSimpleName();

--- a/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
@@ -82,6 +82,12 @@ public class TableScanOperator
         }
 
         @Override
+        public PlanNodeId getPlanNodeId()
+        {
+            return sourceId;
+        }
+
+        @Override
         public String getOperatorType()
         {
             return TableScanOperator.class.getSimpleName();

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -128,7 +128,7 @@ public class WorkProcessorPipelineSourceOperator
         workProcessorOperatorContexts.add(new WorkProcessorOperatorContext(
                 sourceOperator,
                 sourceOperatorFactory.getOperatorId(),
-                sourceOperatorFactory.getSourceId(),
+                sourceOperatorFactory.getPlanNodeId(),
                 sourceOperatorFactory.getOperatorType(),
                 sourceOperatorMemoryTrackingContext));
         WorkProcessor<Page> pages = sourceOperator.getOutputPages();

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorFactory.java
@@ -24,6 +24,8 @@ public interface WorkProcessorSourceOperatorFactory
 
     PlanNodeId getSourceId();
 
+    PlanNodeId getPlanNodeId();
+
     String getOperatorType();
 
     WorkProcessorSourceOperator create(

--- a/presto-main/src/main/java/io/prestosql/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/DictionaryAwarePageProjection.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.DictionaryBlock;
 import io.prestosql.spi.block.DictionaryId;
+import io.prestosql.spi.block.LazyBlock;
 import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
@@ -36,17 +37,21 @@ import static java.util.Objects.requireNonNull;
 public class DictionaryAwarePageProjection
         implements PageProjection
 {
+    private static final DriverYieldSignal NON_YIELDING_SIGNAL = new DriverYieldSignal();
+
     private final PageProjection projection;
     private final Function<DictionaryBlock, DictionaryId> sourceIdFunction;
+    private final boolean produceLazyBlock;
 
     private Block lastInputDictionary;
     private Optional<Block> lastOutputDictionary;
     private long lastDictionaryUsageCount;
 
-    public DictionaryAwarePageProjection(PageProjection projection, Function<DictionaryBlock, DictionaryId> sourceIdFunction)
+    public DictionaryAwarePageProjection(PageProjection projection, Function<DictionaryBlock, DictionaryId> sourceIdFunction, boolean produceLazyBlock)
     {
         this.projection = requireNonNull(projection, "projection is null");
         this.sourceIdFunction = sourceIdFunction;
+        this.produceLazyBlock = produceLazyBlock;
         verify(projection.isDeterministic(), "projection must be deterministic");
         verify(projection.getInputChannels().size() == 1, "projection must have only one input");
     }
@@ -80,9 +85,10 @@ public class DictionaryAwarePageProjection
     {
         private final ConnectorSession session;
         private final DriverYieldSignal yieldSignal;
-        private final Block block;
         private final SelectedPositions selectedPositions;
+        private final boolean produceLazyBlock;
 
+        private Block block;
         private Block result;
         // if the block is RLE or dictionary block, we may use dictionary processing
         private Work<Block> dictionaryProcessingProjectionWork;
@@ -92,27 +98,31 @@ public class DictionaryAwarePageProjection
         public DictionaryAwarePageProjectionWork(@Nullable ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             this.session = session;
-            this.yieldSignal = requireNonNull(yieldSignal, "yieldSignal is null");
-
-            Block block = requireNonNull(page, "page is null").getBlock(0).getLoadedBlock();
-            this.block = block;
+            this.block = requireNonNull(page, "page is null").getBlock(0);
             this.selectedPositions = requireNonNull(selectedPositions, "selectedPositions is null");
+            this.produceLazyBlock = DictionaryAwarePageProjection.this.produceLazyBlock && !isLoadedBlock(block);
 
-            Optional<Block> dictionary = Optional.empty();
-            if (block instanceof RunLengthEncodedBlock) {
-                dictionary = Optional.of(((RunLengthEncodedBlock) block).getValue());
+            if (produceLazyBlock) {
+                this.yieldSignal = NON_YIELDING_SIGNAL;
             }
-            else if (block instanceof DictionaryBlock) {
-                dictionary = Optional.of(((DictionaryBlock) block).getDictionary());
+            else {
+                this.yieldSignal = requireNonNull(yieldSignal, "yieldSignal is null");
+                setupDictionaryBlockProjection();
             }
-
-            // Try use dictionary processing first; if it fails, fall back to the generic case
-            dictionaryProcessingProjectionWork = createDictionaryBlockProjection(dictionary);
-            fallbackProcessingProjectionWork = null;
         }
 
         @Override
         public boolean process()
+        {
+            if (produceLazyBlock) {
+                return true;
+            }
+            else {
+                return processInternal();
+            }
+        }
+
+        private boolean processInternal()
         {
             checkState(result == null, "result has been generated");
             if (fallbackProcessingProjectionWork != null) {
@@ -182,8 +192,34 @@ public class DictionaryAwarePageProjection
         @Override
         public Block getResult()
         {
-            checkState(result != null, "result has not been generated");
-            return result;
+            if (produceLazyBlock) {
+                return new LazyBlock(selectedPositions.size(), lazyBlock -> {
+                    setupDictionaryBlockProjection();
+                    checkState(processInternal(), "processInternal() yielded");
+                    checkState(result != null, "result has not been generated");
+                    lazyBlock.setBlock(result.getLoadedBlock());
+                });
+            }
+            else {
+                checkState(result != null, "result has not been generated");
+                return result;
+            }
+        }
+
+        private void setupDictionaryBlockProjection()
+        {
+            block = block.getLoadedBlock();
+
+            Optional<Block> dictionary = Optional.empty();
+            if (block instanceof RunLengthEncodedBlock) {
+                dictionary = Optional.of(((RunLengthEncodedBlock) block).getValue());
+            }
+            else if (block instanceof DictionaryBlock) {
+                dictionary = Optional.of(((DictionaryBlock) block).getDictionary());
+            }
+
+            // Try use dictionary processing first; if it fails, fall back to the generic case
+            dictionaryProcessingProjectionWork = createDictionaryBlockProjection(dictionary);
         }
 
         private Work<Block> createDictionaryBlockProjection(Optional<Block> dictionary)
@@ -235,5 +271,10 @@ public class DictionaryAwarePageProjection
             }
         }
         return outputIds;
+    }
+
+    private static boolean isLoadedBlock(Block block)
+    {
+        return !(block instanceof LazyBlock) || ((LazyBlock) block).isLoaded();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/InputPageProjection.java
@@ -18,6 +18,7 @@ import io.prestosql.operator.DriverYieldSignal;
 import io.prestosql.operator.Work;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.LazyBlock;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
 
@@ -59,13 +60,29 @@ public class InputPageProjection
         Block block = requireNonNull(page, "page is null").getBlock(0);
         requireNonNull(selectedPositions, "selectedPositions is null");
 
-        Block result;
-        if (selectedPositions.isList()) {
-            result = block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+        if (!isLoadedBlock(block)) {
+            return new CompletedWork<>(
+                    new LazyBlock(
+                            selectedPositions.size(),
+                            lazyBlock -> lazyBlock.setBlock(projectPositions(block, selectedPositions))));
         }
         else {
-            result = block.getRegion(selectedPositions.getOffset(), selectedPositions.size());
+            // TODO: make it lazy when MergePages have better merging heuristics for small lazy pages
+            return new CompletedWork<>(projectPositions(block, selectedPositions));
         }
-        return new CompletedWork<>(result);
+    }
+
+    private Block projectPositions(Block block, SelectedPositions selectedPositions)
+    {
+        if (selectedPositions.isList()) {
+            return block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+        }
+
+        return block.getRegion(selectedPositions.getOffset(), selectedPositions.size());
+    }
+
+    private static boolean isLoadedBlock(Block block)
+    {
+        return !(block instanceof LazyBlock) || ((LazyBlock) block).isLoaded();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/MergePages.java
@@ -20,6 +20,8 @@ import io.prestosql.operator.WorkProcessor;
 import io.prestosql.operator.WorkProcessor.TransformationState;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.LazyBlock;
 import io.prestosql.spi.type.Type;
 
 import java.util.List;
@@ -127,7 +129,8 @@ public class MergePages
                 return ofResult(flush(), false);
             }
 
-            if (inputPage.getPositionCount() >= minRowCount || inputPage.getSizeInBytes() >= minPageSizeInBytes) {
+            // TODO: merge low cardinality blocks lazily
+            if (inputPage.getPositionCount() >= minRowCount || containsNotLoadedLazyBlock(inputPage) || inputPage.getSizeInBytes() >= minPageSizeInBytes) {
                 if (pageBuilder.isEmpty()) {
                     return ofResult(inputPage);
                 }
@@ -167,6 +170,19 @@ public class MergePages
             pageBuilder.reset();
             memoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
             return output;
+        }
+
+        private static boolean containsNotLoadedLazyBlock(Page page)
+        {
+            // TODO: provide better heuristics there, e.g check if last produced page was materialized
+            for (int channel = 0; channel < page.getChannelCount(); ++channel) {
+                Block block = page.getBlock(channel);
+                if ((block instanceof LazyBlock) && !((LazyBlock) block).isLoaded()) {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
@@ -82,7 +82,7 @@ public class PageProcessor
         this.projections = requireNonNull(projections, "projections is null").stream()
                 .map(projection -> {
                     if (projection.getInputChannels().size() == 1 && projection.isDeterministic()) {
-                        return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
+                        return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction, projection instanceof InputPageProjection);
                     }
                     return projection;
                 })

--- a/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/PageProcessor.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.operator.PageUtils.recordMaterializedBytes;
 import static io.prestosql.operator.WorkProcessor.ProcessState.finished;
 import static io.prestosql.operator.WorkProcessor.ProcessState.ofResult;
 import static io.prestosql.operator.WorkProcessor.ProcessState.yield;
@@ -98,11 +99,16 @@ public class PageProcessor
 
     public Iterator<Optional<Page>> process(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page)
     {
-        WorkProcessor<Page> processor = createWorkProcessor(session, yieldSignal, memoryContext, page);
+        return process(session, yieldSignal, memoryContext, page, false);
+    }
+
+    public Iterator<Optional<Page>> process(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page, boolean avoidPageMaterialization)
+    {
+        WorkProcessor<Page> processor = createWorkProcessor(session, yieldSignal, memoryContext, page, avoidPageMaterialization);
         return processor.yieldingIterator();
     }
 
-    public WorkProcessor<Page> createWorkProcessor(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page)
+    public WorkProcessor<Page> createWorkProcessor(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page, boolean avoidPageMaterialization)
     {
         // limit the scope of the dictionary ids to just one page
         dictionarySourceIdFunction.reset();
@@ -123,11 +129,11 @@ public class PageProcessor
             }
 
             if (selectedPositions.size() != page.getPositionCount()) {
-                return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, selectedPositions));
+                return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, selectedPositions, avoidPageMaterialization));
             }
         }
 
-        return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, positionsRange(0, page.getPositionCount())));
+        return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, positionsRange(0, page.getPositionCount()), avoidPageMaterialization));
     }
 
     private class ProjectSelectedPositions
@@ -136,6 +142,7 @@ public class PageProcessor
         private final ConnectorSession session;
         private final DriverYieldSignal yieldSignal;
         private final LocalMemoryContext memoryContext;
+        private final boolean avoidPageMaterialization;
 
         private Page page;
         private Block[] previouslyComputedResults;
@@ -147,7 +154,16 @@ public class PageProcessor
         private int lastComputeBatchSize;
         private Work<Block> pageProjectWork;
 
-        private ProjectSelectedPositions(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page, SelectedPositions selectedPositions)
+        private int outputPagePositions = -1;
+        private long outputPageSizeInBytes;
+
+        private ProjectSelectedPositions(
+                ConnectorSession session,
+                DriverYieldSignal yieldSignal,
+                LocalMemoryContext memoryContext,
+                Page page,
+                SelectedPositions selectedPositions,
+                boolean avoidPageMaterialization)
         {
             checkArgument(!selectedPositions.isEmpty(), "selectedPositions is empty");
 
@@ -155,6 +171,7 @@ public class PageProcessor
             this.yieldSignal = yieldSignal;
             this.page = page;
             this.memoryContext = memoryContext;
+            this.avoidPageMaterialization = avoidPageMaterialization;
             this.selectedPositions = selectedPositions;
             this.previouslyComputedResults = new Block[projections.size()];
         }
@@ -162,6 +179,11 @@ public class PageProcessor
         @Override
         public ProcessState<Page> process()
         {
+            if (avoidPageMaterialization && outputPagePositions != -1) {
+                updateBatchSize(outputPagePositions, outputPageSizeInBytes);
+                outputPagePositions = -1;
+            }
+
             int batchSize;
             while (true) {
                 if (selectedPositions.isEmpty()) {
@@ -200,15 +222,17 @@ public class PageProcessor
                 verify(result.isSuccess());
                 Page resultPage = result.getPage();
 
-                // if we produced a large page or if the expression is expensive, halve the batch size for the next call
-                long pageSize = resultPage.getSizeInBytes();
-                if (resultPage.getPositionCount() > 1 && (pageSize > MAX_PAGE_SIZE_IN_BYTES || expressionProfiler.isExpressionExpensive())) {
-                    projectBatchSize = projectBatchSize / 2;
+                if (!avoidPageMaterialization) {
+                    updateBatchSize(resultPage.getPositionCount(), resultPage.getSizeInBytes());
                 }
-
-                // if we produced a small page, double the batch size for the next call
-                if (pageSize < MIN_PAGE_SIZE_IN_BYTES && projectBatchSize < MAX_BATCH_SIZE && !expressionProfiler.isExpressionExpensive()) {
-                    projectBatchSize = projectBatchSize * 2;
+                else {
+                    // This is executed within WorkProcessorOperator context.
+                    // Therefore it is guaranteed that:
+                    // 1. produced Page is accessed by single thread
+                    // 2. lazy Page can be materialized only before fetching next page from PageProcessor
+                    outputPagePositions = resultPage.getPositionCount();
+                    outputPageSizeInBytes = 0;
+                    resultPage = recordMaterializedBytes(resultPage, sizeInBytes -> outputPageSizeInBytes += sizeInBytes);
                 }
 
                 // remove batch from selectedPositions and previouslyComputedResults
@@ -235,6 +259,19 @@ public class PageProcessor
                 }
 
                 return ofResult(resultPage);
+            }
+        }
+
+        private void updateBatchSize(int positionCount, long pageSize)
+        {
+            // if we produced a large page or if the expression is expensive, halve the batch size for the next call
+            if (positionCount > 1 && (pageSize > MAX_PAGE_SIZE_IN_BYTES || expressionProfiler.isExpressionExpensive())) {
+                projectBatchSize = projectBatchSize / 2;
+            }
+
+            // if we produced a small page, double the batch size for the next call
+            if (pageSize < MIN_PAGE_SIZE_IN_BYTES && projectBatchSize < MAX_BATCH_SIZE && !expressionProfiler.isExpressionExpensive()) {
+                projectBatchSize = projectBatchSize * 2;
             }
         }
 
@@ -300,7 +337,10 @@ public class PageProcessor
                     blocks[i] = previouslyComputedResults[i];
                 }
 
-                pageSize += blocks[i].getSizeInBytes();
+                if (!avoidPageMaterialization) {
+                    blocks[i] = blocks[i].getLoadedBlock();
+                    pageSize += blocks[i].getSizeInBytes();
+                }
             }
             return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
         }

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -248,6 +248,12 @@ public class TestWorkProcessorPipelineSourceOperator
         }
 
         @Override
+        public PlanNodeId getPlanNodeId()
+        {
+            return sourceId;
+        }
+
+        @Override
         public String getOperatorType()
         {
             return TestWorkProcessorSourceOperatorFactory.class.getSimpleName();

--- a/presto-main/src/test/java/io/prestosql/operator/project/TestInputPageProjection.java
+++ b/presto-main/src/test/java/io/prestosql/operator/project/TestInputPageProjection.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.project;
+
+import io.prestosql.operator.DriverYieldSignal;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.LazyBlock;
+import org.testng.annotations.Test;
+
+import static io.prestosql.block.BlockAssertions.createLongSequenceBlock;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestInputPageProjection
+{
+    @Test
+    public void testLazyInputPage()
+    {
+        InputPageProjection projection = new InputPageProjection(0, BIGINT);
+        Block block = createLongSequenceBlock(0, 100);
+        Block result = projection.project(SESSION, new DriverYieldSignal(), new Page(block), SelectedPositions.positionsRange(0, 100)).getResult();
+        assertFalse(result instanceof LazyBlock);
+
+        block = lazyWrapper(block);
+        result = projection.project(SESSION, new DriverYieldSignal(), new Page(block), SelectedPositions.positionsRange(0, 100)).getResult();
+        assertTrue(result instanceof LazyBlock);
+        assertFalse(((LazyBlock) result).isLoaded());
+    }
+
+    private static LazyBlock lazyWrapper(Block block)
+    {
+        return new LazyBlock(block.getPositionCount(), lazyBlock -> lazyBlock.setBlock(block.getLoadedBlock()));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/project/TestPageProcessor.java
@@ -153,6 +153,37 @@ public class TestPageProcessor
     }
 
     @Test
+    public void testSelectAllFilterLazyBlock()
+    {
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT), new InputPageProjection(1, BIGINT)), OptionalInt.of(100));
+
+        LazyBlock inputFilterBlock = lazyWrapper(createLongSequenceBlock(0, 100));
+        LazyBlock inputProjectionBlock = lazyWrapper(createLongSequenceBlock(100, 200));
+        Page inputPage = new Page(inputFilterBlock, inputProjectionBlock);
+
+        Iterator<Optional<Page>> output = processAndAssertRetainedPageSize(pageProcessor, new DriverYieldSignal(), newSimpleAggregatedMemoryContext(), inputPage, true);
+        List<Optional<Page>> outputPages = ImmutableList.copyOf(output);
+
+        assertTrue(inputFilterBlock.isLoaded());
+        assertFalse(inputProjectionBlock.isLoaded());
+        assertEquals(outputPages.size(), 1);
+
+        inputFilterBlock = lazyWrapper(createLongSequenceBlock(0, 200));
+        inputProjectionBlock = lazyWrapper(createLongSequenceBlock(100, 300));
+        inputPage = new Page(inputFilterBlock, inputProjectionBlock);
+
+        // batch size should increase because filter block was materialized
+        output = processAndAssertRetainedPageSize(pageProcessor, new DriverYieldSignal(), newSimpleAggregatedMemoryContext(), inputPage, true);
+        outputPages = ImmutableList.copyOf(output);
+
+        assertEquals(outputPages.size(), 1);
+        assertTrue(inputFilterBlock.isLoaded());
+        assertFalse(inputProjectionBlock.isLoaded());
+        assertPageEquals(ImmutableList.of(BIGINT, BIGINT), outputPages.get(0).get(), new Page(createLongSequenceBlock(0, 200), createLongSequenceBlock(100, 300)));
+        assertTrue(inputProjectionBlock.isLoaded());
+    }
+
+    @Test
     public void testSelectNoneFilter()
     {
         PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)));
@@ -500,13 +531,29 @@ public class TestPageProcessor
 
     private Iterator<Optional<Page>> processAndAssertRetainedPageSize(PageProcessor pageProcessor, DriverYieldSignal yieldSignal, AggregatedMemoryContext memoryContext, Page inputPage)
     {
+        return processAndAssertRetainedPageSize(pageProcessor, yieldSignal, memoryContext, inputPage, false);
+    }
+
+    private Iterator<Optional<Page>> processAndAssertRetainedPageSize(
+            PageProcessor pageProcessor,
+            DriverYieldSignal yieldSignal,
+            AggregatedMemoryContext memoryContext,
+            Page inputPage,
+            boolean avoidPageMaterialization)
+    {
         Iterator<Optional<Page>> output = pageProcessor.process(
                 SESSION,
                 yieldSignal,
                 memoryContext.newLocalMemoryContext(PageProcessor.class.getSimpleName()),
-                inputPage);
+                inputPage,
+                avoidPageMaterialization);
         assertEquals(memoryContext.getBytes(), 0);
         return output;
+    }
+
+    private static LazyBlock lazyWrapper(Block block)
+    {
+        return new LazyBlock(block.getPositionCount(), lazyBlock -> lazyBlock.setBlock(block.getLoadedBlock()));
     }
 
     private static class InvocationCountPageProjection


### PR DESCRIPTION
Followup:
* port semi-join to `WorkProcessorOperator` (@Praveen2112 ?)
* port `FilterAndProjectOperator` to `WorkProcessorOperator`
This way we get (node-local) dynamic filtering for semi joins and `IN (subquery), NOT IN (subquery), x >= ALL (subquery), etc` expressions 