### PR TITLE
Implement periodic cpu usage tracking in resource groups

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroup.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.execution.resourcegroups;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
@@ -48,13 +49,11 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.math.LongMath.saturatedAdd;
 import static com.google.common.math.LongMath.saturatedMultiply;
 import static com.google.common.math.LongMath.saturatedSubtract;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.prestosql.SystemSessionProperties.getQueryPriority;
 import static io.prestosql.server.QueryStateInfo.createQueryStateInfo;
-import static io.prestosql.spi.ErrorType.USER_ERROR;
 import static io.prestosql.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
 import static io.prestosql.spi.resourcegroups.ResourceGroupState.CAN_QUEUE;
 import static io.prestosql.spi.resourcegroups.ResourceGroupState.CAN_RUN;
@@ -123,16 +122,14 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private UpdateablePriorityQueue<ManagedQueryExecution> queuedQueries = new FifoQueue<>();
     @GuardedBy("root")
-    private final Set<ManagedQueryExecution> runningQueries = new HashSet<>();
+    private final Map<ManagedQueryExecution, ResourceUsage> runningQueries = new HashMap<>();
     @GuardedBy("root")
     private int descendantRunningQueries;
     @GuardedBy("root")
     private int descendantQueuedQueries;
-    // Memory usage is cached because it changes very rapidly while queries are running, and would be expensive to track continuously
+    // CPU and memory usage is cached because it changes very rapidly while queries are running, and would be expensive to track continuously
     @GuardedBy("root")
-    private long cachedMemoryUsageBytes;
-    @GuardedBy("root")
-    private long cpuUsageMillis;
+    private ResourceUsage cachedResourceUsage = new ResourceUsage(0, 0);
     @GuardedBy("root")
     private long lastStartMillis;
     @GuardedBy("root")
@@ -166,7 +163,8 @@ public class InternalResourceGroup
                     softConcurrencyLimit,
                     hardConcurrencyLimit,
                     maxQueuedQueries,
-                    DataSize.succinctBytes(cachedMemoryUsageBytes),
+                    DataSize.succinctBytes(cachedResourceUsage.getMemoryUsageBytes()),
+                    Duration.succinctDuration(cachedResourceUsage.getCpuUsageMillis(), MILLISECONDS),
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
@@ -190,7 +188,8 @@ public class InternalResourceGroup
                     softConcurrencyLimit,
                     hardConcurrencyLimit,
                     maxQueuedQueries,
-                    DataSize.succinctBytes(cachedMemoryUsageBytes),
+                    DataSize.succinctBytes(cachedResourceUsage.getMemoryUsageBytes()),
+                    Duration.succinctDuration(cachedResourceUsage.getCpuUsageMillis(), MILLISECONDS),
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
@@ -214,7 +213,8 @@ public class InternalResourceGroup
                     softConcurrencyLimit,
                     hardConcurrencyLimit,
                     maxQueuedQueries,
