### PR TITLE
Minor Code cleanup for ExpressionVerifier

### DIFF
--- a/presto-main/src/main/java/io/prestosql/util/MorePredicates.java
+++ b/presto-main/src/main/java/io/prestosql/util/MorePredicates.java
@@ -29,4 +29,9 @@ public class MorePredicates
         }
         return predicate;
     }
+
+    public static Predicate<Boolean> identity()
+    {
+        return value -> value;
+    }
 }


### PR DESCRIPTION
- Use `Iterables#getOnlyElement` for fetching single value
- Simplify `ExpressionVerifier#process` using `Stream#zip`