### PR TITLE
Fix z-index bug for .sparkline-tooltip in StagePerformance details page.

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/presto.css
+++ b/presto-main/src/main/resources/webapp/assets/presto.css
@@ -337,7 +337,7 @@ pre {
     white-space: nowrap;
     padding: 0 40px 5px 5px;
     border: none;
-    z-index: 100;
+    z-index: 1051;
 }
 
 /** Query list **/


### PR DESCRIPTION
z-index of `.sparkline-tooltip` (100) is smaller than that of `#operator-detail-modal` (1050), so when we go into query detail page → click Stage Performance → click one specific operator → hover on any of statistic, we cannot see the tooltip clearly.
I think 1051 is ok, but I am not sure if it will have impact on other components.