### PR TITLE
[WIP] Optimized batch scheduling for split allocations

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/NodeScheduler.java
@@ -76,6 +76,7 @@ public class NodeScheduler
     private final int maxSplitsPerNode;
     private final int maxPendingSplitsPerTask;
     private final boolean optimizedLocalScheduling;
+    private final boolean optimizedBatchScheduling;
     private final NodeTaskMap nodeTaskMap;
     private final boolean useNetworkTopology;
 
@@ -99,6 +100,7 @@ public class NodeScheduler
         this.maxSplitsPerNode = config.getMaxSplitsPerNode();
         this.maxPendingSplitsPerTask = config.getMaxPendingSplitsPerTask();
         this.optimizedLocalScheduling = config.getOptimizedLocalScheduling();
+        this.optimizedBatchScheduling = config.getOptimizedBatchScheduling();
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
         checkArgument(maxSplitsPerNode >= maxPendingSplitsPerTask, "maxSplitsPerNode must be > maxPendingSplitsPerTask");
         this.useNetworkTopology = !config.getNetworkTopology().equals(NetworkTopologyType.LEGACY);
@@ -190,7 +192,7 @@ public class NodeScheduler
                     networkLocationCache);
         }
         else {
-            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, optimizedLocalScheduling);
+            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, optimizedLocalScheduling, optimizedBatchScheduling);
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/NodeSchedulerConfig.java
@@ -36,6 +36,7 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private String networkTopology = NetworkTopologyType.LEGACY;
     private boolean optimizedLocalScheduling = true;
+    private boolean optimizedBatchScheduling;
 
     @NotNull
     public String getNetworkTopology()
@@ -109,6 +110,18 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setOptimizedLocalScheduling(boolean optimizedLocalScheduling)
     {
         this.optimizedLocalScheduling = optimizedLocalScheduling;
+        return this;
+    }
+
+    public boolean getOptimizedBatchScheduling()
+    {
+        return optimizedBatchScheduling;
+    }
+
+    @Config("node-scheduler.optimized-batch-scheduling")
+    public NodeSchedulerConfig setOptimizedBatchScheduling(boolean optimizedBatchScheduling)
+    {
+        this.optimizedBatchScheduling = optimizedBatchScheduling;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestNodeSchedulerConfig.java
@@ -33,7 +33,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(100)
                 .setMaxPendingSplitsPerTask(10)
                 .setIncludeCoordinator(true)
-                .setOptimizedLocalScheduling(true));
+                .setOptimizedLocalScheduling(true)
+                .setOptimizedBatchScheduling(false));
     }
 
     @Test
@@ -46,6 +47,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-splits-per-node", "101")
                 .put("node-scheduler.optimized-local-scheduling", "false")
+                .put("node-scheduler.optimized-batch-scheduling", "true")
                 .build();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -54,7 +56,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(101)
                 .setMaxPendingSplitsPerTask(11)
                 .setMinCandidates(11)
-                .setOptimizedLocalScheduling(false);
+                .setOptimizedLocalScheduling(false)
+                .setOptimizedBatchScheduling(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
During scheduling, already has global informations about the splits and sampled nodes, we can use batch scheduling to further reduce scheduling overhead and can achieve better allocation result by using batched scheduling instead of per-task scheduling. Here, a batched 2 random choice is used.