### PR TITLE
Ensure to use HTTP 1.1 for presto-cli and presto-jdbc

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.client.ClientSession.stripTransactionId;
 import static io.prestosql.client.OkHttpUtil.basicAuth;
 import static io.prestosql.client.OkHttpUtil.setupCookieJar;
+import static io.prestosql.client.OkHttpUtil.setupHttp1;
 import static io.prestosql.client.OkHttpUtil.setupHttpProxy;
 import static io.prestosql.client.OkHttpUtil.setupKerberos;
 import static io.prestosql.client.OkHttpUtil.setupSocksProxy;
@@ -80,6 +81,7 @@ public class QueryRunner
         setupCookieJar(builder);
         setupSocksProxy(builder, socksProxy);
         setupHttpProxy(builder, httpProxy);
+        setupHttp1(builder);
         setupBasicAuth(builder, session, user, password);
         setupTokenAuth(builder, session, accessToken);
 

--- a/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
@@ -20,6 +20,7 @@ import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -118,6 +119,13 @@ public final class OkHttpUtil
         proxy.map(OkHttpUtil::toUnresolvedAddress)
                 .map(address -> new Proxy(type, address))
                 .ifPresent(clientBuilder::proxy);
+    }
+
+    public static void setupHttp1(OkHttpClient.Builder clientBuilder)
+    {
+        // TODO: https://github.com/prestosql/presto/issues/1169
+        // Need to make sure to use Http 1.1 due to the waiting connection issue of HTTP 2
+        clientBuilder.protocols(Arrays.asList(Protocol.HTTP_1_1));
     }
 
     private static InetSocketAddress toUnresolvedAddress(HostAndPort address)

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.prestosql.client.KerberosUtil.defaultCredentialCachePath;
 import static io.prestosql.client.OkHttpUtil.basicAuth;
 import static io.prestosql.client.OkHttpUtil.setupCookieJar;
+import static io.prestosql.client.OkHttpUtil.setupHttp1;
 import static io.prestosql.client.OkHttpUtil.setupHttpProxy;
 import static io.prestosql.client.OkHttpUtil.setupKerberos;
 import static io.prestosql.client.OkHttpUtil.setupSocksProxy;
@@ -153,6 +154,7 @@ final class PrestoDriverUri
             setupCookieJar(builder);
             setupSocksProxy(builder, SOCKS_PROXY.getValue(properties));
             setupHttpProxy(builder, HTTP_PROXY.getValue(properties));
+            setupHttp1(builder);
 
             // TODO: fix Tempto to allow empty passwords
             String password = PASSWORD.getValue(properties).orElse("");


### PR DESCRIPTION
# Problem
We have found the waiting `Http2Connection` can block the program execution in presto-cli and presto-jdbc. It happens when HTTP 2 is used to communicate between the presto server and client. Although we still need a further investigation to support HTTP 2 by presto, ensuring HTTP 1.1 can be a good intermediate solution for the problem.

# Overview

- [x] : Ensure to use HTTP 1.1 by presto-cli
- [x] : Ensure to use HTTP 1.1 by presto-jdbc

See also : https://github.com/prestosql/presto/issues/1169