-                    DataSize.succinctBytes(cachedMemoryUsageBytes),
+                    DataSize.succinctBytes(cachedResourceUsage.getMemoryUsageBytes()),
+                    Duration.succinctDuration(cachedResourceUsage.getCpuUsageMillis(), MILLISECONDS),
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
@@ -242,7 +242,7 @@ public class InternalResourceGroup
     {
         synchronized (root) {
             if (subGroups.isEmpty()) {
-                return runningQueries.stream()
+                return runningQueries.keySet().stream()
                         .map(ManagedQueryExecution::getBasicQueryInfo)
                         .map(queryInfo -> createQueryStateInfo(queryInfo, Optional.of(id)))
                         .collect(toImmutableList());
@@ -631,7 +631,10 @@ public class InternalResourceGroup
         }
     }
 
-    // This method must be called whenever the group's eligibility to run more queries may have changed.
+    /**
+     * Updates eligibility to run more queries for all groups on the path starting from this group up to the root.
+     * This method must be called whenever the eligibility may have changed for this group.
+     */
     private void updateEligibility()
     {
         checkState(Thread.holdsLock(root), "Must hold lock to update eligibility");
@@ -654,7 +657,7 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock to start a query");
         synchronized (root) {
-            runningQueries.add(query);
+            runningQueries.put(query, new ResourceUsage(0, 0));
             InternalResourceGroup group = this;
             while (group.parent.isPresent()) {
                 group.parent.get().descendantRunningQueries++;
@@ -669,27 +672,41 @@ public class InternalResourceGroup
     private void queryFinished(ManagedQueryExecution query)
     {
         synchronized (root) {
-            if (!runningQueries.contains(query) && !queuedQueries.contains(query)) {
+            if (!runningQueries.containsKey(query) && !queuedQueries.contains(query)) {
                 // Query has already been cleaned up
                 return;
             }
-            // Only count the CPU time if the query succeeded, or the failure was the fault of the user
-            if (!query.getErrorCode().isPresent() || query.getErrorCode().get().getType() == USER_ERROR) {
+
+            ResourceUsage lastUsage = runningQueries.get(query);
+
+            // The query is present in runningQueries
+            if (lastUsage != null) {
+                // CPU is measured cumulatively (i.e. total CPU used until this moment by the query). Memory is measured
+                // instantaneously (how much memory the query is using at this moment). At query completion, memory usage
+                // drops to zero.
+                ResourceUsage finalUsage = new ResourceUsage(
+                        query.getTotalCpuTime().toMillis(),
+                        0L);
+                ResourceUsage delta = finalUsage.subtract(lastUsage);
+
+                runningQueries.remove(query);
+
+                // Update usage statistics up to the root
                 InternalResourceGroup group = this;
                 while (group != null) {
-                    group.cpuUsageMillis = saturatedAdd(group.cpuUsageMillis, query.getTotalCpuTime().toMillis());
-                    group = group.parent.orElse(null);
-                }
-            }
-            if (runningQueries.contains(query)) {
-                runningQueries.remove(query);
-                InternalResourceGroup group = this;
-                while (group.parent.isPresent()) {
-                    group.parent.get().descendantRunningQueries--;
-                    group = group.parent.get();
+                    group.cachedResourceUsage = group.cachedResourceUsage.add(delta);
+                    InternalResourceGroup parent = group.parent.orElse(null);
+                    if (parent != null) {
+                        parent.descendantRunningQueries--;
+                        if (parent.descendantRunningQueries == 0) {
+                            parent.dirtySubGroups.remove(group);
+                        }
+                    }
+                    group = parent;
                 }
             }
             else {
+                // The query must be queued
                 queuedQueries.remove(query);
                 InternalResourceGroup group = this;
                 while (group.parent.isPresent()) {
@@ -697,36 +714,52 @@ public class InternalResourceGroup
                     group = group.parent.get();
                 }
             }
+
             updateEligibility();
+            return;
         }
     }
 
-    // Memory usage stats are expensive to maintain, so this method must be called periodically to update them
-    protected void internalRefreshStats()
+    protected ResourceUsage updateResourceUsageAndGetDelta()
     {
         checkState(Thread.holdsLock(root), "Must hold lock to refresh stats");
         synchronized (root) {
+            ResourceUsage groupUsageDelta = new ResourceUsage(0, 0);
+
             if (subGroups.isEmpty()) {
-                cachedMemoryUsageBytes = 0;
-                for (ManagedQueryExecution query : runningQueries) {
-                    cachedMemoryUsageBytes += query.getUserMemoryReservation().toBytes();
+                // Leaf resource group
+                for (Map.Entry<ManagedQueryExecution, ResourceUsage> entry : runningQueries.entrySet()) {
+                    ManagedQueryExecution query = entry.getKey();
+                    ResourceUsage oldResourceUsage = entry.getValue();
+
+                    ResourceUsage newResourceUsage = new ResourceUsage(
+                            query.getTotalCpuTime().toMillis(),
+                            query.getTotalMemoryReservation().toBytes());
+
+                    // Compute delta and update usage
+                    ResourceUsage queryUsageDelta = newResourceUsage.subtract(oldResourceUsage);
+                    entry.setValue(newResourceUsage);
+                    groupUsageDelta = groupUsageDelta.add(queryUsageDelta);
                 }
+
+                cachedResourceUsage = cachedResourceUsage.add(groupUsageDelta);
             }
             else {
+                // Intermediate resource group
                 for (Iterator<InternalResourceGroup> iterator = dirtySubGroups.iterator(); iterator.hasNext(); ) {
                     InternalResourceGroup subGroup = iterator.next();
-                    long oldMemoryUsageBytes = subGroup.cachedMemoryUsageBytes;
-                    cachedMemoryUsageBytes -= oldMemoryUsageBytes;
-                    subGroup.internalRefreshStats();
-                    cachedMemoryUsageBytes += subGroup.cachedMemoryUsageBytes;
-                    if (!subGroup.isDirty()) {
-                        iterator.remove();
-                    }
-                    if (oldMemoryUsageBytes != subGroup.cachedMemoryUsageBytes) {
+
+                    ResourceUsage subGroupUsageDelta = subGroup.updateResourceUsageAndGetDelta();
+                    groupUsageDelta = groupUsageDelta.add(subGroupUsageDelta);
+                    cachedResourceUsage = cachedResourceUsage.add(subGroupUsageDelta);
+
+                    if (!subGroupUsageDelta.equals(new ResourceUsage(0, 0))) {
                         subGroup.updateEligibility();
                     }
                 }
             }
+
+            return groupUsageDelta;
         }
     }
 
@@ -735,10 +768,21 @@ public class InternalResourceGroup
         checkState(Thread.holdsLock(root), "Must hold lock to generate cpu quota");
         synchronized (root) {
             long newQuota = saturatedMultiply(elapsedSeconds, cpuQuotaGenerationMillisPerSecond);
-            cpuUsageMillis = saturatedSubtract(cpuUsageMillis, newQuota);
-            if (cpuUsageMillis < 0 || cpuUsageMillis == Long.MAX_VALUE) {
-                cpuUsageMillis = 0;
+
+            long oldUsageMillis = cachedResourceUsage.getCpuUsageMillis();
+            long newCpuUsageMillis = saturatedSubtract(oldUsageMillis, newQuota);
+
+            if (newCpuUsageMillis < 0 || newCpuUsageMillis == Long.MAX_VALUE) {
+                newCpuUsageMillis = 0;
             }
+
+            cachedResourceUsage = new ResourceUsage(newCpuUsageMillis, cachedResourceUsage.getMemoryUsageBytes());
+
+            if ((newCpuUsageMillis < hardCpuLimitMillis && oldUsageMillis >= hardCpuLimitMillis) ||
+                    (newCpuUsageMillis < softCpuLimitMillis && oldUsageMillis >= softCpuLimitMillis)) {
+                updateEligibility();
+            }
+
             for (InternalResourceGroup group : subGroups.values()) {
                 group.internalGenerateCpuQuota(elapsedSeconds);
             }
@@ -815,14 +859,6 @@ public class InternalResourceGroup
         return (long) Integer.MAX_VALUE * schedulingWeight;
     }
 
-    private boolean isDirty()
-    {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
-            return runningQueries.size() + descendantRunningQueries > 0;
-        }
-    }
-
     private boolean isEligibleToStartNext()
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
@@ -858,13 +894,16 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
         synchronized (root) {
-            if (cpuUsageMillis >= hardCpuLimitMillis) {
+            long cpuUsageMillis = cachedResourceUsage.getCpuUsageMillis();
+            long memoryUsageBytes = cachedResourceUsage.getMemoryUsageBytes();
+
+            if ((cpuUsageMillis >= hardCpuLimitMillis) || (memoryUsageBytes > softMemoryLimitBytes)) {
                 return false;
             }
 
             int hardConcurrencyLimit = this.hardConcurrencyLimit;
             if (cpuUsageMillis >= softCpuLimitMillis) {
-                // TODO: Consider whether cpu limit math should be performed on softConcurrency or hardConcurrency
+                // TODO: Consider whether CPU limit math should be performed on softConcurrency or hardConcurrency
                 // Linear penalty between soft and hard limit
                 double penalty = (cpuUsageMillis - softCpuLimitMillis) / (double) (hardCpuLimitMillis - softCpuLimitMillis);
                 hardConcurrencyLimit = (int) Math.floor(hardConcurrencyLimit * (1 - penalty));
@@ -873,8 +912,7 @@ public class InternalResourceGroup
                 // Always allow at least one running query
                 hardConcurrencyLimit = Math.max(1, hardConcurrencyLimit);
             }
-            return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit &&
-                    cachedMemoryUsageBytes <= softMemoryLimitBytes;
+            return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit;
         }
     }
 
@@ -882,6 +920,14 @@ public class InternalResourceGroup
     {
         synchronized (root) {
             return subGroups.values();
+        }
+    }
+
+    @VisibleForTesting
+    ResourceUsage getResourceUsageSnapshot()
+    {
+        synchronized (root) {
+            return cachedResourceUsage.clone();
         }
     }
 
@@ -921,9 +967,10 @@ public class InternalResourceGroup
             super(Optional.empty(), name, jmxExportListener, executor);
         }
 
-        public synchronized void processQueuedQueries()
+        public synchronized void updateGroupsAndProcessQueuedQueries()
         {
-            internalRefreshStats();
+            updateResourceUsageAndGetDelta();
+
             while (internalStartNext()) {
                 // start all the queries we can
             }

--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
@@ -207,7 +207,7 @@ public final class InternalResourceGroupManager<C>
                 log.error(e, "Exception while generation cpu quota for %s", group);
             }
             try {
-                group.processQueuedQueries();
+                group.updateGroupsAndProcessQueuedQueries();
             }
             catch (RuntimeException e) {
                 log.error(e, "Exception while processing queued queries for %s", group);

--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/ResourceUsage.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/ResourceUsage.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution.resourcegroups;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static com.google.common.math.LongMath.saturatedAdd;
+import static com.google.common.math.LongMath.saturatedSubtract;
+
+@Immutable
+class ResourceUsage
+{
+    private final long cpuUsageMillis;
+    private final long memoryUsageBytes;
+
+    public ResourceUsage(long cpuUsageMillis, long memoryUsageBytes)
+    {
+        this.cpuUsageMillis = cpuUsageMillis;
+        this.memoryUsageBytes = memoryUsageBytes;
+    }
+
+    public ResourceUsage clone()
+    {
+        return new ResourceUsage(cpuUsageMillis, memoryUsageBytes);
+    }
+
+    public ResourceUsage add(ResourceUsage other)
+    {
+        long newCpuUsageMillis = saturatedAdd(this.cpuUsageMillis, other.cpuUsageMillis);
+        long newMemoryUsageBytes = saturatedAdd(this.memoryUsageBytes, other.memoryUsageBytes);
+        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes);
+    }
+
+    public ResourceUsage subtract(ResourceUsage other)
+    {
+        long newCpuUsageMillis = saturatedSubtract(this.cpuUsageMillis, other.cpuUsageMillis);
+        long newMemoryUsageBytes = saturatedSubtract(this.memoryUsageBytes, other.memoryUsageBytes);
+        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes);
+    }
+
+    public long getCpuUsageMillis()
+    {
+        return cpuUsageMillis;
+    }
+
+    public long getMemoryUsageBytes()
+    {
+        return memoryUsageBytes;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        if ((other == null) || (getClass() != other.getClass())) {
+            return false;
+        }
+
+        ResourceUsage otherUsage = (ResourceUsage) other;
+        return cpuUsageMillis == otherUsage.cpuUsageMillis
+                && memoryUsageBytes == otherUsage.memoryUsageBytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(cpuUsageMillis, memoryUsageBytes);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/io/prestosql/server/ResourceGroupInfo.java
@@ -15,6 +15,7 @@ package io.prestosql.server;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.resourcegroups.ResourceGroupState;
 import io.prestosql.spi.resourcegroups.SchedulingPolicy;
@@ -43,6 +44,7 @@ public class ResourceGroupInfo
     private final int maxQueuedQueries;
 
     private final DataSize memoryUsage;
+    private final Duration cpuUsage;
     private final int numQueuedQueries;
     private final int numRunningQueries;
     private final int numEligibleSubGroups;
@@ -64,6 +66,7 @@ public class ResourceGroupInfo
             int maxQueuedQueries,
 
             DataSize memoryUsage,
+            Duration cpuUsage,
             int numQueuedQueries,
             int numRunningQueries,
             int numEligibleSubGroups,
@@ -85,6 +88,7 @@ public class ResourceGroupInfo
         this.maxQueuedQueries = maxQueuedQueries;
 
         this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        this.cpuUsage = requireNonNull(cpuUsage, "cpuUsage is null");
         this.numQueuedQueries = numQueuedQueries;
         this.numRunningQueries = numRunningQueries;
         this.numEligibleSubGroups = numEligibleSubGroups;
@@ -128,6 +132,12 @@ public class ResourceGroupInfo
     public DataSize getMemoryUsage()
     {
         return memoryUsage;
+    }
+
+    @JsonProperty
+    public Duration getCpuUsage()
+    {
+        return cpuUsage;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -31,14 +31,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.BYTE;
-import static io.airlift.units.DataSize.succinctBytes;
 import static io.prestosql.SystemSessionProperties.QUERY_PRIORITY;
 import static io.prestosql.execution.QueryState.FAILED;
 import static io.prestosql.execution.QueryState.FINISHED;
 import static io.prestosql.execution.QueryState.QUEUED;
 import static io.prestosql.execution.QueryState.RUNNING;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -46,33 +47,41 @@ public class MockManagedQueryExecution
         implements ManagedQueryExecution
 {
     private final List<StateChangeListener<QueryState>> listeners = new ArrayList<>();
-    private final DataSize memoryUsage;
-    private final Duration cpuUsage;
     private final Session session;
+
+    private DataSize memoryUsage;
+    private Duration cpuUsage;
     private QueryState state = QUEUED;
     private Throwable failureCause;
 
-    public MockManagedQueryExecution(long memoryUsage)
+    private MockManagedQueryExecution(String queryId, int priority, DataSize memoryUsage, Duration cpuUsage)
     {
-        this(memoryUsage, "query_id", 1);
-    }
-
-    public MockManagedQueryExecution(long memoryUsage, String queryId, int priority)
-    {
-        this(memoryUsage, queryId, priority, new Duration(0, MILLISECONDS));
-    }
-
-    public MockManagedQueryExecution(long memoryUsage, String queryId, int priority, Duration cpuUsage)
-    {
-        this.memoryUsage = succinctBytes(memoryUsage);
-        this.cpuUsage = cpuUsage;
+        requireNonNull(queryId, "queryId is null");
         this.session = testSessionBuilder()
+                .setQueryId(QueryId.valueOf(queryId))
                 .setSystemProperty(QUERY_PRIORITY, String.valueOf(priority))
                 .build();
+
+        this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        this.cpuUsage = requireNonNull(cpuUsage, "cpuUsage is null");
+    }
+
+    public void consumeCpuTime(Duration cpuTimeDelta)
+    {
+        checkState(state == RUNNING, "cannot consume CPU in a non-running state");
+        long newCpuTime = cpuUsage.toMillis() + cpuTimeDelta.toMillis();
+        this.cpuUsage = new Duration(newCpuTime, MILLISECONDS);
+    }
+
+    public void setMemoryUsage(DataSize memoryUsage)
+    {
+        checkState(state == RUNNING, "cannot set memory usage in a non-running state");
+        this.memoryUsage = memoryUsage;
     }
 
     public void complete()
     {
+        memoryUsage = new DataSize(0, BYTE);
         state = FINISHED;
         fireStateChange();
     }
@@ -120,11 +129,11 @@ public class MockManagedQueryExecution
                         new DataSize(14, BYTE),
                         15,
                         16.0,
-                        new DataSize(17, BYTE),
-                        new DataSize(18, BYTE),
+                        memoryUsage,
+                        memoryUsage,
                         new DataSize(19, BYTE),
                         new DataSize(20, BYTE),
-                        new Duration(21, NANOSECONDS),
+                        cpuUsage,
                         new Duration(22, NANOSECONDS),
                         false,
                         ImmutableSet.of(),
@@ -166,6 +175,7 @@ public class MockManagedQueryExecution
     @Override
     public void fail(Throwable cause)
     {
+        memoryUsage = new DataSize(0, BYTE);
         state = FAILED;
         failureCause = cause;
         fireStateChange();
@@ -187,6 +197,45 @@ public class MockManagedQueryExecution
     {
         for (StateChangeListener<QueryState> listener : listeners) {
             listener.stateChanged(state);
+        }
+    }
+
+    public static class MockManagedQueryExecutionBuilder
+    {
+        private DataSize memoryUsage = new DataSize(0, BYTE);
+        private Duration cpuUsage = new Duration(0, MILLISECONDS);
+        private int priority = 1;
+        private String queryId = "query_id";
+
+        public MockManagedQueryExecutionBuilder() {}
+
+        public MockManagedQueryExecutionBuilder withInitialMemoryUsage(DataSize memoryUsage)
+        {
+            this.memoryUsage = memoryUsage;
+            return this;
+        }
+
+        public MockManagedQueryExecutionBuilder withInitialCpuUsage(Duration cpuUsage)
+        {
+            this.cpuUsage = cpuUsage;
+            return this;
+        }
+
+        public MockManagedQueryExecutionBuilder withPriority(int priority)
+        {
+            this.priority = priority;
+            return this;
+        }
+
+        public MockManagedQueryExecutionBuilder withQueryId(String queryId)
+        {
+            this.queryId = queryId;
+            return this;
+        }
+
+        public MockManagedQueryExecution build()
+        {
+            return new MockManagedQueryExecution(queryId, priority, memoryUsage, cpuUsage);
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
@@ -53,7 +53,7 @@ public class BenchmarkResourceGroup
     @Benchmark
     public Object benchmark(BenchmarkData data)
     {
-        data.getRoot().processQueuedQueries();
+        data.getRoot().updateGroupsAndProcessQueuedQueries();
         return data.getRoot();
     }
 

--- a/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
@@ -15,6 +15,7 @@ package io.prestosql.execution.resourcegroups;
 
 import io.airlift.units.DataSize;
 import io.prestosql.execution.MockManagedQueryExecution;
+import io.prestosql.execution.MockManagedQueryExecution.MockManagedQueryExecutionBuilder;
 import io.prestosql.execution.resourcegroups.InternalResourceGroup.RootInternalResourceGroup;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -37,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 @SuppressWarnings("MethodMayBeStatic")
@@ -83,7 +85,10 @@ public class BenchmarkResourceGroup
                 group.setHardConcurrencyLimit(queries);
             }
             for (int i = 0; i < queries; i++) {
-                group.run(new MockManagedQueryExecution(10));
+                MockManagedQueryExecution query = new MockManagedQueryExecutionBuilder()
+                        .withInitialMemoryUsage(new DataSize(10, BYTE))
+                        .build();
+                group.run(query);
             }
         }
 

--- a/presto-main/src/test/java/io/prestosql/execution/resourcegroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/io/prestosql/execution/resourcegroups/TestResourceGroups.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.prestosql.execution.MockManagedQueryExecution;
+import io.prestosql.execution.MockManagedQueryExecution.MockManagedQueryExecutionBuilder;
 import io.prestosql.execution.resourcegroups.InternalResourceGroup.RootInternalResourceGroup;
 import io.prestosql.server.QueryStateInfo;
 import io.prestosql.server.ResourceGroupInfo;
@@ -64,13 +65,13 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
-        MockManagedQueryExecution query1 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
         root.run(query1);
         assertEquals(query1.getState(), RUNNING);
-        MockManagedQueryExecution query2 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         root.run(query2);
         assertEquals(query2.getState(), QUEUED);
-        MockManagedQueryExecution query3 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
         root.run(query3);
         assertEquals(query3.getState(), FAILED);
         assertEquals(query3.getThrowable().getMessage(), "Too many queued queries for \"root\"");
@@ -95,19 +96,19 @@ public class TestResourceGroups
         group3.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group3.setMaxQueuedQueries(4);
         group3.setHardConcurrencyLimit(1);
-        MockManagedQueryExecution query1a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1a = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1a);
         assertEquals(query1a.getState(), RUNNING);
-        MockManagedQueryExecution query1b = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1b = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1b);
         assertEquals(query1b.getState(), QUEUED);
-        MockManagedQueryExecution query2a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2a = new MockManagedQueryExecutionBuilder().build();
         group2.run(query2a);
         assertEquals(query2a.getState(), QUEUED);
-        MockManagedQueryExecution query2b = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2b = new MockManagedQueryExecutionBuilder().build();
         group2.run(query2b);
         assertEquals(query2b.getState(), QUEUED);
-        MockManagedQueryExecution query3a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query3a = new MockManagedQueryExecutionBuilder().build();
         group3.run(query3a);
         assertEquals(query3a.getState(), QUEUED);
 
@@ -146,16 +147,16 @@ public class TestResourceGroups
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
-        MockManagedQueryExecution query1a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1a = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1a);
         assertEquals(query1a.getState(), RUNNING);
-        MockManagedQueryExecution query1b = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1b = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1b);
         assertEquals(query1b.getState(), QUEUED);
-        MockManagedQueryExecution query1c = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1c = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1c);
         assertEquals(query1c.getState(), QUEUED);
-        MockManagedQueryExecution query2a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2a = new MockManagedQueryExecutionBuilder().build();
         group2.run(query2a);
         assertEquals(query2a.getState(), QUEUED);
 
@@ -188,16 +189,16 @@ public class TestResourceGroups
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
-        MockManagedQueryExecution query1a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1a = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1a);
         assertEquals(query1a.getState(), RUNNING);
-        MockManagedQueryExecution query1b = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1b = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1b);
         assertEquals(query1b.getState(), QUEUED);
-        MockManagedQueryExecution query1c = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query1c = new MockManagedQueryExecutionBuilder().build();
         group1.run(query1c);
         assertEquals(query1c.getState(), QUEUED);
-        MockManagedQueryExecution query2a = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2a = new MockManagedQueryExecutionBuilder().build();
         group2.run(query2a);
         assertEquals(query2a.getState(), QUEUED);
 
@@ -222,15 +223,15 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
-        MockManagedQueryExecution query1 = new MockManagedQueryExecution(2);
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().withInitialMemoryUsage(new DataSize(2, BYTE)).build();
         root.run(query1);
         // Process the group to refresh stats
         root.processQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
-        MockManagedQueryExecution query2 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         root.run(query2);
         assertEquals(query2.getState(), QUEUED);
-        MockManagedQueryExecution query3 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
         root.run(query3);
         assertEquals(query3.getState(), QUEUED);
 
@@ -252,15 +253,15 @@ public class TestResourceGroups
         subgroup.setMaxQueuedQueries(4);
         subgroup.setHardConcurrencyLimit(3);
 
-        MockManagedQueryExecution query1 = new MockManagedQueryExecution(2);
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().withInitialMemoryUsage(new DataSize(2, BYTE)).build();
         subgroup.run(query1);
         // Process the group to refresh stats
         root.processQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
-        MockManagedQueryExecution query2 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         subgroup.run(query2);
         assertEquals(query2.getState(), QUEUED);
-        MockManagedQueryExecution query3 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
         subgroup.run(query3);
         assertEquals(query3.getState(), QUEUED);
 
@@ -281,15 +282,20 @@ public class TestResourceGroups
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(2);
 
-        MockManagedQueryExecution query1 = new MockManagedQueryExecution(1, "query_id", 1, new Duration(1, SECONDS));
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(new DataSize(1, BYTE))
+                .withQueryId("query_id")
+                .withInitialCpuUsage(new Duration(1, SECONDS))
+                .build();
+
         root.run(query1);
         assertEquals(query1.getState(), RUNNING);
 
-        MockManagedQueryExecution query2 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         root.run(query2);
         assertEquals(query2.getState(), RUNNING);
 
-        MockManagedQueryExecution query3 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
         root.run(query3);
         assertEquals(query3.getState(), QUEUED);
 
@@ -313,10 +319,16 @@ public class TestResourceGroups
         root.setCpuQuotaGenerationMillisPerSecond(2000);
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
-        MockManagedQueryExecution query1 = new MockManagedQueryExecution(1, "query_id", 1, new Duration(2, SECONDS));
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(new DataSize(1, BYTE))
+                .withQueryId("query_id")
+                .withInitialCpuUsage(new Duration(2, SECONDS))
+                .build();
+
         root.run(query1);
         assertEquals(query1.getState(), RUNNING);
-        MockManagedQueryExecution query2 = new MockManagedQueryExecution(0);
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         root.run(query2);
         assertEquals(query2.getState(), QUEUED);
 
@@ -357,7 +369,11 @@ public class TestResourceGroups
             }
             while (queries.containsKey(priority));
 
-            MockManagedQueryExecution query = new MockManagedQueryExecution(0, "query_id", priority);
+            MockManagedQueryExecution query = new MockManagedQueryExecutionBuilder()
+                    .withQueryId("query_id")
+                    .withPriority(priority)
+                    .build();
+
             if (random.nextBoolean()) {
                 group1.run(query);
             }
@@ -817,7 +833,11 @@ public class TestResourceGroups
         int existingCount = existingQueries.size();
         Set<MockManagedQueryExecution> queries = new HashSet<>(existingQueries);
         for (int i = 0; i < count - existingCount; i++) {
-            MockManagedQueryExecution query = new MockManagedQueryExecution(0, group.getId().toString().replace(".", "") + Integer.toString(i), queryPriority ? i + 1 : 1);
+            MockManagedQueryExecution query = new MockManagedQueryExecutionBuilder()
+                    .withQueryId(group.getId().toString().replace(".", "") + Integer.toString(i))
+                    .withPriority(queryPriority ? i + 1 : 1)
+                    .build();
+
             queries.add(query);
             group.run(query);
         }

--- a/presto-main/src/test/java/io/prestosql/execution/resourcegroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/io/prestosql/execution/resourcegroups/TestResourceGroups.java
@@ -34,6 +34,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.testing.Assertions.assertBetweenInclusive;
@@ -52,6 +53,7 @@ import static io.prestosql.spi.resourcegroups.SchedulingPolicy.QUERY_PRIORITY;
 import static io.prestosql.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.prestosql.spi.resourcegroups.SchedulingPolicy.WEIGHTED_FAIR;
 import static java.util.Collections.reverse;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -113,7 +115,7 @@ public class TestResourceGroups
         assertEquals(query3a.getState(), QUEUED);
 
         query1a.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         // 2a and not 1b should have started, as group1 was not eligible to start a second query
         assertEquals(query1b.getState(), QUEUED);
         assertEquals(query2a.getState(), RUNNING);
@@ -121,13 +123,13 @@ public class TestResourceGroups
         assertEquals(query3a.getState(), QUEUED);
 
         query2a.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query3a.getState(), RUNNING);
         assertEquals(query2b.getState(), QUEUED);
         assertEquals(query1b.getState(), QUEUED);
 
         query3a.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query1b.getState(), RUNNING);
         assertEquals(query2b.getState(), QUEUED);
     }
