### PR TITLE
Minor fixes around aggregation execution

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -43,7 +43,7 @@ import static io.prestosql.operator.annotations.FunctionsParserHelper.parseDescr
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class AggregationFromAnnotationsParser
+public final class AggregationFromAnnotationsParser
 {
     private AggregationFromAnnotationsParser()
     {
@@ -172,7 +172,7 @@ public class AggregationFromAnnotationsParser
         }
     }
 
-    public static Method getCombineFunction(Class<?> clazz, Class<?> stateClass)
+    private static Method getCombineFunction(Class<?> clazz, Class<?> stateClass)
     {
         // Only include methods that match this state class
         List<Method> combineFunctions = FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(clazz, CombineFunction.class).stream()

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/GenericAccumulatorFactory.java
@@ -80,8 +80,8 @@ public class GenericAccumulatorFactory
             List<Integer> orderByChannels,
             List<SortOrder> orderings,
             PagesIndex.Factory pagesIndexFactory,
-            JoinCompiler joinCompiler,
-            Session session,
+            @Nullable JoinCompiler joinCompiler,
+            @Nullable Session session,
             boolean distinct)
     {
         this.stateDescriptors = requireNonNull(stateDescriptors, "stateDescriptors is null");


### PR DESCRIPTION
Minor fixes around aggregation execution

- Prefer Java Stream API over Guava Lists.transform
- Remove unused methods
- Annotate nullable parameters
- Limit access to methods
- Use for-each loop
- Remove unused return value
- Annotate class final
- Fix typo
