### PR TITLE
Enable the Information Schema Connector to load data lazily

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSource.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSource.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.connector.informationschema;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.QualifiedTablePrefix;
+import io.prestosql.security.AccessControl;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorViewDefinition;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.GrantInfo;
+import io.prestosql.spi.security.PrestoPrincipal;
+import io.prestosql.spi.security.RoleGrant;
+import io.prestosql.spi.type.Type;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Sets.union;
+import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLES;
+import static io.prestosql.metadata.MetadataListing.listSchemas;
+import static io.prestosql.metadata.MetadataListing.listTableColumns;
+import static io.prestosql.metadata.MetadataListing.listTablePrivileges;
+import static io.prestosql.metadata.MetadataListing.listTables;
+import static io.prestosql.metadata.MetadataListing.listViews;
+import static io.prestosql.spi.security.PrincipalType.USER;
+import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
+import static java.util.Objects.requireNonNull;
+
+public class InformationSchemaPageSource
+        implements ConnectorPageSource
+{
+    private enum InformationSchemaTableType
+    {
+        TABLE_COLUMNS,
+        TABLE_TABLES,
+        TABLE_VIEWS,
+        TABLE_SCHEMATA,
+        TABLE_TABLE_PRIVILEGES,
+        TABLE_ROLES,
+        TABLE_APPLICABLE_ROLES,
+        TABLE_ENABLED_ROLES;
+
+        private static InformationSchemaTableType of(SchemaTableName schemaTableName)
+        {
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_COLUMNS)) {
+                return InformationSchemaTableType.TABLE_COLUMNS;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_TABLES)) {
+                return InformationSchemaTableType.TABLE_TABLES;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_VIEWS)) {
+                return InformationSchemaTableType.TABLE_VIEWS;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_SCHEMATA)) {
+                return InformationSchemaTableType.TABLE_SCHEMATA;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES)) {
+                return InformationSchemaTableType.TABLE_TABLE_PRIVILEGES;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_ROLES)) {
+                return InformationSchemaTableType.TABLE_ROLES;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_APPLICABLE_ROLES)) {
+                return InformationSchemaTableType.TABLE_APPLICABLE_ROLES;
+            }
+            if (schemaTableName.equals(InformationSchemaMetadata.TABLE_ENABLED_ROLES)) {
+                return InformationSchemaTableType.TABLE_ENABLED_ROLES;
+            }
+            throw new IllegalArgumentException("table does not exist: " + schemaTableName);
+        }
+    }
+
+    private final Session session;
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+    private final String catalogName;
+    private final Iterator<QualifiedTablePrefix> tablePrefixIterator;
+
+    private final InformationSchemaTableType tableType;
+
+    private final List<Type> columnTypes;
+    private final Queue<Page> rawPages = new ArrayDeque<>();
+    private final PageBuilder rawPageBuilder;
+    private final List<Integer> outputPageChannels;
+
+    // Used only for tables "schemata", "roles", "applicable_roles" and "enabled_roles", which are catalog-wise
+    // and don't need a set of table prefixes
+    private boolean noMoreBuild;
+
+    private long completedBytes;
+    private long memoryUsageBytes;
+    private boolean closed;
+
+    public InformationSchemaPageSource(
+            Session session,
+            Metadata metadata,
+            AccessControl accessControl,
+            InformationSchemaTableHandle tableHandle,
+            List<ColumnHandle> outputColumns)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+
+        requireNonNull(tableHandle, "tableHandle is null");
+        catalogName = tableHandle.getCatalogName();
+        tablePrefixIterator = tableHandle.getPrefixes().iterator();
+
+        SchemaTableName schemaTableName = tableHandle.getSchemaTableName();
+
+        tableType = InformationSchemaTableType.of(schemaTableName);
+
+        List<ColumnMetadata> columnMetadata = TABLES.get(schemaTableName).getColumns();
+        columnTypes = columnMetadata.stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList());
+
+        rawPageBuilder = new PageBuilder(columnTypes);
+
+        Map<String, Integer> columnNameToChannelMapping = IntStream.range(0, columnMetadata.size())
+                .boxed()
+                .collect(toImmutableMap(i -> columnMetadata.get(i).getName(), Function.identity()));
+
+        outputPageChannels = outputColumns.stream()
+                .map(columnHandle -> (InformationSchemaColumnHandle) columnHandle)
+                .map(columnHandle -> columnNameToChannelMapping.get(columnHandle.getColumnName()))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        if (isTablesEnumeratingTable(tableType)) {
+            return closed || (rawPages.isEmpty() && !tablePrefixIterator.hasNext());
+        }
+        return closed || (rawPages.isEmpty() && noMoreBuild);
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+        if (rawPages.isEmpty()) {
+            buildRawPages();
+        }
+
+        Page rawPage = rawPages.poll();
+        if (rawPage == null) {
+            return null;
+        }
+        memoryUsageBytes -= rawPage.getRetainedSizeInBytes();
+        Block[] blocks = new Block[outputPageChannels.size()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = rawPage.getBlock(outputPageChannels.get(i));
+        }
+        Page outputPage = new Page(rawPage.getPositionCount(), blocks);
+        completedBytes += outputPage.getSizeInBytes();
+        return outputPage;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return memoryUsageBytes + rawPageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closed = true;
+    }
+
+    private void buildRawPages()
+    {
+        if (isTablesEnumeratingTable(tableType)) {
+            while (rawPages.isEmpty() && tablePrefixIterator.hasNext()) {
+                QualifiedTablePrefix prefix = tablePrefixIterator.next();
+                switch (tableType) {
+                    case TABLE_COLUMNS:
+                        addColumnsRecordsFor(prefix);
+                        break;
+                    case TABLE_TABLE_PRIVILEGES:
+                        addTablePrivilegesRecordsFor(prefix);
+                        break;
+                    case TABLE_TABLES:
+                        addTablesRecordsFor(prefix);
+                        break;
+                    case TABLE_VIEWS:
+                        addViewsRecordsFor(prefix);
+                        break;
+                }
+            }
+            // Flush the residual page
+            if (!tablePrefixIterator.hasNext()) {
+                flushPageBuilder();
+            }
+            return;
+        }
+
+        if (noMoreBuild) {
+            return;
+        }
+        switch (tableType) {
+            case TABLE_SCHEMATA:
+                addSchemataRecords();
+                break;
+            case TABLE_ROLES:
+                addRolesRecords();
+                break;
+            case TABLE_APPLICABLE_ROLES:
+                addApplicableRolesRecords();
+                break;
+            case TABLE_ENABLED_ROLES:
+                addEnabledRolesRecords();
+                break;
+        }
+        flushPageBuilder();
+        noMoreBuild = true;
+    }
+
+    private void addSchemataRecords()
+    {
+        for (String schema : listSchemas(session, metadata, accessControl, catalogName)) {
+            addRecord(catalogName, schema);
+        }
+    }
+
+    private void addRolesRecords()
+    {
+        try {
+            accessControl.checkCanShowRoles(session.getRequiredTransactionId(), session.getIdentity(), catalogName);
+        }
+        catch (AccessDeniedException exception) {
+            return;
+        }
+
+        for (String role : metadata.listRoles(session, catalogName)) {
+            addRecord(role);
+        }
+    }
+
+    private void addApplicableRolesRecords()
+    {
+        for (RoleGrant grant : metadata.listApplicableRoles(session, new PrestoPrincipal(USER, session.getUser()), catalogName)) {
+            PrestoPrincipal grantee = grant.getGrantee();
+            addRecord(
+                    grantee.getName(),
+                    grantee.getType().toString(),
+                    grant.getRoleName(),
+                    grant.isGrantable() ? "YES" : "NO");
+        }
+    }
+
+    private void addEnabledRolesRecords()
+    {
+        for (String role : metadata.listEnabledRoles(session, catalogName)) {
+            addRecord(role);
+        }
+    }
+
+    private void addColumnsRecordsFor(QualifiedTablePrefix prefix)
+    {
+        for (Map.Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+            SchemaTableName tableName = entry.getKey();
+            int ordinalPosition = 1;
+            for (ColumnMetadata column : entry.getValue()) {
+                if (column.isHidden()) {
+                    continue;
+                }
+                addRecord(
+                        prefix.getCatalogName(),
+                        tableName.getSchemaName(),
+                        tableName.getTableName(),
+                        column.getName(),
+                        ordinalPosition,
+                        null,
+                        "YES",
+                        column.getType().getDisplayName(),
+                        column.getComment(),
+                        column.getExtraInfo(),
+                        column.getComment());
+                ordinalPosition++;
+            }
+        }
+    }
+
+    private void addTablePrivilegesRecordsFor(QualifiedTablePrefix prefix)
+    {
+        List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
+        for (GrantInfo grant : grants) {
+            addRecord(
+                    grant.getGrantor().map(PrestoPrincipal::getName).orElse(null),
+                    grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
+                    grant.getGrantee().getName(),
+                    grant.getGrantee().getType().toString(),
+                    prefix.getCatalogName(),
+                    grant.getSchemaTableName().getSchemaName(),
+                    grant.getSchemaTableName().getTableName(),
+                    grant.getPrivilegeInfo().getPrivilege().name(),
+                    grant.getPrivilegeInfo().isGrantOption() ? "YES" : "NO",
+                    grant.getWithHierarchy().map(withHierarchy -> withHierarchy ? "YES" : "NO").orElse(null));
+        }
+    }
+
+    private void addTablesRecordsFor(QualifiedTablePrefix prefix)
+    {
+        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
+        Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
+
+        for (SchemaTableName name : union(tables, views)) {
+            // if table and view names overlap, the view wins
+            String type = views.contains(name) ? "VIEW" : "BASE TABLE";
+            addRecord(
+                    prefix.getCatalogName(),
+                    name.getSchemaName(),
+                    name.getTableName(),
+                    type,
+                    null);
+        }
+    }
+
+    private void addViewsRecordsFor(QualifiedTablePrefix prefix)
+    {
+        for (Map.Entry<QualifiedObjectName, ConnectorViewDefinition> entry : metadata.getViews(session, prefix).entrySet()) {
+            addRecord(
+                    entry.getKey().getCatalogName(),
+                    entry.getKey().getSchemaName(),
+                    entry.getKey().getObjectName(),
+                    entry.getValue().getOriginalSql());
+        }
+    }
+
+    private void addRecord(Object... values)
+    {
+        rawPageBuilder.declarePosition();
+        for (int i = 0; i < columnTypes.size(); i++) {
+            writeNativeValue(columnTypes.get(i), rawPageBuilder.getBlockBuilder(i), values[i]);
+        }
+
+        if (rawPageBuilder.isFull()) {
+            flushPageBuilder();
+        }
+    }
+
+    private void flushPageBuilder()
+    {
+        if (!rawPageBuilder.isEmpty()) {
+            rawPages.add(rawPageBuilder.build());
+            memoryUsageBytes += rawPageBuilder.getRetainedSizeInBytes();
+            rawPageBuilder.reset();
+        }
+    }
+
+    private static boolean isTablesEnumeratingTable(InformationSchemaTableType tableType)
+    {
+        return (tableType == InformationSchemaTableType.TABLE_COLUMNS
+                || tableType == InformationSchemaTableType.TABLE_TABLES
+                || tableType == InformationSchemaTableType.TABLE_VIEWS
+                || tableType == InformationSchemaTableType.TABLE_TABLE_PRIVILEGES);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSourceProvider.java
@@ -13,55 +13,20 @@
  */
 package io.prestosql.connector.informationschema;
 
-import com.google.common.collect.ImmutableList;
 import io.prestosql.FullConnectorSession;
 import io.prestosql.Session;
-import io.prestosql.metadata.InternalTable;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.metadata.QualifiedObjectName;
-import io.prestosql.metadata.QualifiedTablePrefix;
 import io.prestosql.security.AccessControl;
-import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ColumnHandle;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
-import io.prestosql.spi.connector.ConnectorViewDefinition;
-import io.prestosql.spi.connector.FixedPageSource;
-import io.prestosql.spi.connector.SchemaTableName;
-import io.prestosql.spi.security.AccessDeniedException;
-import io.prestosql.spi.security.GrantInfo;
-import io.prestosql.spi.security.PrestoPrincipal;
-import io.prestosql.spi.security.RoleGrant;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Sets.union;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_APPLICABLE_ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_COLUMNS;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_ENABLED_ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_SCHEMATA;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_TABLES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
-import static io.prestosql.connector.informationschema.InformationSchemaMetadata.TABLE_VIEWS;
-import static io.prestosql.metadata.MetadataListing.listSchemas;
-import static io.prestosql.metadata.MetadataListing.listTableColumns;
-import static io.prestosql.metadata.MetadataListing.listTablePrivileges;
-import static io.prestosql.metadata.MetadataListing.listTables;
-import static io.prestosql.metadata.MetadataListing.listViews;
-import static io.prestosql.spi.security.PrincipalType.USER;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class InformationSchemaPageSourceProvider
@@ -79,210 +44,19 @@ public class InformationSchemaPageSourceProvider
     @Override
     public ConnectorPageSource createPageSource(
             ConnectorTransactionHandle transaction,
-            ConnectorSession session,
+            ConnectorSession connectorSession,
             ConnectorSplit split,
             ConnectorTableHandle tableHandle,
             List<ColumnHandle> columns)
     {
-        InternalTable table = getInternalTable(session, tableHandle);
-
-        List<Integer> channels = new ArrayList<>();
-        for (ColumnHandle column : columns) {
-            String columnName = ((InformationSchemaColumnHandle) column).getColumnName();
-            int columnIndex = table.getColumnIndex(columnName);
-            channels.add(columnIndex);
-        }
-
-        ImmutableList.Builder<Page> pages = ImmutableList.builder();
-        for (Page page : table.getPages()) {
-            Block[] blocks = new Block[channels.size()];
-            for (int index = 0; index < blocks.length; index++) {
-                blocks[index] = page.getBlock(channels.get(index));
-            }
-            pages.add(new Page(page.getPositionCount(), blocks));
-        }
-        return new FixedPageSource(pages.build());
-    }
-
-    private InternalTable getInternalTable(ConnectorSession connectorSession, ConnectorTableHandle tablehandle)
-    {
         Session session = ((FullConnectorSession) connectorSession).getSession();
-        InformationSchemaTableHandle handle = (InformationSchemaTableHandle) tablehandle;
-        Set<QualifiedTablePrefix> prefixes = handle.getPrefixes();
+        InformationSchemaTableHandle handle = (InformationSchemaTableHandle) tableHandle;
 
-        return getInformationSchemaTable(session, handle.getCatalogName(), handle.getSchemaTableName(), prefixes);
-    }
-
-    public InternalTable getInformationSchemaTable(Session session, String catalog, SchemaTableName table, Set<QualifiedTablePrefix> prefixes)
-    {
-        if (table.equals(TABLE_COLUMNS)) {
-            return buildColumns(session, prefixes);
-        }
-        if (table.equals(TABLE_TABLES)) {
-            return buildTables(session, prefixes);
-        }
-        if (table.equals(TABLE_VIEWS)) {
-            return buildViews(session, prefixes);
-        }
-        if (table.equals(TABLE_SCHEMATA)) {
-            return buildSchemata(session, catalog);
-        }
-        if (table.equals(TABLE_TABLE_PRIVILEGES)) {
-            return buildTablePrivileges(session, prefixes);
-        }
-        if (table.equals(TABLE_ROLES)) {
-            return buildRoles(session, catalog);
-        }
-        if (table.equals(TABLE_APPLICABLE_ROLES)) {
-            return buildApplicableRoles(session, catalog);
-        }
-        if (table.equals(TABLE_ENABLED_ROLES)) {
-            return buildEnabledRoles(session, catalog);
-        }
-
-        throw new IllegalArgumentException(format("table does not exist: %s", table));
-    }
-
-    private InternalTable buildColumns(Session session, Set<QualifiedTablePrefix> prefixes)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_COLUMNS));
-        for (QualifiedTablePrefix prefix : prefixes) {
-            for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
-                SchemaTableName tableName = entry.getKey();
-                int ordinalPosition = 1;
-                for (ColumnMetadata column : entry.getValue()) {
-                    if (column.isHidden()) {
-                        continue;
-                    }
-                    table.add(
-                            prefix.getCatalogName(),
-                            tableName.getSchemaName(),
-                            tableName.getTableName(),
-                            column.getName(),
-                            ordinalPosition,
-                            null,
-                            "YES",
-                            column.getType().getDisplayName(),
-                            column.getComment(),
-                            column.getExtraInfo(),
-                            column.getComment());
-                    ordinalPosition++;
-                }
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildTables(Session session, Set<QualifiedTablePrefix> prefixes)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLES));
-        for (QualifiedTablePrefix prefix : prefixes) {
-            Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
-            Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
-
-            for (SchemaTableName name : union(tables, views)) {
-                // if table and view names overlap, the view wins
-                String type = views.contains(name) ? "VIEW" : "BASE TABLE";
-                table.add(
-                        prefix.getCatalogName(),
-                        name.getSchemaName(),
-                        name.getTableName(),
-                        type,
-                        null);
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildTablePrivileges(Session session, Set<QualifiedTablePrefix> prefixes)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLE_PRIVILEGES));
-        for (QualifiedTablePrefix prefix : prefixes) {
-            List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
-            for (GrantInfo grant : grants) {
-                table.add(
-                        grant.getGrantor().map(PrestoPrincipal::getName).orElse(null),
-                        grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
-                        grant.getGrantee().getName(),
-                        grant.getGrantee().getType().toString(),
-                        prefix.getCatalogName(),
-                        grant.getSchemaTableName().getSchemaName(),
-                        grant.getSchemaTableName().getTableName(),
-                        grant.getPrivilegeInfo().getPrivilege().name(),
-                        grant.getPrivilegeInfo().isGrantOption() ? "YES" : "NO",
-                        grant.getWithHierarchy().map(withHierarchy -> withHierarchy ? "YES" : "NO").orElse(null));
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildViews(Session session, Set<QualifiedTablePrefix> prefixes)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_VIEWS));
-        for (QualifiedTablePrefix prefix : prefixes) {
-            for (Entry<QualifiedObjectName, ConnectorViewDefinition> entry : metadata.getViews(session, prefix).entrySet()) {
-                table.add(
-                        entry.getKey().getCatalogName(),
-                        entry.getKey().getSchemaName(),
-                        entry.getKey().getObjectName(),
-                        entry.getValue().getOriginalSql());
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildSchemata(Session session, String catalogName)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_SCHEMATA));
-        for (String schema : listSchemas(session, metadata, accessControl, catalogName)) {
-            table.add(catalogName, schema);
-        }
-        return table.build();
-    }
-
-    private InternalTable buildRoles(Session session, String catalog)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_ROLES));
-
-        try {
-            accessControl.checkCanShowRoles(session.getRequiredTransactionId(), session.getIdentity(), catalog);
-        }
-        catch (AccessDeniedException exception) {
-            return table.build();
-        }
-
-        for (String role : metadata.listRoles(session, catalog)) {
-            table.add(role);
-        }
-        return table.build();
-    }
-
-    private InternalTable buildApplicableRoles(Session session, String catalog)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_APPLICABLE_ROLES));
-        for (RoleGrant grant : metadata.listApplicableRoles(session, new PrestoPrincipal(USER, session.getUser()), catalog)) {
-            PrestoPrincipal grantee = grant.getGrantee();
-            table.add(
-                    grantee.getName(),
-                    grantee.getType().toString(),
-                    grant.getRoleName(),
-                    grant.isGrantable() ? "YES" : "NO");
-        }
-        return table.build();
-    }
-
-    private InternalTable buildEnabledRoles(Session session, String catalog)
-    {
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_ENABLED_ROLES));
-        for (String role : metadata.listEnabledRoles(session, catalog)) {
-            table.add(role);
-        }
-        return table.build();
-    }
-
-    private static List<ColumnMetadata> informationSchemaTableColumns(SchemaTableName tableName)
-    {
-        checkArgument(TABLES.containsKey(tableName), "table does not exist: %s", tableName);
-        return TABLES.get(tableName).getColumns();
+        return new InformationSchemaPageSource(
+                session,
+                metadata,
+                accessControl,
+                handle,
+                columns);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
@@ -15,12 +15,11 @@ package io.prestosql.connector.informationschema;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableSet;
-import io.prestosql.metadata.QualifiedTablePrefix;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.SchemaTableName;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -31,19 +30,22 @@ public class InformationSchemaTableHandle
     private final String catalogName;
     private final String schemaName;
     private final String tableName;
-    private final Set<QualifiedTablePrefix> prefixes;
+    private final Optional<Set<String>> schemas;
+    private final Optional<Set<String>> tables;
 
     @JsonCreator
     public InformationSchemaTableHandle(
             @JsonProperty("catalogName") String catalogName,
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
-            @JsonProperty("prefixes") Set<QualifiedTablePrefix> prefixes)
+            @JsonProperty("schemas") Optional<Set<String>> schemas,
+            @JsonProperty("tables") Optional<Set<String>> tables)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.prefixes = ImmutableSet.copyOf(requireNonNull(prefixes, "prefixes is null"));
+        this.schemas = requireNonNull(schemas, "schemas is null");
+        this.tables = requireNonNull(tables, "tables");
     }
 
     @JsonProperty