@@ -203,7 +205,7 @@ public class TestResourceGroups
         assertEquals(query2a.getState(), QUEUED);
 
         query1a.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         // 1b and not 2a should have started, as it became queued first and group1 was eligible to run more
         assertEquals(query1b.getState(), RUNNING);
         assertEquals(query1c.getState(), QUEUED);
@@ -211,7 +213,7 @@ public class TestResourceGroups
 
         // 2a and not 1c should have started, as all eligible sub groups get fair sharing
         query1b.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2a.getState(), RUNNING);
         assertEquals(query1c.getState(), QUEUED);
     }
@@ -226,7 +228,7 @@ public class TestResourceGroups
         MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().withInitialMemoryUsage(new DataSize(2, BYTE)).build();
         root.run(query1);
         // Process the group to refresh stats
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
         MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         root.run(query2);
@@ -236,7 +238,7 @@ public class TestResourceGroups
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), RUNNING);
         assertEquals(query3.getState(), RUNNING);
     }
@@ -256,7 +258,7 @@ public class TestResourceGroups
         MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().withInitialMemoryUsage(new DataSize(2, BYTE)).build();
         subgroup.run(query1);
         // Process the group to refresh stats
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
         MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
         subgroup.run(query2);
@@ -266,7 +268,7 @@ public class TestResourceGroups
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), RUNNING);
         assertEquals(query3.getState(), RUNNING);
     }
