### PR TITLE
Add credential provider for JDBC connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -14,24 +14,25 @@
 package io.prestosql.plugin.jdbc;
 
 import io.airlift.configuration.Config;
-import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
+import io.prestosql.plugin.jdbc.credential.CredentialProviderType;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class BaseJdbcConfig
 {
     private String connectionUrl;
-    private String connectionUser;
-    private String connectionPassword;
     private String userCredentialName;
     private String passwordCredentialName;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    private CredentialProviderType credentialProviderType = INLINE;
 
     @NotNull
     public String getConnectionUrl()
@@ -43,33 +44,6 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setConnectionUrl(String connectionUrl)
     {
         this.connectionUrl = connectionUrl;
-        return this;
-    }
-
-    @Nullable
-    public String getConnectionUser()
-    {
-        return connectionUser;
-    }
-
-    @Config("connection-user")
-    public BaseJdbcConfig setConnectionUser(String connectionUser)
-    {
-        this.connectionUser = connectionUser;
-        return this;
-    }
-
-    @Nullable
-    public String getConnectionPassword()
-    {
-        return connectionPassword;
-    }
-
-    @Config("connection-password")
-    @ConfigSecuritySensitive
-    public BaseJdbcConfig setConnectionPassword(String connectionPassword)
-    {
-        this.connectionPassword = connectionPassword;
         return this;
     }
 
@@ -122,6 +96,19 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    public CredentialProviderType getCredentialProviderType()
+    {
+        return credentialProviderType;
+    }
+
+    @Config("credential-provider.type")
+    public BaseJdbcConfig setCredentialProviderType(CredentialProviderType credentialProviderType)
+    {
+        this.credentialProviderType = requireNonNull(credentialProviderType, "credentialProviderType is null");
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
+
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
@@ -32,24 +34,24 @@ public class DriverConnectionFactory
     private final Optional<String> userCredentialName;
     private final Optional<String> passwordCredentialName;
 
-    public DriverConnectionFactory(Driver driver, BaseJdbcConfig config)
+    public DriverConnectionFactory(Driver driver, BaseJdbcConfig config, CredentialProvider credentialProvider)
     {
         this(
                 driver,
                 config.getConnectionUrl(),
                 Optional.ofNullable(config.getUserCredentialName()),
                 Optional.ofNullable(config.getPasswordCredentialName()),
-                basicConnectionProperties(config));
+                basicConnectionProperties(credentialProvider));
     }
 
-    public static Properties basicConnectionProperties(BaseJdbcConfig config)
+    public static Properties basicConnectionProperties(CredentialProvider credentialProvider)
     {
         Properties connectionProperties = new Properties();
-        if (config.getConnectionUser() != null) {
-            connectionProperties.setProperty("user", config.getConnectionUser());
+        if (credentialProvider.getConnectionUser(Optional.empty()).isPresent()) {
+            connectionProperties.setProperty("user", credentialProvider.getConnectionUser(Optional.empty()).get());
         }
-        if (config.getConnectionPassword() != null) {
-            connectionProperties.setProperty("password", config.getConnectionPassword());
+        if (credentialProvider.getConnectionPassword(Optional.empty()).isPresent()) {
+            connectionProperties.setProperty("password", credentialProvider.getConnectionPassword(Optional.empty()).get());
         }
         return connectionProperties;
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnectorFactory.java
@@ -17,6 +17,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.prestosql.plugin.base.jmx.MBeanServerModule;
+import io.prestosql.plugin.jdbc.credential.CredentialProviderModule;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorContext;
@@ -68,6 +69,7 @@ public class JdbcConnectorFactory
             Bootstrap app = new Bootstrap(
                     binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()),
                     new JdbcModule(catalogName),
+                    new CredentialProviderModule(),
                     new MBeanServerModule(),
                     new MBeanModule(),
                     module);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ConfigFileBasedCredentialProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ConfigFileBasedCredentialProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConfigFileBasedCredentialProvider
+        implements CredentialProvider
+{
+    private final Optional<String> connectionUser;
+    private final Optional<String> connectionPassword;
+
+    @Inject
+    public ConfigFileBasedCredentialProvider(CredentialConfig credentialsConfig)
+    {
+        requireNonNull(credentialsConfig, "credentialsConfig is null");
+        this.connectionUser = credentialsConfig.getConnectionUser();
+        this.connectionPassword = credentialsConfig.getConnectionPassword();
+    }
+
+    @Override
+    public Optional<String> getConnectionUser(Optional<JdbcIdentity> jdbcIdentity)
+    {
+        return connectionUser;
+    }
+
+    @Override
+    public Optional<String> getConnectionPassword(Optional<JdbcIdentity> jdbcIdentity)
+    {
+        return connectionPassword;
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import java.util.Optional;
+
+public class CredentialConfig
+{
+    private String connectionUser;
+    private String connectionPassword;
+
+    public Optional<String> getConnectionUser()
+    {
+        return Optional.ofNullable(connectionUser);
+    }
+
+    @Config("connection-user")
+    @ConfigDescription("user name for JDBC client")
+    public CredentialConfig setConnectionUser(String connectionUser)
+    {
+        this.connectionUser = connectionUser;
+        return this;
+    }
+
+    public Optional<String> getConnectionPassword()
+    {
+        return Optional.ofNullable(connectionPassword);
+    }
+
+    @Config("connection-password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password for JDBC client")
+    public CredentialConfig setConnectionPassword(String connectionPassword)
+    {
+        this.connectionPassword = connectionPassword;
+        return this;
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+
+import java.util.Optional;
+
+public interface CredentialProvider
+{
+    Optional<String> getConnectionUser(Optional<JdbcIdentity> jdbcIdentity);
+
+    Optional<String> getConnectionPassword(Optional<JdbcIdentity> jdbcIdentity);
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
@@ -44,14 +44,15 @@ public class CredentialProviderModule
                 INLINE,
                 internalBinder -> {
                     configBinder(internalBinder).bindConfig(CredentialConfig.class);
-                    internalBinder.bind(CredentialProvider.class).to(ConfigFileBasedCredentialProvider.class).in(SINGLETON);
+                    internalBinder.bind(CredentialProvider.class).annotatedWith(ForExtraCredentialProvider.class).to(ConfigFileBasedCredentialProvider.class).in(SINGLETON);
                 });
         bindCredentialProviderModule(
                 FILE,
                 internalBinder -> {
                     configBinder(binder).bindConfig(ConfigFileBasedCredentialProviderConfig.class);
-                    internalBinder.bind(CredentialProvider.class).toProvider(ConfigFileBasedCredentialProviderFactory.class).in(SINGLETON);
+                    internalBinder.bind(CredentialProvider.class).annotatedWith(ForExtraCredentialProvider.class).toProvider(ConfigFileBasedCredentialProviderFactory.class).in(SINGLETON);
                 });
+        binder.bind(CredentialProvider.class).to(ExtraCredentialProvider.class).in(SINGLETON);
     }
 
     private void bindCredentialProviderModule(CredentialProviderType name, Module module)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.ConfigurationFactory;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.credential.file.ConfigFileBasedCredentialProviderConfig;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.FILE;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
+import static java.util.Objects.requireNonNull;
+
+public class CredentialProviderModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        bindCredentialProviderModule(
+                INLINE,
+                internalBinder -> {
+                    configBinder(internalBinder).bindConfig(CredentialConfig.class);
+                    internalBinder.bind(CredentialProvider.class).to(ConfigFileBasedCredentialProvider.class).in(SINGLETON);
+                });
+        bindCredentialProviderModule(
+                FILE,
+                internalBinder -> {
+                    configBinder(binder).bindConfig(ConfigFileBasedCredentialProviderConfig.class);
+                    internalBinder.bind(CredentialProvider.class).toProvider(ConfigFileBasedCredentialProviderFactory.class).in(SINGLETON);
+                });
+    }
+
+    private void bindCredentialProviderModule(CredentialProviderType name, Module module)
+    {
+        install(installModuleIf(
+                BaseJdbcConfig.class,
+                config -> name.equals(config.getCredentialProviderType()),
+                module));
+    }
+
+    private static class ConfigFileBasedCredentialProviderFactory
+            implements Provider<CredentialProvider>
+    {
+        private final CredentialConfig credentialsConfig;
+
+        @Inject
+        public ConfigFileBasedCredentialProviderFactory(ConfigFileBasedCredentialProviderConfig config)
+                throws IOException
+        {
+            requireNonNull(config, "config is null");
+            Map<String, String> properties = loadPropertiesFrom(config.getCredentialFile());
+            credentialsConfig = new ConfigurationFactory(properties).build(CredentialConfig.class);
+        }
+
+        @Override
+        public CredentialProvider get()
+        {
+            return new ConfigFileBasedCredentialProvider(credentialsConfig);
+        }
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderType.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderType.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+public enum CredentialProviderType
+{
+    INLINE,
+    FILE,
+    /**/
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ExtraCredentialProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ExtraCredentialProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExtraCredentialProvider
+        implements CredentialProvider
+{
+    private final Optional<String> userCredentialName;
+    private final Optional<String> passwordCredentialName;
+    private final CredentialProvider delegate;
+
+    @Inject
+    public ExtraCredentialProvider(BaseJdbcConfig baseJdbcConfig, @ForExtraCredentialProvider CredentialProvider delegate)
+    {
+        this(Optional.ofNullable(baseJdbcConfig.getUserCredentialName()), Optional.ofNullable(baseJdbcConfig.getPasswordCredentialName()), delegate);
+    }
+
+    public ExtraCredentialProvider(Optional<String> userCredentialName, Optional<String> passwordCredentialName, CredentialProvider delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.userCredentialName = requireNonNull(userCredentialName, "userCredentialName is null");
+        this.passwordCredentialName = requireNonNull(passwordCredentialName, "passwordCredentialName is null");
+    }
+
+    @Override
+    public Optional<String> getConnectionUser(Optional<JdbcIdentity> jdbcIdentity)
+    {
+        if (jdbcIdentity.isPresent() && userCredentialName.isPresent()) {
+            Map<String, String> extraCredentials = jdbcIdentity.get().getExtraCredentials();
+            if (extraCredentials.containsKey(userCredentialName.get())) {
+                return Optional.of(extraCredentials.get(userCredentialName.get()));
+            }
+        }
+        return delegate.getConnectionUser(jdbcIdentity);
+    }
+
+    @Override
+    public Optional<String> getConnectionPassword(Optional<JdbcIdentity> jdbcIdentity)
+    {
+        if (jdbcIdentity.isPresent() && passwordCredentialName.isPresent()) {
+            Map<String, String> extraCredentials = jdbcIdentity.get().getExtraCredentials();
+            if (extraCredentials.containsKey(passwordCredentialName.get())) {
+                return Optional.of(extraCredentials.get(passwordCredentialName.get()));
+            }
+        }
+        return delegate.getConnectionPassword(jdbcIdentity);
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ForExtraCredentialProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ForExtraCredentialProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForExtraCredentialProvider
+{
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/file/ConfigFileBasedCredentialProviderConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/file/ConfigFileBasedCredentialProviderConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential.file;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class ConfigFileBasedCredentialProviderConfig
+{
+    private String credentialsFile;
+
+    @Config("connection-credential-file")
+    @ConfigDescription("Location of the file where credentials are present")
+    public ConfigFileBasedCredentialProviderConfig setCredentialFile(String connectionUser)
+    {
+        this.credentialsFile = connectionUser;
+        return this;
+    }
+
+    @NotNull
+    public String getCredentialFile()
+    {
+        return credentialsFile;
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.FILE;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -32,12 +34,11 @@ public class TestBaseJdbcConfig
     {
         assertRecordedDefaults(recordDefaults(BaseJdbcConfig.class)
                 .setConnectionUrl(null)
-                .setConnectionUser(null)
-                .setConnectionPassword(null)
                 .setUserCredentialName(null)
                 .setPasswordCredentialName(null)
                 .setCaseInsensitiveNameMatching(false)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setCredentialProviderType(INLINE));
     }
 
     @Test
@@ -45,22 +46,20 @@ public class TestBaseJdbcConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("connection-url", "jdbc:h2:mem:config")
-                .put("connection-user", "user")
-                .put("connection-password", "password")
                 .put("user-credential-name", "foo")
                 .put("password-credential-name", "bar")
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
+                .put("credential-provider.type", "FILE")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
-                .setConnectionUser("user")
-                .setConnectionPassword("password")
                 .setUserCredentialName("foo")
                 .setPasswordCredentialName("bar")
                 .setCaseInsensitiveNameMatching(true)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
+                .setCredentialProviderType(FILE);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
@@ -13,6 +13,9 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import io.prestosql.plugin.jdbc.credential.ConfigFileBasedCredentialProvider;
+import io.prestosql.plugin.jdbc.credential.CredentialConfig;
+import io.prestosql.plugin.jdbc.credential.ExtraCredentialProvider;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplitSource;
 import io.prestosql.spi.connector.SchemaTableName;
@@ -22,7 +25,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -45,7 +47,7 @@ final class TestingDatabase
         jdbcClient = new BaseJdbcClient(
                 new BaseJdbcConfig(),
                 "\"",
-                new DriverConnectionFactory(new Driver(), connectionUrl, Optional.empty(), Optional.empty(), new Properties()));
+                new DriverConnectionFactory(new Driver(), connectionUrl, new Properties(), new ExtraCredentialProvider(new BaseJdbcConfig(), new ConfigFileBasedCredentialProvider(new CredentialConfig()))));
 
         connection = DriverManager.getConnection(connectionUrl);
         connection.createStatement().execute("CREATE SCHEMA example");

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcModule.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import org.h2.Driver;
 
 import java.util.Map;
@@ -43,9 +44,9 @@ class TestingH2JdbcModule
 
     @Provides
     @Singleton
-    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config)
+    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
     {
-        return new DriverConnectionFactory(new Driver(), config);
+        return new DriverConnectionFactory(new Driver(), config, credentialProvider);
     }
 
     public static Map<String, String> createProperties()

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestCredentialConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestCredentialConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestCredentialConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(CredentialConfig.class)
+                .setConnectionUser(null)
+                .setConnectionPassword(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-user", "foo",
+                "connection-password", "bar");
+
+        CredentialConfig expected = new CredentialConfig()
+                .setConnectionUser("foo")
+                .setConnectionPassword("bar");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestCredentialProvider.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestCredentialProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.bootstrap.Bootstrap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestCredentialProvider
+{
+    @Test
+    public void testInlineCredentialProvider()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "connection-user", "user_from_inline",
+                "connection-password", "password_for_user_from_inline");
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        assertEquals(credentialProvider.getConnectionUser(Optional.empty()).get(), "user_from_inline");
+        assertEquals(credentialProvider.getConnectionPassword(Optional.empty()).get(), "password_for_user_from_inline");
+    }
+
+    @Test
+    public void testFileCredentialProvider()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "credential-provider.type", "FILE",
+                "connection-credential-file", getResourceFilePath("credentials.properties"));
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        assertEquals(credentialProvider.getConnectionUser(Optional.empty()).get(), "user_from_file");
+        assertEquals(credentialProvider.getConnectionPassword(Optional.empty()).get(), "password_for_user_from_file");
+    }
+
+    private CredentialProvider getCredentialProvider(Map<String, String> properties)
+            throws Exception
+    {
+        return new Bootstrap(ImmutableList.of(new CredentialProviderModule()))
+                .setOptionalConfigurationProperties(properties)
+                .initialize()
+                .getInstance(CredentialProvider.class);
+    }
+
+    private String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestExtraCredentialProvider.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/TestExtraCredentialProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.bootstrap.Bootstrap;
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestExtraCredentialProvider
+{
+    @Test
+    public void testUserNameOverwritten()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "connection-user", "default_user",
+                "connection-password", "default_password",
+                "user-credential-name", "user");
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        Optional<JdbcIdentity> jdbcIdentity = Optional.of(new JdbcIdentity("user", ImmutableMap.of("user", "overwritten_user")));
+        assertEquals(credentialProvider.getConnectionUser(jdbcIdentity).get(), "overwritten_user");
+        assertEquals(credentialProvider.getConnectionPassword(jdbcIdentity).get(), "default_password");
+    }
+
+    @Test
+    public void testPasswordOverwritten()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "connection-user", "default_user",
+                "connection-password", "default_password",
+                "password-credential-name", "password");
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        Optional<JdbcIdentity> jdbcIdentity = Optional.of(new JdbcIdentity("user", ImmutableMap.of("password", "overwritten_password")));
+        assertEquals(credentialProvider.getConnectionUser(jdbcIdentity).get(), "default_user");
+        assertEquals(credentialProvider.getConnectionPassword(jdbcIdentity).get(), "overwritten_password");
+    }
+
+    @Test
+    public void testCredentialsOverwritten()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "connection-user", "default_user",
+                "connection-password", "default_password",
+                "user-credential-name", "user",
+                "password-credential-name", "password");
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        Optional<JdbcIdentity> jdbcIdentity = Optional.of(new JdbcIdentity("user", ImmutableMap.of("user", "overwritten_user", "password", "overwritten_password")));
+        assertEquals(credentialProvider.getConnectionUser(jdbcIdentity).get(), "overwritten_user");
+        assertEquals(credentialProvider.getConnectionPassword(jdbcIdentity).get(), "overwritten_password");
+    }
+
+    @Test
+    public void testCredentialsNotOverwritten()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "connection-url", "jdbc:h2:mem:config",
+                "connection-user", "default_user",
+                "connection-password", "default_password",
+                "user-credential-name", "user",
+                "password-credential-name", "password");
+
+        CredentialProvider credentialProvider = getCredentialProvider(properties);
+        Optional<JdbcIdentity> jdbcIdentity = Optional.of(new JdbcIdentity("user", ImmutableMap.of()));
+        assertEquals(credentialProvider.getConnectionUser(jdbcIdentity).get(), "default_user");
+        assertEquals(credentialProvider.getConnectionPassword(jdbcIdentity).get(), "default_password");
+
+        jdbcIdentity = Optional.of(new JdbcIdentity("user", ImmutableMap.of("connection_user", "overwritten_user", "connection_password", "overwritten_password")));
+        assertEquals(credentialProvider.getConnectionUser(jdbcIdentity).get(), "default_user");
+        assertEquals(credentialProvider.getConnectionPassword(jdbcIdentity).get(), "default_password");
+    }
+
+    private CredentialProvider getCredentialProvider(Map<String, String> properties)
+            throws Exception
+    {
+        return new Bootstrap(ImmutableList.of(new CredentialProviderModule()))
+                .setRequiredConfigurationProperties(properties)
+                .initialize()
+                .getInstance(CredentialProvider.class);
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/file/TestConfigFileBasedCredentialProviderConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/credential/file/TestConfigFileBasedCredentialProviderConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc.credential.file;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestConfigFileBasedCredentialProviderConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ConfigFileBasedCredentialProviderConfig.class)
+                .setCredentialFile(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("connection-credential-file", "/presto/credentials")
+                .build();
+
+        ConfigFileBasedCredentialProviderConfig expected = new ConfigFileBasedCredentialProviderConfig()
+                .setCredentialFile("/presto/credentials");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-base-jdbc/src/test/resources/credentials.properties
+++ b/presto-base-jdbc/src/test/resources/credentials.properties
@@ -1,0 +1,2 @@
+connection-user=user_from_file
+connection-password=password_for_user_from_file

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClientModule.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 
 import java.sql.SQLException;
 import java.util.Optional;
@@ -58,10 +59,10 @@ public class MySqlClientModule
 
     @Provides
     @Singleton
-    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, MySqlConfig mySqlConfig)
+    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, MySqlConfig mySqlConfig)
             throws SQLException
     {
-        Properties connectionProperties = basicConnectionProperties(config);
+        Properties connectionProperties = basicConnectionProperties(credentialProvider);
         connectionProperties.setProperty("useInformationSchema", "true");
         connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
         connectionProperties.setProperty("useUnicode", "true");

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClientModule.java
@@ -26,12 +26,10 @@ import io.prestosql.plugin.jdbc.JdbcClient;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 
 import java.sql.SQLException;
-import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.prestosql.plugin.jdbc.DriverConnectionFactory.basicConnectionProperties;
 
 public class MySqlClientModule
         extends AbstractConfigurationAwareModule
@@ -62,7 +60,7 @@ public class MySqlClientModule
     public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, MySqlConfig mySqlConfig)
             throws SQLException
     {
-        Properties connectionProperties = basicConnectionProperties(credentialProvider);
+        Properties connectionProperties = new Properties();
         connectionProperties.setProperty("useInformationSchema", "true");
         connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
         connectionProperties.setProperty("useUnicode", "true");
@@ -79,8 +77,7 @@ public class MySqlClientModule
         return new DriverConnectionFactory(
                 new Driver(),
                 config.getConnectionUrl(),
-                Optional.ofNullable(config.getUserCredentialName()),
-                Optional.ofNullable(config.getPasswordCredentialName()),
-                connectionProperties);
+                connectionProperties,
+                credentialProvider);
     }
 }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
