### PR TITLE
Add Timestamp statistics for ORC file

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
@@ -41,6 +41,7 @@ import io.prestosql.orc.metadata.statistics.StatisticsHasher;
 import io.prestosql.orc.metadata.statistics.StringStatistics;
 import io.prestosql.orc.metadata.statistics.StringStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.StripeStatistics;
+import io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
@@ -604,7 +605,7 @@ public class OrcWriteValidation
                 return Optional.empty();
             }
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
-            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null));
+            statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null));
             columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             return Optional.of(new ColumnMetadata<>(statisticsBuilders.build()));
         }
@@ -677,7 +678,7 @@ public class OrcWriteValidation
                 fieldBuilders = ImmutableList.of();
             }
             else if (TIMESTAMP.equals(type)) {
-                statisticsBuilder = new CountStatisticsBuilder();
+                statisticsBuilder = new TimestampStatisticsBuilder(new NoOpBloomFilterBuilder());
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
@@ -761,7 +762,7 @@ public class OrcWriteValidation
         @Override
         public ColumnStatistics buildColumnStatistics()
         {
-            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null);
+            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null);
         }
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
@@ -432,7 +432,7 @@ public final class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(ROOT_COLUMN, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(ROOT_COLUMN, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null));
+        columnStatistics.put(ROOT_COLUMN, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null, null));
 
         // add footer
         StripeFooter stripeFooter = new StripeFooter(allStreams, toColumnMetadata(columnEncodings, orcTypes.size()), ZoneId.of("UTC"));

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -27,6 +27,7 @@ import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
 import io.prestosql.spi.type.VarcharType;
@@ -217,6 +218,9 @@ public class TupleDomainOrcPredicate
         }
         else if (type instanceof DateType && columnStatistics.getDateStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getDateStatistics(), value -> (long) value);
+        }
+        else if (type instanceof TimestampType && columnStatistics.getTimestampStatistics() != null) {
+            return createDomain(type, hasNullValue, columnStatistics.getTimestampStatistics(), value -> (long) value);
         }
         else if (type.getJavaType() == long.class && columnStatistics.getIntegerStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getIntegerStatistics());

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
@@ -34,6 +34,7 @@ import io.prestosql.orc.metadata.statistics.DoubleStatistics;
 import io.prestosql.orc.metadata.statistics.IntegerStatistics;
 import io.prestosql.orc.metadata.statistics.StringStatistics;
 import io.prestosql.orc.metadata.statistics.StripeStatistics;
+import io.prestosql.orc.metadata.statistics.TimestampStatistics;
 import io.prestosql.orc.proto.OrcProto;
 import io.prestosql.orc.proto.OrcProto.RowIndexEntry;
 import io.prestosql.orc.protobuf.ByteString;
@@ -71,6 +72,7 @@ import static io.prestosql.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE
 import static io.prestosql.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static io.prestosql.orc.metadata.statistics.ShortDecimalStatisticsBuilder.SHORT_DECIMAL_VALUE_BYTES;
 import static io.prestosql.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
+import static io.prestosql.orc.metadata.statistics.TimestampStatistics.TIMESTAMP_VALUE_BYTES;
 import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
 import static java.lang.Math.toIntExact;
 
@@ -269,6 +271,9 @@ public class OrcMetadataReader
         else if (statistics.hasDateStatistics()) {
             minAverageValueBytes = DATE_VALUE_BYTES;
         }
+        else if (statistics.hasTimestampStatistics()) {
+            minAverageValueBytes = TIMESTAMP_VALUE_BYTES;
+        }
         else if (statistics.hasDecimalStatistics()) {
             // could be 8 or 16; return the smaller one given it is a min average
             minAverageValueBytes = DECIMAL_VALUE_BYTES_OVERHEAD + SHORT_DECIMAL_VALUE_BYTES;
@@ -292,6 +297,7 @@ public class OrcMetadataReader
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,
                 statistics.hasStringStatistics() ? toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup) : null,
                 statistics.hasDateStatistics() ? toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup) : null,
+                statistics.hasTimestampStatistics() ? toTimestampStatistics(hiveWriterVersion, statistics.getTimestampStatistics(), isRowGroup) : null,
                 statistics.hasDecimalStatistics() ? toDecimalStatistics(statistics.getDecimalStatistics()) : null,
                 statistics.hasBinaryStatistics() ? toBinaryStatistics(statistics.getBinaryStatistics()) : null,
                 null);
