### PR TITLE
Support reading PostgreSQL timestamp[] when gap in JVM zone

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -311,18 +311,19 @@ public final class StandardColumnMappings
 
     public static ColumnMapping timestampColumnMapping(ConnectorSession session)
     {
-        if (session.isLegacyTimestamp()) {
-            ZoneId sessionZone = ZoneId.of(session.getTimeZoneKey().getId());
-            return ColumnMapping.longMapping(
-                    TIMESTAMP,
-                    (resultSet, columnIndex) -> toPrestoLegacyTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class), sessionZone),
-                    timestampWriteFunction(session));
-        }
-
         return ColumnMapping.longMapping(
                 TIMESTAMP,
-                (resultSet, columnIndex) -> toPrestoTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class)),
+                timestampReadFunction(session),
                 timestampWriteFunction(session));
+    }
+
+    public static LongReadFunction timestampReadFunction(ConnectorSession session)
+    {
+        if (session.isLegacyTimestamp()) {
+            ZoneId sessionZone = ZoneId.of(session.getTimeZoneKey().getId());
+            return (resultSet, columnIndex) -> toPrestoLegacyTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class), sessionZone);
+        }
+        return (resultSet, columnIndex) -> toPrestoTimestamp(resultSet.getObject(columnIndex, LocalDateTime.class));
     }
 
     /**

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -544,17 +544,9 @@ public class TestPostgreSqlTypeMapping
                     .addRoundTrip(timestampDataType(), timeDoubledInJvmZone)
                     .addRoundTrip(timestampDataType(), timeDoubledInVilnius);
 
-            if (insertWithPresto) {
-                // When inserting with Presto, we effectively go through PostgreSQL driver's PreparedStatement.
-                // The driver converts LocalDateTime to string representing date-time in JVM zone
-                // TODO https://github.com/pgjdbc/pgjdbc/issues/1390 or find a different way to write timestamp values
-            }
-            else {
-                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, epoch); // epoch also is a gap in JVM zone
-                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone1);
-                addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone2);
-            }
-
+            addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, epoch); // epoch also is a gap in JVM zone
+            addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone1);
+            addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone2);
             addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInVilnius);
             addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInKathmandu);
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -544,9 +544,12 @@ public class TestPostgreSqlTypeMapping
                     .addRoundTrip(timestampDataType(), timeDoubledInJvmZone)
                     .addRoundTrip(timestampDataType(), timeDoubledInVilnius);
 
-            if (!insertWithPresto) {
-                // when writing, Postgres JDBC driver converts LocalDateTime to string representing date-time in JVM zone
-                // TODO upgrade driver or find a different way to write timestamp values
+            if (insertWithPresto) {
+                // When inserting with Presto, we effectively go through PostgreSQL driver's PreparedStatement.
+                // The driver converts LocalDateTime to string representing date-time in JVM zone
+                // TODO https://github.com/pgjdbc/pgjdbc/issues/1390 or find a different way to write timestamp values
+            }
+            else {
                 addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, epoch); // epoch also is a gap in JVM zone
                 addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone1);
                 addTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, timeGapInJvmZone2);

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -589,14 +589,18 @@ public class TestPostgreSqlTypeMapping
             DataTypeTest tests = DataTypeTest.create()
                     .addRoundTrip(dataType, asList(beforeEpoch))
                     .addRoundTrip(dataType, asList(afterEpoch))
-                    // timeGapInJvmZone is shifted by 1 hour when using java.sql.Timestamp
-                    // Commenting those tests until it will be possible to use java.time.LocalDateTime with org.postgresql.jdbc.PgArray (https://github.com/pgjdbc/pgjdbc/issues/1225#issuecomment-516312324)
-                    //.addRoundTrip(dataType, asList(epoch)) // epoch also is a gap in JVM zone
-                    //.addRoundTrip(dataType, asList(timeGapInJvmZone1))
-                    //.addRoundTrip(dataType, asList(timeGapInJvmZone2))
                     .addRoundTrip(dataType, asList(timeDoubledInJvmZone))
                     .addRoundTrip(dataType, asList(timeDoubledInVilnius));
 
+            if (insertWithPresto) {
+                // When inserting with Presto, we effectively go through PostgreSQL driver's PreparedStatement.
+                // TODO https://github.com/pgjdbc/pgjdbc/issues/1225 the driver needs to support writing arrays using LocalDateTime objects
+            }
+            else {
+                addArrayTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, dataType, epoch);
+                addArrayTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, dataType, timeGapInJvmZone1);
+                addArrayTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, dataType, timeGapInJvmZone2);
+            }
             addArrayTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, dataType, timeGapInVilnius);
             addArrayTimestampTestIfSupported(tests, legacyTimestamp, sessionZone, dataType, timeGapInKathmandu);
 


### PR DESCRIPTION
Support reading PostgreSQL timestamp arrays containing date/time values
being a "gap" in JVM zone.