### PR TITLE
Prevent writes to Hive transactional tables

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -220,6 +220,7 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
+import static org.apache.hadoop.hive.ql.io.AcidUtils.isTransactionalTable;
 
 public class HiveMetadata
         implements TransactionalMetadata
@@ -314,6 +315,12 @@ public class HiveMetadata
         }
 
         verifyOnline(tableName, Optional.empty(), getProtectMode(table.get()), table.get().getParameters());
+
+        if (isTransactionalTable(table.get().getParameters())) {
+            // TODO support reading from transactional tables
+            throw new PrestoException(NOT_SUPPORTED, "Hive transactional tables are not supported: " + tableName);
+        }
+
         return new HiveTableHandle(
                 tableName.getSchemaName(),
                 tableName.getTableName(),

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriteUtils.java
@@ -425,7 +425,7 @@ public final class HiveWriteUtils
         // verify transactional
         if (isTransactionalTable(parameters)) {
             // TODO support writing to transactional tables
-            throw new PrestoException(NOT_SUPPORTED, "Inserting into Hive transactional tables is not supported: " + tableName);
+            throw new PrestoException(NOT_SUPPORTED, "Hive transactional tables are not supported: " + tableName);
         }
     }
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
@@ -24,6 +24,21 @@ public class TestHiveTransactionalTable
         extends ProductTest
 {
     @Test
+    public void testSelectFromTransactionalTable()
+    {
+        onHive().executeQuery("" +
+                "CREATE TABLE test_select_from_transactional_table(a bigint)" +
+                "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES ('transactional'='true', 'bucketing_version'='1')");
+        try {
+            assertThat(() -> query("SELECT * FROM test_select_from_transactional_table"))
+                    .failsWithMessage("Hive transactional tables are not supported: default.test_select_from_transactional_table");
+        }
+        finally {
+            onHive().executeQuery("DROP TABLE test_select_from_transactional_table");
+        }
+    }
+
+    @Test
     public void testInsertIntoTransactionalTable()
     {
         onHive().executeQuery("" +

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import io.prestosql.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
+import static io.prestosql.tempto.query.QueryExecutor.query;
+import static io.prestosql.tests.utils.QueryExecutors.onHive;
+
+public class TestHiveTransactionalTable
+        extends ProductTest
+{
+    @Test
+    public void testInsertIntoTransactionalTable()
+    {
+        onHive().executeQuery("" +
+                "CREATE TABLE test_insert_into_transactional_table(a bigint)" +
+                "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES ('transactional'='true', 'bucketing_version'='1')");
+
+        try {
+            assertThat(() -> query("INSERT INTO test_insert_into_transactional_table (a) VALUES (42)"))
+                    .failsWithMessage("Hive transactional tables are not supported: default.test_insert_into_transactional_table");
+        }
+        finally {
+            onHive().executeQuery("DROP TABLE test_insert_into_transactional_table");
+        }
+    }
+}

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestInsertIntoHiveTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestInsertIntoHiveTable.java
@@ -35,7 +35,6 @@ import static io.prestosql.tempto.fulfillment.table.TableRequirements.immutableT
 import static io.prestosql.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.prestosql.tempto.query.QueryExecutor.query;
 import static io.prestosql.tests.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
-import static io.prestosql.tests.utils.QueryExecutors.onHive;
 
 public class TestInsertIntoHiveTable
         extends ProductTest
@@ -146,18 +145,5 @@ public class TestInsertIntoHiveTable
         String tableNameInDatabase = mutableTablesState().get(PARTITIONED_TABLE_WITH_SERDE).getNameInDatabase();
         assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'presto', '2018-01-01'")).containsExactly(row(1));
         assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsExactly(row(1, "presto", "2018-01-01"));
-    }
-
-    @Test
-    public void testInsertIntoTransactionalTable()
-    {
-        onHive().executeQuery("" +
-                "CREATE TABLE test_insert_into_transactional_table(a bigint)" +
-                "CLUSTERED BY(a) INTO 4 BUCKETS STORED AS ORC TBLPROPERTIES ('transactional'='true', 'bucketing_version'='1')");
-
-        assertThat(() -> query("INSERT INTO test_insert_into_transactional_table (a) VALUES (42)"))
-                .failsWithMessage("Inserting into Hive transactional tables is not supported: default.test_insert_into_transactional_table");
-
-        onHive().executeQuery("DROP TABLE test_insert_into_transactional_table");
     }
 }


### PR DESCRIPTION
Previously it would fail _after_ writing with something like:

> `org.apache.hadoop.hive.metastore.api.MetaException: Cannot change stats state for a transactional table without providing the transactional write state for verification (new write ID -1, valid write IDs null; current state null; new state {"COLUMN_STATS":{"creation_time":"true","current_flag":"true","eff_end_time":"true","eff_start_time":"true","extract_time":"true","id":"true","key":"true","modified_time":"true","name":"true","nickname":"true"}}`

Now it fails cleanly _before_ writing.

Also, I suppose previously it wouldn't fail at all if stats collection was disabled.