@@ -481,6 +487,17 @@ public class OrcMetadataReader
         return new DateStatistics(
                 dateStatistics.hasMinimum() ? dateStatistics.getMinimum() : null,
                 dateStatistics.hasMaximum() ? dateStatistics.getMaximum() : null);
+    }
+
+    private static TimestampStatistics toTimestampStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.TimestampStatistics timestampStatistics, boolean isRowGroup)
+    {
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
+            return null;
+        }
+
+        return new TimestampStatistics(
+                timestampStatistics.hasMinimumUtc() ? timestampStatistics.getMinimumUtc() : null,
+                timestampStatistics.hasMaximumUtc() ? timestampStatistics.getMaximumUtc() : null);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
@@ -271,6 +271,13 @@ public class OrcMetadataWriter
                     .build());
         }
 
+        if (columnStatistics.getTimestampStatistics() != null) {
+            builder.setTimestampStatistics(OrcProto.TimestampStatistics.newBuilder()
+                    .setMinimumUtc(columnStatistics.getTimestampStatistics().getMin())
+                    .setMaximumUtc(columnStatistics.getTimestampStatistics().getMax())
+                    .build());
+        }
+
         if (columnStatistics.getDecimalStatistics() != null) {
             builder.setDecimalStatistics(OrcProto.DecimalStatistics.newBuilder()
                     .setMinimum(columnStatistics.getDecimalStatistics().getMin().toString())

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -67,6 +67,7 @@ public class BinaryStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 binaryStatistics.orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -76,6 +76,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ColumnStatistics.java
@@ -27,6 +27,7 @@ import static io.prestosql.orc.metadata.statistics.DoubleStatisticsBuilder.merge
 import static io.prestosql.orc.metadata.statistics.IntegerStatisticsBuilder.mergeIntegerStatistics;
 import static io.prestosql.orc.metadata.statistics.LongDecimalStatisticsBuilder.mergeDecimalStatistics;
 import static io.prestosql.orc.metadata.statistics.StringStatisticsBuilder.mergeStringStatistics;
+import static io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder.mergeTimestampStatistics;
 
 public class ColumnStatistics
         implements Hashable
@@ -41,6 +42,7 @@ public class ColumnStatistics
     private final DoubleStatistics doubleStatistics;
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
+    private final TimestampStatistics timestampStatistics;
     private final DecimalStatistics decimalStatistics;
     private final BinaryStatistics binaryStatistics;
     private final BloomFilter bloomFilter;
@@ -53,6 +55,7 @@ public class ColumnStatistics
             DoubleStatistics doubleStatistics,
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
+            TimestampStatistics timestampStatistics,
             DecimalStatistics decimalStatistics,
             BinaryStatistics binaryStatistics,
             BloomFilter bloomFilter)
@@ -65,6 +68,7 @@ public class ColumnStatistics
         this.doubleStatistics = doubleStatistics;
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
+        this.timestampStatistics = timestampStatistics;
         this.decimalStatistics = decimalStatistics;
         this.binaryStatistics = binaryStatistics;
         this.bloomFilter = bloomFilter;
@@ -131,6 +135,11 @@ public class ColumnStatistics
         return binaryStatistics;
     }
 
