### PR TITLE
Keep query alive when the index is greater than array size

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
@@ -182,7 +182,7 @@ public class ArraySubscriptOperator
 
     public static void checkIndex(Block array, long index)
     {
-        // ensure index > 0
+        // make sure the array subscripts (index) > 0
         checkArrayIndex(index);
 //        if (index > array.getPositionCount()) {
 //            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Array subscript must be less than or equal to array length: %s > %s", index, array.getPositionCount()));

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
@@ -182,6 +182,7 @@ public class ArraySubscriptOperator
 
     public static void checkIndex(Block array, long index)
     {
+        // ensure index > 0
         checkArrayIndex(index);
 //        if (index > array.getPositionCount()) {
 //            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Array subscript must be less than or equal to array length: %s > %s", index, array.getPositionCount()));

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
@@ -94,7 +94,7 @@ public class ArraySubscriptOperator
     public static Long longSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
-        // when index is greater than array size, return null
+        // when index is greater than array size, return null, not PrestoException
         if (array.getPositionCount() < index){
             return null;
         }
@@ -110,7 +110,7 @@ public class ArraySubscriptOperator
     public static Boolean booleanSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
-        // when index is greater than array size, return null
+        // when index is greater than array size, return null, not PrestoException
         if (array.getPositionCount() < index){
             return null;
         }
@@ -126,7 +126,7 @@ public class ArraySubscriptOperator
     public static Double doubleSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
-        // when index is greater than array size, return null
+        // when index is greater than array size, return null, not PrestoException
         if (array.getPositionCount() < index){
             return null;
         }
@@ -142,7 +142,7 @@ public class ArraySubscriptOperator
     public static Slice sliceSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
-        // when index is greater than array size, return null
+        // when index is greater than array size, return null, not PrestoException
         if (array.getPositionCount() < index){
             return null;
         }
@@ -158,7 +158,7 @@ public class ArraySubscriptOperator
     public static Object objectSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
-        // when index is greater than array size, return null
+        // when index is greater than array size, return null, not PrestoException
         if (array.getPositionCount() < index){
             return null;
         }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArraySubscriptOperator.java
@@ -94,6 +94,10 @@ public class ArraySubscriptOperator
     public static Long longSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
+        // when index is greater than array size, return null
+        if (array.getPositionCount() < index){
+            return null;
+        }
         int position = toIntExact(index - 1);
         if (array.isNull(position)) {
             return null;
@@ -106,6 +110,10 @@ public class ArraySubscriptOperator
     public static Boolean booleanSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
+        // when index is greater than array size, return null
+        if (array.getPositionCount() < index){
+            return null;
+        }
         int position = toIntExact(index - 1);
         if (array.isNull(position)) {
             return null;
@@ -118,6 +126,10 @@ public class ArraySubscriptOperator
     public static Double doubleSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
+        // when index is greater than array size, return null
+        if (array.getPositionCount() < index){
+            return null;
+        }
         int position = toIntExact(index - 1);
         if (array.isNull(position)) {
             return null;
@@ -130,6 +142,10 @@ public class ArraySubscriptOperator
     public static Slice sliceSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
+        // when index is greater than array size, return null
+        if (array.getPositionCount() < index){
+            return null;
+        }
         int position = toIntExact(index - 1);
         if (array.isNull(position)) {
             return null;
@@ -142,6 +158,10 @@ public class ArraySubscriptOperator
     public static Object objectSubscript(Type elementType, Block array, long index)
     {
         checkIndex(array, index);
+        // when index is greater than array size, return null
+        if (array.getPositionCount() < index){
+            return null;
+        }
         int position = toIntExact(index - 1);
         if (array.isNull(position)) {
             return null;
@@ -163,8 +183,8 @@ public class ArraySubscriptOperator
     public static void checkIndex(Block array, long index)
     {
         checkArrayIndex(index);
-        if (index > array.getPositionCount()) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Array subscript must be less than or equal to array length: %s > %s", index, array.getPositionCount()));
-        }
+//        if (index > array.getPositionCount()) {
+//            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Array subscript must be less than or equal to array length: %s > %s", index, array.getPositionCount()));
+//        }
     }
 }


### PR DESCRIPTION
In my company, we use prestosql  315. 
We find that queries have frequently failed to execute recently .

The most important reason: "Array subscript out of bounds", This result is unfriendly to user.

Take an actual scenario:
The number of users whose favorite fruit is bananas

sql: select count(*) from userinfo where 'banana'= array_fruits[1];
array_fruits is a array which represents a list of favorite fruits in descending order

The query failed most of the time, Because some array_fruits information is empty.

Resolution :
when index is greater than array size return null, not a PrestoException .

So prestosql 315 can keep query alive when the index is greater than array size, then do some other logic of the query.
In addition，there are lower usage costs for analysts who are from Hive to Presto