### PR TITLE
Fix error reporting for invalid executionPolicy value

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
@@ -706,7 +706,7 @@ public class SqlQueryExecution
         {
             String executionPolicyName = SystemSessionProperties.getExecutionPolicy(stateMachine.getSession());
             ExecutionPolicy executionPolicy = executionPolicies.get(executionPolicyName);
-            checkArgument(executionPolicy != null, "No execution policy %s", executionPolicy);
+            checkArgument(executionPolicy != null, "No execution policy %s", executionPolicyName);
 
             return new SqlQueryExecution(
                     preparedQuery,


### PR DESCRIPTION
currently it just reports "No execution policy null" for an invalid property value.