+    public TimestampStatistics getTimestampStatistics()
+    {
+        return timestampStatistics;
+    }
+
     public BloomFilter getBloomFilter()
     {
         return bloomFilter;
@@ -146,6 +155,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
@@ -168,6 +178,9 @@ public class ColumnStatistics
         }
         if (dateStatistics != null) {
             retainedSizeInBytes += dateStatistics.getRetainedSizeInBytes();
+        }
+        if (timestampStatistics != null) {
+            retainedSizeInBytes += timestampStatistics.getRetainedSizeInBytes();
         }
         if (decimalStatistics != null) {
             retainedSizeInBytes += decimalStatistics.getRetainedSizeInBytes();
@@ -198,6 +211,7 @@ public class ColumnStatistics
                 Objects.equals(doubleStatistics, that.doubleStatistics) &&
                 Objects.equals(stringStatistics, that.stringStatistics) &&
                 Objects.equals(dateStatistics, that.dateStatistics) &&
+                Objects.equals(timestampStatistics, that.timestampStatistics) &&
                 Objects.equals(decimalStatistics, that.decimalStatistics) &&
                 Objects.equals(binaryStatistics, that.binaryStatistics) &&
                 Objects.equals(bloomFilter, that.bloomFilter);
@@ -214,6 +228,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
@@ -230,6 +245,7 @@ public class ColumnStatistics
                 .add("doubleStatistics", doubleStatistics)
                 .add("stringStatistics", stringStatistics)
                 .add("dateStatistics", dateStatistics)
+                .add("timestampStatistics", timestampStatistics)
                 .add("decimalStatistics", decimalStatistics)
                 .add("binaryStatistics", binaryStatistics)
                 .add("bloomFilter", bloomFilter)
@@ -245,6 +261,7 @@ public class ColumnStatistics
                 .putOptionalHashable(doubleStatistics)
                 .putOptionalHashable(stringStatistics)
                 .putOptionalHashable(dateStatistics)
+                .putOptionalHashable(timestampStatistics)
                 .putOptionalHashable(decimalStatistics)
                 .putOptionalHashable(binaryStatistics)
                 .putOptionalHashable(bloomFilter);
@@ -271,6 +288,7 @@ public class ColumnStatistics
                 mergeDoubleStatistics(stats).orElse(null),
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
+                mergeTimestampStatistics(stats).orElse(null),
                 mergeDecimalStatistics(stats).orElse(null),
                 mergeBinaryStatistics(stats).orElse(null),
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -77,6 +77,7 @@ public class DateStatisticsBuilder
                 dateStatistics.orElse(null),
                 null,
                 null,
+                null,
                 bloomFilterBuilder.buildBloomFilter());
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -113,6 +113,7 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 bloomFilterBuilder.buildBloomFilter());
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -102,6 +102,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -67,6 +67,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -137,6 +137,7 @@ public class StringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 bloomFilterBuilder.buildBloomFilter());
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatistics.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatistics.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.metadata.statistics;
+
+import io.prestosql.orc.metadata.statistics.StatisticsHasher.Hashable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TimestampStatistics
+        implements RangeStatistics<Long>, Hashable
+{
+    // 1 byte to denote if null + 8 bytes for the value
+    public static final long TIMESTAMP_VALUE_BYTES = Byte.BYTES + Long.BYTES;
+
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampStatistics.class).instanceSize();
+
+    private final boolean hasMinimum;
+    private final boolean hasMaximum;
+
+    private final long minimum;
+    private final long maximum;
+
+    public TimestampStatistics(Long minimum, Long maximum)
+    {
+        checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
+
+        this.hasMinimum = minimum != null;
+        this.minimum = hasMinimum ? minimum : 0;
+
+        this.hasMaximum = maximum != null;
+        this.maximum = hasMaximum ? maximum : 0;
+    }
+
+    @Override
+    public Long getMin()
+    {
+        return hasMinimum ? minimum : null;
+    }
+
+    @Override
+    public Long getMax()
+    {
+        return hasMaximum ? maximum : null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimestampStatistics that = (TimestampStatistics) o;
+        return Objects.equals(getMin(), that.getMin()) &&
+                Objects.equals(getMax(), that.getMax());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getMin(), getMax());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("min", getMin())
+                .add("max", getMax())
+                .toString();
+    }
+
+    @Override
+    public void addHash(StatisticsHasher hasher)
+    {
+        hasher.putOptionalLong(hasMinimum, minimum)
+                .putOptionalLong(hasMaximum, maximum);
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatisticsBuilder.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/statistics/TimestampStatisticsBuilder.java
@@ -16,23 +16,20 @@ package io.prestosql.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
-import static io.prestosql.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
-import static java.lang.Math.addExact;
+import static io.prestosql.orc.metadata.statistics.TimestampStatistics.TIMESTAMP_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
-public class IntegerStatisticsBuilder
+public class TimestampStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
     private long minimum = Long.MAX_VALUE;
     private long maximum = Long.MIN_VALUE;
-    private long sum;
-    private boolean overflow;
     private final BloomFilterBuilder bloomFilterBuilder;
 
-    public IntegerStatisticsBuilder(BloomFilterBuilder bloomFilterBuilder)
+    public TimestampStatisticsBuilder(BloomFilterBuilder bloomFilterBuilder)
     {
-        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is null");
+        this.bloomFilterBuilder = requireNonNull(bloomFilterBuilder, "bloomFilterBuilder is nulll");
     }
 
     @Override
@@ -42,19 +39,10 @@ public class IntegerStatisticsBuilder
 
         minimum = Math.min(value, minimum);
         maximum = Math.max(value, maximum);
-
-        if (!overflow) {
-            try {
-                sum = addExact(sum, value);
-            }
-            catch (ArithmeticException e) {
-                overflow = true;
-            }
-        }
         bloomFilterBuilder.addLong(value);
     }
 
