### PR TITLE
Hide $bucket column for bucketing v2

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUtil.java
@@ -100,6 +100,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.transform;
+import static io.prestosql.plugin.hive.HiveBucketing.isHiveBucketingV1;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.bucketColumnHandle;
@@ -832,7 +833,7 @@ public final class HiveUtil
 
         // add hidden columns
         columns.add(pathColumnHandle());
-        if (table.getStorage().getBucketProperty().isPresent()) {
+        if (table.getStorage().getBucketProperty().isPresent() && isHiveBucketingV1(table)) {
             columns.add(bucketColumnHandle());
         }
 


### PR DESCRIPTION
Before the change, selecting `"$bucket"` would fail at run-time with

```
Query 20190820_065833_00012_nk9ff failed: No value present
java.util.NoSuchElementException: No value present
	at java.util.OptionalInt.getAsInt(OptionalInt.java:118)
	at io.prestosql.plugin.hive.HiveUtil.getPrefilledColumnValue(HiveUtil.java:920)
	at io.prestosql.plugin.hive.HivePageSourceProvider$ColumnMapping.buildColumnMappings(HivePageSourceProvider.java:332)
	at io.prestosql.plugin.hive.HivePageSourceProvider.createHivePageSource(HivePageSourceProvider.java:143)
	at io.prestosql.plugin.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:98)
```