### PR TITLE
Avoid extra getStatus calls on FileSystem in SyncPartitionMetadataProcedure

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/SyncPartitionMetadataProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/SyncPartitionMetadataProcedure.java
@@ -147,7 +147,7 @@ public class SyncPartitionMetadataProcedure
 
         try {
             return Stream.of(fileSystem.listStatus(current.getPath()))
-                    .filter(fileStatus -> isValidPartitionPath(fileSystem, fileStatus, partitionColumns.get(partitionColumns.size() - depth)))
+                    .filter(fileStatus -> isValidPartitionPath(fileStatus, partitionColumns.get(partitionColumns.size() - depth)))
                     .flatMap(directory -> listDirectory(fileSystem, directory, partitionColumns, depth - 1).stream())
                     .collect(toImmutableList());
         }
@@ -156,16 +156,11 @@ public class SyncPartitionMetadataProcedure
         }
     }
 
-    private static boolean isValidPartitionPath(FileSystem fileSystem, FileStatus file, Column column)
+    private static boolean isValidPartitionPath(FileStatus file, Column column)
     {
-        try {
-            Path path = file.getPath();
-            String prefix = column.getName() + '=';
-            return fileSystem.isDirectory(path) && path.getName().startsWith(prefix);
-        }
-        catch (IOException e) {
-            throw new PrestoException(HIVE_FILESYSTEM_ERROR, e);
-        }
+        Path path = file.getPath();
+        String prefix = column.getName() + '=';
+        return file.isDirectory() && path.getName().startsWith(prefix);
     }
 
     // calculate relative complement of set b with respect to set a


### PR DESCRIPTION
Current implementation performs a getStatus call on FileSystem for every partition to verify whether the partition path is a directory. This slows down SyncPartitionMetadataProcedure considerably on S3 filesystem for large number of partitions (~25m for 1800 partitions). This change re-uses isDirectory from FileStatus to avoid the extra calls and reduce execution time (~10 seconds for 1800 partitions).  