### PR TITLE
Correctly export JMX mbeans in DbResourceGroupsConfigurationManager

### DIFF
--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -16,10 +16,12 @@ package io.prestosql.plugin.resourcegroups.db;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.prestosql.plugin.base.jmx.MBeanServerModule;
 import io.prestosql.spi.memory.ClusterMemoryPoolManager;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManager;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManagerContext;
 import io.prestosql.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
+import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -39,6 +41,8 @@ public class DbResourceGroupConfigurationManagerFactory
     {
         try {
             Bootstrap app = new Bootstrap(
+                    new MBeanModule(),
+                    new MBeanServerModule(),
                     new JsonModule(),
                     new DbResourceGroupsModule(),
                     new PrefixObjectNameGeneratorModule(),


### PR DESCRIPTION
`DbResoruceGroupConfigurationManager` has a `refreshFailures` counter, but it does not get emitted since `MBeanModule` and `MBeanServerModule` are not initialized.  