### PR TITLE
Prepend jdbc: to DatabaseMetaData.getURL result

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDatabaseMetaData.java
@@ -58,7 +58,7 @@ public class PrestoDatabaseMetaData
     public String getURL()
             throws SQLException
     {
-        return connection.getURI().toString();
+        return "jdbc:" + connection.getURI().toString();
     }
 
     @Override

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDatabaseMetaData.java
@@ -130,6 +130,14 @@ public class TestPrestoDatabaseMetaData
         }
     }
 
+    @Test
+    public void testGetUrl()
+            throws Exception
+    {
+        DatabaseMetaData metaData = connection.getMetaData();
+        assertEquals(metaData.getURL(), "jdbc:presto://" + server.getAddress());
+    }
+
     private static void assertColumnSpec(ResultSet rs, int dataType, Long precision, Long numPrecRadix, String typeName)
             throws SQLException
     {


### PR DESCRIPTION
Current `DatabaseMetaData.getURL` implementation returns without `jdbc:`, but it should be included it as other databases do it. 

Related post on Stackoverflow: https://stackoverflow.com/questions/56488588/url-must-start-with-jdbc-error-while-connecting-to-presto-using-spring-boot