### PR TITLE
Compatibility fix for Athena Glue

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -41,6 +41,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 
 public final class GlueToPrestoConverter
 {
@@ -69,7 +70,8 @@ public final class GlueToPrestoConverter
                 .setDatabaseName(dbName)
                 .setTableName(glueTable.getName())
                 .setOwner(nullToEmpty(glueTable.getOwner()))
-                .setTableType(glueTable.getTableType())
+                // Athena treats missing table type as EXTERNAL_TABLE.
+                .setTableType(firstNonNull(glueTable.getTableType(), EXTERNAL_TABLE.name()))
                 .setDataColumns(sd.getColumns().stream()
                         .map(GlueToPrestoConverter::convertColumn)
                         .collect(toList()))

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueToPrestoConverter.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueToPrestoConverter.java
@@ -33,6 +33,7 @@ import static io.prestosql.plugin.hive.metastore.glue.TestingMetastoreObjects.ge
 import static io.prestosql.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestDatabase;
 import static io.prestosql.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestPartition;
 import static io.prestosql.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestTable;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -81,6 +82,15 @@ public class TestGlueToPrestoConverter
         assertStorage(prestoTable.getStorage(), testTable.getStorageDescriptor());
         assertEquals(prestoTable.getViewOriginalText().get(), testTable.getViewOriginalText());
         assertEquals(prestoTable.getViewExpandedText().get(), testTable.getViewExpandedText());
+    }
+
+    @Test
+    public void testConvertTableWithoutTableType()
+    {
+        Table table = getGlueTestTable(testDatabase.getName());
+        table.setTableType(null);
+        io.prestosql.plugin.hive.metastore.Table prestoTable = GlueToPrestoConverter.convertTable(table, testDatabase.getName());
+        assertEquals(prestoTable.getTableType(), MANAGED_TABLE.name());
     }
 
     @Test


### PR DESCRIPTION
Athena is fine reading Glue tables that have no table type set. The same table will cause Presto to NPE as the
table type can not be null in presto. This fix will use MANAGED_TABLE if the table type is not set.