### PR TITLE
Remove "tpcds:" prefix from TpcdsTableHandle.toString

### DIFF
--- a/presto-tpcds/src/main/java/io/prestosql/plugin/tpcds/TpcdsTableHandle.java
+++ b/presto-tpcds/src/main/java/io/prestosql/plugin/tpcds/TpcdsTableHandle.java
@@ -51,7 +51,7 @@ public class TpcdsTableHandle
     @Override
     public String toString()
     {
-        return "tpcds:" + tableName + ":sf" + scaleFactor;
+        return tableName + ":sf" + scaleFactor;
     }
 
     @Override


### PR DESCRIPTION
Same as `TpchTableHandle`: https://github.com/prestodb/presto/commit/fa5cf889d177c99202dceea2f59041287fe13a30