### PR TITLE
Make Kerberos config properties consistent

### DIFF
--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -127,10 +127,10 @@ credentials for the internal communication, in addition to the SSL/TLS propertie
 
     The service name and keytab file used for internal Kerberos authentication is
     taken from server Kerberos authentication properties, documented in :doc:`Kerberos</security/server>`,
-    ``http.server.authentication.krb5.service-name`` and ``http.server.authentication.krb5.keytab``
+    ``http-server.authentication.krb5.service-name`` and ``http-server.authentication.krb5.keytab``
     respectively. Make sure you have the Kerberos setup done on the worker nodes as well.
     The Kerberos principal for internal communication is built from
-    ``http.server.authentication.krb5.service-name`` after appending it with the hostname of
+    ``http-server.authentication.krb5.service-name`` after appending it with the hostname of
     the node where Presto is running on and default realm from Kerberos configuration.
 
 Performance with SSL/TLS enabled

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -86,10 +86,10 @@ Kerberos authentication is configured in the coordinator node's
 
     http-server.authentication.type=KERBEROS
 
-    http.server.authentication.krb5.service-name=presto
-    http.server.authentication.krb5.principal-hostname=presto.prestosql.io
-    http.server.authentication.krb5.keytab=/etc/presto/presto.keytab
-    http.authentication.krb5.config=/etc/krb5.conf
+    http-server.authentication.krb5.service-name=presto
+    http-server.authentication.krb5.principal-hostname=presto.prestosql.io
+    http-server.authentication.krb5.keytab=/etc/presto/presto.keytab
+    http-server.authentication.krb5.config=/etc/krb5.conf
 
     http-server.https.enabled=true
     http-server.https.port=7778
@@ -102,16 +102,16 @@ Property                                                Description
 ======================================================= ======================================================
 ``http-server.authentication.type``                     Authentication type for the Presto
                                                         coordinator. Must be set to ``KERBEROS``.
-``http.server.authentication.krb5.service-name``        The Kerberos service name for the Presto coordinator.
+``http-server.authentication.krb5.service-name``        The Kerberos service name for the Presto coordinator.
                                                         Must match the Kerberos principal.
-``http.server.authentication.krb5.principal-hostname``  The Kerberos hostname for the Presto coordinator.
+``http-server.authentication.krb5.principal-hostname``  The Kerberos hostname for the Presto coordinator.
                                                         Must match the Kerberos principal. This parameter is
                                                         optional. If included, Presto will use this value
                                                         in the host part of the Kerberos principal instead
                                                         of the machine's hostname.
-``http.server.authentication.krb5.keytab``              The location of the keytab that can be used to
+``http-server.authentication.krb5.keytab``              The location of the keytab that can be used to
                                                         authenticate the Kerberos principal.
-``http.authentication.krb5.config``                     The location of the Kerberos configuration file.
+``http-server.authentication.krb5.config``              The location of the Kerberos configuration file.
 ``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
                                                         Should be set to ``true``.
 ``http-server.https.port``                              HTTPS server port.

--- a/presto-main/src/main/java/io/prestosql/server/security/KerberosConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/KerberosConfig.java
@@ -14,6 +14,7 @@
 package io.prestosql.server.security;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.NotNull;
 
@@ -23,7 +24,7 @@ import static io.prestosql.server.security.KerberosNameType.HOSTBASED_SERVICE;
 
 public class KerberosConfig
 {
-    public static final String HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB = "http.server.authentication.krb5.keytab";
+    public static final String HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB = "http-server.authentication.krb5.keytab";
 
     private File kerberosConfig;
     private String serviceName;
@@ -37,7 +38,8 @@ public class KerberosConfig
         return kerberosConfig;
     }
 
-    @Config("http.authentication.krb5.config")
+    @Config("http-server.authentication.krb5.config")
+    @LegacyConfig("http.authentication.krb5.config")
     public KerberosConfig setKerberosConfig(File kerberosConfig)
     {
         this.kerberosConfig = kerberosConfig;
@@ -50,7 +52,8 @@ public class KerberosConfig
         return serviceName;
     }
 
-    @Config("http.server.authentication.krb5.service-name")
+    @Config("http-server.authentication.krb5.service-name")
+    @LegacyConfig("http.server.authentication.krb5.service-name")
     public KerberosConfig setServiceName(String serviceName)
     {
         this.serviceName = serviceName;
@@ -63,6 +66,7 @@ public class KerberosConfig
     }
 
     @Config(HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB)