-    private void addIntegerStatistics(long valueCount, IntegerStatistics value)
+    private void addTimestampStatistics(long valueCount, TimestampStatistics value)
     {
         requireNonNull(value, "value is null");
         requireNonNull(value.getMin(), "value.getMin() is null");
@@ -63,62 +51,47 @@ public class IntegerStatisticsBuilder
         nonNullValueCount += valueCount;
         minimum = Math.min(value.getMin(), minimum);
         maximum = Math.max(value.getMax(), maximum);
-
-        if (value.getSum() == null) {
-            // if input value does not have a sum tag this stat as overflowed
-            // to prevent creation of the sum stats (since it was not provided
-            // for these values).
-            overflow = true;
-        }
-        else if (!overflow) {
-            try {
-                sum = addExact(sum, value.getSum());
-            }
-            catch (ArithmeticException e) {
-                overflow = true;
-            }
-        }
     }
 
-    private Optional<IntegerStatistics> buildIntegerStatistics()
+    private Optional<TimestampStatistics> buildTimestampStatistics()
     {
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
-        return Optional.of(new IntegerStatistics(minimum, maximum, overflow ? null : sum));
+        return Optional.of(new TimestampStatistics(minimum, maximum));
     }
 
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
-        Optional<IntegerStatistics> integerStatistics = buildIntegerStatistics();
+        Optional<TimestampStatistics> timestampStatistics = buildTimestampStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
-                integerStatistics.map(s -> INTEGER_VALUE_BYTES).orElse(0L),
-                null,
-                integerStatistics.orElse(null),
+                timestampStatistics.map(s -> TIMESTAMP_VALUE_BYTES).orElse(0L),
                 null,
                 null,
                 null,
                 null,
+                null,
+                timestampStatistics.orElse(null),
                 null,
                 null,
                 bloomFilterBuilder.buildBloomFilter());
     }
 
-    public static Optional<IntegerStatistics> mergeIntegerStatistics(List<ColumnStatistics> stats)
+    public static Optional<TimestampStatistics> mergeTimestampStatistics(List<ColumnStatistics> stats)
     {
-        IntegerStatisticsBuilder integerStatisticsBuilder = new IntegerStatisticsBuilder(new NoOpBloomFilterBuilder());
+        TimestampStatisticsBuilder timestampStatisticsBuilder = new TimestampStatisticsBuilder(new NoOpBloomFilterBuilder());
         for (ColumnStatistics columnStatistics : stats) {
-            IntegerStatistics partialStatistics = columnStatistics.getIntegerStatistics();
+            TimestampStatistics partialStatistics = columnStatistics.getTimestampStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
                 if (partialStatistics == null) {
-                    // there are non null values but no statistics, so we cannot say anything about the data
+                    // there are non null values but no statistics, so we can not say anything about the data
                     return Optional.empty();
                 }
-                integerStatisticsBuilder.addIntegerStatistics(columnStatistics.getNumberOfValues(), partialStatistics);
+                timestampStatisticsBuilder.addTimestampStatistics(columnStatistics.getNumberOfValues(), partialStatistics);
             }
         }
-        return integerStatisticsBuilder.buildIntegerStatistics();
+        return timestampStatisticsBuilder.buildTimestampStatistics();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ByteColumnWriter.java
@@ -113,7 +113,7 @@ public class ByteColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(columnId, statistics);

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ColumnWriters.java
@@ -25,6 +25,7 @@ import io.prestosql.orc.metadata.statistics.DateStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.DoubleStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.IntegerStatisticsBuilder;
 import io.prestosql.orc.metadata.statistics.StringStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.prestosql.spi.type.Type;
 
 import java.util.function.Supplier;
