### PR TITLE
Port Join operator to WorkProcessor model 

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/FilterAndProjectOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/FilterAndProjectOperator.java
@@ -21,6 +21,7 @@ import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperator;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperatorFactory;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.operator.project.PageProcessor;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
@@ -142,12 +143,12 @@ public class FilterAndProjectOperator
         }
 
         @Override
-        public AdapterWorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal)
+        public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
         {
             return new FilterAndProjectOperator(
-                    session,
-                    memoryTrackingContext,
-                    yieldSignal,
+                    processorContext.getSession(),
+                    processorContext.getMemoryTrackingContext(),
+                    processorContext.getDriverYieldSignal(),
                     Optional.empty(),
                     processor.get(),
                     types,
@@ -174,12 +175,12 @@ public class FilterAndProjectOperator
         }
 
         @Override
-        public WorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Page> sourcePages)
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
         {
             return new FilterAndProjectOperator(
-                    session,
-                    memoryTrackingContext,
-                    yieldSignal,
+                    processorContext.getSession(),
+                    processorContext.getMemoryTrackingContext(),
+                    processorContext.getDriverYieldSignal(),
                     Optional.of(sourcePages),
                     processor.get(),
                     types,

--- a/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
@@ -15,7 +15,6 @@ package io.prestosql.operator;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.prestosql.Session;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.memory.context.MemoryTrackingContext;
@@ -23,6 +22,7 @@ import io.prestosql.operator.SetBuilderOperator.SetSupplier;
 import io.prestosql.operator.WorkProcessor.TransformationState;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperator;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperatorFactory;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
@@ -91,9 +91,9 @@ public class HashSemiJoinOperator
         }
 
         @Override
-        public AdapterWorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal)
+        public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
         {
-            return new HashSemiJoinOperator(Optional.empty(), setSupplier, probeJoinChannel, probeJoinHashChannel, memoryTrackingContext);
+            return new HashSemiJoinOperator(Optional.empty(), setSupplier, probeJoinChannel, probeJoinHashChannel, processorContext.getMemoryTrackingContext());
         }
 
         @Override
@@ -115,9 +115,9 @@ public class HashSemiJoinOperator
         }
 
         @Override
