### PR TITLE
Fix Iceberg partition tables

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -43,6 +43,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeSystemTable;
 import io.prestosql.spi.statistics.ComputedStatistics;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.TimestampType;
@@ -153,7 +154,8 @@ public class IcebergMetadata
         IcebergTableHandle table = IcebergTableHandle.from(tableName);
         if (table.getTableType() == TableType.PARTITIONS) {
             org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
-            return Optional.of(new PartitionTable(table, session, typeManager, icebergTable));
+            SystemTable systemTable = new PartitionTable(table, session, typeManager, icebergTable);
+            return Optional.of(new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
         }
         return Optional.empty();
     }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
@@ -277,7 +277,7 @@ public class PartitionTable
                 .collect(Collectors.toMap(identity(), partitionColumns::get));
         TupleDomain<HiveColumnHandle> predicates = constraint.transform(fieldIdToColumnHandle::get);
 
-        return IcebergUtil.getTableScan(session, predicates, tableHandle.getSnapshotId(), icebergTable);
+        return IcebergUtil.getTableScan(session, predicates, tableHandle.getSnapshotId(), icebergTable).includeColumnStats();
     }
 
     private Map<Integer, Object> toMap(Map<Integer, ByteBuffer> idToMetricMap)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
@@ -154,7 +154,7 @@ public class PartitionTable
                 RowType.from(ImmutableList.of(
                         new RowType.Field(Optional.of("min"), toPrestoType(column.type(), typeManager)),
                         new RowType.Field(Optional.of("max"), toPrestoType(column.type(), typeManager)),
-                        new RowType.Field(Optional.of("nullCount"), BIGINT)))))
+                        new RowType.Field(Optional.of("null_count"), BIGINT)))))
                 .collect(toImmutableList());
     }
 

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
@@ -339,8 +339,8 @@ public class PartitionTable
             this.recordCount = recordCount;
             this.fileCount = 1;
             this.size = size;
-            this.minValues = ImmutableMap.copyOf(requireNonNull(minValues, "minValues is null"));
-            this.maxValues = ImmutableMap.copyOf(requireNonNull(maxValues, "maxValues is null"));
+            this.minValues = new HashMap<>(requireNonNull(minValues, "minValues is null"));
+            this.maxValues = new HashMap<>(requireNonNull(maxValues, "maxValues is null"));
             // we are assuming if minValues is not present, max will be not be present either.
             this.corruptedStats = nonPartitionPrimitiveColumns.stream()
                     .map(Types.NestedField::fieldId)

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -16,15 +16,21 @@ package io.prestosql.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.Session;
 import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.MaterializedRow;
 import io.prestosql.tests.AbstractTestIntegrationSmokeTest;
 import org.apache.iceberg.FileFormat;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.time.LocalDate;
+import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.prestosql.testing.MaterializedResult.DEFAULT_PRECISION;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -196,6 +202,45 @@ public class TestIcebergSmoke
         assertQuery(session, "SELECT * from test_create_partitioned_table_as", "SELECT orderkey, shippriority, orderstatus FROM orders");
 
         dropTable(session, "test_create_partitioned_table_as");
+    }
+
+    @Test
+    public void testPartitionTableBasic()
+    {
+        testWithAllFileFormats(this::testPartitionTableBasic);
+    }
+
+    private void testPartitionTableBasic(Session session, FileFormat fileFormat)
+    {
+        assertUpdate(session, "CREATE TABLE test_partition_table_basic (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'], format = '" + fileFormat + "')");
+
+        assertUpdate(session, "INSERT INTO test_partition_table_basic VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
+        assertUpdate(session, "INSERT INTO test_partition_table_basic VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
+
+        assertQuery(session, "SHOW COLUMNS FROM \"test_partition_table_basic$partitions\"",
+                "VALUES ('_date', 'date', '', '')," +
+                        "('record_count', 'bigint', '', '')," +
+                        "('file_count', 'bigint', '', '')," +
+                        "('total_size', 'bigint', '', '')," +
+                        "('_bigint', 'row(min bigint, max bigint, null_count bigint)', '', '')");
+
+        MaterializedResult result = computeActual("SELECT * from \"test_partition_table_basic$partitions\"");
+        assertEquals(result.getRowCount(), 3);
+
+        Map<LocalDate, MaterializedRow> rowsByPartition = result.getMaterializedRows().stream()
+                .collect(toImmutableMap(row -> (LocalDate) row.getField(0), Function.identity()));
+
+        // Test if record counts are computed correctly
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(1), Long.valueOf(1));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(1), Long.valueOf(3));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1), Long.valueOf(2));
+
+        // Test if min/max values and null value count are computed correctly.
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(0), Long.valueOf(0), Long.valueOf(0)));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(1), Long.valueOf(3), Long.valueOf(0)));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(4), Long.valueOf(5), Long.valueOf(0)));
+
+        dropTable(session, "test_partition_table_basic");
     }
 
     private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeSystemTable.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeSystemTable.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.connector.classloader;
+
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.RecordCursor;
+import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.predicate.TupleDomain;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClassLoaderSafeSystemTable
+        implements SystemTable
+{
+    private final SystemTable delegate;
+    private final ClassLoader classLoader;
+
+    public ClassLoaderSafeSystemTable(SystemTable delegate, ClassLoader classLoader)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getDistribution();
+        }
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableMetadata();
+        }
+    }
+
+    @Override
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.cursor(transactionHandle, session, constraint);
+        }
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.pageSource(transactionHandle, session, constraint);
+        }
+    }
+}

--- a/presto-spi/src/test/java/io/prestosql/spi/connector/classloader/TestClassLoaderSafeWrappers.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/connector/classloader/TestClassLoaderSafeWrappers.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorSplitSource;
+import io.prestosql.spi.connector.SystemTable;
 import org.testng.annotations.Test;
 
 import static io.prestosql.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
@@ -36,5 +37,6 @@ public class TestClassLoaderSafeWrappers
         assertAllMethodsOverridden(ConnectorSplitManager.class, ClassLoaderSafeConnectorSplitManager.class);
         assertAllMethodsOverridden(ConnectorNodePartitioningProvider.class, ClassLoaderSafeNodePartitioningProvider.class);
         assertAllMethodsOverridden(ConnectorSplitSource.class, ClassLoaderSafeConnectorSplitSource.class);
+        assertAllMethodsOverridden(SystemTable.class, ClassLoaderSafeSystemTable.class);
     }
 }

--- a/presto-tests/src/main/java/io/prestosql/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/TestingPrestoClient.java
@@ -24,6 +24,7 @@ import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.MapType;
+import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.Type;
@@ -244,6 +245,11 @@ public class TestingPrestoClient
                             convertToRowValue(((MapType) type).getKeyType(), k),
                             convertToRowValue(((MapType) type).getValueType(), v)));
             return result;
+        }
+        else if (type instanceof RowType) {
+            List<Type> fieldTypes = type.getTypeParameters();
+            List<Object> fieldValues = ImmutableList.copyOf(((Map<Object, Object>) value).values());
+            return dataToRow(fieldTypes).apply(fieldValues);
         }
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);


### PR DESCRIPTION
This commit includes two fixes:
1. Use a table scan which loads column stats with each data file.
   Otherwise the column stats returned by Iceberg are null.
2. Make minValues and maxValues in class Partition mutable so that
   Partition::updateStats doesn't throw an error.

cc: @electrum @Parth-Brahmbhatt 