### PR TITLE
 Emulate metastore calls in BenchmarkInformationSchema

### DIFF
--- a/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
@@ -75,8 +75,6 @@ public class BenchmarkInformationSchema
         private String schemasCount = "200";
         @Param("200")
         private String tablesCount = "200";
-        @Param("100")
-        private String columnsCount = "100";
 
         private QueryRunner queryRunner;
 


### PR DESCRIPTION
Before the commit:
```
# Run complete. Total time: 00:03:10

Benchmark                                                (queryId)  (schemasCount)  (tablesCount)  Mode  Cnt     Score     Error  Units
BenchmarkInformationSchema.queryInformationSchema        FULL_SCAN             200            200  avgt   10  2863.929 ± 329.840  ms/op
BenchmarkInformationSchema.queryInformationSchema   LIKE_PREDICATE             200            200  avgt   10    26.482 ±   7.837  ms/op
BenchmarkInformationSchema.queryInformationSchema  MIXED_PREDICATE             200            200  avgt   10    61.268 ±  13.492  ms/op
```

After:
```
# Run complete. Total time: 00:15:20

Benchmark                                                (queryId)  (schemasCount)  (tablesCount)  Mode  Cnt      Score     Error  Units
BenchmarkInformationSchema.queryInformationSchema        FULL_SCAN             200            200  avgt   10  55259.057 ± 712.193  ms/op
BenchmarkInformationSchema.queryInformationSchema   LIKE_PREDICATE             200            200  avgt   10     26.804 ±   4.957  ms/op
BenchmarkInformationSchema.queryInformationSchema  MIXED_PREDICATE             200            200  avgt   10    345.492 ±  25.485  ms/op
```

cc: @kokosing 