@@ -72,7 +73,7 @@ public final class ColumnWriters
                 return new DecimalColumnWriter(columnId, type, compression, bufferSize);
 
             case TIMESTAMP:
-                return new TimestampColumnWriter(columnId, type, compression, bufferSize);
+                return new TimestampColumnWriter(columnId, type, compression, bufferSize, () -> new TimestampStatisticsBuilder(bloomFilterBuilder.get()));
 
             case BINARY:
                 return new SliceDirectColumnWriter(columnId, type, compression, bufferSize, BinaryStatisticsBuilder::new);

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/StructColumnWriter.java
@@ -135,7 +135,7 @@ public class StructColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -26,6 +26,8 @@ import io.prestosql.orc.metadata.RowGroupIndex;
 import io.prestosql.orc.metadata.Stream;
 import io.prestosql.orc.metadata.Stream.StreamKind;
 import io.prestosql.orc.metadata.statistics.ColumnStatistics;
+import io.prestosql.orc.metadata.statistics.LongValueStatisticsBuilder;
+import io.prestosql.orc.metadata.statistics.TimestampStatisticsBuilder;
 import io.prestosql.orc.stream.LongOutputStream;
 import io.prestosql.orc.stream.LongOutputStreamV2;
 import io.prestosql.orc.stream.PresentOutputStream;
@@ -40,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -68,11 +71,12 @@ public class TimestampColumnWriter
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private final long baseTimestampInSeconds;
 
-    private int nonNullValueCount;
+    private final Supplier<TimestampStatisticsBuilder> statisticsBuilderSupplier;
+    private LongValueStatisticsBuilder statisticsBuilder;
 
     private boolean closed;
 
-    public TimestampColumnWriter(OrcColumnId columnId, Type type, CompressionKind compression, int bufferSize)
+    public TimestampColumnWriter(OrcColumnId columnId, Type type, CompressionKind compression, int bufferSize, Supplier<TimestampStatisticsBuilder> statisticsBuilderSupplier)
     {
         this.columnId = requireNonNull(columnId, "columnId is null");
         this.type = requireNonNull(type, "type is null");
@@ -82,6 +86,8 @@ public class TimestampColumnWriter
         this.nanosStream = new LongOutputStreamV2(compression, bufferSize, false, SECONDARY);
         this.presentStream = new PresentOutputStream(compression, bufferSize);
         this.baseTimestampInSeconds = OffsetDateTime.of(2015, 1, 1, 0, 0, 0, 0, UTC).toEpochSecond();
+        this.statisticsBuilderSupplier = requireNonNull(statisticsBuilderSupplier, "statisticsBuilderSupplier is null");
+        this.statisticsBuilder = statisticsBuilderSupplier.get();
     }
 
     @Override
@@ -141,7 +147,7 @@ public class TimestampColumnWriter
 
                 secondsStream.writeLong(seconds);
                 nanosStream.writeLong(encodedNanos);
-                nonNullValueCount++;
+                statisticsBuilder.addValue(value);
             }
         }
     }
@@ -150,9 +156,9 @@ public class TimestampColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
-        nonNullValueCount = 0;
+        statisticsBuilder = statisticsBuilderSupplier.get();
         return ImmutableMap.of(columnId, statistics);
     }
 
@@ -253,6 +259,6 @@ public class TimestampColumnWriter
         nanosStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
-        nonNullValueCount = 0;
+        statisticsBuilder = statisticsBuilderSupplier.get();
     }
 }

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -150,7 +150,7 @@ public class TimestampColumnWriter
     public Map<OrcColumnId, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(columnId, statistics);

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -238,7 +238,7 @@ public class TimestampColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = secondsStream.getRetainedBytes() + nanosStream.getRetainedBytes() + presentStream.getRetainedBytes();
+        long retainedBytes = INSTANCE_SIZE + secondsStream.getRetainedBytes() + nanosStream.getRetainedBytes() + presentStream.getRetainedBytes();
         for (ColumnStatistics statistics : rowGroupColumnStatistics) {
             retainedBytes += statistics.getRetainedSizeInBytes();
         }

--- a/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
@@ -267,6 +267,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 new Utf8BloomFilterBuilder(1000, 0.01)
                         .addLong(1234L)
                         .buildBloomFilter())));
