### PR TITLE
Remove precondition for DriverWindowInfo list to create WindowOperatorStats

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/WindowOperatorStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/WindowOperatorStats.java
@@ -17,8 +17,6 @@ import io.prestosql.operator.WindowInfo;
 import io.prestosql.operator.WindowInfo.DriverWindowInfo;
 import io.prestosql.util.Mergeable;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 class WindowOperatorStats
         implements Mergeable<WindowOperatorStats>
 {
@@ -35,8 +33,6 @@ class WindowOperatorStats
 
     public static WindowOperatorStats create(WindowInfo info)
     {
-        checkArgument(info.getWindowInfos().size() > 0, "WindowInfo cannot have empty list of DriverWindowInfos");
-
         int activeDrivers = 0;
         int totalDrivers = 0;
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestWindowOperatorStats.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestWindowOperatorStats.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.planprinter;
+
+import io.prestosql.operator.WindowInfo;
+import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestWindowOperatorStats
+{
+    @Test
+    public void testEmptyDriverInfosList()
+    {
+        WindowInfo info = new WindowInfo(emptyList());
+
+        WindowOperatorStats stats = WindowOperatorStats.create(info);
+
+        assertThat(stats.getIndexSizeStdDev()).isEqualTo(Double.NaN);
+        assertThat(stats.getIndexPositionsStdDev()).isEqualTo(Double.NaN);
+        assertThat(stats.getIndexCountPerDriverStdDev()).isEqualTo(Double.NaN);
+        assertThat(stats.getPartitionRowsStdDev()).isEqualTo(Double.NaN);
+        assertThat(stats.getRowsPerDriverStdDev()).isEqualTo(Double.NaN);
+        assertThat(stats.getActiveDrivers()).isEqualTo(0);
+        assertThat(stats.getTotalDrivers()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
    The existing precondition is that the DriverWindowInfo list can't be empty.
    This precondition fails from time to time, terminating the whole
    EXPLAIN ANALYSE VERBOSE query, which seems to be too eager. The outcome
    in such scenario is that all the standard deviations calculated
    by WindowOperatorStats equals to NaN, which is still better than
    not showing the results at all.
    This behaviour can be recreated when executing query like:
    
    SELECT * FROM (
            SELECT custkey, max(orderdate) OVER (partition by custkey) FROM tpch.tiny.orders
            UNION ALL (
                    SELECT custkey, max(orderdate) OVER (partition by custkey) FROM tpch.tiny.orders
                    UNION ALL
                    SELECT custkey, max(orderdate) OVER (partition by custkey) FROM tpch.tiny.orders
                    UNION ALL ...
            )
    ) LIMIT 1
    
    Unfortunately even for such artificial query the execution is successful most of the time.
    
    List of changes:
    - removing Precondition from WindowOperatorStats
    - documenting the expected behaviour for situation when Stats are created for no DriverWindowInfo in a test