@@ -300,12 +302,12 @@ public class TestResourceGroups
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), RUNNING);
         assertEquals(query3.getState(), QUEUED);
 
         root.generateCpuQuota(2);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), RUNNING);
         assertEquals(query3.getState(), RUNNING);
     }
@@ -333,12 +335,370 @@ public class TestResourceGroups
         assertEquals(query2.getState(), QUEUED);
 
         query1.complete();
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), QUEUED);
 
         root.generateCpuQuota(2);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(query2.getState(), RUNNING);
+    }
+
+    /**
+     * Test resource group CPU usage update by manually invoking the CPU quota regeneration and queue processing methods
+     * that are invoked periodically by the resource group manager
+     */
+    @Test(timeOut = 10_000)
+    public void testCpuUsageUpdateForRunningQuery()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setCpuQuotaGenerationMillisPerSecond((new Duration(1, MILLISECONDS)).toMillis());
+            group.setHardCpuLimit(new Duration(3, MILLISECONDS));
+            group.setSoftCpuLimit(new Duration(3, MILLISECONDS));
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertEquals(q1.getState(), RUNNING);
+        q1.consumeCpuTime(new Duration(4, MILLISECONDS));
+
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertExceedsCpuLimit(group, 4));
+
+        // q2 gets queued, because the cached usage is greater than the limit
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertEquals(q2.getState(), QUEUED);
+
+        // Generating CPU quota before the query finishes. This assertion verifies CPU update during quota generation.
+        root.generateCpuQuota(2);
+        Stream.of(root, child).forEach(group -> assertWithinCpuLimit(group, 2));
+
+        // An incoming query starts running right away.
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q3);
+        assertEquals(q3.getState(), RUNNING);
+
+        // A queued query starts running only after invoking `updateGroupsAndProcessQueuedQueries`.
+        assertEquals(q2.getState(), QUEUED);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertEquals(q2.getState(), RUNNING);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testCpuUsageUpdateAtQueryCompletion()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setCpuQuotaGenerationMillisPerSecond((new Duration(1, MILLISECONDS)).toMillis());
+            group.setHardCpuLimit(new Duration(3, MILLISECONDS));
+            group.setSoftCpuLimit(new Duration(3, MILLISECONDS));
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertEquals(q1.getState(), RUNNING);
+
+        q1.consumeCpuTime(new Duration(4, MILLISECONDS));
+        q1.complete();
+
+        // Query completion updates the cached usage to 2s. q1 will be removed from runningQueries at this point.
+        // Therefore, updateGroupsAndProcessQueuedQueries invocation will not be able to update its CPU usage later.
+        Stream.of(root, child).forEach(group -> assertExceedsCpuLimit(group, 4));
+
+        // q2 gets queued since cached usage exceeds the limit.
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertEquals(q2.getState(), QUEUED);
+
+        root.generateCpuQuota(2);
+        Stream.of(root, child).forEach(group -> assertWithinCpuLimit(group, 2));
+        assertEquals(q2.getState(), QUEUED);
+
+        // q2 should run after groups are updated. CPU usage should not be double counted.
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertWithinCpuLimit(group, 2));
+        assertEquals(q2.getState(), RUNNING);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testMemoryUsageUpdateForRunningQuery()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setSoftMemoryLimit(new DataSize(3, BYTE));
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertEquals(q1.getState(), RUNNING);
+        q1.setMemoryUsage(new DataSize(4, BYTE));
+
+        Stream.of(root, child).forEach(group -> assertWithinMemoryLimit(group, 0));
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertExceedsMemoryLimit(group, 4));
+
+        // A new query gets queued since the current usage exceeds the limit.
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertEquals(q2.getState(), QUEUED);
+
+        q1.setMemoryUsage(new DataSize(2, BYTE));
+
+        // A new incoming query q3 gets queued since cached usage still exceeds the limit.
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q3);
+        assertEquals(q3.getState(), QUEUED);
+
+        // q2 and q3 start running when cached usage is updated and queued queries are processed.
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertWithinMemoryLimit(group, 2));
+        assertEquals(q2.getState(), RUNNING);
+        assertEquals(q3.getState(), RUNNING);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testMemoryUsageUpdateAtQueryCompletion()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setSoftMemoryLimit(new DataSize(3, BYTE));
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertEquals(q1.getState(), RUNNING);
+        q1.setMemoryUsage(new DataSize(4, BYTE));
+
+        Stream.of(root, child).forEach(group -> assertWithinMemoryLimit(group, 0));
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertExceedsMemoryLimit(group, 4));
+
+        // Query completion should reduce the cached memory usage to 0B.
+        q1.complete();
+        Stream.of(root, child).forEach(group -> assertWithinMemoryLimit(group, 0));
+
+        // q2 starts running since usage is within the limit.
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertEquals(q2.getState(), RUNNING);
+    }
+
+    /**
+     * A test for correct CPU usage update aggregation and propagation in non-leaf nodes. It uses in a multi
+     * level resource group tree, with non-leaf resource groups having more than one child.
+     */
+    @Test(timeOut = 10_000)
+    public void testRecursiveCpuUsageUpdate()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup rootChild1 = root.getOrCreateSubGroup("rootChild1");
+        InternalResourceGroup rootChild2 = root.getOrCreateSubGroup("rootChild2");
+        InternalResourceGroup rootChild1Child1 = rootChild1.getOrCreateSubGroup("rootChild1Child1");
+        InternalResourceGroup rootChild1Child2 = rootChild1.getOrCreateSubGroup("rootChild1Child2");
+
+        // Set the same values in all the groups for some configurations
+        Stream.of(root, rootChild1, rootChild2, rootChild1Child1, rootChild1Child2).forEach(group -> {
+            group.setCpuQuotaGenerationMillisPerSecond((new Duration(1, MILLISECONDS)).toMillis());
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+        });
+
+        root.setHardCpuLimit(new Duration(16, MILLISECONDS));
+        rootChild1.setHardCpuLimit(new Duration(6, MILLISECONDS));
+
+        // Setting a higher limit for leaf nodes to make sure they are always in the limit
+        rootChild1Child1.setHardCpuLimit(new Duration(100, MILLISECONDS));
+        rootChild1Child2.setHardCpuLimit(new Duration(100, MILLISECONDS));
+        rootChild2.setHardCpuLimit(new Duration(100, MILLISECONDS));
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+
+        rootChild1Child1.run(q1);
+        rootChild1Child2.run(q2);
+        rootChild2.run(q3);
+
+        assertEquals(q1.getState(), RUNNING);
+        assertEquals(q2.getState(), RUNNING);
+        assertEquals(q3.getState(), RUNNING);
+
+        q1.consumeCpuTime(new Duration(4, MILLISECONDS));
+        q2.consumeCpuTime(new Duration(10, MILLISECONDS));
+        q3.consumeCpuTime(new Duration(4, MILLISECONDS));
+
+        // This invocation will update the cached usage for the nodes
+        root.updateGroupsAndProcessQueuedQueries();
+
+        assertExceedsCpuLimit(root, 18);
+        assertExceedsCpuLimit(rootChild1, 14);
+        assertWithinCpuLimit(rootChild2, 4);
+        assertWithinCpuLimit(rootChild1Child1, 4);
+        assertWithinCpuLimit(rootChild1Child2, 10);
+
+        // q4 submitted in rootChild2 gets queued because root's CPU usage exceeds the limit
+        MockManagedQueryExecution q4 = new MockManagedQueryExecutionBuilder().build();
+        rootChild2.run(q4);
+        assertEquals(q4.getState(), QUEUED);
+
+        // q5 submitted in rootChild1Child1 gets queued because root's CPU usage exceeds the limit
+        MockManagedQueryExecution q5 = new MockManagedQueryExecutionBuilder().build();
+        rootChild1Child1.run(q5);
+        assertEquals(q5.getState(), QUEUED);
+
+        // Assert CPU usage update after quota regeneration
+        root.generateCpuQuota(4);
+        assertWithinCpuLimit(root, 14);
+        assertExceedsCpuLimit(rootChild1, 10);
+        assertWithinCpuLimit(rootChild2, 0);
+        assertWithinCpuLimit(rootChild1Child1, 0);
+        assertWithinCpuLimit(rootChild1Child2, 6);
+
+        root.updateGroupsAndProcessQueuedQueries();
+
+        // q4 gets dequeued, because CPU usages of root and rootChild2 are below their limits.
+        assertEquals(q4.getState(), RUNNING);
+        // q5 does not get dequeued, because rootChild1's CPU usage exceeds the limit.
+        assertEquals(q5.getState(), QUEUED);
+
+        q2.consumeCpuTime(new Duration(3, MILLISECONDS));
+        q2.complete();
+
+        // Query completion updates cached CPU usage of root, rootChild1 and rootChild1Child2.
+        assertExceedsCpuLimit(root, 17);
+        assertExceedsCpuLimit(rootChild1, 13);
+        assertWithinCpuLimit(rootChild1Child2, 9);
+
+        // q6 in rootChild2 gets queued because root's CPU usage exceeds the limit.
+        MockManagedQueryExecution q6 = new MockManagedQueryExecutionBuilder().build();
+        rootChild2.run(q6);
+        assertEquals(q6.getState(), QUEUED);
+
+        // Assert usage after regeneration
+        root.generateCpuQuota(6);
+        assertWithinCpuLimit(root, 11);
+        assertExceedsCpuLimit(rootChild1, 7);
+        assertWithinCpuLimit(rootChild2, 0);
+        assertWithinCpuLimit(rootChild1Child1, 0);
+        assertWithinCpuLimit(rootChild1Child2, 3);
+
+        root.updateGroupsAndProcessQueuedQueries();
+
+        // q5 is queued, because rootChild1's usage still exceeds the limit.
+        assertEquals(q5.getState(), QUEUED);
+        // q6 starts running, because usage in rootChild2 and root are within their limits.
+        assertEquals(q6.getState(), RUNNING);
+
+        // q5 starts running after rootChild1's usage comes within the limit
+        root.generateCpuQuota(2);
+        assertWithinCpuLimit(rootChild1, 5);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertEquals(q5.getState(), RUNNING);
+    }
+
+    /**
+     * A test for correct memory usage update aggregation and propagation in non-leaf nodes. It uses in a multi
+     * level resource group tree, with non-leaf resource groups having more than one child.
+     */
+    @Test(timeOut = 10_000)
+    public void testMemoryUpdateRecursively()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup rootChild1 = root.getOrCreateSubGroup("rootChild1");
+        InternalResourceGroup rootChild2 = root.getOrCreateSubGroup("rootChild2");
+        InternalResourceGroup rootChild1Child1 = rootChild1.getOrCreateSubGroup("rootChild1Child1");
+        InternalResourceGroup rootChild1Child2 = rootChild1.getOrCreateSubGroup("rootChild1Child2");
+
+        // Set the same values in all the groups for some configurations
+        Stream.of(root, rootChild1, rootChild2, rootChild1Child1, rootChild1Child2).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+        });
+
+        root.setSoftMemoryLimit(new DataSize(8, BYTE));
+        rootChild1.setSoftMemoryLimit(new DataSize(3, BYTE));
+        // Setting a higher limit for leaf nodes
+        rootChild2.setSoftMemoryLimit(new DataSize(100, BYTE));
+        rootChild1Child1.setSoftMemoryLimit(new DataSize(100, BYTE));
+        rootChild1Child2.setSoftMemoryLimit(new DataSize(100, BYTE));
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+
+        rootChild1Child1.run(q1);
+        rootChild1Child2.run(q2);
+        rootChild2.run(q3);
+
+        assertEquals(q1.getState(), RUNNING);
+        assertEquals(q2.getState(), RUNNING);
+        assertEquals(q3.getState(), RUNNING);
+
+        q1.setMemoryUsage(new DataSize(2, BYTE));
+        q2.setMemoryUsage(new DataSize(5, BYTE));
+        q3.setMemoryUsage(new DataSize(2, BYTE));
+
+        // The cached memory usage gets updated for the tree
+        root.updateGroupsAndProcessQueuedQueries();
+        assertExceedsMemoryLimit(root, 9);
+        assertExceedsMemoryLimit(rootChild1, 7);
+        assertWithinMemoryLimit(rootChild2, 2);
+        assertWithinMemoryLimit(rootChild1Child1, 2);
+        assertWithinMemoryLimit(rootChild1Child2, 5);
+
+        // q4 submitted in rootChild2 gets queued because root's memory usage exceeds the limit
+        MockManagedQueryExecution q4 = new MockManagedQueryExecutionBuilder().build();
+        rootChild2.run(q4);
+        assertEquals(q4.getState(), QUEUED);
+
+        // q5 submitted in rootChild1Child1 gets queued because root's memory usage) exceeds the limit
+        MockManagedQueryExecution q5 = new MockManagedQueryExecutionBuilder().build();
+        rootChild1Child1.run(q5);
+        assertEquals(q5.getState(), QUEUED);
+
+        q1.setMemoryUsage(new DataSize(0, BYTE));
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertWithinMemoryLimit(root, 7);
+        assertExceedsMemoryLimit(rootChild1, 5);
+        assertWithinMemoryLimit(rootChild1Child1, 0);
+
+        // q4 starts running since usage in root and rootChild2 is within the limits
+        assertEquals(q4.getState(), RUNNING);
+        // q5 is queued since usage in rootChild1 exceeds the limit.
+        assertEquals(q5.getState(), QUEUED);
+
+        // q2's completion triggers memory updates
+        q2.complete();
+        assertWithinMemoryLimit(root, 2);
+        assertWithinMemoryLimit(rootChild1, 0);
+
+        // An incoming query starts running
+        MockManagedQueryExecution q6 = new MockManagedQueryExecutionBuilder().build();
+        rootChild1Child2.run(q6);
+        assertEquals(q6.getState(), RUNNING);
+
+        // queued queries will start running after the update
+        assertEquals(q5.getState(), QUEUED);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertEquals(q5.getState(), RUNNING);
     }
 
     @Test(timeOut = 10_000)
