### PR TITLE
Make TestTable name really unique

### DIFF
--- a/presto-tests/src/main/java/io/prestosql/tests/sql/TestTable.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/sql/TestTable.java
@@ -13,20 +13,25 @@
  */
 package io.prestosql.tests.sql;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.security.SecureRandom;
+
+import static java.lang.Character.MAX_RADIX;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
 
 public class TestTable
         implements AutoCloseable
 {
+    private static final SecureRandom random = new SecureRandom();
+    private static final int RANDOM_SUFFIX_LENGTH = 12;
+
     private final SqlExecutor sqlExecutor;
     private final String name;
-
-    private static final AtomicInteger instanceCounter = new AtomicInteger();
 
     public TestTable(SqlExecutor sqlExecutor, String namePrefix, String createDdlTemplate)
     {
         this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + "_" + instanceCounter.incrementAndGet();
+        this.name = namePrefix + "_" + randomTableSuffix();
         sqlExecutor.execute(createDdlTemplate.replace("{TABLE_NAME}", this.name));
     }
 
@@ -39,5 +44,11 @@ public class TestTable
     public void close()
     {
         sqlExecutor.execute("DROP TABLE " + name);
+    }
+
+    private static String randomTableSuffix()
+    {
+        String randomSuffix = Long.toString(abs(random.nextLong()), MAX_RADIX);
+        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
     }
 }


### PR DESCRIPTION
Some connector tests might be executed in parallel
with different configuration. In such case
names of temporary table should not clash