@@ -24,6 +24,9 @@ import io.prestosql.plugin.jdbc.InternalBaseJdbc;
 import io.prestosql.plugin.jdbc.JdbcClient;
 import io.prestosql.plugin.jdbc.JdbcPageSinkProvider;
 import io.prestosql.plugin.jdbc.JdbcRecordSetProvider;
+import io.prestosql.plugin.jdbc.credential.ConfigFileBasedCredentialProvider;
+import io.prestosql.plugin.jdbc.credential.CredentialConfig;
+import io.prestosql.plugin.jdbc.credential.ExtraCredentialProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorRecordSetProvider;
@@ -93,9 +96,11 @@ public class PhoenixClientModule
         return new DriverConnectionFactory(
                 DriverManager.getDriver(config.getConnectionUrl()),
                 config.getConnectionUrl(),
-                Optional.empty(),
-                Optional.empty(),
-                getConnectionProperties(config));
+                getConnectionProperties(config),
+                new ExtraCredentialProvider(
+                        Optional.empty(),
+                        Optional.empty(),
+                        new ConfigFileBasedCredentialProvider(new CredentialConfig())));
     }
 
     public static Properties getConnectionProperties(PhoenixConfig config)

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClientModule.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClientModule.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import org.postgresql.Driver;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -39,8 +40,8 @@ public class PostgreSqlClientModule
 
     @Provides
     @Singleton
-    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config)
+    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
     {
-        return new DriverConnectionFactory(new Driver(), config);
+        return new DriverConnectionFactory(new Driver(), config, credentialProvider);
     }
 }

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClientModule.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClientModule.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import org.postgresql.Driver;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -38,8 +39,8 @@ public class RedshiftClientModule
 
     @Singleton
     @Provides
-    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config)
+    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
     {
-        return new DriverConnectionFactory(new Driver(), config);
+        return new DriverConnectionFactory(new Driver(), config, credentialProvider);
     }
 }

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClientModule.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClientModule.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -38,8 +39,8 @@ public class SqlServerClientModule
 
     @Provides
     @Singleton
-    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config)
+    public ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
     {
-        return new DriverConnectionFactory(new SQLServerDriver(), config);
+        return new DriverConnectionFactory(new SQLServerDriver(), config, credentialProvider);
     }
 }


### PR DESCRIPTION
This enables the JDBC connector to pass credentials as a seperate file
or as a part of the existing connector properties