### PR TITLE
Add a new S3FileSystemType in addition to PRESTO and EMRFS

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
@@ -45,6 +45,9 @@ public class HiveS3Module
             validateEmrFsClass();
             newSetBinder(binder, ConfigurationInitializer.class).addBinding().to(EmrFsS3ConfigurationInitializer.class).in(Scopes.SINGLETON);
         }
+        else if (type == S3FileSystemType.HADOOP_DEFAULT) {
+            // configuration is done using Hadoop configuration files
+        }
         else {
             throw new RuntimeException("Unknown file system type: " + type);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3FileSystemType.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3FileSystemType.java
@@ -17,4 +17,5 @@ public enum S3FileSystemType
 {
     PRESTO,
     EMRFS,
+    HADOOP_DEFAULT,
 }


### PR DESCRIPTION
This small PR aims to allow a storage service to serve URLs with `s3` scheme. Currently, input with URLs like `s3://bucket/path` can only be served by `PrestoS3FileSystem` or EMR FS class (i.e., `com.amazon.ws.emr.hadoop.fs.EmrFileSystem`). In addition to these two possible choices, a RuntimeException will be thrown. This PR enables Presto to be served by additional services (e.g., Alluxio as a caching layer on top of S3 but without change HMS). 

Particularly,  users can update `etc/config.properties` 
```
hive.s3-file-system-type=CUSTOM
```
and update `core-site.xml`

```
<property>
  <name>fs.s3.impl</name>
  <value>alluxio.hadoop.ShimFileSystem</value>
</property>
```
As a result, end users can transparently benefit from the caching from Alluxio for Presto.

Fixes https://github.com/prestosql/presto/issues/1416