### PR TITLE
Add readOnly access level to file-based system access control

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -93,16 +93,23 @@ following fields:
 
 * ``user`` (optional): regex to match against user name. Defaults to ``.*``.
 * ``catalog`` (optional): regex to match against catalog name. Defaults to ``.*``.
-* ``allow`` (required): boolean indicating whether a user has access to the catalog
+* ``allow`` (required): string indicating whether a user has access to the catalog.
+  This value can be ``all``, ``read-only`` or ``none``, and defaults to ``none``.
+  Setting this value to ``read-only`` has the same behavior as the ``read-only``
+  system access control plugin.
 
 .. note::
 
     By default, all users have access to the ``system`` catalog. You can
     override this behavior by adding a rule.
 
+    Boolean ``true`` and ``false`` are also supported as legacy values for ``allow``,
+    to support backwards compatibility.  ``true`` maps to ``all``, and ``false`` maps to ``none``.
+
 For example, if you want to allow only the user ``admin`` to access the
 ``mysql`` and the ``system`` catalog, allow all users to access the ``hive``
-catalog, and deny all other access, you can use the following rules:
+catalog, allow the user ``alice`` read-only access to the ``postgresql`` catalog,
+and deny all other access, you can use the following rules:
 
 .. code-block:: json
 
@@ -111,15 +118,20 @@ catalog, and deny all other access, you can use the following rules:
         {
           "user": "admin",
           "catalog": "(mysql|system)",
-          "allow": true
+          "allow": "all"
         },
         {
           "catalog": "hive",
-          "allow": true
+          "allow": "all"
+        },
+        {
+          "user": "alice",
+          "catalog": "postgresql",
+          "allow": "read-only"
         },
         {
           "catalog": "system",
-          "allow": false
+          "allow": "none"
         }
       ]
     }

--- a/presto-main/src/test/resources/catalog_allow_unset.json
+++ b/presto-main/src/test/resources/catalog_allow_unset.json
@@ -1,0 +1,7 @@
+{
+  "catalogs": [
+    {
+      "catalog": "allowed-absent"
+    }
+  ]
+}

--- a/presto-main/src/test/resources/catalog_invalid_allow_value.json
+++ b/presto-main/src/test/resources/catalog_invalid_allow_value.json
@@ -1,0 +1,8 @@
+{
+  "catalogs": [
+    {
+      "catalog": "invalid-allow-value",
+      "allow": "not-a-valid-value"
+    }
+  ]
+}

--- a/presto-main/src/test/resources/catalog_read_only.json
+++ b/presto-main/src/test/resources/catalog_read_only.json
@@ -3,35 +3,35 @@
     {
       "user": "admin",
       "catalog": ".*",
-      "allow": true
+      "allow": "read-only"
     },
     {
       "catalog": "secret",
-      "allow": false
+      "allow": "none"
     },
     {
       "user": ".*",
       "catalog": "open-to-all",
-      "allow": true
+      "allow": "read-only"
     },
     {
       "catalog": "all-allowed",
-      "allow": true
+      "allow": "read-only"
     },
     {
       "user": "alice",
       "catalog": "alice-catalog",
-      "allow": true
+      "allow": "read-only"
     },
     {
       "user": "bob",
       "catalog": "alice-catalog",
-      "allow": false
+      "allow": "none"
     },
     {
       "user": "\u0194\u0194\u0194",
       "catalog": "\u0200\u0200\u0200",
-      "allow": true
+      "allow": "read-only"
     }
   ]
 }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/CatalogAccessControlRule.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/CatalogAccessControlRule.java
