### PR TITLE
Enable instance and custom credential provider for glue

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -30,6 +30,8 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
+    private Optional<String> awsCredentialsProvider = Optional.empty();
+    private boolean useInstanceCredentials;
     private Optional<String> catalogId = Optional.empty();
 
     public Optional<String> getGlueRegion()
@@ -135,6 +137,30 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setCatalogId(String catalogId)
     {
         this.catalogId = Optional.ofNullable(catalogId);
+        return this;
+    }
+
+    public boolean isUseInstanceCredentials()
+    {
+        return useInstanceCredentials;
+    }
+
+    @Config("hive.metastore.glue.use-instance-credentials")
+    public GlueHiveMetastoreConfig setUseInstanceCredentials(boolean useInstanceCredentials)
+    {
+        this.useInstanceCredentials = useInstanceCredentials;
+        return this;
+    }
+
+    public Optional<String> getAwsCredentialsProvider()
+    {
+        return awsCredentialsProvider;
+    }
+
+    @Config("hive.metastore.glue.aws-credentials-provider")
+    public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
+    {
+        this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
         return this;
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -35,7 +35,9 @@ public class TestGlueHiveMetastoreConfig
                 .setIamRole(null)
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null)
-                .setCatalogId(null));
+                .setAwsCredentialsProvider(null)
+                .setCatalogId(null)
+                .setUseInstanceCredentials(false));
     }
 
     @Test
@@ -49,7 +51,9 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
+                .put("hive.metastore.glue.aws-credentials-provider", "custom")
                 .put("hive.metastore.glue.catalogid", "0123456789")
+                .put("hive.metastore.glue.use-instance-credentials", "true")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -60,7 +64,9 @@ public class TestGlueHiveMetastoreConfig
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
                 .setAwsSecretKey("DEF")
-                .setCatalogId("0123456789");
+                .setAwsCredentialsProvider("custom")
+                .setCatalogId("0123456789")
+                .setUseInstanceCredentials(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add two configs for glue credential provider

Use instance credential(glue configuration property)
hive.metastore.glue.use-instance-credentials=true

Use custom credential class(hdfs configuration)
presto.glue.credentials-provider

where value is fully qualified class name of
custom aws credential provider implementation