### PR TITLE
Update scripts to generate TPC-DS and TPC-H Data

### DIFF
--- a/presto-benchto-benchmarks/generate_schemas/generate-tpcds.py
+++ b/presto-benchto-benchmarks/generate_schemas/generate-tpcds.py
@@ -2,9 +2,13 @@
 
 schemas = [
     # (new_schema, source_schema)
-    ('tpcds_10gb_orc', 'tpcds.sf10'),
-    ('tpcds_100gb_orc', 'tpcds.sf100'),
-    ('tpcds_1tb_orc', 'tpcds.sf1000'),
+    ('tpcds_sf10_orc', 'tpcds.sf10'),
+    ('tpcds_sf30_orc', 'tpcds.sf30'),
+    ('tpcds_sf100_orc', 'tpcds.sf100'),
+    ('tpcds_sf300_orc', 'tpcds.sf300'),
+    ('tpcds_sf1000_orc', 'tpcds.sf1000'),
+    ('tpcds_sf3000_orc', 'tpcds.sf3000'),
+    ('tpcds_sf10000_orc', 'tpcds.sf10000'),
 ]
 
 tables = [

--- a/presto-benchto-benchmarks/generate_schemas/generate-tpch.py
+++ b/presto-benchto-benchmarks/generate_schemas/generate-tpch.py
@@ -2,15 +2,13 @@
 
 schemas = [
     # (new_schema, source_schema)
-    ('tpch_10gb_orc', 'tpch.sf10'),
-    ('tpch_100gb_orc', 'tpch.sf100'),
-    ('tpch_1tb_orc', 'tpch.sf1000'),
-    ('tpch_10tb_orc', 'tpch.sf10000'),
+    ('tpch_sf300_orc', 'tpch.sf300'),
+    ('tpch_sf1000_orc', 'tpch.sf1000'),
+    ('tpch_sf3000_orc', 'tpch.sf3000'),
 
-    ('tpch_10gb_text', 'hive.tpch_10gb_orc'),
-    ('tpch_100gb_text', 'hive.tpch_100gb_orc'),
-    ('tpch_1tb_text', 'hive.tpch_1tb_orc'),
-    ('tpch_10tb_text', 'hive.tpch_10tb_orc'),
+    ('tpch_sf300_text', 'hive.tpch_sf300_orc'),
+    ('tpch_sf1000_text', 'hive.tpch_sf1000_orc'),
+    ('tpch_sf3000_text', 'hive.tpch_sf3000_orc'),
 ]
 
 tables = [


### PR DESCRIPTION
Looks like the Presto Benchto benchmarks were updated in https://github.com/prestodb/presto/commit/b238a3de47f811ca881ea4bf7db77d99399ae1ff. We should update the generate-tpc*.py scripts to produce the expected schemas.