@@ -389,7 +749,7 @@ public class TestResourceGroups
         reverse(orderedQueries);
 
         for (MockManagedQueryExecution query : orderedQueries) {
-            root.processQueuedQueries();
+            root.updateGroupsAndProcessQueuedQueries();
             assertEquals(query.getState(), RUNNING);
             query.complete();
         }
@@ -430,7 +790,7 @@ public class TestResourceGroups
                 }
             }
             group2Ran += completeGroupQueries(group2Queries);
-            root.processQueuedQueries();
+            root.updateGroupsAndProcessQueuedQueries();
             group1Queries = fillGroupTo(group1, group1Queries, 2);
             group2Queries = fillGroupTo(group2, group2Queries, 2);
         }
@@ -477,7 +837,7 @@ public class TestResourceGroups
         for (int i = 0; i < 1000; i++) {
             group1Ran += completeGroupQueries(group1Queries);
             group2Ran += completeGroupQueries(group2Queries);
-            root.processQueuedQueries();
+            root.updateGroupsAndProcessQueuedQueries();
             group1Queries = fillGroupTo(group1, group1Queries, 4);
             group2Queries = fillGroupTo(group2, group2Queries, 4);
         }
@@ -530,7 +890,7 @@ public class TestResourceGroups
             group1Ran += completeGroupQueries(group1Queries);
             group2Ran += completeGroupQueries(group2Queries);
             group3Ran += completeGroupQueries(group3Queries);
