### PR TITLE
Fix typo in the ConnectorSplitManager section title

### DIFF
--- a/presto-docs/src/main/sphinx/develop/connectors.rst
+++ b/presto-docs/src/main/sphinx/develop/connectors.rst
@@ -39,7 +39,7 @@ connector does), you may need to get creative about how you map your
 data source to Presto's schema, table, and column concepts.
 
 ConnectorSplitManager
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 The split manager partitions the data for a table into the individual
 chunks that Presto will distribute to workers for processing.

--- a/presto-docs/src/main/sphinx/develop/connectors.rst
+++ b/presto-docs/src/main/sphinx/develop/connectors.rst
@@ -38,7 +38,7 @@ to adapt something that is not a relational database (as the Example HTTP
 connector does), you may need to get creative about how you map your
 data source to Presto's schema, table, and column concepts.
 
-ConnectorSplitManger
+ConnectorSplitManager
 ^^^^^^^^^^^^^^^^^^^^
 
 The split manager partitions the data for a table into the individual


### PR DESCRIPTION
Typo in the title of the ConnectorSplitManger section, it was Manger one `a` was missing.