@@ -70,9 +72,15 @@ public class InformationSchemaTableHandle
     }
 
     @JsonProperty
-    public Set<QualifiedTablePrefix> getPrefixes()
+    public Optional<Set<String>> getSchemas()
     {
-        return prefixes;
+        return schemas;
+    }
+
+    @JsonProperty
+    public Optional<Set<String>> getTables()
+    {
+        return tables;
     }
 
     @Override
@@ -99,6 +107,8 @@ public class InformationSchemaTableHandle
         InformationSchemaTableHandle other = (InformationSchemaTableHandle) obj;
         return Objects.equals(this.catalogName, other.catalogName) &&
                 Objects.equals(this.schemaName, other.schemaName) &&
-                Objects.equals(this.tableName, other.tableName);
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.schemas, other.schemas) &&
+                Objects.equals(this.tables, other.tables);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
@@ -217,7 +217,7 @@ public class MockConnectorFactory
             @Override
             public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
             {
-                return Optional.of(getViews.apply(session, viewName.toSchemaTablePrefix()).get(viewName));
+                return Optional.ofNullable(getViews.apply(session, viewName.toSchemaTablePrefix()).get(viewName));
             }
         }
     }

--- a/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
@@ -71,9 +71,10 @@ public class BenchmarkInformationSchema
         private final Map<String, String> queries = ImmutableMap.of(
                 "FULL_SCAN", "SELECT count(*) FROM information_schema.columns",
                 "LIKE_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema LIKE 'schema_0'",
-                "MIXED_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema = 'schema_0'");
+                "MIXED_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema = 'schema_0'",
+                "LIMIT_SCAN", "SELECT column_name FROM information_schema.columns LIMIT 100");
 
