### PR TITLE
Fix count() handling in ScalarAggregationToJoinRewriter

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
@@ -58,8 +58,8 @@ import static java.util.Objects.requireNonNull;
  *   - Join(LEFT_OUTER, D = C)
  *     - AssignUniqueId(adds symbol U)
  *       - (input) plan which produces symbols: [A, B, C]
- *     - Filter(E > 5)
- *       - projection which adds non null symbol used for count() function
+ *     - projection which adds non null symbol used for count() function
+ *       - Filter(E > 5)
  *         - plan which produces symbols: [D, E, F]
  * </pre>
  * <p>

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -174,7 +174,8 @@ public class ScalarAggregationToJoinRewriter
         for (Map.Entry<Symbol, Aggregation> entry : scalarAggregation.getAggregations().entrySet()) {
             Aggregation aggregation = entry.getValue();
             Symbol symbol = entry.getKey();
-            if (aggregation.getSignature().getName().equals("count")) {
+            // Only count() and count(*) require rewriting to count(non_null) in order to preserve the row count. count(argument) shouldn't be rewritten.
+            if (aggregation.getSignature().getName().equals("count") && aggregation.getArguments().size() == 0) {
                 List<TypeSignature> scalarAggregationSourceTypeSignatures = ImmutableList.of(
                         symbolAllocator.getTypes().get(nonNullableAggregationSourceSymbol).getTypeSignature());
                 aggregations.put(symbol, new Aggregation(

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -3634,10 +3634,10 @@ public abstract class AbstractTestQueries
                 " WHERE n3.nationkey = n1.nationkey)" +
                 "FROM nation n1");
 
-        //count in subquery
+        // count in subquery
         assertQuery("SELECT * " +
-                        "FROM (VALUES (0),( 1), (2), (7)) AS v1(c1) " +
-                        "WHERE v1.c1 > (SELECT count(c1) FROM (VALUES (0),( 1), (2)) AS v2(c1) WHERE v1.c1 = v2.c1)",
+                        "FROM (VALUES (0), (1), (2), (7)) AS v1(c1) " +
+                        "WHERE v1.c1 > (SELECT count(c1) FROM (VALUES (0), (1), (2)) AS v2(c1) WHERE v1.c1 = v2.c1)",
                 "VALUES (2), (7)");
     }
 

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -3639,6 +3639,18 @@ public abstract class AbstractTestQueries
                         "FROM (VALUES (0), (1), (2), (7)) AS v1(c1) " +
                         "WHERE v1.c1 > (SELECT count(c1) FROM (VALUES (0), (1), (2)) AS v2(c1) WHERE v1.c1 = v2.c1)",
                 "VALUES (2), (7)");
+
+        // count rows
+        assertQuery("SELECT (SELECT count(*) FROM (VALUES (1, true), (null, true)) inner_table(a, b) WHERE inner_table.b = outer_table.b) FROM (VALUES (true)) outer_table(b)",
+                "VALUES (2)");
+
+        // count rows
+        assertQuery("SELECT (SELECT count() FROM (VALUES (1, true), (null, true)) inner_table(a, b) WHERE inner_table.b = outer_table.b) FROM (VALUES (true)) outer_table(b)",
+                "VALUES (2)");
+
+        // count non null values
+        assertQuery("SELECT (SELECT count(a) FROM (VALUES (1, true), (null, true)) inner_table(a, b) WHERE inner_table.b = outer_table.b) FROM (VALUES (true)) outer_table(b)",
+                "VALUES (1)");
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug in decorrelating a scalar subquery with count() aggregation.

Before this change, the aggregation function `count(argument)` was rewritten in the way that it returned a row count instead of non-null value count for the `argument`.