### PR TITLE
Log JdbcClient invocations

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -99,12 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>parameternames</artifactId>
-            <version>1.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -15,9 +15,9 @@ package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
-import io.prestosql.plugin.hive.util.LoggingInvocationHandler;
-import io.prestosql.plugin.hive.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
-import io.prestosql.plugin.hive.util.LoggingInvocationHandler.ParameterNamesProvider;
+import io.prestosql.plugin.base.util.LoggingInvocationHandler;
+import io.prestosql.plugin.base.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
+import io.prestosql.plugin.base.util.LoggingInvocationHandler.ParameterNamesProvider;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestLoggingInvocationHandlerWithHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestLoggingInvocationHandlerWithHiveMetastore.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.util;
+
+import io.prestosql.plugin.base.util.LoggingInvocationHandler;
+import io.prestosql.plugin.base.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.reflect.Reflection.newProxy;
+import static java.lang.reflect.Proxy.newProxyInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggingInvocationHandlerWithHiveMetastore
+{
+    private static final String DURATION_PATTERN = "\\d+(\\.\\d+)?\\w{1,2}";
+
+    @Test
+    public void testWithThriftHiveMetastoreClient()
+            throws Exception
+    {
+        List<String> messages = new ArrayList<>();
+        // LoggingInvocationHandler is used e.g. with ThriftHiveMetastore.Iface. Since the logging is reflection-based,
+        // we test it with this interface as well.
+        ThriftHiveMetastore.Iface proxy = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(
+                dummyThriftHiveMetastoreClient(),
+                new AirliftParameterNamesProvider(ThriftHiveMetastore.Iface.class, ThriftHiveMetastore.Client.class),
+                messages::add));
+        proxy.get_table("some_database", "some_table_name");
+        assertThat(messages)
+                .hasSize(1)
+                .element(0).matches(message -> message.matches("\\QInvocation of get_table(dbname='some_database', tbl_name='some_table_name') succeeded in\\E " + DURATION_PATTERN));
+    }
+
+    private static ThriftHiveMetastore.Iface dummyThriftHiveMetastoreClient()
+    {
+        return (ThriftHiveMetastore.Iface) newProxyInstance(
+                TestLoggingInvocationHandlerWithHiveMetastore.class.getClassLoader(),
+                new Class<?>[] {ThriftHiveMetastore.Iface.class},
+                (proxy, method, args) -> null);
+    }
+}

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -33,6 +33,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>parameternames</artifactId>
+            <version>1.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/LoggingInvocationHandler.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/LoggingInvocationHandler.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -26,6 +26,12 @@
         <dependency>
             <groupId>io.airlift.drift</groupId>
             <artifactId>drift-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>parameternames</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
```
INFO	dispatcher-query-36	io.prestosql.event.QueryMonitor	TIMELINE: Query 20190810_204626_01200_jd4ta :: Transaction:[3311da6d-3e21-418f-af97-2237f2096afd] :: elapsed 14ms :: planning 3ms :: waiting 3ms :: scheduling 4ms :: running 6ms :: finishing 1ms :: begin 2019-08-10T15:46:26.967-05:00 :: end 2019-08-10T15:46:26.981-05:00
2019-08-10T15:46:27.023-0500	DEBUG	Query-20190810_204627_01201_jd4ta-710	io.prestosql.plugin.jdbc.JdbcClient	Invocation of getTableHandle(identity=JdbcIdentity{user=user, extraCredentials=[]}, schemaTableName=tpch.orders) succeeded in 455.84us
2019-08-10T15:46:27.025-0500	DEBUG	Query-20190810_204627_01201_jd4ta-710	io.prestosql.plugin.jdbc.JdbcClient	Invocation of getColumns(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, tableHandle=tpch.orders TEST-7768427258835813315.TPCH.ORDERS) succeeded in 1.89ms
2019-08-10T15:46:27.028-0500	DEBUG	Query-20190810_204627_01201_jd4ta-638	io.prestosql.plugin.jdbc.JdbcClient	Invocation of getTableStatistics(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, handle=tpch.orders TEST-7768427258835813315.TPCH.ORDERS, tupleDomain=TupleDomain{ALL}) succeeded in 8.73us
2019-08-10T15:46:27.029-0500	DEBUG	Query-20190810_204627_01201_jd4ta-638	io.prestosql.plugin.jdbc.JdbcClient	Invocation of getSplits(identity=JdbcIdentity{user=user, extraCredentials=[]}, tableHandle=tpch.orders TEST-7768427258835813315.TPCH.ORDERS) succeeded in 9.14us
2019-08-10T15:46:27.030-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of getConnection(identity=JdbcIdentity{user=user, extraCredentials=[]}, split=io.prestosql.plugin.jdbc.JdbcSplit@69792765) succeeded in 83.35us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=-5, jdbcTypeName=BIGINT, columnSize=19, decimalDigits=0}) succeeded in 19.76us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=-5, jdbcTypeName=BIGINT, columnSize=19, decimalDigits=0}) succeeded in 6.33us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=12, jdbcTypeName=VARCHAR, columnSize=1, decimalDigits=0}) succeeded in 7.27us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=8, jdbcTypeName=DOUBLE, columnSize=17, decimalDigits=0}) succeeded in 5.05us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=91, jdbcTypeName=DATE, columnSize=10, decimalDigits=0}) succeeded in 3.33us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=12, jdbcTypeName=VARCHAR, columnSize=15, decimalDigits=0}) succeeded in 6.84us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=12, jdbcTypeName=VARCHAR, columnSize=15, decimalDigits=0}) succeeded in 4.17us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=4, jdbcTypeName=INTEGER, columnSize=10, decimalDigits=0}) succeeded in 2.95us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of toPrestoType(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, typeHandle=JdbcTypeHandle{jdbcType=12, jdbcTypeName=VARCHAR, columnSize=79, decimalDigits=0}) succeeded in 3.35us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of buildSql(session=FullConnectorSession{queryId=20190810_204627_01201_jd4ta, user=user, source=test, timeZoneKey=Pacific/Apia, locale=en, startTime=1565469987022, properties={}}, connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=, split=io.prestosql.plugin.jdbc.JdbcSplit@69792765, table=tpch.orders TEST-7768427258835813315.TPCH.ORDERS, columns=[ORDERKEY:bigint:Optional[BIGINT], CUSTKEY:bigint:Optional[BIGINT], ORDERSTATUS:varchar(1):Optional[VARCHAR], TOTALPRICE:double:Optional[DOUBLE], ORDERDATE:date:Optional[DATE], ORDERPRIORITY:varchar(15):Optional[VARCHAR], CLERK:varchar(15):Optional[VARCHAR], SHIPPRIORITY:integer:Optional[INTEGER], COMMENT:varchar(79):Optional[VARCHAR]]) succeeded in 49.28us
2019-08-10T15:46:27.031-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcRecordCursor	Executing: prep4600: SELECT "ORDERKEY", "CUSTKEY", "ORDERSTATUS", "TOTALPRICE", "ORDERDATE", "ORDERPRIORITY", "CLERK", "SHIPPRIORITY", "COMMENT" FROM "TEST-7768427258835813315"."TPCH"."ORDERS"
2019-08-10T15:46:27.065-0500	DEBUG	20190810_204627_01201_jd4ta.1.0-0-582	io.prestosql.plugin.jdbc.JdbcClient	Invocation of abortReadConnection(connection=conn2649: url=jdbc:h2:mem:test-7768427258835813315 user=) succeeded in 7.12us
2019-08-10T15:46:27.072-0500	I
```