-            root.processQueuedQueries();
+            root.updateGroupsAndProcessQueuedQueries();
             group1Queries = fillGroupTo(group1, group1Queries, 4);
             group2Queries = fillGroupTo(group2, group2Queries, 4);
             group3Queries = fillGroupTo(group3, group3Queries, 4);
@@ -578,7 +938,7 @@ public class TestResourceGroups
         for (int i = 0; i < 2000; i++) {
             group1Ran += completeGroupQueries(group1Queries);
             completeGroupQueries(group2Queries);
-            root.processQueuedQueries();
+            root.updateGroupsAndProcessQueuedQueries();
             group1Queries = fillGroupTo(group1, group1Queries, 4);
             group2Queries = fillGroupTo(group2, group2Queries, 4);
         }
@@ -641,7 +1001,7 @@ public class TestResourceGroups
 
         // root.maxRunningQueries = 4, root.a.maxRunningQueries = 2, root.b.maxRunningQueries = 2. Will have 4 queries running and 36 left queued.
         root.setHardConcurrencyLimit(4);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         info = root.getInfo();
         assertEquals(info.getNumRunningQueries(), 4);
         assertEquals(info.getNumQueuedQueries(), 36);
@@ -657,21 +1017,21 @@ public class TestResourceGroups
         }
 
         // 4 more queries start running, 32 left queued.
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         info = root.getInfo();
         assertEquals(info.getNumRunningQueries(), 4);
         assertEquals(info.getNumQueuedQueries(), 32);
 
         // root.maxRunningQueries = 10, root.a.maxRunningQueries = 2, root.b.maxRunningQueries = 2. Still only have 4 running queries and 32 left queued.
         root.setHardConcurrencyLimit(10);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         info = root.getInfo();
         assertEquals(info.getNumRunningQueries(), 4);
         assertEquals(info.getNumQueuedQueries(), 32);
 
         // root.maxRunningQueries = 10, root.a.maxRunningQueries = 2, root.b.maxRunningQueries = 10. Will have 10 running queries and 26 left queued.
         rootB.setHardConcurrencyLimit(10);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         info = root.getInfo();
         assertEquals(info.getNumRunningQueries(), 10);
         assertEquals(info.getNumQueuedQueries(), 26);
