### PR TITLE
Fix table listing in Iceberg to skip non-Iceberg tables

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -45,6 +45,8 @@ public interface HiveMetastore
 
     List<String> getAllTables(String databaseName);
 
+    List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
+
     List<String> getAllViews(String databaseName);
 
     void createDatabase(Database database);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/TablesWithParameterCacheKey.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/TablesWithParameterCacheKey.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+@Immutable
+public class TablesWithParameterCacheKey
+{
+    private final String databaseName;
+    private final String parameterKey;
+    private final String parameterValue;
+
+    @JsonCreator
+    public TablesWithParameterCacheKey(
+            @JsonProperty("databaseName") String databaseName,
+            @JsonProperty("parameterKey") String parameterKey,
+            @JsonProperty("parameterValue") String parameterValue)
+    {
+        this.databaseName = databaseName;
+        this.parameterKey = parameterKey;
+        this.parameterValue = parameterValue;
+    }
+
+    @JsonProperty
+    public String getDatabaseName()
+    {
+        return databaseName;
+    }
+
+    @JsonProperty
+    public String getParameterKey()
+    {
+        return parameterKey;
+    }
+
+    @JsonProperty
+    public String getParameterValue()
+    {
+        return parameterValue;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TablesWithParameterCacheKey other = (TablesWithParameterCacheKey) o;
+        return Objects.equals(databaseName, other.databaseName) &&
+                Objects.equals(parameterKey, other.parameterKey) &&
+                Objects.equals(parameterValue, other.parameterValue);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(databaseName, parameterKey, parameterValue);
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -366,6 +366,13 @@ public class GlueHiveMetastore
     }
 
     @Override
+    public synchronized List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        // TODO
+        throw new UnsupportedOperationException("getTablesWithParameter for GlueHiveMetastore is not implemented");
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
     {
         try {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -126,6 +126,12 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
     {
         return delegate.getAllViews(databaseName);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -54,6 +54,8 @@ public interface ThriftMetastore
 
     List<String> getAllTables(String databaseName);
 
+    List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
+
     List<String> getAllViews(String databaseName);
 
     Optional<Database> getDatabase(String databaseName);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreStats.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreStats.java
@@ -21,6 +21,7 @@ public class ThriftMetastoreStats
     private final ThriftMetastoreApiStats getAllDatabases = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats getDatabase = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats getAllTables = new ThriftMetastoreApiStats();
+    private final ThriftMetastoreApiStats getTablesWithParameter = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats getAllViews = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats getTable = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats getFields = new ThriftMetastoreApiStats();
@@ -68,6 +69,13 @@ public class ThriftMetastoreStats
     public ThriftMetastoreApiStats getGetAllTables()
     {
         return getAllTables;
+    }
+
+    @Managed
+    @Nested
+    public ThriftMetastoreApiStats getGetTablesWithParameter()
+    {
+        return getTablesWithParameter;
     }
 
     @Managed

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -131,6 +131,7 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.getTableStatistics("database", "table"), PARTITION_STATISTICS);
         assertEquals(hiveMetastore.getPartitionStatistics("database", "table", ImmutableSet.of("value")), ImmutableMap.of("value", PARTITION_STATISTICS));
         assertEquals(hiveMetastore.getAllTables("database"), ImmutableList.of("table"));
+        assertEquals(hiveMetastore.getTablesWithParameter("database", "param", "value3"), ImmutableList.of("table"));
         assertEquals(hiveMetastore.getAllViews("database"), ImmutableList.of());
         assertEquals(hiveMetastore.getPartition("database", "table", ImmutableList.of("value")), Optional.of(PARTITION));
         assertEquals(hiveMetastore.getPartitionNames("database", "table"), Optional.of(ImmutableList.of("value")));
@@ -207,6 +208,15 @@ public class TestRecordingHiveMetastore
                 return ImmutableList.of("table");
             }
 
+            return ImmutableList.of();
+        }
+
+        @Override
+        public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+        {
+            if (databaseName.equals("database") && parameterKey.equals("param") && parameterValue.equals("value3")) {
+                return ImmutableList.of("table");
+            }
             return ImmutableList.of();
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -83,6 +83,12 @@ class UnimplementedHiveMetastore
     }
 
     @Override
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
     {
         throw new UnsupportedOperationException();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -54,6 +54,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.prestosql.plugin.hive.HiveBasicStatistics.createEmptyStatistics;
@@ -281,6 +282,19 @@ public class InMemoryThriftMetastore
             }
         }
         return tables.build();
+    }
+
+    @Override
+    public synchronized List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        requireNonNull(parameterKey, "parameterKey is null");
+        requireNonNull(parameterValue, "parameterValue is null");
+
+        return relations.entrySet().stream()
+                .filter(entry -> entry.getKey().getSchemaName().equals(databaseName)
+                        && parameterValue.equals(entry.getValue().getParameters().get(parameterKey)))
+                .map(entry -> entry.getKey().getTableName())
+                .collect(toImmutableList());
     }
 
     @Override