-        @Param({"FULL_SCAN", "LIKE_PREDICATE", "MIXED_PREDICATE"})
+        @Param({"FULL_SCAN", "LIKE_PREDICATE", "MIXED_PREDICATE", "LIMIT_SCAN"})
         private String queryId = "LIKE_PREDICATE";
         @Param("200")
         private String schemasCount = "200";

--- a/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.connector.MockConnectorFactory;
+import io.prestosql.plugin.tpch.TpchPlugin;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.connector.ConnectorFactory;
+import io.prestosql.spi.connector.SchemaTableName;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class TestInformationSchemaConnector
+        extends AbstractTestQueryFramework
+{
+    public TestInformationSchemaConnector()
+    {
+        super(TestInformationSchemaConnector::createQueryRunner);
+    }
+
+    @Test
+    public void testBasic()
+    {
+        assertQuery("SELECT count(*) FROM tpch.information_schema.schemata", "VALUES 10");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables", "VALUES 80");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns", "VALUES 585");
+        assertQuery("SELECT * FROM tpch.information_schema.schemata ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('tpch', 'tiny')");
+        assertQuery("SELECT * FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'BASE TABLE')");
+        assertQuery("SELECT * FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'suppkey', 1, NULL, 'YES', 'bigint', NULL, NULL)");
+    }
+
+    @Test
+    public void testSchemaNamePredicate()
+    {
+        assertQuery("SELECT count(*) FROM tpch.information_schema.schemata WHERE schema_name = 'sf1'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_schema = 'sf1'", "VALUES 8");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'sf1'", "VALUES 61");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'information_schema'", "VALUES 36");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema > 'sf100'", "VALUES 427");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema != 'sf100'", "VALUES 524");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema LIKE 'sf100'", "VALUES 61");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema LIKE 'sf%'", "VALUES 488");
+    }
+
+    @Test
+    public void testTableNamePredicate()
+    {
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_name = 'orders'", "VALUES 9");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_name LIKE 'orders'", "VALUES 9");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_name < 'orders'", "VALUES 30");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_name LIKE 'part'", "VALUES 9");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_name LIKE 'part%'", "VALUES 18");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_name = 'orders'", "VALUES 81");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_name LIKE 'orders'", "VALUES 81");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_name < 'orders'", "VALUES 267");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_name LIKE 'part'", "VALUES 81");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_name LIKE 'part%'", "VALUES 126");
+    }
+
+    @Test
+    public void testMixedPredicate()
+    {
+        assertQuery("SELECT * FROM tpch.information_schema.tables WHERE table_schema = 'sf1' and table_name = 'orders'", "VALUES ('tpch', 'sf1', 'orders', 'BASE TABLE')");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'sf1' and table_name = 'orders'", "VALUES 9");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_schema > 'sf1' and table_name < 'orders'", "VALUES 24");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema > 'sf1' and table_name < 'orders'", "VALUES 224");
+    }
+
+    @Test
+    public void testProject()
+    {
+        assertQuery("SELECT schema_name FROM tpch.information_schema.schemata ORDER BY 1 DESC LIMIT 1", "VALUES 'tiny'");
+        assertQuery("SELECT table_name, table_type FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('views', 'BASE TABLE')");
+        assertQuery("SELECT column_name, data_type FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('with_hierarchy', 'varchar')");
+    }
+
+    @Test
+    public void testNestedPredicate()
+    {
+        assertQuery("SELECT count(*) FROM (SELECT * FROM tpch.information_schema.tables WHERE table_name IN ('supplier', 'part', 'customer'))u WHERE u.table_name IN ('supplier', 'part', 'orders')", "VALUES 18");
+    }
+
+    @Test
+    public void testLargeData()
+    {
+        assertQuery("SELECT count(*) from test_catalog.information_schema.tables", "VALUES 300008");
+        assertQuery("SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'", "VALUES 100000");
+        assertQuery("SELECT count(*) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'", "VALUES 2");
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(4)
+                .build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(new Plugin() {
+                @Override
+                public Iterable<ConnectorFactory> getConnectorFactories()
+                {
+                    List<SchemaTableName> tablesTestSchema1 = IntStream.range(0, 100000)
+                            .mapToObj(i -> new SchemaTableName("test_schema1", "test_table" + i))
+                            .collect(toImmutableList());
+                    List<SchemaTableName> tablesTestSchema2 = IntStream.range(0, 200000)
+                            .mapToObj(i -> new SchemaTableName("test_schema2", "test_table" + i))
+                            .collect(toImmutableList());
+                    List<SchemaTableName> tables = Stream.concat(tablesTestSchema1.stream(), tablesTestSchema2.stream()).collect(toImmutableList());
+                    MockConnectorFactory.Builder builder = MockConnectorFactory.builder();
+                    MockConnectorFactory mockConnectorFactory = builder.withListSchemaNames(connectorSession -> ImmutableList.of("test_schema1", "test_schema2"))
+                            .withListTables((connectorSession, schemaNameOrNull) -> {
+                                if (schemaNameOrNull == null) {
+                                    return tables;
+                                }
+                                else {
+                                    return tables.stream().filter(schemaTableName -> schemaTableName.getSchemaName().equals(schemaNameOrNull)).collect(toImmutableList());
+                                }
+                            })
+                            .build();
+                    return ImmutableList.of(mockConnectorFactory);
+                }
+            });
+            queryRunner.createCatalog("test_catalog", "mock", ImmutableMap.of());
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This commit changes both metadata side and read side of the Information Schema Connector:
1. Metadata side: this commit removes the computation logic in `InformationSchemaMetadata::applyFilter` and delegates it to `InformationSchemaPageSource`. The change reduces the time of query planning, so that it doesn't bottleneck the query execution.
2. Read side: this commit makes `InformationSchemaPageSource` be able to build pages on the fly when `getNextPage` is called. Before this change, all the pages are built beforehand before downstream tasks can start execution.

This commit also adds a more comprehensive set of unit tests for the Information Schema Connector.

This lazy-dataloading feature brings the following benefits:
1. It decreases the latency of first query result.
2. It benefits queries with a limit clause, e.g., `SELECT * FROM hive.information_schema.columns LIMIT 1`.
3. For queries touching a lot of tables (e.g., `SELECT * from hive.information_schema.columns`), it's highly possible that some tables have invalid metadata, which eventually fails the query. The new approach passes Pages to downstream tasks as soon as they are ready. In this way, failures can be detected sooner.

Running BenchmarkInformationSchema.queryInformationSchema
```
Before:
Benchmark                                          (columnsCount)        (queryId)  (schemasCount)  (tablesCount)  Mode  Cnt     Score     Error  Units
BenchmarkInformationSchema.queryInformationSchema             100        FULL_SCAN             200            200  avgt   10  2838.890 ± 349.474  ms/op
BenchmarkInformationSchema.queryInformationSchema             100   LIKE_PREDICATE             200            200  avgt   10   114.690 ±  21.006  ms/op
BenchmarkInformationSchema.queryInformationSchema             100  MIXED_PREDICATE             200            200  avgt   10    69.226 ±  14.637  ms/op
BenchmarkInformationSchema.queryInformationSchema             100       LIMIT_SCAN             200            200  avgt   10  3071.904 ± 345.259  ms/op
```


```
After:
Benchmark                                          (columnsCount)        (queryId)  (schemasCount)  (tablesCount)  Mode  Cnt     Score     Error  Units
BenchmarkInformationSchema.queryInformationSchema             100        FULL_SCAN             200            200  avgt   10  2286.313 ± 109.109  ms/op
BenchmarkInformationSchema.queryInformationSchema             100   LIKE_PREDICATE             200            200  avgt   10    41.420 ±  10.933  ms/op
BenchmarkInformationSchema.queryInformationSchema             100  MIXED_PREDICATE             200            200  avgt   10    70.408 ±  13.001  ms/op
BenchmarkInformationSchema.queryInformationSchema             100       LIMIT_SCAN             200            200  avgt   10    45.527 ±   8.346  ms/op
```
#1046 #998 