+    @LegacyConfig("http.server.authentication.krb5.keytab")
     public KerberosConfig setKeytab(File keytab)
     {
         this.keytab = keytab;
@@ -74,7 +78,8 @@ public class KerberosConfig
         return principalHostname;
     }
 
-    @Config("http.server.authentication.krb5.principal-hostname")
+    @Config("http-server.authentication.krb5.principal-hostname")
+    @LegacyConfig("http.server.authentication.krb5.principal-hostname")
     public KerberosConfig setPrincipalHostname(String principalHostname)
     {
         this.principalHostname = principalHostname;
@@ -87,7 +92,8 @@ public class KerberosConfig
         return nameType;
     }
 
-    @Config("http.server.authentication.krb5.name-type")
+    @Config("http-server.authentication.krb5.name-type")
+    @LegacyConfig("http.server.authentication.krb5.name-type")
     public KerberosConfig setNameType(KerberosNameType nameType)
     {
         this.nameType = nameType;

--- a/presto-main/src/test/java/io/prestosql/server/security/TestKerberosConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestKerberosConfig.java
@@ -42,11 +42,11 @@ public class TestKerberosConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("http.authentication.krb5.config", "/etc/krb5.conf")
-                .put("http.server.authentication.krb5.service-name", "airlift")
-                .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
-                .put("http.server.authentication.krb5.principal-hostname", "presto.prestosql.io")
-                .put("http.server.authentication.krb5.name-type", "USER_NAME")
+                .put("http-server.authentication.krb5.config", "/etc/krb5.conf")
+                .put("http-server.authentication.krb5.service-name", "airlift")
+                .put("http-server.authentication.krb5.keytab", "/tmp/presto.keytab")
+                .put("http-server.authentication.krb5.principal-hostname", "presto.prestosql.io")
+                .put("http-server.authentication.krb5.name-type", "USER_NAME")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()

--- a/presto-product-tests/conf/presto/etc/multinode-tls-kerberos-master.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-kerberos-master.properties
@@ -37,10 +37,10 @@ http-server.https.port=7778
 http-server.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks
 http-server.https.keystore.key=123456
 
-http.authentication.krb5.config=/etc/krb5.conf
+http-server.authentication.krb5.config=/etc/krb5.conf
 http-server.authentication.type=KERBEROS
-http.server.authentication.krb5.service-name=presto-server
-http.server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
+http-server.authentication.krb5.service-name=presto-server
+http-server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
 
 internal-communication.https.required=true
 internal-communication.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks

--- a/presto-product-tests/conf/presto/etc/multinode-tls-kerberos-worker.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-kerberos-worker.properties
@@ -35,10 +35,10 @@ http-server.https.port=7778
 http-server.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks
 http-server.https.keystore.key=123456
 
-http.authentication.krb5.config=/etc/krb5.conf
+http-server.authentication.krb5.config=/etc/krb5.conf
 http-server.authentication.type=KERBEROS
-http.server.authentication.krb5.service-name=presto-server
-http.server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
+http-server.authentication.krb5.service-name=presto-server
+http-server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
 
 internal-communication.https.required=true
 internal-communication.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks

--- a/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
@@ -17,15 +17,15 @@ query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=https://presto-master.docker.cluster:7778
 
-http.authentication.krb5.config=/etc/krb5.conf
+http-server.authentication.krb5.config=/etc/krb5.conf
 http-server.authentication.type=KERBEROS,CERTIFICATE
-http.server.authentication.krb5.service-name=presto-server
+http-server.authentication.krb5.service-name=presto-server
 http-server.http.enabled=false
 http-server.https.enabled=true
 http-server.https.port=7778
 http-server.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks
 http-server.https.keystore.key=123456
-http.server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
+http-server.authentication.krb5.keytab=/etc/presto/conf/presto-server.keytab
 
 internal-communication.https.required=true
 internal-communication.https.keystore.path=/docker/volumes/conf/presto/etc/docker.cluster.jks


### PR DESCRIPTION
Previously kerberos configuration required properties like:

http.authentication.krb5.config=etc/kerberos/testing-krb5.conf
http-server.authentication.type=KERBEROS
http.server.authentication.krb5.service-name=presto-server
http.server.authentication.krb5.keytab=etc/kerberos/presto-server_presto-master.docker.cluster.keytab

Now all properties would have common "http-server" prefix