### PR TITLE
Simplify signature of Metastore.getAllTables, getAllViews

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -211,7 +211,6 @@ import static io.prestosql.spi.statistics.TableStatisticType.ROW_COUNT;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -575,7 +574,7 @@ public class HiveMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllTables(schemaName).orElse(emptyList())) {
+            for (String tableName : metastore.getAllTables(schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }
@@ -1599,7 +1598,7 @@ public class HiveMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllViews(schemaName).orElse(emptyList())) {
+            for (String tableName : metastore.getAllViews(schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/CachingHiveMetastore.java
@@ -75,10 +75,10 @@ public class CachingHiveMetastore
     private final LoadingCache<String, Optional<Database>> databaseCache;
     private final LoadingCache<String, List<String>> databaseNamesCache;
     private final LoadingCache<HiveTableName, Optional<Table>> tableCache;
-    private final LoadingCache<String, Optional<List<String>>> tableNamesCache;
+    private final LoadingCache<String, List<String>> tableNamesCache;
     private final LoadingCache<HiveTableName, PartitionStatistics> tableStatisticsCache;
     private final LoadingCache<HivePartitionName, PartitionStatistics> partitionStatisticsCache;
-    private final LoadingCache<String, Optional<List<String>>> viewNamesCache;
+    private final LoadingCache<String, List<String>> viewNamesCache;
     private final LoadingCache<HivePartitionName, Optional<Partition>> partitionCache;
     private final LoadingCache<PartitionFilter, Optional<List<String>>> partitionFilterCache;
     private final LoadingCache<HiveTableName, Optional<List<String>>> partitionNamesCache;
@@ -353,23 +353,23 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllTables(String databaseName)
+    public List<String> getAllTables(String databaseName)
     {
         return get(tableNamesCache, databaseName);
     }
 
-    private Optional<List<String>> loadAllTables(String databaseName)
+    private List<String> loadAllTables(String databaseName)
     {
         return delegate.getAllTables(databaseName);
     }
 
     @Override
-    public Optional<List<String>> getAllViews(String databaseName)
+    public List<String> getAllViews(String databaseName)
     {
         return get(viewNamesCache, databaseName);
     }
 
-    private Optional<List<String>> loadAllViews(String databaseName)
+    private List<String> loadAllViews(String databaseName)
     {
         return delegate.getAllViews(databaseName);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -43,9 +43,9 @@ public interface HiveMetastore
 
     void updatePartitionStatistics(String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 
-    Optional<List<String>> getAllTables(String databaseName);
+    List<String> getAllTables(String databaseName);
 
-    Optional<List<String>> getAllViews(String databaseName);
+    List<String> getAllViews(String databaseName);
 
     void createDatabase(Database database);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -72,8 +72,8 @@ public class RecordingHiveMetastore
     private final Cache<String, Set<ColumnStatisticType>> supportedColumnStatisticsCache;
     private final Cache<HiveTableName, PartitionStatistics> tableStatisticsCache;
     private final Cache<Set<HivePartitionName>, Map<String, PartitionStatistics>> partitionStatisticsCache;
-    private final Cache<String, Optional<List<String>>> allTablesCache;
-    private final Cache<String, Optional<List<String>>> allViewsCache;
+    private final Cache<String, List<String>> allTablesCache;
+    private final Cache<String, List<String>> allViewsCache;
     private final Cache<HivePartitionName, Optional<Partition>> partitionCache;
     private final Cache<HiveTableName, Optional<List<String>>> partitionNamesCache;
     private final Cache<PartitionFilter, Optional<List<String>>> partitionNamesByPartsCache;
@@ -248,13 +248,13 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllTables(String databaseName)
+    public List<String> getAllTables(String databaseName)
     {
         return loadValue(allTablesCache, databaseName, () -> delegate.getAllTables(databaseName));
     }
 
     @Override
-    public Optional<List<String>> getAllViews(String databaseName)
+    public List<String> getAllViews(String databaseName)
     {
         return loadValue(allViewsCache, databaseName, () -> delegate.getAllViews(databaseName));
     }
@@ -501,8 +501,8 @@ public class RecordingHiveMetastore
         private final List<Pair<String, Set<ColumnStatisticType>>> supportedColumnStatistics;
         private final List<Pair<HiveTableName, PartitionStatistics>> tableStatistics;
         private final List<Pair<Set<HivePartitionName>, Map<String, PartitionStatistics>>> partitionStatistics;
-        private final List<Pair<String, Optional<List<String>>>> allTables;
-        private final List<Pair<String, Optional<List<String>>>> allViews;
+        private final List<Pair<String, List<String>>> allTables;
+        private final List<Pair<String, List<String>>> allViews;
         private final List<Pair<HivePartitionName, Optional<Partition>>> partitions;
         private final List<Pair<HiveTableName, Optional<List<String>>>> partitionNames;
         private final List<Pair<PartitionFilter, Optional<List<String>>>> partitionNamesByParts;
@@ -519,8 +519,8 @@ public class RecordingHiveMetastore
                 @JsonProperty("supportedColumnStatistics") List<Pair<String, Set<ColumnStatisticType>>> supportedColumnStatistics,
                 @JsonProperty("tableStatistics") List<Pair<HiveTableName, PartitionStatistics>> tableStatistics,
                 @JsonProperty("partitionStatistics") List<Pair<Set<HivePartitionName>, Map<String, PartitionStatistics>>> partitionStatistics,
-                @JsonProperty("allTables") List<Pair<String, Optional<List<String>>>> allTables,
-                @JsonProperty("allViews") List<Pair<String, Optional<List<String>>>> allViews,
+                @JsonProperty("allTables") List<Pair<String, List<String>>> allTables,
+                @JsonProperty("allViews") List<Pair<String, List<String>>> allViews,
                 @JsonProperty("partitions") List<Pair<HivePartitionName, Optional<Partition>>> partitions,
                 @JsonProperty("partitionNames") List<Pair<HiveTableName, Optional<List<String>>>> partitionNames,
                 @JsonProperty("partitionNamesByParts") List<Pair<PartitionFilter, Optional<List<String>>>> partitionNamesByParts,
@@ -588,13 +588,13 @@ public class RecordingHiveMetastore
         }
 
         @JsonProperty
-        public List<Pair<String, Optional<List<String>>>> getAllTables()
+        public List<Pair<String, List<String>>> getAllTables()
         {
             return allTables;
         }
 
         @JsonProperty
-        public List<Pair<String, Optional<List<String>>>> getAllViews()
+        public List<Pair<String, List<String>>> getAllViews()
         {
             return allViews;
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -135,7 +135,7 @@ public class SemiTransactionalHiveMetastore
         return delegate.getDatabase(databaseName);
     }
 
-    public synchronized Optional<List<String>> getAllTables(String databaseName)
+    public synchronized List<String> getAllTables(String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
@@ -279,7 +279,7 @@ public class SemiTransactionalHiveMetastore
                 modifiedPartitionMap);
     }
 
-    public synchronized Optional<List<String>> getAllViews(String databaseName)
+    public synchronized List<String> getAllViews(String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -338,7 +338,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllTables(String databaseName)
+    public List<String> getAllTables(String databaseName)
     {
         try {
             List<String> tableNames = new ArrayList<>();
@@ -354,11 +354,11 @@ public class GlueHiveMetastore
             }
             while (nextToken != null);
 
-            return Optional.of(tableNames);
+            return tableNames;
         }
         catch (EntityNotFoundException e) {
             // database does not exist
-            return Optional.empty();
+            return ImmutableList.of();
         }
         catch (AmazonServiceException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
@@ -366,7 +366,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllViews(String databaseName)
+    public List<String> getAllViews(String databaseName)
     {
         try {
             List<String> views = new ArrayList<>();
@@ -384,11 +384,11 @@ public class GlueHiveMetastore
             }
             while (nextToken != null);
 
-            return Optional.of(views);
+            return views;
         }
         catch (EntityNotFoundException e) {
             // database does not exist
-            return Optional.empty();
+            return ImmutableList.of();
         }
         catch (AmazonServiceException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -120,13 +120,13 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllTables(String databaseName)
+    public List<String> getAllTables(String databaseName)
     {
         return delegate.getAllTables(databaseName);
     }
 
     @Override
-    public Optional<List<String>> getAllViews(String databaseName)
+    public List<String> getAllViews(String databaseName)
     {
         return delegate.getAllViews(databaseName);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -52,9 +52,9 @@ public interface ThriftMetastore
 
     List<String> getAllDatabases();
 
-    Optional<List<String>> getAllTables(String databaseName);
+    List<String> getAllTables(String databaseName);
 
-    Optional<List<String>> getAllViews(String databaseName);
+    List<String> getAllViews(String databaseName);
 
     Optional<Database> getDatabase(String databaseName);
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestCachingHiveMetastore.java
@@ -43,6 +43,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestCachingHiveMetastore
@@ -86,21 +87,21 @@ public class TestCachingHiveMetastore
     public void testGetAllTable()
     {
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getAllTables(TEST_DATABASE).get(), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getAllTables(TEST_DATABASE).get(), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 1);
 
         metastore.flushCache();
 
-        assertEquals(metastore.getAllTables(TEST_DATABASE).get(), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 2);
     }
 
     @Test
     public void testInvalidDbGetAllTAbles()
     {
-        assertFalse(metastore.getAllTables(BAD_DATABASE).isPresent());
+        assertTrue(metastore.getAllTables(BAD_DATABASE).isEmpty());
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -130,8 +130,8 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.getSupportedColumnStatistics(createVarcharType(123)), ImmutableSet.of(MIN_VALUE, MAX_VALUE));
         assertEquals(hiveMetastore.getTableStatistics("database", "table"), PARTITION_STATISTICS);
         assertEquals(hiveMetastore.getPartitionStatistics("database", "table", ImmutableSet.of("value")), ImmutableMap.of("value", PARTITION_STATISTICS));
-        assertEquals(hiveMetastore.getAllTables("database"), Optional.of(ImmutableList.of("table")));
-        assertEquals(hiveMetastore.getAllViews("database"), Optional.empty());
+        assertEquals(hiveMetastore.getAllTables("database"), ImmutableList.of("table"));
+        assertEquals(hiveMetastore.getAllViews("database"), ImmutableList.of());
         assertEquals(hiveMetastore.getPartition("database", "table", ImmutableList.of("value")), Optional.of(PARTITION));
         assertEquals(hiveMetastore.getPartitionNames("database", "table"), Optional.of(ImmutableList.of("value")));
         assertEquals(hiveMetastore.getPartitionNamesByParts("database", "table", ImmutableList.of("value")), Optional.of(ImmutableList.of("value")));
@@ -201,19 +201,19 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public Optional<List<String>> getAllTables(String databaseName)
+        public List<String> getAllTables(String databaseName)
         {
             if (databaseName.equals("database")) {
-                return Optional.of(ImmutableList.of("table"));
+                return ImmutableList.of("table");
             }
 
-            return Optional.empty();
+            return ImmutableList.of();
         }
 
         @Override
-        public Optional<List<String>> getAllViews(String databaseName)
+        public List<String> getAllViews(String databaseName)
         {
-            return Optional.empty();
+            return ImmutableList.of();
         }
 
         @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -77,13 +77,13 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public Optional<List<String>> getAllTables(String databaseName)
+    public List<String> getAllTables(String databaseName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<List<String>> getAllViews(String databaseName)
+    public List<String> getAllViews(String databaseName)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -125,7 +125,7 @@ public class InMemoryThriftMetastore
         if (!databases.containsKey(databaseName)) {
             throw new SchemaNotFoundException(databaseName);
         }
-        if (!getAllTables(databaseName).orElse(ImmutableList.of()).isEmpty()) {
+        if (!getAllTables(databaseName).isEmpty()) {
             throw new PrestoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + databaseName);
         }
         databases.remove(databaseName);
@@ -272,7 +272,7 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public synchronized Optional<List<String>> getAllTables(String databaseName)
+    public synchronized List<String> getAllTables(String databaseName)
     {
         ImmutableList.Builder<String> tables = ImmutableList.builder();
         for (SchemaTableName schemaTableName : this.relations.keySet()) {
@@ -280,11 +280,11 @@ public class InMemoryThriftMetastore
                 tables.add(schemaTableName.getTableName());
             }
         }
-        return Optional.of(tables.build());
+        return tables.build();
     }
 
     @Override
-    public synchronized Optional<List<String>> getAllViews(String databaseName)
+    public synchronized List<String> getAllViews(String databaseName)
     {
         ImmutableList.Builder<String> tables = ImmutableList.builder();
         for (SchemaTableName schemaTableName : this.views.keySet()) {
@@ -292,7 +292,7 @@ public class InMemoryThriftMetastore
                 tables.add(schemaTableName.getTableName());
             }
         }
-        return Optional.of(tables.build());
+        return tables.build();
     }
 
     @Override


### PR DESCRIPTION
The methods were supposed to return `Optional.empty()` when database
does not exist. However, we never used this information. Also,
`ThriftHiveMetastore.getAllViews()` did not guarantee to return
`Optional.empty()` for non-existing database.