### PR TITLE
Rename Benchmark classes for consistency

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
@@ -85,7 +85,7 @@ import static java.util.stream.Collectors.toList;
 @Warmup(iterations = 20)
 @Fork(3)
 @SuppressWarnings("UseOfSystemOutOrSystemErr")
-public class HiveFileFormatBenchmark
+public class BenchmarkHiveFileFormat
 {
     private static final long MIN_DATA_SIZE = new DataSize(50, MEGABYTE).toBytes();
 
@@ -136,11 +136,11 @@ public class HiveFileFormatBenchmark
 
     private final File targetDir = createTempDir("presto-benchmark");
 
-    public HiveFileFormatBenchmark()
+    public BenchmarkHiveFileFormat()
     {
     }
 
-    public HiveFileFormatBenchmark(DataSet dataSet, HiveCompressionCodec compression, FileFormat fileFormat)
+    public BenchmarkHiveFileFormat(DataSet dataSet, HiveCompressionCodec compression, FileFormat fileFormat)
     {
         this.dataSet = dataSet;
         this.compression = compression;
@@ -466,7 +466,7 @@ public class HiveFileFormatBenchmark
     private static <E extends TpchEntity> TestData createTpchDataSet(FileFormat format, TpchTable<E> tpchTable, List<TpchColumn<E>> columns)
     {
         List<String> columnNames = columns.stream().map(TpchColumn::getColumnName).collect(toList());
-        List<Type> columnTypes = columns.stream().map(HiveFileFormatBenchmark::getColumnType)
+        List<Type> columnTypes = columns.stream().map(BenchmarkHiveFileFormat::getColumnType)
                 .map(type -> format.supportsDate() || !DATE.equals(type) ? type : createUnboundedVarcharType())
                 .collect(toList());
 
@@ -576,7 +576,7 @@ public class HiveFileFormatBenchmark
             throws Exception
     {
         Options opt = new OptionsBuilder()
-                .include(".*\\." + HiveFileFormatBenchmark.class.getSimpleName() + ".*")
+                .include(".*\\." + BenchmarkHiveFileFormat.class.getSimpleName() + ".*")
                 .jvmArgsAppend("-Xmx4g", "-Xms4g", "-XX:+UseG1GC")
                 .build();
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -32,7 +32,7 @@ import io.prestosql.plugin.hive.HiveTypeName;
 import io.prestosql.plugin.hive.HiveTypeTranslator;
 import io.prestosql.plugin.hive.RecordFileWriter;
 import io.prestosql.plugin.hive.TypeTranslator;
-import io.prestosql.plugin.hive.benchmark.HiveFileFormatBenchmark.TestData;
+import io.prestosql.plugin.hive.benchmark.BenchmarkHiveFileFormat.TestData;
 import io.prestosql.plugin.hive.orc.OrcPageSourceFactory;
 import io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.prestosql.plugin.hive.rcfile.RcFilePageSourceFactory;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/TestHiveFileFormatBenchmark.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/TestHiveFileFormatBenchmark.java
@@ -14,8 +14,8 @@
 package io.prestosql.plugin.hive.benchmark;
 
 import io.prestosql.plugin.hive.HiveCompressionCodec;
-import io.prestosql.plugin.hive.benchmark.HiveFileFormatBenchmark.CompressionCounter;
-import io.prestosql.plugin.hive.benchmark.HiveFileFormatBenchmark.DataSet;
+import io.prestosql.plugin.hive.benchmark.BenchmarkHiveFileFormat.CompressionCounter;
+import io.prestosql.plugin.hive.benchmark.BenchmarkHiveFileFormat.DataSet;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -58,7 +58,7 @@ public class TestHiveFileFormatBenchmark
     private static void executeBenchmark(DataSet dataSet, HiveCompressionCodec codec, FileFormat format)
             throws IOException
     {
-        HiveFileFormatBenchmark benchmark = new HiveFileFormatBenchmark(dataSet, codec, format);
+        BenchmarkHiveFileFormat benchmark = new BenchmarkHiveFileFormat(dataSet, codec, format);
         try {
             benchmark.setup();
             benchmark.read(new CompressionCounter());

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkRegexpFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkRegexpFunctions.java
@@ -49,7 +49,7 @@ import static org.openjdk.jmh.annotations.Scope.Thread;
 @Fork(1)
 @Warmup(iterations = 10)
 @Measurement(iterations = 10)
-public class RegexpFunctionsBenchmark
+public class BenchmarkRegexpFunctions
 {
     @Benchmark
     public boolean benchmarkLikeJoni(DotStarAroundData data)
@@ -140,7 +140,7 @@ public class RegexpFunctionsBenchmark
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + RegexpFunctionsBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkRegexpFunctions.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkStringFunctions.java
@@ -59,7 +59,7 @@ import static org.openjdk.jmh.annotations.Scope.Thread;
 @Fork(1)
 @Warmup(iterations = 4, time = 500, timeUnit = MILLISECONDS)
 @Measurement(iterations = 5, time = 500, timeUnit = MILLISECONDS)
-public class StringFunctionsBenchmark
+public class BenchmarkStringFunctions
 {
     @Benchmark
     public long benchmarkLength(BenchmarkData data)
@@ -259,7 +259,7 @@ public class StringFunctionsBenchmark
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + StringFunctionsBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkStringFunctions.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/presto-main/src/test/java/io/prestosql/sql/gen/BenchmarkInCodeGenerator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/BenchmarkInCodeGenerator.java
@@ -64,7 +64,7 @@ import static org.openjdk.jmh.annotations.Mode.AverageTime;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @BenchmarkMode(AverageTime)
 @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
-public class InCodeGeneratorBenchmark
+public class BenchmarkInCodeGenerator
 {
     @Param({"1", "5", "10", "25", "50", "75", "100", "150", "200", "250", "300", "350", "400", "450", "500", "750", "1000", "10000"})
     private int inListCount = 1;
@@ -147,7 +147,7 @@ public class InCodeGeneratorBenchmark
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + InCodeGeneratorBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkInCodeGenerator.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/presto-main/src/test/java/io/prestosql/sql/gen/BenchmarkPageProcessor2.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/BenchmarkPageProcessor2.java
@@ -74,7 +74,7 @@ import static java.util.stream.Collectors.toList;
 @Warmup(iterations = 10)
 @Measurement(iterations = 10)
 @BenchmarkMode(Mode.AverageTime)
-public class PageProcessorBenchmark
+public class BenchmarkPageProcessor2
 {
     private static final Map<String, Type> TYPE_MAP = ImmutableMap.of("bigint", BIGINT, "varchar", VARCHAR);
     private static final Metadata METADATA = createTestMetadataManager();
@@ -196,7 +196,7 @@ public class PageProcessorBenchmark
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + PageProcessorBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkPageProcessor2.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/presto-main/src/test/java/io/prestosql/util/BenchmarkPagesSort.java
+++ b/presto-main/src/test/java/io/prestosql/util/BenchmarkPagesSort.java
@@ -63,7 +63,7 @@ import static org.testng.Assert.assertEquals;
 @Fork(1)
 @Warmup(iterations = 5, time = 400, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 400, timeUnit = TimeUnit.MILLISECONDS)
-public class PagesSortBenchmark
+public class BenchmarkPagesSort
 {
     private static final OrderingCompiler ORDERING_COMPILER = new OrderingCompiler();
 
@@ -273,7 +273,7 @@ public class PagesSortBenchmark
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + PagesSortBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkPagesSort.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();


### PR DESCRIPTION
Benchmarks in `presto-benchmark` still do not follow the `Benchmark*`
pattern.