@@ -15,7 +15,12 @@ package io.prestosql.plugin.base.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -23,27 +28,77 @@ import static java.util.Objects.requireNonNull;
 
 public class CatalogAccessControlRule
 {
-    private final boolean allow;
+    private final AccessMode accessMode;
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> catalogRegex;
 
     @JsonCreator
     public CatalogAccessControlRule(
-            @JsonProperty("allow") boolean allow,
+            @JsonProperty("allow") AccessMode accessMode,
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("catalog") Optional<Pattern> catalogRegex)
     {
-        this.allow = allow;
+        this.accessMode = requireNonNull(accessMode, "accessMode is null");
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
     }
 
-    public Optional<Boolean> match(String user, String catalog)
+    public Optional<AccessMode> match(String user, String catalog)
     {
         if (userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 catalogRegex.map(regex -> regex.matcher(catalog).matches()).orElse(true)) {
-            return Optional.of(allow);
+            return Optional.of(accessMode);
         }
         return Optional.empty();
+    }
+
+    public enum AccessMode
+    {
+        ALL("all"),
+        READ_ONLY("read-only"),
+        NONE("none");
+
+        private static final Map<String, AccessMode> modeByName = Maps.uniqueIndex(ImmutableList.copyOf(AccessMode.values()), AccessMode::toString);
+
+        private final String stringValue;
+
+        AccessMode(String stringValue)
+        {
+            this.stringValue = requireNonNull(stringValue, "stringValue is null");
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return stringValue;
+        }
+
+        @JsonCreator
+        public static AccessMode fromJson(Object value)
+        {
+            if (Boolean.TRUE.equals(value)) {
+                return ALL;
+            }
+            if (Boolean.FALSE.equals(value)) {
+                return NONE;
+            }
+            if (value instanceof String) {
+                AccessMode accessMode = modeByName.get(((String) value).toLowerCase(Locale.US));
+                if (accessMode != null) {
+                    return accessMode;
+                }
+            }
+
+            throw new IllegalArgumentException("Unknown " + AccessMode.class.getSimpleName() + ": " + value);
+        }
+
+        boolean implies(AccessMode other)
+        {
+            if (this == ALL && other == READ_ONLY) {
+                return true;
+            }
+            return this == other;
+        }
     }
 }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
@@ -49,16 +49,19 @@ import static io.prestosql.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.prestosql.spi.security.AccessDeniedException.denyAddColumn;
 import static io.prestosql.spi.security.AccessDeniedException.denyCatalogAccess;
 import static io.prestosql.spi.security.AccessDeniedException.denyCommentTable;
+import static io.prestosql.spi.security.AccessDeniedException.denyCreateSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyCreateTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyCreateView;
 import static io.prestosql.spi.security.AccessDeniedException.denyCreateViewWithSelect;
 import static io.prestosql.spi.security.AccessDeniedException.denyDeleteTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyDropColumn;
+import static io.prestosql.spi.security.AccessDeniedException.denyDropSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyDropTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyDropView;
 import static io.prestosql.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static io.prestosql.spi.security.AccessDeniedException.denyInsertTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyRenameColumn;
+import static io.prestosql.spi.security.AccessDeniedException.denyRenameSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyRenameTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static io.prestosql.spi.security.AccessDeniedException.denySetUser;
@@ -214,16 +217,25 @@ public class FileBasedSystemAccessControl
     @Override
     public void checkCanCreateSchema(SystemSecurityContext context, CatalogSchemaName schema)
     {
+        if (!canAccessCatalog(context.getIdentity(), schema.getCatalogName(), ALL)) {
+            denyCreateSchema(schema.toString());
+        }
     }
 
     @Override
     public void checkCanDropSchema(SystemSecurityContext context, CatalogSchemaName schema)
     {
+        if (!canAccessCatalog(context.getIdentity(), schema.getCatalogName(), ALL)) {
+            denyDropSchema(schema.toString());
+        }
     }
 
     @Override
     public void checkCanRenameSchema(SystemSecurityContext context, CatalogSchemaName schema, String newSchemaName)
     {
+        if (!canAccessCatalog(context.getIdentity(), schema.getCatalogName(), ALL)) {
+            denyRenameSchema(schema.toString(), newSchemaName);
+        }
     }
 
     @Override

--- a/presto-plugin-toolkit/src/test/resources/catalog.json
+++ b/presto-plugin-toolkit/src/test/resources/catalog.json
@@ -29,9 +29,6 @@
       "allow": false
     },
     {
-      "catalog": "allowed-absent"
-    },
-    {
       "user": "\u0194\u0194\u0194",
       "catalog": "\u0200\u0200\u0200",
       "allow": true


### PR DESCRIPTION
* add a `read-only` field to the file-based system access control mechanism
* optional, defaults to `false` if not specified
* first rule which has `read-only` field explicitly set will be honored, from top to bottom

https://prestosql.io/docs/current/security/built-in-system-access-control.html
