### PR TITLE
Add SemanticErrorName to QueryFailureInfo

### DIFF
--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -51,6 +51,7 @@ import io.prestosql.spi.eventlistener.QueryOutputMetadata;
 import io.prestosql.spi.eventlistener.QueryStatistics;
 import io.prestosql.spi.eventlistener.StageCpuDistribution;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
+import io.prestosql.sql.analyzer.SemanticErrorCode;
 import io.prestosql.sql.planner.planprinter.ValuePrinter;
 import io.prestosql.transaction.TransactionId;
 import org.joda.time.DateTime;
@@ -335,6 +336,7 @@ public class QueryMonitor
 
         return Optional.of(new QueryFailureInfo(
                 failureInfo.getErrorCode(),
+                failureInfo.getSemanticErrorCode().map(SemanticErrorCode::name),
                 Optional.ofNullable(failureInfo.getType()),
                 Optional.ofNullable(failureInfo.getMessage()),
                 failedTask.map(task -> task.getTaskStatus().getTaskId().toString()),

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryFailureInfo.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryFailureInfo.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 public class QueryFailureInfo
 {
     private final ErrorCode errorCode;
+    private final Optional<String> semanticErrorName;
     private final Optional<String> failureType;
     private final Optional<String> failureMessage;
     private final Optional<String> failureTask;
@@ -30,6 +31,7 @@ public class QueryFailureInfo
 
     public QueryFailureInfo(
             ErrorCode errorCode,
+            Optional<String> semanticErrorName,
             Optional<String> failureType,
             Optional<String> failureMessage,
             Optional<String> failureTask,
@@ -37,6 +39,7 @@ public class QueryFailureInfo
             String failuresJson)
     {
         this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        this.semanticErrorName = requireNonNull(semanticErrorName, "semanticErrorName is null");
         this.failureType = requireNonNull(failureType, "failureType is null");
         this.failureMessage = requireNonNull(failureMessage, "failureMessage is null");
         this.failureTask = requireNonNull(failureTask, "failureTask is null");
@@ -47,6 +50,11 @@ public class QueryFailureInfo
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    public Optional<String> getSemanticErrorName()
+    {
+        return semanticErrorName;
     }
 
     public Optional<String> getFailureType()


### PR DESCRIPTION
https://github.com/prestosql/presto/pull/790#issuecomment-495089807
https://prestosql.slack.com/archives/CFLB9AMBN/p1563316688115000

But I don't know how to test.
I guess it's better to add a test method like ```testErrorQuery```  in ```TestEventListener```.