### PR TITLE
Upgrading aws-sdk version to current (1.11.602)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dep.airlift.version>0.183</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.36</dep.slice.version>
-        <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.11.602</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
We noticed elevated 5xx errors for `List.Objects.v1`, this PR is for switching to `List.Objects.v2`.

From AWS-support:
-------------------
`List.Objects.v2 is a revised API to list objects. It improves the performance and has better handling on large object list and version bucket. It is recommended to use when you need to call ListObject API. The current version of AWS JAVA SDK is 1.11.602. Your SDK version 1.11.445 is released on Nov 8, 2018. There are many bug fixes and improvement since this version. I recommend you to update your SDK to the latest version and use ListObjectV2 to try the request again.`
