### PR TITLE
Do not rely on jdk based zone info provider in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,12 +604,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>joda-to-java-time-bridge</artifactId>
-                <version>3</version>
-            </dependency>
-
-            <dependency>
                 <groupId>io.airlift.drift</groupId>
                 <artifactId>drift-api</artifactId>
                 <version>${dep.drift.version}</version>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -242,12 +242,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -84,12 +84,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -85,12 +85,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -141,12 +141,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
         </dependency>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -94,12 +94,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -61,12 +61,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -187,11 +187,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.teradata</groupId>
             <artifactId>re2j-td</artifactId>
         </dependency>
@@ -395,11 +390,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <org.joda.time.DateTimeZone.Provider>io.airlift.jodabridge.JdkBasedZoneInfoProvider</org.joda.time.DateTimeZone.Provider>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
@@ -13,11 +13,9 @@
  */
 package io.prestosql.util;
 
-import io.airlift.jodabridge.JdkBasedZoneInfoProvider;
 import io.prestosql.spi.type.TimeZoneKey;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.time.ZoneId;
@@ -32,17 +30,6 @@ import static org.testng.Assert.assertEquals;
 
 public class TestTimeZoneUtils
 {
-    @BeforeClass
-    protected void validateJodaZoneInfoProvider()
-    {
-        try {
-            JdkBasedZoneInfoProvider.registerAsJodaZoneInfoProvider();
-        }
-        catch (RuntimeException e) {
-            throw new RuntimeException("Set the following system property to JVM running the test: -Dorg.joda.time.DateTimeZone.Provider=io.airlift.jodabridge.JdkBasedZoneInfoProvider");
-        }
-    }
-
     @Test
     public void test()
     {
@@ -50,8 +37,6 @@ public class TestTimeZoneUtils
 
         TreeSet<String> jodaZones = new TreeSet<>(DateTimeZone.getAvailableIDs());
         TreeSet<String> jdkZones = new TreeSet<>(ZoneId.getAvailableZoneIds());
-        // We use JdkBasedZoneInfoProvider for joda
-        assertEquals(jodaZones, jdkZones);
 
         for (String zoneId : new TreeSet<>(jdkZones)) {
             if (zoneId.startsWith("Etc/") || zoneId.startsWith("GMT") || zoneId.startsWith("SystemV/")) {

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -67,12 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-raptor-legacy/pom.xml
+++ b/presto-raptor-legacy/pom.xml
@@ -103,12 +103,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -33,12 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.8.1</version>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -74,12 +74,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -32,12 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -32,12 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>


### PR DESCRIPTION
- joda-to-java-time-bridge was added in https://github.com/prestosql/presto/commit/8ac4b8466a7db96d9941e27cecf7aaf64c85bfaf
- it was later removed in 6af161535aa6b7888d9e37e3cca8ad3c04dc22d5, but not completely. It is still registered for the tests

Some comments on Slack from @dain and @electrum:

> The bridge doesn’t work.  Turns out joda has a number of unspecified behaviors that break things unexpectedly
>
> It could be made to work but someone needs to dig into the code and figure out the undocumented behaviors
>
> My gut says to remove it unless someone wants to dig into making it work correctly
>
> We had hopes of fixing it soon after it was added but that never happened. Normally we wouldn’t keep such dead code around.

This PR removes the bridge completely. It will also be needed for https://github.com/prestosql/presto/pull/1221 