### PR TITLE
Fix encoded url parameter of url_extract_parameter

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestUrlFunctions.java
@@ -46,6 +46,7 @@ public class TestUrlFunctions
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k1=v2&k1&k1#Ref1', 'k1')", createVarcharType(53), "v1");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1&k1=v1&k1&k1#Ref1', 'k1')", createVarcharType(50), "");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", createVarcharType(47), "a=b=c");
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=a%26k2%3Db&k2=c#Ref1', 'k2')", createVarcharType(54), "c");
         assertFunction("url_extract_parameter('foo', 'k1')", createVarcharType(3), null);
     }
 


### PR DESCRIPTION
Fix https://github.com/prestodb/presto/issues/11203

[URI.getQuery](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#getQuery--) returns decoded query parameter. It leads to wrong result if the parameter contains %26(&) and %3D(=).

Also, url_extract_query function uses the getQuery method.
```
presto> SELECT url_extract_query('http://example.com/path1/p.php?k1=a%26k2%3Db&k2=c#Ref1');
     _col0      
----------------
 k1=a&k2=b&k2=c 

```