### PR TITLE
Set UGI before creating database in Hive

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/MetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/MetastoreLocator.java
@@ -15,11 +15,13 @@ package io.prestosql.plugin.hive.metastore.thrift;
 
 import org.apache.thrift.TException;
 
+import java.util.Optional;
+
 public interface MetastoreLocator
 {
     /**
      * Create a connected {@link ThriftMetastoreClient}
      */
-    ThriftMetastoreClient createMetastoreClient()
+    ThriftMetastoreClient createMetastoreClient(Optional<String> username)
             throws TException;
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -62,7 +63,7 @@ public class StaticMetastoreLocator
      * connection succeeds or there are no more fallback metastores.
      */
     @Override
-    public ThriftMetastoreClient createMetastoreClient()
+    public ThriftMetastoreClient createMetastoreClient(Optional<String> username)
             throws TException
     {
         List<HostAndPort> metastores = new ArrayList<>(addresses);
@@ -72,7 +73,10 @@ public class StaticMetastoreLocator
         for (HostAndPort metastore : metastores) {
             try {
                 ThriftMetastoreClient client = clientFactory.create(metastore);
-                if (!isNullOrEmpty(metastoreUsername)) {
+                if (username.isPresent()) {
+                    client.setUGI(username.get());
+                }
+                else if (!isNullOrEmpty(metastoreUsername)) {
                     client.setUGI(metastoreUsername);
                 }
                 return client;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -771,7 +771,7 @@ public class ThriftHiveMetastore
                     .stopOn(AlreadyExistsException.class, InvalidObjectException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("createDatabase", stats.getCreateDatabase().wrap(() -> {
-                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = createMetastoreClient(database.getOwnerName())) {
                             client.createDatabase(database);
                         }
                         return null;
@@ -1336,7 +1336,13 @@ public class ThriftHiveMetastore
     private ThriftMetastoreClient createMetastoreClient()
             throws TException
     {
-        return clientProvider.createMetastoreClient();
+        return clientProvider.createMetastoreClient(Optional.empty());
+    }
+
+    private ThriftMetastoreClient createMetastoreClient(String username)
+            throws TException
+    {
+        return clientProvider.createMetastoreClient(Optional.of(username));
     }
 
     private RetryDriver retry()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -274,7 +274,7 @@ public class TestCachingHiveMetastore
         }
 
         @Override
-        public ThriftMetastoreClient createMetastoreClient()
+        public ThriftMetastoreClient createMetastoreClient(Optional<String> username)
         {
             return client;
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -50,7 +50,7 @@ public class TestStaticMetastoreLocator
             throws TException
     {
         MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, singletonList(DEFAULT_CLIENT));
-        assertEquals(locator.createMetastoreClient(), DEFAULT_CLIENT);
+        assertEquals(locator.createMetastoreClient(Optional.empty()), DEFAULT_CLIENT);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class TestStaticMetastoreLocator
             throws TException
     {
         MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK, asList(null, null, FALLBACK_CLIENT));
-        assertEquals(locator.createMetastoreClient(), FALLBACK_CLIENT);
+        assertEquals(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class TestStaticMetastoreLocator
             throws TException
     {
         MetastoreLocator locator = createMetastoreLocator(CONFIG_WITH_FALLBACK_WITH_USER, asList(null, null, FALLBACK_CLIENT));
-        assertEquals(locator.createMetastoreClient(), FALLBACK_CLIENT);
+        assertEquals(locator.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
     }
 
     @Test
@@ -92,7 +92,7 @@ public class TestStaticMetastoreLocator
 
     private static void assertCreateClientFails(MetastoreLocator locator, String message)
     {
-        assertThatThrownBy(locator::createMetastoreClient)
+        assertThatThrownBy(() -> locator.createMetastoreClient(Optional.empty()))
                 .hasCauseInstanceOf(TException.class)
                 .hasMessage(message);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
@@ -18,6 +18,8 @@ import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.authentication.NoHiveMetastoreAuthentication;
 import org.apache.thrift.TException;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class TestingMetastoreLocator
@@ -33,7 +35,7 @@ public class TestingMetastoreLocator
     }
 
     @Override
-    public ThriftMetastoreClient createMetastoreClient()
+    public ThriftMetastoreClient createMetastoreClient(Optional<String> username)
             throws TException
     {
         return new ThriftMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(address);


### PR DESCRIPTION
When we create new database via Hive connector,  the database owner on Hive metastore is enduser name but the ugi become `hive` user in my environment. This commit explicitly sets the ugi as enduser name.