### PR TITLE
Fix output data size reporting for PartitionedOutputOperator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PartitionedOutputOperator.java
@@ -218,7 +218,8 @@ public class PartitionedOutputOperator
                 outputBuffer,
                 serdeFactory,
                 sourceTypes,
-                maxMemory);
+                maxMemory,
+                operatorContext);
 
         operatorContext.setInfoSupplier(this::getInfo);
         this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
@@ -275,8 +276,6 @@ public class PartitionedOutputOperator
         page = pagePreprocessor.apply(page);
         partitionFunction.partitionPage(page);
 
-        operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
-
         // We use getSizeInBytes() here instead of getRetainedSizeInBytes() for an approximation of
         // the amount of memory used by the pageBuilders, because calculating the retained
         // size can be expensive especially for complex types.
@@ -306,6 +305,7 @@ public class PartitionedOutputOperator
         private final AtomicLong rowsAdded = new AtomicLong();
         private final AtomicLong pagesAdded = new AtomicLong();
         private boolean hasAnyRowBeenReplicated;
+        private OperatorContext operatorContext;
 
         public PagePartitioner(
                 PartitionFunction partitionFunction,
@@ -316,7 +316,8 @@ public class PartitionedOutputOperator
                 OutputBuffer outputBuffer,
                 PagesSerdeFactory serdeFactory,
                 List<Type> sourceTypes,
-                DataSize maxMemory)
+                DataSize maxMemory,
+                OperatorContext operatorContext)
         {
             this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
             this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
@@ -328,6 +329,7 @@ public class PartitionedOutputOperator
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
             this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
+            this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
 
             int partitionCount = partitionFunction.getPartitionCount();
             int pageSize = min(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, ((int) maxMemory.toBytes()) / partitionCount);
@@ -427,6 +429,8 @@ public class PartitionedOutputOperator
                 if (!partitionPageBuilder.isEmpty() && (force || partitionPageBuilder.isFull())) {
                     Page pagePartition = partitionPageBuilder.build();
                     partitionPageBuilder.reset();
+
+                    operatorContext.recordOutput(pagePartition.getSizeInBytes(), pagePartition.getPositionCount());
 
                     List<SerializedPage> serializedPages = splitPage(pagePartition, DEFAULT_MAX_PAGE_SIZE_IN_BYTES).stream()
                             .map(serde::serialize)

--- a/presto-main/src/test/java/io/prestosql/operator/TestPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestPartitionedOutputOperator.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import io.prestosql.execution.StateMachine;
+import io.prestosql.execution.buffer.OutputBuffers;
+import io.prestosql.execution.buffer.PagesSerdeFactory;
+import io.prestosql.execution.buffer.PartitionedOutputBuffer;
+import io.prestosql.memory.context.SimpleLocalMemoryContext;
+import io.prestosql.operator.exchange.LocalPartitionGenerator;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+import io.prestosql.testing.TestingTaskContext;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.prestosql.SessionTestUtils.TEST_SESSION;
+import static io.prestosql.block.BlockAssertions.createLongDictionaryBlock;
+import static io.prestosql.block.BlockAssertions.createLongSequenceBlock;
+import static io.prestosql.block.BlockAssertions.createRLEBlock;
+import static io.prestosql.execution.buffer.BufferState.OPEN;
+import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
+import static io.prestosql.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
+import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestPartitionedOutputOperator
+{
+    private static final int PAGE_COUNT = 100;
+    private static final int POSITIONS_PER_PAGE = 1000;
+
+    private static final int PARTITION_COUNT = 512;
+    private static final DataSize MAX_MEMORY = new DataSize(1, GIGABYTE);
+    private static final DataSize PARTITION_MAX_MEMORY = new DataSize(5, MEGABYTE);
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT);
+    private static final List<Type> REPLICATION_TYPES = ImmutableList.of(BIGINT, BIGINT);
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
+    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+
+    private static final Block NULL_BLOCK = new RunLengthEncodedBlock(BIGINT.createBlockBuilder(null, 1).appendNull().build(), POSITIONS_PER_PAGE);
+    private static final Block TESTING_BLOCK = createLongSequenceBlock(0, POSITIONS_PER_PAGE);
+    private static final Block TESTING_DICTIONARY_BLOCK = createLongDictionaryBlock(0, POSITIONS_PER_PAGE);
+    private static final Block TESTING_RLE_BLOCK = createRLEBlock(new Random(0).nextLong(), POSITIONS_PER_PAGE);
+    private static final Page TESTING_PAGE = new Page(TESTING_BLOCK);
+    private static final Page TESTING_PAGE_WITH_NULL_BLOCK = new Page(POSITIONS_PER_PAGE, NULL_BLOCK, TESTING_BLOCK);
+
+    @Test
+    public void testOutputForSimplePage()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(false);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(TESTING_PAGE);
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getPositionCount());
+    }
+
+    @Test
+    public void testOutputForPageWithDictionary()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(false);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(new Page(TESTING_DICTIONARY_BLOCK));
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getPositionCount());
+    }
+
+    @Test
+    public void testOutputForPageWithRunLength()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(false);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(new Page(TESTING_RLE_BLOCK));
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * TESTING_PAGE.getPositionCount());
+    }
+
+    @Test
+    public void testOutputForSimplePageAndReplication()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(true);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(new Page(POSITIONS_PER_PAGE, NULL_BLOCK, TESTING_BLOCK));
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getPositionCount());
+    }
+
+    @Test
+    public void testOutputForPageWithDictionaryAndReplication()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(true);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(new Page(POSITIONS_PER_PAGE, NULL_BLOCK, TESTING_DICTIONARY_BLOCK));
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getPositionCount());
+    }
+
+    @Test
+    public void testOutputForPageWithRunLengthAndReplication()
+    {
+        PartitionedOutputOperator partitionedOutputOperator = createPartitionedOutputOperator(true);
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            partitionedOutputOperator.addInput(new Page(POSITIONS_PER_PAGE, NULL_BLOCK, TESTING_RLE_BLOCK));
+        }
+        partitionedOutputOperator.finish();
+
+        OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
+        assertEquals(operatorContext.getOutputDataSize().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getSizeInBytes());
+        assertEquals(operatorContext.getOutputPositions().getTotalCount(), PAGE_COUNT * PARTITION_COUNT * TESTING_PAGE_WITH_NULL_BLOCK.getPositionCount());
+    }
+
+    private static PartitionedOutputOperator createPartitionedOutputOperator(boolean shouldReplicate)
+    {
+        PartitionFunction partitionFunction = new LocalPartitionGenerator(new InterpretedHashGenerator(ImmutableList.of(BIGINT), new int[] {0}), PARTITION_COUNT);
+        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(createTestMetadataManager().getBlockEncodingSerde(), false);
+
+        DriverContext driverContext = TestingTaskContext.builder(EXECUTOR, SCHEDULER, TEST_SESSION)
+                .setMemoryPoolSize(MAX_MEMORY)
+                .build()
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+
+        OutputBuffers buffers = OutputBuffers.createInitialEmptyOutputBuffers(PARTITIONED);
+        for (int partition = 0; partition < PARTITION_COUNT; partition++) {
+            buffers = buffers.withBuffer(new OutputBuffers.OutputBufferId(partition), partition);
+        }
+        PartitionedOutputBuffer buffer = new PartitionedOutputBuffer(
+                "task-instance-id",
+                new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                buffers.withNoMoreBufferIds(),
+                new DataSize(Long.MAX_VALUE, BYTE),
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
+                SCHEDULER);
+
+        PartitionedOutputOperator.PartitionedOutputFactory operatorFactory;
+        if (shouldReplicate) {
+            operatorFactory = new PartitionedOutputOperator.PartitionedOutputFactory(
+                    partitionFunction,
+                    ImmutableList.of(0),
+                    ImmutableList.of(Optional.empty()),
+                    true,
+                    OptionalInt.of(0),
+                    buffer,
+                    PARTITION_MAX_MEMORY);
+            return (PartitionedOutputOperator) operatorFactory
+                    .createOutputOperator(0, new PlanNodeId("plan-node-0"), REPLICATION_TYPES, Function.identity(), serdeFactory)
+                    .createOperator(driverContext);
+        }
+        else {
+            operatorFactory = new PartitionedOutputOperator.PartitionedOutputFactory(
+                    partitionFunction,
+                    ImmutableList.of(0),
+                    ImmutableList.of(Optional.empty(), Optional.empty()),
+                    false,
+                    OptionalInt.empty(),
+                    buffer,
+                    PARTITION_MAX_MEMORY);
+            return (PartitionedOutputOperator) operatorFactory
+                    .createOutputOperator(0, new PlanNodeId("plan-node-0"), TYPES, Function.identity(), serdeFactory)
+                    .createOperator(driverContext);
+        }
+    }
+}


### PR DESCRIPTION
Extracted from: https://github.com/prestodb/presto/pull/13224