--- a/presto-iceberg/README.md
+++ b/presto-iceberg/README.md
@@ -73,8 +73,6 @@ as a time travel feature which lets you query your table's snapshot at a given t
 
 * Update the README to reflect the current status, and convert it to proper connector documentation
   before announcing the connector as ready for use.
-* Fix table listing to skip non-Iceberg tables. This will need a new metastore method to list tables
-  filtered on a property name, similar to how view listing works in `ThriftHiveMetastore`.
 * Predicate pushdown is currently broken, which means delete is also broken. The code from the
   original `getTableLayouts()` implementation needs to be updated for `applyFilter()`.
 * All of the `HdfsContext` calls that use `/tmp` need to be fixed.

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
@@ -24,6 +24,7 @@ import io.prestosql.plugin.base.security.AllowAllAccessControl;
 import io.prestosql.plugin.hive.HiveCatalogName;
 import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationModule;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
 import io.prestosql.plugin.hive.s3.HiveS3Module;
 import io.prestosql.spi.NodeManager;
@@ -48,10 +49,18 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
 
 public class IcebergConnectorFactory
         implements ConnectorFactory
 {
+    private final Optional<HiveMetastore> metastore;
+
+    public IcebergConnectorFactory(Optional<HiveMetastore> metastore)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+    }
+
     @Override
     public String getName()
     {
@@ -76,7 +85,7 @@ public class IcebergConnectorFactory
                     new IcebergModule(),
                     new HiveS3Module(),
                     new HiveAuthenticationModule(),
-                    new HiveMetastoreModule(Optional.empty()),
+                    new HiveMetastoreModule(metastore),
                     new MBeanServerModule(),
                     binder -> {
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -100,6 +100,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.Transactions.createTableTransaction;
 
@@ -172,11 +174,10 @@ public class IcebergMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        // TODO: this should skip non-Iceberg tables
         return schemaName.map(Collections::singletonList)
                 .orElseGet(metastore::getAllDatabases)
                 .stream()
-                .flatMap(schema -> metastore.getAllTables(schema).stream()
+                .flatMap(schema -> metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE).stream()
                         .map(table -> new SchemaTableName(schema, table))
                         .collect(toList())
                         .stream())

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPlugin.java
@@ -14,15 +14,32 @@
 package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class IcebergPlugin
         implements Plugin
 {
+    private final Optional<HiveMetastore> metastore;
+
+    public IcebergPlugin()
+    {
+        this(Optional.empty());
+    }
+
+    public IcebergPlugin(Optional<HiveMetastore> metastore)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+    }
+
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new IcebergConnectorFactory());
+        return ImmutableList.of(new IcebergConnectorFactory(metastore));
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveConfig;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.HivePlugin;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.spi.security.Identity;
+import io.prestosql.spi.security.SelectedRole;
+import io.prestosql.tests.AbstractTestQueryFramework;
+import io.prestosql.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestIcebergMetadataListing
+        extends AbstractTestQueryFramework
+{
+    private static HiveMetastore metastore;
+
+    public TestIcebergMetadataListing()
+    {
+        super(TestIcebergMetadataListing::createQueryRunner);
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setIdentity(new Identity(
+                        "hive",
+                        Optional.empty(),
+                        ImmutableMap.of("hive", new SelectedRole(ROLE, Optional.of("admin")))))
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+
+        HiveConfig hiveConfig = new HiveConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveConfig, new NoHdfsAuthentication());
+
+        metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+
+        queryRunner.installPlugin(new IcebergPlugin(Optional.of(metastore)));
+        queryRunner.createCatalog("iceberg", "iceberg");
+        queryRunner.installPlugin(new HivePlugin("hive", Optional.of(metastore)));
+        queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        assertQuerySucceeds("CREATE SCHEMA hive.test_schema");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
+        assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
+        assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS hive.test_schema.hive_table");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table2");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table1");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS hive.test_schema");
+    }
+
+    @Test
+    public void testTableListing()
+    {
+        assertQuery("SHOW TABLES FROM iceberg.test_schema", "VALUES 'iceberg_table1', 'iceberg_table2'");
+    }
+
+    @Test
+    public void testTableColumnListing()
+    {
+        // Verify information_schema.columns does not include columns from non-Iceberg tables
+        assertQuery("SELECT table_name, column_name FROM iceberg.information_schema.columns WHERE table_schema = 'test_schema'",
+                "VALUES ('iceberg_table1', '_string'), ('iceberg_table1', '_integer'), ('iceberg_table2', '_double')");
+    }
+
+    @Test
+    public void testTableDescribing()
+    {
+        assertQuery("DESCRIBE iceberg.test_schema.iceberg_table1", "VALUES ('_string', 'varchar', '', ''), ('_integer', 'integer', '', '')");
+    }
+
+    @Test
+    public void testTableValidation()
+    {
+        assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
+        assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+    }
+}


### PR DESCRIPTION
#1324 

Tests done:
1. `mvn clean install` builds successfully in `presto-hive` directory.
2. Introduced `TestIcebergMetadataListing`. `mvn clean install` builds successfully in `presto-iceberg` directory.
3. End-to-end tests look good.