@@ -717,6 +1077,7 @@ public class TestResourceGroups
         assertEquals(rootInfo.getState(), CAN_RUN);
         assertEquals(rootInfo.getSoftMemoryLimit(), root.getSoftMemoryLimit());
         assertEquals(rootInfo.getMemoryUsage(), new DataSize(0, BYTE));
+        assertEquals(rootInfo.getCpuUsage(), new Duration(0, MILLISECONDS));
         assertEquals(rootInfo.getSubGroups().size(), 2);
         assertGroupInfoEquals(rootInfo.getSubGroups().get(0), rootA.getInfo());
         assertEquals(rootInfo.getSubGroups().get(0).getId(), rootA.getId());
@@ -799,7 +1160,7 @@ public class TestResourceGroups
         assertEquals(rootBY.getWaitingQueuedQueries(), 10);
 
         root.setHardConcurrencyLimit(20);
-        root.processQueuedQueries();
+        root.updateGroupsAndProcessQueuedQueries();
         assertEquals(root.getWaitingQueuedQueries(), 0);
         assertEquals(rootA.getWaitingQueuedQueries(), 5);
         assertEquals(rootAX.getWaitingQueuedQueries(), 6);
@@ -857,6 +1218,35 @@ public class TestResourceGroups
                 actual.getState() == expected.getState() &&
                 actual.getSchedulingPolicy() == expected.getSchedulingPolicy() &&
                 Objects.equals(actual.getSoftMemoryLimit(), expected.getSoftMemoryLimit()) &&
