### PR TITLE
Remove catalogName from TableHandle toString

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
@@ -78,7 +78,7 @@ public class InformationSchemaTableHandle
     @Override
     public String toString()
     {
-        return catalogName + ":" + schemaName + ":" + tableName;
+        return schemaName + ":" + tableName;
     }
 
     @Override

--- a/presto-tpcds/src/main/java/io/prestosql/plugin/tpcds/TpcdsTableHandle.java
+++ b/presto-tpcds/src/main/java/io/prestosql/plugin/tpcds/TpcdsTableHandle.java
@@ -51,7 +51,7 @@ public class TpcdsTableHandle
     @Override
     public String toString()
     {
-        return "tpcds:" + tableName + ":sf" + scaleFactor;
+        return tableName + ":sf" + scaleFactor;
     }
 
     @Override


### PR DESCRIPTION
In EXPLAIN, ScanProject.table is always prefixed with catalogName