@@ -281,6 +282,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 new Utf8BloomFilterBuilder(1000, 0.01)
                         .buildBloomFilter())));
 
@@ -289,6 +291,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
 {
     public enum StatisticsType
     {
-        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL
+        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL, TIMESTAMP
     }
 
     private final StatisticsType statisticsType;
@@ -171,7 +171,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -301,6 +301,7 @@ public class TestStringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatistics.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatistics.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.metadata.statistics;
+
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+
+public class TestTimestampStatistics
+        extends AbstractRangeStatisticsTest<TimestampStatistics, Long>
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampStatistics.class).instanceSize();
+
+    @Override
+    protected TimestampStatistics getCreateStatistics(Long min, Long max)
+    {
+        return new TimestampStatistics(min, max);
+    }
+
+    @Test
+    public void test()
+    {
+        assertMinMax(0L, 42L);
+        assertMinMax(42L, 42L);
+        assertMinMax(MIN_VALUE, 42L);
+        assertMinMax(42L, MAX_VALUE);
+        assertMinMax(MIN_VALUE, MAX_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(0L, 42L, INSTANCE_SIZE);
+        assertRetainedSize(42L, 42L, INSTANCE_SIZE);
+        assertRetainedSize(Long.MIN_VALUE, 42L, INSTANCE_SIZE);
+        assertRetainedSize(42L, Long.MAX_VALUE, INSTANCE_SIZE);
+        assertRetainedSize(Long.MIN_VALUE, Long.MAX_VALUE, INSTANCE_SIZE);
+    }
+}

--- a/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.metadata.statistics;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import org.testng.annotations.Test;
+
+import static io.prestosql.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.TIMESTAMP;
+import static io.prestosql.orc.metadata.statistics.TimestampStatistics.TIMESTAMP_VALUE_BYTES;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestampStatisticsBuilder
+        extends AbstractStatisticsBuilderTest<TimestampStatisticsBuilder, Long>
+{
+    public TestTimestampStatisticsBuilder()
+    {
+        super(TIMESTAMP, () -> new TimestampStatisticsBuilder(new NoOpBloomFilterBuilder()), TimestampStatisticsBuilder::addValue);
+    }
+
+    @Test
+    public void testMinMaxValues()
+    {
+        assertMinMaxValues(0L, 0L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, MIN_VALUE);
+        assertMinMaxValues(MAX_VALUE, MAX_VALUE);
+
+        assertMinMaxValues(0L, 42L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, 42L);
+        assertMinMaxValues(42L, MAX_VALUE);
+        assertMinMaxValues(MIN_VALUE, MAX_VALUE);
+
+        assertValues(-42L, 0L, ContiguousSet.create(Range.closed(-42L, 0L), DiscreteDomain.longs()).asList());
+        assertValues(-42L, 42L, ContiguousSet.create(Range.closed(-42L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(0L, 42L, ContiguousSet.create(Range.closed(0L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(MIN_VALUE, MIN_VALUE + 42, ContiguousSet.create(Range.closed(MIN_VALUE, MIN_VALUE + 42), DiscreteDomain.longs()).asList());
+        assertValues(MAX_VALUE - 42L, MAX_VALUE, ContiguousSet.create(Range.closed(MAX_VALUE - 42L, MAX_VALUE), DiscreteDomain.longs()).asList());
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(42L));
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(0L));
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(0L, 42L, 42L, 43L));
+    }
+
+    @Test
+    public void testBloomFilter()
+    {
+        TimestampStatisticsBuilder statisticsBuilder = new TimestampStatisticsBuilder(new Utf8BloomFilterBuilder(3, 0.01));
+        statisticsBuilder.addValue(314L);
+        statisticsBuilder.addValue(1011L);
+        statisticsBuilder.addValue(4242L);
+        BloomFilter bloomFilter = statisticsBuilder.buildColumnStatistics().getBloomFilter();
+        assertNotNull(bloomFilter);
+        assertTrue(bloomFilter.testLong(314L));
+        assertTrue(bloomFilter.testLong(1011L));
+        assertTrue(bloomFilter.testLong(4242L));
+        assertFalse(bloomFilter.testLong(100L));
+    }
+}


### PR DESCRIPTION
This patch enables us to skip certain stripes and row groups in ORC file based on timestamp statistics.