### PR TITLE
Pushdown more when visit Project Node.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -283,7 +283,7 @@ public class PredicatePushDown
 
             // candidate symbols for inlining are
             //   1. references to simple constants
-            //   2. references to complex expressions that appear only once
+            //   2. references to complex expressions that appear <= 4
             // which come from the node, as opposed to an enclosing scope.
             Set<Symbol> childOutputSet = ImmutableSet.copyOf(node.getOutputSymbols());
             Map<Symbol, Long> dependencies = SymbolsExtractor.extractAll(expression).stream()
@@ -291,7 +291,7 @@ public class PredicatePushDown
                     .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
             return dependencies.entrySet().stream()
-                    .allMatch(entry -> entry.getValue() == 1 || node.getAssignments().get(entry.getKey()) instanceof Literal);
+                    .allMatch(entry -> entry.getValue() <= 4 || node.getAssignments().get(entry.getKey()) instanceof Literal);
         }
 
         @Override


### PR DESCRIPTION
Due to commit [6dcd67](https://github.com/freewheel/presto/commit/6dcd67fdffbe291ca68f1c5fe8936a575cce86df) `Inline only simple expressions in predicate pushdown`, 
the SQL with pattern like
```
SELECT fact.field_x
FROM hive.fact.table as fact
JOIN hive.dim.table as dimension 
ON fact.field_y = dimension.field_y AND fact.field_z = 12345
WHERE
(partition_key = TIMESTAMP '2019-04-11' OR partition_key = TIMESTAMP '2019-05-11')
``` 
will scan full table data rather than the data in such 2 partitions.

One of the reason is the function `isInliningCandidate` thinks `references to complex expressions that appear only once (entry.getValue() == 1)` can go through the predicate pushdown on Project node, but `partition_key` appears 2 times in above case.
I think the above pattern is common, and `== 1` is too aggressive, so maybe `<= 4(8/16)` is more reasonable.