-        public WorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Page> sourcePages)
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
         {
-            return new HashSemiJoinOperator(Optional.of(sourcePages), setSupplier, probeJoinChannel, probeJoinHashChannel, memoryTrackingContext);
+            return new HashSemiJoinOperator(Optional.of(sourcePages), setSupplier, probeJoinChannel, probeJoinHashChannel, processorContext.getMemoryTrackingContext());
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperator.java
@@ -16,10 +16,15 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.operator.JoinProbe.JoinProbeFactory;
 import io.prestosql.operator.LookupJoinOperators.JoinType;
 import io.prestosql.operator.LookupSourceProvider.LookupSourceLease;
 import io.prestosql.operator.PartitionedConsumption.Partition;
+import io.prestosql.operator.WorkProcessor.Transformation;
+import io.prestosql.operator.WorkProcessor.TransformationState;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperator;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.operator.exchange.LocalPartitionGenerator;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
@@ -47,59 +52,25 @@ import static io.airlift.concurrent.MoreFutures.checkSuccess;
 import static io.airlift.concurrent.MoreFutures.getDone;
 import static io.prestosql.operator.LookupJoinOperators.JoinType.FULL_OUTER;
 import static io.prestosql.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
+import static io.prestosql.operator.Operator.NOT_BLOCKED;
+import static io.prestosql.operator.WorkProcessor.TransformationState.blocked;
+import static io.prestosql.operator.WorkProcessor.TransformationState.finished;
+import static io.prestosql.operator.WorkProcessor.TransformationState.needsMoreData;
+import static io.prestosql.operator.WorkProcessor.TransformationState.ofResult;
+import static io.prestosql.operator.WorkProcessor.TransformationState.yield;
 import static java.lang.String.format;
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
 public class LookupJoinOperator
-        implements Operator
+        implements AdapterWorkProcessorOperator
 {
-    private final OperatorContext operatorContext;
-    private final List<Type> probeTypes;
-    private final JoinProbeFactory joinProbeFactory;
-    private final Runnable afterClose;
-    private final OptionalInt lookupJoinsCount;
-    private final HashGenerator hashGenerator;
-    private final LookupSourceFactory lookupSourceFactory;
-    private final PartitioningSpillerFactory partitioningSpillerFactory;
-
+    private final PageBuffer pageBuffer = new PageBuffer();
+    private final WorkProcessor<Page> pages;
+    private final JoinProcessor joinProcessor;
     private final JoinStatisticsCounter statisticsCounter;
 
-    private final LookupJoinPageBuilder pageBuilder;
-
-    private final boolean probeOnOuterSide;
-
-    private final ListenableFuture<LookupSourceProvider> lookupSourceProviderFuture;
-    private LookupSourceProvider lookupSourceProvider;
-    private JoinProbe probe;
-
-    private Page outputPage;
-
-    private Optional<PartitioningSpiller> spiller = Optional.empty();
-    private Optional<LocalPartitionGenerator> partitionGenerator = Optional.empty();
-    private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
-    private long inputPageSpillEpoch;
-    private boolean closed;
-    private boolean finishing;
-    private boolean unspilling;
-    private boolean finished;
-    private long joinPosition = -1;
-    private int joinSourcePositions;
-
-    private boolean currentProbePositionProducedRow;
-
-    private final Map<Integer, SavedRow> savedRows = new HashMap<>();
-    @Nullable
-    private ListenableFuture<PartitionedConsumption<Supplier<LookupSource>>> partitionedConsumption;
-    @Nullable
-    private Iterator<Partition<Supplier<LookupSource>>> lookupPartitions;
-    private Optional<Partition<Supplier<LookupSource>>> currentPartition = Optional.empty();
-    private Optional<ListenableFuture<Supplier<LookupSource>>> unspilledLookupSource = Optional.empty();
-    private Iterator<Page> unspilledInputPages = emptyIterator();
-
-    public LookupJoinOperator(
-            OperatorContext operatorContext,
-            List<Type> probeTypes,
+    public LookupJoinOperator(List<Type> probeTypes,
             List<Type> buildOutputTypes,
             JoinType joinType,
             LookupSourceFactory lookupSourceFactory,
@@ -107,480 +78,650 @@ public class LookupJoinOperator
             Runnable afterClose,
             OptionalInt lookupJoinsCount,
             HashGenerator hashGenerator,
-            PartitioningSpillerFactory partitioningSpillerFactory)
+            PartitioningSpillerFactory partitioningSpillerFactory,
+            ProcessorContext processorContext,
+            Optional<WorkProcessor<Page>> sourcePages)
     {
-        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
-
-        requireNonNull(joinType, "joinType is null");
-        // Cannot use switch case here, because javac will synthesize an inner class and cause IllegalAccessError
-        probeOnOuterSide = joinType == PROBE_OUTER || joinType == FULL_OUTER;
-
-        this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
-        this.afterClose = requireNonNull(afterClose, "afterClose is null");
-        this.lookupJoinsCount = requireNonNull(lookupJoinsCount, "lookupJoinsCount is null");
-        this.hashGenerator = requireNonNull(hashGenerator, "hashGenerator is null");
-        this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
-        this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
-        this.lookupSourceProviderFuture = lookupSourceFactory.createLookupSourceProvider();
-
         this.statisticsCounter = new JoinStatisticsCounter(joinType);
-        operatorContext.setInfoSupplier(this.statisticsCounter);
-
-        this.pageBuilder = new LookupJoinPageBuilder(buildOutputTypes);
+        this.joinProcessor = new JoinProcessor(probeTypes,
+                buildOutputTypes,
+                joinType,
+                lookupSourceFactory,
+                joinProbeFactory,
+                afterClose,
+                lookupJoinsCount,
+                hashGenerator,
+                partitioningSpillerFactory,
+                statisticsCounter,
+                processorContext.getDriverYieldSignal(),
+                processorContext.getSpillContext(),
+                processorContext.getMemoryTrackingContext());
+        pages = sourcePages.orElse(pageBuffer.pages()).transform(joinProcessor);
     }
 
     @Override
-    public OperatorContext getOperatorContext()
+    public Optional<OperatorInfo> getOperatorInfo()
     {
-        return operatorContext;
-    }
-
-    @Override
-    public void finish()
-    {
-        if (finishing) {
-            return;
-        }
-
-        if (!spillInProgress.isDone()) {
-            return;
-        }
-
-        checkSuccess(spillInProgress, "spilling failed");
-        finishing = true;
-    }
-
-    @Override
-    public boolean isFinished()
-    {
-        boolean finished = this.finished && probe == null && pageBuilder.isEmpty() && outputPage == null;
-
-        // if finished drop references so memory is freed early
-        if (finished) {
-            close();
-        }
-        return finished;
-    }
-
-    @Override
-    public ListenableFuture<?> isBlocked()
-    {
-        if (!spillInProgress.isDone()) {
-            // Input spilling can happen only after lookupSourceProviderFuture was done.
-            return spillInProgress;
-        }
-        if (unspilledLookupSource.isPresent()) {
-            // Unspilling can happen only after lookupSourceProviderFuture was done.
-            return unspilledLookupSource.get();
-        }
-
-        if (finishing) {
-            return NOT_BLOCKED;
-        }
-
-        return lookupSourceProviderFuture;
+        return Optional.of(statisticsCounter.get());
     }
 
     @Override
     public boolean needsInput()
     {
-        return !finishing
-                && lookupSourceProviderFuture.isDone()
-                && spillInProgress.isDone()
-                && probe == null
-                && outputPage == null;
+        return joinProcessor.lookupSourceProviderFuture.isDone() && pageBuffer.isEmpty() && !pageBuffer.isFinished();
     }
 
     @Override
     public void addInput(Page page)
     {
-        requireNonNull(page, "page is null");
-        checkState(probe == null, "Current page has not been completely processed yet");
-
-        checkState(tryFetchLookupSourceProvider(), "Not ready to handle input yet");
-
-        SpillInfoSnapshot spillInfoSnapshot = lookupSourceProvider.withLease(SpillInfoSnapshot::from);
-        addInput(page, spillInfoSnapshot);
-    }
-
-    private void addInput(Page page, SpillInfoSnapshot spillInfoSnapshot)
-    {
-        requireNonNull(spillInfoSnapshot, "spillInfoSnapshot is null");
-
-        if (spillInfoSnapshot.hasSpilled()) {
-            page = spillAndMaskSpilledPositions(page, spillInfoSnapshot.getSpillMask());
-            if (page.getPositionCount() == 0) {
-                return;
-            }
-        }
-
-        // create probe
-        inputPageSpillEpoch = spillInfoSnapshot.getSpillEpoch();
-        probe = joinProbeFactory.createJoinProbe(page);
-
-        // initialize to invalid join position to force output code to advance the cursors
-        joinPosition = -1;
-    }
-
-    private boolean tryFetchLookupSourceProvider()
-    {
-        if (lookupSourceProvider == null) {
-            if (!lookupSourceProviderFuture.isDone()) {
-                return false;
-            }
-            lookupSourceProvider = requireNonNull(getDone(lookupSourceProviderFuture));
-            statisticsCounter.updateLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
-        }
-        return true;
-    }
-
-    private Page spillAndMaskSpilledPositions(Page page, IntPredicate spillMask)
-    {
-        checkState(spillInProgress.isDone(), "Previous spill still in progress");
-        checkSuccess(spillInProgress, "spilling failed");
-
-        if (!spiller.isPresent()) {
-            spiller = Optional.of(partitioningSpillerFactory.create(
-                    probeTypes,
-                    getPartitionGenerator(),
-                    operatorContext.getSpillContext().newLocalSpillContext(),
-                    operatorContext.newAggregateSystemMemoryContext()));
-        }
-
-        PartitioningSpillResult result = spiller.get().partitionAndSpill(page, spillMask);
-        spillInProgress = result.getSpillingFuture();
-        return result.getRetained();
-    }
-
-    public LocalPartitionGenerator getPartitionGenerator()
-    {
-        if (!partitionGenerator.isPresent()) {
-            partitionGenerator = Optional.of(new LocalPartitionGenerator(hashGenerator, lookupSourceFactory.partitions()));
-        }
-        return partitionGenerator.get();
+        pageBuffer.add(page);
     }
 
     @Override
-    public Page getOutput()
+    public void finish()
     {
-        // TODO introduce explicit state (enum), like in HBO
-
-        if (!spillInProgress.isDone()) {
-            /*
-             * We cannot produce output when there is some previous input spilling. This is because getOutput() may result in additional portion of input being spilled
-             * (when spilling state has changed in partitioned lookup source since last time) and spiller does not allow multiple concurrent spills.
-             */
-            return null;
-        }
-        checkSuccess(spillInProgress, "spilling failed");
-
-        if (probe == null && pageBuilder.isEmpty() && !finishing) {
-            return null;
-        }
-
-        if (!tryFetchLookupSourceProvider()) {
-            if (!finishing) {
-                return null;
-            }
-
-            verify(finishing);
-            // We are no longer interested in the build side (the lookupSourceProviderFuture's value).
-            addSuccessCallback(lookupSourceProviderFuture, LookupSourceProvider::close);
-            lookupSourceProvider = new StaticLookupSourceProvider(new EmptyLookupSource());
-        }
-
-        if (probe == null && finishing && !unspilling) {
-            /*
-             * We do not have input probe and we won't have any, as we're finishing.
-             * Let LookupSourceFactory know LookupSources can be disposed as far as we're concerned.
-             */
-            verify(partitionedConsumption == null, "partitioned consumption already started");
-            partitionedConsumption = lookupSourceFactory.finishProbeOperator(lookupJoinsCount);
-            unspilling = true;
-        }
-
-        if (probe == null && unspilling && !finished) {
-            /*
-             * If no current partition or it was exhausted, unspill next one.
-             * Add input there when it needs one, produce output. Be Happy.
-             */
-            tryUnspillNext();
-        }
-
-        if (probe != null) {
-            processProbe();
-        }
-
-        if (outputPage != null) {
-            verify(pageBuilder.isEmpty());
-            Page output = outputPage;
-            outputPage = null;
-            return output;
-        }
-
-        // It is impossible to have probe == null && !pageBuilder.isEmpty(),
-        // because we will flush a page whenever we reach the probe end
-        verify(probe != null || pageBuilder.isEmpty());
-        return null;
+        pageBuffer.finish();
     }
 
-    private void tryUnspillNext()
+    @Override
+    public WorkProcessor<Page> getOutputPages()
     {
-        verify(probe == null);
-
-        if (!partitionedConsumption.isDone()) {
-            return;
-        }
-
-        if (lookupPartitions == null) {
-            lookupPartitions = getDone(partitionedConsumption).beginConsumption();
-        }
-
-        if (unspilledInputPages.hasNext()) {
-            addInput(unspilledInputPages.next());
-            return;
-        }
-
-        if (unspilledLookupSource.isPresent()) {
-            if (!unspilledLookupSource.get().isDone()) {
-                // Not unspilled yet
-                return;
-            }
-            LookupSource lookupSource = getDone(unspilledLookupSource.get()).get();
-            unspilledLookupSource = Optional.empty();
-
-            // Close previous lookupSourceProvider (either supplied initially or for the previous partition)
-            lookupSourceProvider.close();
-            lookupSourceProvider = new StaticLookupSourceProvider(lookupSource);
-            // If the partition was spilled during processing, its position count will be considered twice.
-            statisticsCounter.updateLookupSourcePositions(lookupSource.getJoinPositionCount());
-
-            int partition = currentPartition.get().number();
-            unspilledInputPages = spiller.map(spiller -> spiller.getSpilledPages(partition))
-                    .orElse(emptyIterator());
-
-            Optional.ofNullable(savedRows.remove(partition)).ifPresent(savedRow -> {
-                restoreProbe(
-                        savedRow.row,
-                        savedRow.joinPositionWithinPartition,
-                        savedRow.currentProbePositionProducedRow,
-                        savedRow.joinSourcePositions,
-                        SpillInfoSnapshot.noSpill());
-            });
-
-            return;
-        }
-
-        if (lookupPartitions.hasNext()) {
-            currentPartition.ifPresent(Partition::release);
-            currentPartition = Optional.of(lookupPartitions.next());
-            unspilledLookupSource = Optional.of(currentPartition.get().load());
-
-            return;
-        }
-
-        currentPartition.ifPresent(Partition::release);
-        if (lookupSourceProvider != null) {
-            // There are no more partitions to process, so clean up everything
-            lookupSourceProvider.close();
-            lookupSourceProvider = null;
-        }
-        spiller.ifPresent(PartitioningSpiller::verifyAllPartitionsRead);
-        finished = true;
-    }
-
-    private void processProbe()
-    {
-        verifyNotNull(probe);
-
-        Optional<SpillInfoSnapshot> spillInfoSnapshotIfSpillChanged = lookupSourceProvider.withLease(lookupSourceLease -> {
-            if (lookupSourceLease.spillEpoch() == inputPageSpillEpoch) {
-                // Spill state didn't change, so process as usual.
-                processProbe(lookupSourceLease.getLookupSource());
-                return Optional.empty();
-            }
-
-            return Optional.of(SpillInfoSnapshot.from(lookupSourceLease));
-        });
-
-        if (!spillInfoSnapshotIfSpillChanged.isPresent()) {
-            return;
-        }
-        SpillInfoSnapshot spillInfoSnapshot = spillInfoSnapshotIfSpillChanged.get();
-        long joinPositionWithinPartition;
-        if (joinPosition >= 0) {
-            joinPositionWithinPartition = lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().joinPositionWithinPartition(joinPosition));
-        }
-        else {
-            joinPositionWithinPartition = -1;
-        }
-
-        /*
-         * Spill state changed. All probe rows that were not processed yet should be treated as regular input (and be partially spilled).
-         * If current row maps to the now-spilled partition, it needs to be saved for later. If it maps to a partition still in memory, it
-         * should be added together with not-yet-processed rows. In either case we need to resume processing the row starting at its
-         * current position in the lookup source.
-         */
-        verify(spillInfoSnapshot.hasSpilled());
-        verify(spillInfoSnapshot.getSpillEpoch() > inputPageSpillEpoch);
-
-        Page currentPage = probe.getPage();
-        int currentPosition = probe.getPosition();
-        long currentJoinPosition = this.joinPosition;
-        boolean currentProbePositionProducedRow = this.currentProbePositionProducedRow;
-
-        clearProbe();
-
-        if (currentPosition < 0) {
-            // Processing of the page hasn't been started yet.
-            addInput(currentPage, spillInfoSnapshot);
-        }
-        else {
-            int currentRowPartition = getPartitionGenerator().getPartition(currentPage, currentPosition);
-            boolean currentRowSpilled = spillInfoSnapshot.getSpillMask().test(currentRowPartition);
-
-            if (currentRowSpilled) {
-                savedRows.merge(
-                        currentRowPartition,
-                        new SavedRow(currentPage, currentPosition, joinPositionWithinPartition, currentProbePositionProducedRow, joinSourcePositions),
-                        (oldValue, newValue) -> {
-                            throw new IllegalStateException(format("Partition %s is already spilled", currentRowPartition));
-                        });
-                joinSourcePositions = 0;
-                Page unprocessed = pageTail(currentPage, currentPosition + 1);
-                addInput(unprocessed, spillInfoSnapshot);
-            }
-            else {
-                Page remaining = pageTail(currentPage, currentPosition);
-                restoreProbe(remaining, currentJoinPosition, currentProbePositionProducedRow, joinSourcePositions, spillInfoSnapshot);
-            }
-        }
-    }
-
-    private void processProbe(LookupSource lookupSource)
-    {
-        verifyNotNull(probe);
-
-        DriverYieldSignal yieldSignal = operatorContext.getDriverContext().getYieldSignal();
-        while (!yieldSignal.isSet()) {
-            if (probe.getPosition() >= 0) {
-                if (!joinCurrentPosition(lookupSource, yieldSignal)) {
-                    break;
-                }
-                if (!currentProbePositionProducedRow) {
-                    currentProbePositionProducedRow = true;
-                    if (!outerJoinCurrentPosition()) {
-                        break;
-                    }
-                }
-            }
-            currentProbePositionProducedRow = false;
-            if (!advanceProbePosition(lookupSource)) {
-                break;
-            }
-            statisticsCounter.recordProbe(joinSourcePositions);
-            joinSourcePositions = 0;
-        }
-    }
-
-    private void restoreProbe(Page probePage, long joinPosition, boolean currentProbePositionProducedRow, int joinSourcePositions, SpillInfoSnapshot spillInfoSnapshot)
-    {
-        verify(probe == null);
-
-        addInput(probePage, spillInfoSnapshot);
-        verify(probe.advanceNextPosition());
-        this.joinPosition = joinPosition;
-        this.currentProbePositionProducedRow = currentProbePositionProducedRow;
-        this.joinSourcePositions = joinSourcePositions;
-    }
-
-    private Page pageTail(Page currentPage, int startAtPosition)
-    {
-        verify(currentPage.getPositionCount() - startAtPosition >= 0);
-        return currentPage.getRegion(startAtPosition, currentPage.getPositionCount() - startAtPosition);
+        return pages;
     }
 
     @Override
     public void close()
+            throws Exception
     {
-        if (closed) {
-            return;
-        }
-        closed = true;
-        probe = null;
-
-        try (Closer closer = Closer.create()) {
-            // `afterClose` must be run last.
-            // Closer is documented to mimic try-with-resource, which implies close will happen in reverse order.
-            closer.register(afterClose::run);
-
-            closer.register(pageBuilder::reset);
-            closer.register(() -> Optional.ofNullable(lookupSourceProvider).ifPresent(LookupSourceProvider::close));
-            spiller.ifPresent(closer::register);
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        joinProcessor.close();
     }
 
-    /**
-     * Produce rows matching join condition for the current probe position. If this method was called previously
-     * for the current probe position, calling this again will produce rows that wasn't been produced in previous
-     * invocations.
-     *
-     * @return true if all eligible rows have been produced; false otherwise
-     */
-    private boolean joinCurrentPosition(LookupSource lookupSource, DriverYieldSignal yieldSignal)
+    private class JoinProcessor
+            implements Transformation<Page, Page>
     {
-        // while we have a position on lookup side to join against...
-        while (joinPosition >= 0) {
-            if (lookupSource.isJoinPositionEligible(joinPosition, probe.getPosition(), probe.getPage())) {
-                currentProbePositionProducedRow = true;
+        private final List<Type> probeTypes;
+        private final JoinProbeFactory joinProbeFactory;
+        private final Runnable afterClose;
+        private final OptionalInt lookupJoinsCount;
+        private final HashGenerator hashGenerator;
+        private final LookupSourceFactory lookupSourceFactory;
+        private final PartitioningSpillerFactory partitioningSpillerFactory;
 
-                pageBuilder.appendRow(probe, lookupSource, joinPosition);
-                joinSourcePositions++;
+        private final JoinStatisticsCounter statisticsCounter;
+
+        private final LookupJoinPageBuilder pageBuilder;
+
+        private final boolean probeOnOuterSide;
+
+        private final ListenableFuture<LookupSourceProvider> lookupSourceProviderFuture;
+        private LookupSourceProvider lookupSourceProvider;
+        private JoinProbe probe;
+
+        private Page outputPage;
+
+        private Optional<PartitioningSpiller> spiller = Optional.empty();
+        private Optional<LocalPartitionGenerator> partitionGenerator = Optional.empty();
+        private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
+        private long inputPageSpillEpoch;
+        private boolean closed;
+        private boolean finishing;
+        private boolean unspilling;
+        private boolean finished;
+        private long joinPosition = -1;
+        private int joinSourcePositions;
+
+        private boolean currentProbePositionProducedRow;
+
+        private final Map<Integer, SavedRow> savedRows = new HashMap<>();
+        @Nullable
+        private ListenableFuture<PartitionedConsumption<Supplier<LookupSource>>> partitionedConsumption;
+        @Nullable
+        private Iterator<Partition<Supplier<LookupSource>>> lookupPartitions;
+        private Optional<Partition<Supplier<LookupSource>>> currentPartition = Optional.empty();
+        private Optional<ListenableFuture<Supplier<LookupSource>>> unspilledLookupSource = Optional.empty();
+        private Iterator<Page> unspilledInputPages = emptyIterator();
+        private final DriverYieldSignal yieldSignal;
+        private final SpillContext spillContext;
+        private final MemoryTrackingContext memoryTrackingContext;
+
+        public JoinProcessor(
+                List<Type> probeTypes,
+                List<Type> buildOutputTypes,
+                JoinType joinType,
+                LookupSourceFactory lookupSourceFactory,
+                JoinProbeFactory joinProbeFactory,
+                Runnable afterClose,
+                OptionalInt lookupJoinsCount,
+                HashGenerator hashGenerator,
+                PartitioningSpillerFactory partitioningSpillerFactory,
+                JoinStatisticsCounter statisticsCounter,
+                DriverYieldSignal yieldSignal,
+                SpillContext spillContext,
+                MemoryTrackingContext memoryTrackingContext)
+        {
+            this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
+
+            requireNonNull(joinType, "joinType is null");
+            // Cannot use switch case here, because javac will synthesize an inner class and cause IllegalAccessError
+            probeOnOuterSide = joinType == PROBE_OUTER || joinType == FULL_OUTER;
+
+            this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
+            this.afterClose = requireNonNull(afterClose, "afterClose is null");
+            this.lookupJoinsCount = requireNonNull(lookupJoinsCount, "lookupJoinsCount is null");
+            this.hashGenerator = requireNonNull(hashGenerator, "hashGenerator is null");
+            this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
+            this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
+            this.lookupSourceProviderFuture = lookupSourceFactory.createLookupSourceProvider();
+
+            this.statisticsCounter = statisticsCounter;
+
+            this.pageBuilder = new LookupJoinPageBuilder(buildOutputTypes);
+            this.yieldSignal = requireNonNull(yieldSignal, "yieldSignal is null");
+            this.spillContext = requireNonNull(spillContext, "spillContext is null");
+            this.memoryTrackingContext = requireNonNull(memoryTrackingContext, "memoryTrackingContext is null");
+        }
+
+        private void finish()
+        {
+            if (finishing) {
+                return;
             }
 
-            // get next position on lookup side for this probe row
-            joinPosition = lookupSource.getNextJoinPosition(joinPosition, probe.getPosition(), probe.getPage());
+            if (!spillInProgress.isDone()) {
+                return;
+            }
 
-            if (yieldSignal.isSet() || tryBuildPage()) {
+            checkSuccess(spillInProgress, "spilling failed");
+            finishing = true;
+        }
+
+        private boolean isFinished()
+        {
+            boolean finished = this.finished && probe == null && pageBuilder.isEmpty() && outputPage == null;
+
+            // if finished drop references so memory is freed early
+            if (finished) {
+                close();
+            }
+            return finished;
+        }
+
+        private ListenableFuture<?> isBlocked()
+        {
+            if (!spillInProgress.isDone()) {
+                // Input spilling can happen only after lookupSourceProviderFuture was done.
+                return spillInProgress;
+            }
+            if (unspilledLookupSource.isPresent()) {
+                // Unspilling can happen only after lookupSourceProviderFuture was done.
+                return unspilledLookupSource.get();
+            }
+
+            if (finishing) {
+                return NOT_BLOCKED;
+            }
+
+            return lookupSourceProviderFuture;
+        }
+
+        private boolean needsInput()
+        {
+            return !finishing
+                    && lookupSourceProviderFuture.isDone()
+                    && spillInProgress.isDone()
+                    && probe == null
+                    && outputPage == null;
+        }
+
+        private void addInput(Page page)
+        {
+            requireNonNull(page, "page is null");
+            checkState(probe == null, "Current page has not been completely processed yet");
+
+            checkState(tryFetchLookupSourceProvider(), "Not ready to handle input yet");
+
+            SpillInfoSnapshot spillInfoSnapshot = lookupSourceProvider.withLease(SpillInfoSnapshot::from);
+            addInput(page, spillInfoSnapshot);
+        }
+
+        private void addInput(Page page, SpillInfoSnapshot spillInfoSnapshot)
+        {
+            requireNonNull(spillInfoSnapshot, "spillInfoSnapshot is null");
+
+            if (spillInfoSnapshot.hasSpilled()) {
+                page = spillAndMaskSpilledPositions(page, spillInfoSnapshot.getSpillMask());
+                if (page.getPositionCount() == 0) {
+                    return;
+                }
+            }
+
+            // create probe
+            inputPageSpillEpoch = spillInfoSnapshot.getSpillEpoch();
+            probe = joinProbeFactory.createJoinProbe(page);
+
+            // initialize to invalid join position to force output code to advance the cursors
+            joinPosition = -1;
+        }
+
+        private boolean tryFetchLookupSourceProvider()
+        {
+            if (lookupSourceProvider == null) {
+                if (!lookupSourceProviderFuture.isDone()) {
+                    return false;
+                }
+                lookupSourceProvider = requireNonNull(getDone(lookupSourceProviderFuture));
+                statisticsCounter.updateLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
+            }
+            return true;
+        }
+
+        private Page spillAndMaskSpilledPositions(Page page, IntPredicate spillMask)
+        {
+            checkState(spillInProgress.isDone(), "Previous spill still in progress");
+            checkSuccess(spillInProgress, "spilling failed");
+
+            if (!spiller.isPresent()) {
+                spiller = Optional.of(partitioningSpillerFactory.create(
+                        probeTypes,
+                        getPartitionGenerator(),
+                        spillContext.newLocalSpillContext(),
+                        memoryTrackingContext.newAggregateSystemMemoryContext()));
+            }
+
+            PartitioningSpillResult result = spiller.get().partitionAndSpill(page, spillMask);
+            spillInProgress = result.getSpillingFuture();
+            return result.getRetained();
+        }
+
+        private LocalPartitionGenerator getPartitionGenerator()
+        {
+            if (!partitionGenerator.isPresent()) {
+                partitionGenerator = Optional.of(new LocalPartitionGenerator(hashGenerator, lookupSourceFactory.partitions()));
+            }
+            return partitionGenerator.get();
+        }
+
+        private Page getOutput()
+        {
+            // TODO introduce explicit state (enum), like in HBO
+
+            if (!spillInProgress.isDone()) {
+                /*
+                 * We cannot produce output when there is some previous input spilling. This is because getOutput() may result in additional portion of input being spilled
+                 * (when spilling state has changed in partitioned lookup source since last time) and spiller does not allow multiple concurrent spills.
+                 */
+                return null;
+            }
+            checkSuccess(spillInProgress, "spilling failed");
+
+            if (probe == null && pageBuilder.isEmpty() && !finishing) {
+                return null;
+            }
+
+            if (!tryFetchLookupSourceProvider()) {
+                if (!finishing) {
+                    return null;
+                }
+
+                verify(finishing);
+                // We are no longer interested in the build side (the lookupSourceProviderFuture's value).
+                addSuccessCallback(lookupSourceProviderFuture, LookupSourceProvider::close);
+                lookupSourceProvider = new StaticLookupSourceProvider(new EmptyLookupSource());
+            }
+
+            if (probe == null && finishing && !unspilling) {
+                /*
+                 * We do not have input probe and we won't have any, as we're finishing.
+                 * Let LookupSourceFactory know LookupSources can be disposed as far as we're concerned.
+                 */
+                verify(partitionedConsumption == null, "partitioned consumption already started");
+                partitionedConsumption = lookupSourceFactory.finishProbeOperator(lookupJoinsCount);
+                unspilling = true;
+            }
+
+            if (probe == null && unspilling && !finished) {
+                /*
+                 * If no current partition or it was exhausted, unspill next one.
+                 * Add input there when it needs one, produce output. Be Happy.
+                 */
+                tryUnspillNext();
+            }
+
+            if (probe != null) {
+                processProbe();
+            }
+
+            if (outputPage != null) {
+                verify(pageBuilder.isEmpty());
+                Page output = outputPage;
+                outputPage = null;
+                return output;
+            }
+
+            // It is impossible to have probe == null && !pageBuilder.isEmpty(),
+            // because we will flush a page whenever we reach the probe end
+            verify(probe != null || pageBuilder.isEmpty());
+            return null;
+        }
+
+        private void tryUnspillNext()
+        {
+            verify(probe == null);
+
+            if (!partitionedConsumption.isDone()) {
+                return;
+            }
+
+            if (lookupPartitions == null) {
+                lookupPartitions = getDone(partitionedConsumption).beginConsumption();
+            }
+
+            if (unspilledInputPages.hasNext()) {
+                addInput(unspilledInputPages.next());
+                return;
+            }
+
+            if (unspilledLookupSource.isPresent()) {
+                if (!unspilledLookupSource.get().isDone()) {
+                    // Not unspilled yet
+                    return;
+                }
+                LookupSource lookupSource = getDone(unspilledLookupSource.get()).get();
+                unspilledLookupSource = Optional.empty();
+
+                // Close previous lookupSourceProvider (either supplied initially or for the previous partition)
+                lookupSourceProvider.close();
+                lookupSourceProvider = new StaticLookupSourceProvider(lookupSource);
+                // If the partition was spilled during processing, its position count will be considered twice.
+                statisticsCounter.updateLookupSourcePositions(lookupSource.getJoinPositionCount());
+
+                int partition = currentPartition.get().number();
+                unspilledInputPages = spiller.map(spiller -> spiller.getSpilledPages(partition))
+                        .orElse(emptyIterator());
+
+                Optional.ofNullable(savedRows.remove(partition)).ifPresent(savedRow -> {
+                    restoreProbe(
+                            savedRow.row,
+                            savedRow.joinPositionWithinPartition,
+                            savedRow.currentProbePositionProducedRow,
+                            savedRow.joinSourcePositions,
+                            SpillInfoSnapshot.noSpill());
+                });
+
+                return;
+            }
+
+            if (lookupPartitions.hasNext()) {
+                currentPartition.ifPresent(Partition::release);
+                currentPartition = Optional.of(lookupPartitions.next());
+                unspilledLookupSource = Optional.of(currentPartition.get().load());
+
+                return;
+            }
+
+            currentPartition.ifPresent(Partition::release);
+            if (lookupSourceProvider != null) {
+                // There are no more partitions to process, so clean up everything
+                lookupSourceProvider.close();
+                lookupSourceProvider = null;
+            }
+            spiller.ifPresent(PartitioningSpiller::verifyAllPartitionsRead);
+            finished = true;
+        }
+
+        private void processProbe()
+        {
+            verifyNotNull(probe);
+
+            Optional<SpillInfoSnapshot> spillInfoSnapshotIfSpillChanged = lookupSourceProvider.withLease(lookupSourceLease -> {
+                if (lookupSourceLease.spillEpoch() == inputPageSpillEpoch) {
+                    // Spill state didn't change, so process as usual.
+                    processProbe(lookupSourceLease.getLookupSource());
+                    return Optional.empty();
+                }
+
+                return Optional.of(SpillInfoSnapshot.from(lookupSourceLease));
+            });
+
+            if (!spillInfoSnapshotIfSpillChanged.isPresent()) {
+                return;
+            }
+            SpillInfoSnapshot spillInfoSnapshot = spillInfoSnapshotIfSpillChanged.get();
+            long joinPositionWithinPartition;
+            if (joinPosition >= 0) {
+                joinPositionWithinPartition = lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().joinPositionWithinPartition(joinPosition));
+            }
+            else {
+                joinPositionWithinPartition = -1;
+            }
+
+            /*
+             * Spill state changed. All probe rows that were not processed yet should be treated as regular input (and be partially spilled).
+             * If current row maps to the now-spilled partition, it needs to be saved for later. If it maps to a partition still in memory, it
+             * should be added together with not-yet-processed rows. In either case we need to resume processing the row starting at its
+             * current position in the lookup source.
+             */
+            verify(spillInfoSnapshot.hasSpilled());
+            verify(spillInfoSnapshot.getSpillEpoch() > inputPageSpillEpoch);
+
+            Page currentPage = probe.getPage();
+            int currentPosition = probe.getPosition();
+            long currentJoinPosition = this.joinPosition;
+            boolean currentProbePositionProducedRow = this.currentProbePositionProducedRow;
+
+            clearProbe();
+
+            if (currentPosition < 0) {
+                // Processing of the page hasn't been started yet.
+                addInput(currentPage, spillInfoSnapshot);
+            }
+            else {
+                int currentRowPartition = getPartitionGenerator().getPartition(currentPage, currentPosition);
+                boolean currentRowSpilled = spillInfoSnapshot.getSpillMask().test(currentRowPartition);
+
+                if (currentRowSpilled) {
+                    savedRows.merge(
+                            currentRowPartition,
+                            new SavedRow(currentPage, currentPosition, joinPositionWithinPartition, currentProbePositionProducedRow, joinSourcePositions),
+                            (oldValue, newValue) -> {
+                                throw new IllegalStateException(format("Partition %s is already spilled", currentRowPartition));
+                            });
+                    joinSourcePositions = 0;
+                    Page unprocessed = pageTail(currentPage, currentPosition + 1);
+                    addInput(unprocessed, spillInfoSnapshot);
+                }
+                else {
+                    Page remaining = pageTail(currentPage, currentPosition);
+                    restoreProbe(remaining, currentJoinPosition, currentProbePositionProducedRow, joinSourcePositions, spillInfoSnapshot);
+                }
+            }
+        }
+
+        private void processProbe(LookupSource lookupSource)
+        {
+            verifyNotNull(probe);
+
+            while (!yieldSignal.isSet()) {
+                if (probe.getPosition() >= 0) {
+                    if (!joinCurrentPosition(lookupSource, yieldSignal)) {
+                        break;
+                    }
+                    if (!currentProbePositionProducedRow) {
+                        currentProbePositionProducedRow = true;
+                        if (!outerJoinCurrentPosition()) {
+                            break;
+                        }
+                    }
+                }
+                currentProbePositionProducedRow = false;
+                if (!advanceProbePosition(lookupSource)) {
+                    break;
+                }
+                statisticsCounter.recordProbe(joinSourcePositions);
+                joinSourcePositions = 0;
+            }
+        }
+
+        private void restoreProbe(Page probePage, long joinPosition, boolean currentProbePositionProducedRow, int joinSourcePositions, SpillInfoSnapshot spillInfoSnapshot)
+        {
+            verify(probe == null);
+
+            addInput(probePage, spillInfoSnapshot);
+            verify(probe.advanceNextPosition());
+            this.joinPosition = joinPosition;
+            this.currentProbePositionProducedRow = currentProbePositionProducedRow;
+            this.joinSourcePositions = joinSourcePositions;
+        }
+
+        private Page pageTail(Page currentPage, int startAtPosition)
+        {
+            verify(currentPage.getPositionCount() - startAtPosition >= 0);
+            return currentPage.getRegion(startAtPosition, currentPage.getPositionCount() - startAtPosition);
+        }
+
+        public void close()
+        {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            probe = null;
+
+            try (Closer closer = Closer.create()) {
+                // `afterClose` must be run last.
+                // Closer is documented to mimic try-with-resource, which implies close will happen in reverse order.
+                closer.register(afterClose::run);
+
+                closer.register(pageBuilder::reset);
+                closer.register(() -> Optional.ofNullable(lookupSourceProvider).ifPresent(LookupSourceProvider::close));
+                spiller.ifPresent(closer::register);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         * Produce rows matching join condition for the current probe position. If this method was called previously
+         * for the current probe position, calling this again will produce rows that wasn't been produced in previous
+         * invocations.
+         *
+         * @return true if all eligible rows have been produced; false otherwise
+         */
+        private boolean joinCurrentPosition(LookupSource lookupSource, DriverYieldSignal yieldSignal)
+        {
+            // while we have a position on lookup side to join against...
+            while (joinPosition >= 0) {
+                if (lookupSource.isJoinPositionEligible(joinPosition, probe.getPosition(), probe.getPage())) {
+                    currentProbePositionProducedRow = true;
+
+                    pageBuilder.appendRow(probe, lookupSource, joinPosition);
+                    joinSourcePositions++;
+                }
+
+                // get next position on lookup side for this probe row
+                joinPosition = lookupSource.getNextJoinPosition(joinPosition, probe.getPosition(), probe.getPage());
+
+                if (yieldSignal.isSet() || tryBuildPage()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /**
+         * @return whether there are more positions on probe side
+         */
+        private boolean advanceProbePosition(LookupSource lookupSource)
+        {
+            if (!probe.advanceNextPosition()) {
+                clearProbe();
                 return false;
             }
-        }
-        return true;
-    }
 
-    /**
-     * @return whether there are more positions on probe side
-     */
-    private boolean advanceProbePosition(LookupSource lookupSource)
-    {
-        if (!probe.advanceNextPosition()) {
-            clearProbe();
+            // update join position
+            joinPosition = probe.getCurrentJoinPosition(lookupSource);
+            return true;
+        }
+
+        /**
+         * Produce a row for the current probe position, if it doesn't match any row on lookup side and this is an outer join.
+         *
+         * @return whether pageBuilder became full
+         */
+        private boolean outerJoinCurrentPosition()
+        {
+            if (probeOnOuterSide && joinPosition < 0) {
+                pageBuilder.appendNullForBuild(probe);
+                if (tryBuildPage()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public TransformationState<Page> process(@Nullable Page element)
+        {
+            if (element == null) {
+                finish();
+            }
+
+            if (isFinished()) {
+                return finished();
+            }
+
+            ListenableFuture<?> blocked = isBlocked();
+            if (!blocked.isDone()) {
+                return blocked(blocked);
+            }
+
+            boolean consumedInput = false;
+            if (needsInput()) {
+                addInput(element);
+                consumedInput = true;
+            }
+
+            Page outputPage = getOutput();
+            if (outputPage != null) {
+                return ofResult(outputPage, consumedInput && !isFinished());
+            }
+
+            if (consumedInput) {
+                return needsMoreData();
+            }
+
+            return yield();
+        }
+
+        private boolean tryBuildPage()
+        {
+            if (pageBuilder.isFull()) {
+                buildPage();
+                return true;
+            }
             return false;
         }
 
-        // update join position
-        joinPosition = probe.getCurrentJoinPosition(lookupSource);
-        return true;
-    }
+        private void buildPage()
+        {
+            verify(outputPage == null);
+            verify(probe != null);
 
-    /**
-     * Produce a row for the current probe position, if it doesn't match any row on lookup side and this is an outer join.
-     *
-     * @return whether pageBuilder became full
-     */
-    private boolean outerJoinCurrentPosition()
-    {
-        if (probeOnOuterSide && joinPosition < 0) {
-            pageBuilder.appendNullForBuild(probe);
-            if (tryBuildPage()) {
-                return false;
+            if (pageBuilder.isEmpty()) {
+                return;
             }
+
+            outputPage = pageBuilder.build(probe);
+            pageBuilder.reset();
         }
-        return true;
+
+        private void clearProbe()
+        {
+            // Before updating the probe flush the current page
+            buildPage();
+            probe = null;
+        }
     }
 
     // This class must be public because LookupJoinOperator is isolated.
@@ -635,18 +776,18 @@ public class LookupJoinOperator
         public final Page row;
 
         /**
-         * A snapshot of {@link LookupJoinOperator#joinPosition} "de-partitioned", i.e. {@link LookupJoinOperator#joinPosition} is a join position
+         * A snapshot of {@link JoinProcessor#joinPosition} "de-partitioned", i.e. {@link JoinProcessor#joinPosition} is a join position
          * with respect to (potentially) partitioned lookup source, while this value is a join position with respect to containing partition.
          */
         public final long joinPositionWithinPartition;
 
         /**
-         * A snapshot of {@link LookupJoinOperator#currentProbePositionProducedRow}
+         * A snapshot of {@link JoinProcessor#currentProbePositionProducedRow}
          */
         public final boolean currentProbePositionProducedRow;
 
         /**
-         * A snapshot of {@link LookupJoinOperator#joinSourcePositions}
+         * A snapshot of {@link JoinProcessor#joinSourcePositions}
          */
         public final int joinSourcePositions;
 
@@ -658,34 +799,5 @@ public class LookupJoinOperator
             this.currentProbePositionProducedRow = currentProbePositionProducedRow;
             this.joinSourcePositions = joinSourcePositions;
         }
-    }
-
-    private boolean tryBuildPage()
-    {
-        if (pageBuilder.isFull()) {
-            buildPage();
-            return true;
-        }
-        return false;
-    }
-
-    private void buildPage()
-    {
-        verify(outputPage == null);
-        verifyNotNull(probe);
-
-        if (pageBuilder.isEmpty()) {
-            return;
-        }
-
-        outputPage = pageBuilder.build(probe);
-        pageBuilder.reset();
-    }
-
-    private void clearProbe()
-    {
-        // Before updating the probe flush the current page
-        buildPage();
-        probe = null;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
@@ -138,8 +138,6 @@ public class LookupJoinOperatorFactory
 
         OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, LookupJoinOperator.class.getSimpleName());
 
-        lookupSourceFactory.setTaskContext(driverContext.getPipelineContext().getTaskContext());
-
         joinBridgeManager.probeOperatorCreated(driverContext.getLifespan());
         return new LookupJoinOperator(
                 operatorContext,

--- a/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
@@ -14,11 +14,11 @@
 package io.prestosql.operator;
 
 import com.google.common.collect.ImmutableList;
-import io.prestosql.Session;
 import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.operator.WorkProcessor.TransformationState;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperator;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperatorFactory;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.SortOrder;
 import io.prestosql.spi.type.Type;
@@ -103,13 +103,11 @@ public class TopNOperator
 
         @Override
         public WorkProcessorOperator create(
-                Session session,
-                MemoryTrackingContext memoryTrackingContext,
-                DriverYieldSignal yieldSignal,
+                ProcessorContext processorContext,
                 WorkProcessor<Page> sourcePages)
         {
             return new TopNOperator(
-                    memoryTrackingContext,
+                    processorContext.getMemoryTrackingContext(),
                     Optional.of(sourcePages),
                     sourceTypes,
                     n,
@@ -118,13 +116,10 @@ public class TopNOperator
         }
 
         @Override
-        public AdapterWorkProcessorOperator create(
-                Session session,
-                MemoryTrackingContext memoryTrackingContext,
-                DriverYieldSignal yieldSignal)
+        public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
         {
             return new TopNOperator(
-                    memoryTrackingContext,
+                    processorContext.getMemoryTrackingContext(),
                     Optional.empty(),
                     sourceTypes,
                     n,

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
@@ -13,8 +13,7 @@
  */
 package io.prestosql.operator;
 
-import io.prestosql.Session;
-import io.prestosql.memory.context.MemoryTrackingContext;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
@@ -27,8 +26,6 @@ public interface WorkProcessorOperatorFactory
     String getOperatorType();
 
     WorkProcessorOperator create(
-            Session session,
-            MemoryTrackingContext memoryTrackingContext,
-            DriverYieldSignal yieldSignal,
+            ProcessorContext processorContext,
             WorkProcessor<Page> sourcePages);
 }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.operator;
 
+import io.prestosql.execution.Lifespan;
 import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -28,4 +29,14 @@ public interface WorkProcessorOperatorFactory
     WorkProcessorOperator create(
             ProcessorContext processorContext,
             WorkProcessor<Page> sourcePages);
+
+    default void lifespanFinished(Lifespan lifespan)
+    {
+        //do nothing
+    }
+
+    default void close()
+    {
+        //do nothing
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.prestosql.execution.Lifespan;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.memory.context.MemoryTrackingContext;
@@ -711,7 +712,14 @@ public class WorkProcessorPipelineSourceOperator
         @Override
         public void noMoreOperators()
         {
+            this.operatorFactories.forEach(WorkProcessorOperatorFactory::close);
             closed = true;
+        }
+
+        @Override
+        public void noMoreOperators(Lifespan lifespan)
+        {
+            this.operatorFactories.forEach(operatorFactory -> operatorFactory.lifespanFinished(lifespan));
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -25,6 +25,7 @@ import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.metadata.Split;
 import io.prestosql.operator.OperationTimer.OperationTiming;
 import io.prestosql.operator.WorkProcessor.ProcessState;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.UpdatablePageSource;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -143,9 +144,7 @@ public class WorkProcessorPipelineSourceOperator
             MemoryTrackingContext operatorMemoryTrackingContext = createMemoryTrackingContext(operatorContext, operatorIndex);
             operatorMemoryTrackingContext.initializeLocalMemoryContexts(operatorFactory.getOperatorType());
             WorkProcessorOperator operator = operatorFactory.create(
-                    operatorContext.getSession(),
-                    operatorMemoryTrackingContext,
-                    operatorContext.getDriverContext().getYieldSignal(),
+                    new ProcessorContext(operatorContext.getSession(), operatorMemoryTrackingContext, operatorContext),
                     pages);
             workProcessorOperatorContexts.add(new WorkProcessorOperatorContext(
                     operator,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -1581,7 +1581,10 @@ public class LocalExecutionPlanner
                     false,
                     UNGROUPED_EXECUTION,
                     UNGROUPED_EXECUTION,
-                    lifespan -> indexLookupSourceFactory,
+                    lifespan -> {
+                        indexLookupSourceFactory.setTaskContext(context.taskContext);
+                        return indexLookupSourceFactory;
+                    },
                     indexLookupSourceFactory.getOutputTypes());
 
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
 
 import java.util.Iterator;
 import java.util.List;
@@ -49,12 +50,14 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.prestosql.RowPagesBuilder.rowPagesBuilder;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
+import static io.prestosql.operator.JoinBridgeManager.lookupAllAtOnce;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
@@ -185,7 +188,7 @@ public class BenchmarkHashBuildAndJoinOperators
         protected List<Page> probePages;
         protected List<Integer> outputChannels;
 
-        protected JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory;
+        protected OperatorFactory joinOperatorFactory;
 
         @Override
         @Setup
@@ -207,23 +210,29 @@ public class BenchmarkHashBuildAndJoinOperators
                     throw new UnsupportedOperationException(format("Unknown outputColumns value [%s]", hashColumns));
             }
 
-            lookupSourceFactory = new BenchmarkHashBuildAndJoinOperators().benchmarkBuildHash(this, outputChannels);
+            JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory = getLookupSourceFactoryManager(this, outputChannels);
+            joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
+                    HASH_JOIN_OPERATOR_ID,
+                    TEST_PLAN_NODE_ID,
+                    lookupSourceFactory,
+                    types,
+                    hashChannels,
+                    hashChannel,
+                    Optional.of(outputChannels),
+                    OptionalInt.empty(),
+                    unsupportedPartitioningSpillerFactory());
+            buildHash(this, lookupSourceFactory, outputChannels);
             initializeProbePages();
         }
 
-        public JoinBridgeManager<PartitionedLookupSourceFactory> getLookupSourceFactory()
+        public OperatorFactory getJoinOperatorFactory()
         {
-            return lookupSourceFactory;
+            return joinOperatorFactory;
         }
 
         public List<Page> getProbePages()
         {
             return probePages;
-        }
-
-        public List<Integer> getOutputChannels()
-        {
-            return outputChannels;
         }
 
         protected void initializeProbePages()
@@ -277,14 +286,15 @@ public class BenchmarkHashBuildAndJoinOperators
     @Benchmark
     public JoinBridgeManager<PartitionedLookupSourceFactory> benchmarkBuildHash(BuildContext buildContext)
     {
-        return benchmarkBuildHash(buildContext, ImmutableList.of(0, 1, 2));
+        List<Integer> outputChannels = ImmutableList.of(0, 1, 2);
+        JoinBridgeManager<PartitionedLookupSourceFactory> joinBridgeManager = getLookupSourceFactoryManager(buildContext, outputChannels);
+        buildHash(buildContext, joinBridgeManager, outputChannels);
+        return joinBridgeManager;
     }
 
-    private JoinBridgeManager<PartitionedLookupSourceFactory> benchmarkBuildHash(BuildContext buildContext, List<Integer> outputChannels)
+    private static JoinBridgeManager<PartitionedLookupSourceFactory> getLookupSourceFactoryManager(BuildContext buildContext, List<Integer> outputChannels)
     {
-        DriverContext driverContext = buildContext.createTaskContext().addPipelineContext(0, true, true, false).addDriverContext();
-
-        JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = JoinBridgeManager.lookupAllAtOnce(new PartitionedLookupSourceFactory(
+        return lookupAllAtOnce(new PartitionedLookupSourceFactory(
                 buildContext.getTypes(),
                 outputChannels.stream()
                         .map(buildContext.getTypes()::get)
@@ -295,6 +305,12 @@ public class BenchmarkHashBuildAndJoinOperators
                 1,
                 requireNonNull(ImmutableMap.of(), "layout is null"),
                 false));
+    }
+
+    private static void buildHash(BuildContext buildContext, JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager, List<Integer> outputChannels)
+    {
+        DriverContext driverContext = buildContext.createTaskContext().addPipelineContext(0, true, true, false).addDriverContext();
+
         HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
                 HASH_BUILD_OPERATOR_ID,
                 TEST_PLAN_NODE_ID,
@@ -314,34 +330,22 @@ public class BenchmarkHashBuildAndJoinOperators
         for (Page page : buildContext.getBuildPages()) {
             operator.addInput(page);
         }
-        operator.finish();
 
         LookupSourceFactory lookupSourceFactory = lookupSourceFactoryManager.getJoinBridge(Lifespan.taskWide());
         ListenableFuture<LookupSourceProvider> lookupSourceProvider = lookupSourceFactory.createLookupSourceProvider();
+        operator.finish();
         if (!lookupSourceProvider.isDone()) {
             throw new AssertionError("Expected lookup source provider to be ready");
         }
         getFutureValue(lookupSourceProvider).close();
-
-        return lookupSourceFactoryManager;
     }
 
     @Benchmark
     public List<Page> benchmarkJoinHash(JoinContext joinContext)
+            throws Exception
     {
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
-                HASH_JOIN_OPERATOR_ID,
-                TEST_PLAN_NODE_ID,
-                joinContext.getLookupSourceFactory(),
-                joinContext.getTypes(),
-                joinContext.getHashChannels(),
-                joinContext.getHashChannel(),
-                Optional.of(joinContext.getOutputChannels()),
-                OptionalInt.empty(),
-                unsupportedPartitioningSpillerFactory());
-
         DriverContext driverContext = joinContext.createTaskContext().addPipelineContext(0, true, true, false).addDriverContext();
-        Operator joinOperator = joinOperatorFactory.createOperator(driverContext);
+        Operator joinOperator = joinContext.getJoinOperatorFactory().createOperator(driverContext);
 
         Iterator<Page> input = joinContext.getProbePages().iterator();
         ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
@@ -365,7 +369,32 @@ public class BenchmarkHashBuildAndJoinOperators
             }
         }
 
+        joinOperator.close();
+
         return outputPages.build();
+    }
+
+    @Test
+    public void testBenchmarkJoinHash()
+            throws Exception
+    {
+        JoinContext joinContext = new JoinContext();
+        joinContext.setup();
+        benchmarkJoinHash(joinContext);
+        // ensure that build side hash table is not freed
+        List<Page> pages = benchmarkJoinHash(joinContext);
+
+        // assert that there are any rows
+        checkState(!pages.isEmpty());
+        checkState(pages.get(0).getPositionCount() > 0);
+    }
+
+    @Test
+    public void testBenchmakrBuildHash()
+    {
+        BuildContext buildContext = new BuildContext();
+        buildContext.setup();
+        benchmarkBuildHash(buildContext);
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -24,6 +24,7 @@ import io.prestosql.metadata.Split;
 import io.prestosql.operator.WorkProcessor.Transformation;
 import io.prestosql.operator.WorkProcessor.TransformationState;
 import io.prestosql.operator.WorkProcessorAssertion.Transform;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.ProcessorContext;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.UpdatablePageSource;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -407,7 +408,7 @@ public class TestWorkProcessorPipelineSourceOperator
         }
 
         @Override
-        public WorkProcessorOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Page> sourcePages)
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
         {
             assertNull(operator, "source operator already created");
             operator = new TestWorkProcessorOperator(sourcePages.transform(transformation));

--- a/presto-tests/src/test/java/io/prestosql/tests/TestWorkProcessorPipelineQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestWorkProcessorPipelineQueries.java
@@ -57,6 +57,12 @@ public class TestWorkProcessorPipelineQueries
         assertLazyQuery("SELECT * FROM orders WHERE orderkey NOT IN (SELECT orderkey FROM orders WHERE orderdate >= DATE '1994-01-01')");
     }
 
+    @Test
+    public void testJoin()
+    {
+        assertLazyQuery("SELECT * FROM lineitem INNER JOIN part ON lineitem.partkey = part.partkey AND mfgr = 'Manufacturer#5'");
+    }
+
     private void assertLazyQuery(@Language("SQL") String sql)
     {
         DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();


### PR DESCRIPTION
TO-DO:

- Track memory for the output pages

The benchmark that we took 

```
                                                                                                                                                                 Normal                         Work Processor
Benchmark                                              (buildHashEnabled)  (buildRowsRepetition)  (hashColumns)  (matchRate)  (outputColumns)  Mode  Cnt     Score     Error  Units          Score     Error  Units
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      1        varchar          N/A              N/A  avgt   30   853.215 ±   5.996  ms/op       843.781 ±   7.716  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      1         bigint          N/A              N/A  avgt   30   531.294 ±  49.266  ms/op       480.013 ±  11.462  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      1            all          N/A              N/A  avgt   30  1314.879 ± 266.532  ms/op       955.585 ±  21.856  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      5        varchar          N/A              N/A  avgt   30  1967.050 ± 113.097  ms/op      1170.089 ±  24.498  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      5         bigint          N/A              N/A  avgt   30  1251.594 ± 190.671  ms/op       584.872 ±   4.955  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash               false                      5            all          N/A              N/A  avgt   30  2322.659 ± 153.450  ms/op      1385.845 ±  15.290  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      1        varchar          N/A              N/A  avgt   30  1137.780 ±  77.309  ms/op      1168.215 ± 110.874  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      1         bigint          N/A              N/A  avgt   30  1098.345 ± 141.290  ms/op      1066.497 ± 112.083  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      1            all          N/A              N/A  avgt   30  1437.359 ±  86.187  ms/op      1400.772 ±  86.195  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      5        varchar          N/A              N/A  avgt   30  1801.792 ± 133.888  ms/op      1768.608 ± 122.690  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      5         bigint          N/A              N/A  avgt   30  1274.933 ± 219.359  ms/op      1508.048 ± 232.207  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkBuildHash                true                      5            all          N/A              N/A  avgt   30  2133.180 ± 173.386  ms/op      2083.435 ± 156.605  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar          0.1           bigint  avgt   30   501.720 ±  40.658  ms/op       491.646 ±  38.148  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar          0.1              all  avgt   30   508.512 ±  37.853  ms/op       515.810 ±  38.215  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar            1           bigint  avgt   30   495.618 ±  31.399  ms/op       491.188 ±  36.070  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar            1              all  avgt   30   608.514 ±  34.263  ms/op       548.757 ±  36.449  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar            2           bigint  avgt   30   307.822 ±  22.860  ms/op       310.354 ±  24.534  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1        varchar            2              all  avgt   30   413.530 ±  27.973  ms/op       368.702 ±  29.651  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint          0.1           bigint  avgt   30   385.541 ±  31.138  ms/op       427.413 ±  42.924  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint          0.1              all  avgt   30   418.381 ±  33.469  ms/op       456.264 ±  46.562  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint            1           bigint  avgt   30   393.607 ±  28.436  ms/op       376.974 ±  29.006  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint            1              all  avgt   30   534.679 ±  32.480  ms/op       471.156 ±  35.624  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint            2           bigint  avgt   30   238.572 ±  16.595  ms/op       222.459 ±  15.790  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1         bigint            2              all  avgt   30   351.910 ±  25.507  ms/op       314.410 ±  23.851  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all          0.1           bigint  avgt   30   530.216 ±  45.057  ms/op       547.886 ±  42.634  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all          0.1              all  avgt   30   549.515 ±  42.296  ms/op       566.152 ±  47.411  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all            1           bigint  avgt   30   566.055 ±  44.590  ms/op       521.172 ±  32.902  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all            1              all  avgt   30   639.596 ±  38.572  ms/op       590.736 ±  41.050  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all            2           bigint  avgt   30   347.534 ±  28.444  ms/op       333.202 ±  24.433  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      1            all            2              all  avgt   30   465.093 ±  33.190  ms/op       412.810 ±  29.516  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar          0.1           bigint  avgt   30   453.407 ±  35.255  ms/op       462.998 ±  41.880  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar          0.1              all  avgt   30   590.261 ±  48.365  ms/op       593.472 ±  46.046  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar            1           bigint  avgt   30   862.731 ±  64.805  ms/op       828.970 ±  39.277  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar            1              all  avgt   30  1382.688 ±  81.018  ms/op      1335.846 ±  69.668  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar            2           bigint  avgt   30   610.187 ±  54.426  ms/op       606.609 ±  42.457  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5        varchar            2              all  avgt   30  1212.495 ±  74.364  ms/op      1149.922 ±  69.049  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint          0.1           bigint  avgt   30   332.809 ±  31.834  ms/op       428.480 ±  35.487  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint          0.1              all  avgt   30   463.897 ±  37.050  ms/op       571.712 ±  42.395  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint            1           bigint  avgt   30   754.607 ±  42.370  ms/op       751.556 ±  48.769  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint            1              all  avgt   30  1312.524 ±  81.300  ms/op      1249.487 ±  74.263  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint            2           bigint  avgt   30   538.278 ±  31.206  ms/op       350.649 ±   2.183  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5         bigint            2              all  avgt   30  1125.858 ±  70.048  ms/op       735.775 ±  10.836  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all          0.1           bigint  avgt   30   498.699 ±  36.658  ms/op       320.271 ±   9.060  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all          0.1              all  avgt   30   614.061 ±  43.807  ms/op       400.066 ±   5.442  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all            1           bigint  avgt   30   948.549 ±  67.885  ms/op       576.193 ±  19.730  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all            1              all  avgt   30  1429.589 ±  74.592  ms/op       951.784 ±   5.846  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all            2           bigint  avgt   30   675.079 ±  49.582  ms/op       489.229 ±  60.943  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                false                      5            all            2              all  avgt   30  1236.805 ±  65.670  ms/op       782.930 ±   5.811  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar          0.1           bigint  avgt   30   353.206 ±  28.255  ms/op       208.393 ±   6.011  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar          0.1              all  avgt   30   385.564 ±  27.942  ms/op       314.950 ±  62.543  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar            1           bigint  avgt   30   430.317 ±  29.014  ms/op       425.125 ±  38.157  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar            1              all  avgt   30   559.318 ±  33.943  ms/op       500.482 ±  30.443  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar            2           bigint  avgt   30   278.476 ±  19.800  ms/op       268.309 ±  21.216  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1        varchar            2              all  avgt   30   379.907 ±  27.119  ms/op       336.251 ±  23.976  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint          0.1           bigint  avgt   30   338.865 ±  34.612  ms/op       341.070 ±  29.223  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint          0.1              all  avgt   30   378.213 ±  29.146  ms/op       375.125 ±  32.809  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint            1           bigint  avgt   30   383.541 ±  26.826  ms/op       366.838 ±  30.932  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint            1              all  avgt   30   536.607 ±  36.405  ms/op       478.893 ±  32.060  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint            2           bigint  avgt   30   239.812 ±  16.928  ms/op       227.144 ±  16.707  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1         bigint            2              all  avgt   30   362.953 ±  28.234  ms/op       312.567 ±  24.701  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all          0.1           bigint  avgt   30   456.443 ±  38.262  ms/op       478.295 ±  35.756  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all          0.1              all  avgt   30   451.874 ±  39.621  ms/op       459.029 ±  46.079  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all            1           bigint  avgt   30   496.606 ±  37.871  ms/op       407.739 ±  62.407  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all            1              all  avgt   30   617.664 ±  39.957  ms/op       344.157 ±   3.700  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all            2           bigint  avgt   30   309.336 ±  20.785  ms/op       190.537 ±   0.883  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      1            all            2              all  avgt   30   420.864 ±  29.838  ms/op       330.008 ±  47.625  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar          0.1           bigint  avgt   30   324.342 ±  24.455  ms/op       333.935 ±  28.268  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar          0.1              all  avgt   30   453.015 ±  41.154  ms/op       474.684 ±  41.022  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar            1           bigint  avgt   30   798.051 ±  45.413  ms/op       785.330 ±  45.606  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar            1              all  avgt   30  1305.680 ±  75.774  ms/op      1276.600 ±  65.511  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar            2           bigint  avgt   30   592.777 ±  44.939  ms/op       574.000 ±  42.446  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5        varchar            2              all  avgt   30  1222.249 ±  75.990  ms/op      1140.042 ±  63.089  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint          0.1           bigint  avgt   30   316.400 ±  25.455  ms/op       357.719 ±  52.560  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint          0.1              all  avgt   30   454.575 ±  33.161  ms/op       502.640 ±  48.392  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint            1           bigint  avgt   30   755.437 ±  43.953  ms/op       719.082 ±  42.112  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint            1              all  avgt   30  1332.002 ±  81.092  ms/op      1270.086 ±  77.205  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint            2           bigint  avgt   30   531.291 ±  40.300  ms/op       518.361 ±  46.572  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5         bigint            2              all  avgt   30  1146.824 ±  62.395  ms/op      1093.630 ±  65.947  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all          0.1           bigint  avgt   30   463.740 ±  37.975  ms/op       461.982 ±  34.699  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all          0.1              all  avgt   30   536.401 ±  52.768  ms/op       578.423 ±  43.188  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all            1           bigint  avgt   30   866.933 ±  50.954  ms/op       857.101 ±  50.179  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all            1              all  avgt   30  1417.945 ± 100.627  ms/op      1327.941 ±  75.018  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all            2           bigint  avgt   30   667.043 ±  38.734  ms/op       614.397 ±  38.889  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                 true                      5            all            2              all  avgt   30  1209.488 ±  66.812  ms/op      1154.332 ±  69.110  ms/op

```