-                Objects.equals(actual.getMemoryUsage(), expected.getMemoryUsage()));
+                Objects.equals(actual.getMemoryUsage(), expected.getMemoryUsage()) &&
+                Objects.equals(actual.getCpuUsage(), expected.getCpuUsage()));
+    }
+
+    private static void assertExceedsCpuLimit(InternalResourceGroup group, long expectedMillis)
+    {
+        long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
+        assertEquals(actualMillis, expectedMillis);
+        assertTrue(actualMillis >= group.getHardCpuLimit().toMillis());
+    }
+
+    private static void assertWithinCpuLimit(InternalResourceGroup group, long expectedMillis)
+    {
+        long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
+        assertEquals(actualMillis, expectedMillis);
+        assertTrue(actualMillis < group.getHardCpuLimit().toMillis());
+    }
+
+    private static void assertExceedsMemoryLimit(InternalResourceGroup group, long expectedBytes)
+    {
+        long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
+        assertEquals(actualBytes, expectedBytes);
+        assertTrue(actualBytes > group.getSoftMemoryLimit().toBytes());
+    }
+
+    private static void assertWithinMemoryLimit(InternalResourceGroup group, long expectedBytes)
+    {
+        long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
+        assertEquals(actualBytes, expectedBytes);
+        assertTrue(actualBytes <= group.getSoftMemoryLimit().toBytes());
     }
 }


### PR DESCRIPTION
This PR contains the following changes at a high level:

* Periodically update and cache cpu usage for resource groups.
* Add memory and cpu usage update at query completion.
* Update eligibility through a post-order traversal in `updateEligibilityAll` after resource usage update to avoid calling `updateEligibility` recursively in the `internalRefreshStats`.
* Rename `processQueuedQueries` to reflect what the method is doing
* move memory limit check in `canRunMore` for better readability.

Resolves #1059 . @dain @wagnermarkd 