### PR TITLE
Add support for "Asia/Qostanay" IANA time zone.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>
-        <dep.joda.version>2.10</dep.joda.version>
+        <dep.joda.version>2.10.3</dep.joda.version>
         <dep.tempto.version>165</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-spi/src/main/resources/io/prestosql/spi/type/zone-index.properties
+++ b/presto-spi/src/main/resources/io/prestosql/spi/type/zone-index.properties
@@ -2235,3 +2235,4 @@
 2226 Asia/Atyrau
 2227 Asia/Famagusta
 2228 Europe/Saratov
+2229 Asia/Qostanay

--- a/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
@@ -213,7 +213,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -4582158485614614451L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -972834036790299986L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
## Problem statement
Getting this error when running tests:

```
io.prestosql.spi.type.TimeZoneNotSupportedException: Time zone not supported: Asia/Qostanay
    at io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey(TimeZoneKey.java:132)
    at io.prestosql.util.TestTimeZoneUtils.test(TestTimeZoneUtils.java:70)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
    at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
    at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
    at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
    at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

```
$ java -version
java version "1.8.0_221"
Java(TM) SE Runtime Environment (build 1.8.0_221-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.221-b11, mixed mode)
```

## Root cause

Timezone **Asia/Qostanay** was introduced in JRE Update Releases 12.0.2, 11.0.4, 8u221 and 7u231 with Timezone Tzdata version tzdata2018h.

- https://www.oracle.com/technetwork/java/javase/tzdata-versions-138805.html
- http://mm.icann.org/pipermail/tz-announce/2018-December/000053.html