### PR TITLE
Decorrelate subqueries with Limit or TopN

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedJoinToJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedJoinToJoin.java
@@ -54,7 +54,7 @@ public class TransformCorrelatedJoinToJoin
     {
         PlanNode subquery = correlatedJoinNode.getSubquery();
 
-        PlanNodeDecorrelator planNodeDecorrelator = new PlanNodeDecorrelator(context.getIdAllocator(), context.getLookup());
+        PlanNodeDecorrelator planNodeDecorrelator = new PlanNodeDecorrelator(context.getIdAllocator(), context.getSymbolAllocator(), context.getLookup());
         Optional<DecorrelatedNode> decorrelatedNodeOptional = planNodeDecorrelator.decorrelateFilters(subquery, correlatedJoinNode.getCorrelation());
 
         return decorrelatedNodeOptional

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformExistsApplyToCorrelatedJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformExistsApplyToCorrelatedJoin.java
@@ -131,7 +131,7 @@ public class TransformExistsApplyToCorrelatedJoin
                         false),
                 Assignments.of(subqueryTrue, TRUE_LITERAL));
 
-        PlanNodeDecorrelator decorrelator = new PlanNodeDecorrelator(context.getIdAllocator(), context.getLookup());
+        PlanNodeDecorrelator decorrelator = new PlanNodeDecorrelator(context.getIdAllocator(), context.getSymbolAllocator(), context.getLookup());
         if (!decorrelator.decorrelateFilters(subquery, applyNode.getCorrelation()).isPresent()) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -145,7 +145,7 @@ public class PlanNodeDecorrelator
         @Override
         public Optional<DecorrelationResult> visitLimit(LimitNode node, Void context)
         {
-            if (node.getCount() == 0) {
+            if (node.getCount() == 0 || node.isWithTies()) {
                 return Optional.empty();
             }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -21,9 +21,12 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import io.prestosql.spi.block.SortOrder;
 import io.prestosql.sql.ExpressionUtils;
+import io.prestosql.sql.planner.OrderingScheme;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
 import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.SymbolAllocator;
 import io.prestosql.sql.planner.SymbolsExtractor;
 import io.prestosql.sql.planner.iterative.Lookup;
 import io.prestosql.sql.planner.plan.AggregationNode;
@@ -32,8 +35,13 @@ import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.PlanNodeId;
 import io.prestosql.sql.planner.plan.PlanVisitor;
 import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.RowNumberNode;
+import io.prestosql.sql.planner.plan.TopNNode;
+import io.prestosql.sql.planner.plan.TopNRowNumberNode;
+import io.prestosql.sql.planner.plan.WindowNode.Specification;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.SymbolReference;
@@ -47,18 +55,22 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.prestosql.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class PlanNodeDecorrelator
 {
     private final PlanNodeIdAllocator idAllocator;
+    private final SymbolAllocator symbolAllocator;
     private final Lookup lookup;
 
-    public PlanNodeDecorrelator(PlanNodeIdAllocator idAllocator, Lookup lookup)
+    public PlanNodeDecorrelator(PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator, Lookup lookup)
     {
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+        this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
         this.lookup = requireNonNull(lookup, "lookup is null");
     }
 
@@ -159,20 +171,38 @@ public class PlanNodeDecorrelator
                 return childDecorrelationResultOptional;
             }
 
-            if (node.getCount() != 1) {
-                return Optional.empty();
+            if (node.getCount() == 1) {
+                return rewriteLimitWithRowCountOne(childDecorrelationResult, node.getId());
             }
+            return rewriteLimitWithRowCountGreaterThanOne(childDecorrelationResult, node);
+        }
 
-            Set<Symbol> constantSymbols = childDecorrelationResult.getConstantSymbols();
+        // TODO Limit (1) could be decorrelated by the method rewriteLimitWithRowCountGreaterThanOne() as well.
+        // The current decorrelation method for Limit (1) cannot deal with subqueries outputting other symbols
+        // than constants.
+        //
+        // An example query that is currently not supported:
+        // SELECT (
+        //      SELECT a+b
+        //      FROM (VALUES (1, 2), (1, 2)) inner_relation(a, b)
+        //      WHERE a=x
+        //      LIMIT 1)
+        // FROM (VALUES (1)) outer_relation(x)
+        //
+        // Switching the decorrelation method would change the way that queries with EXISTS are executed,
+        // and thus it needs benchmarking.
+        private Optional<DecorrelationResult> rewriteLimitWithRowCountOne(DecorrelationResult childDecorrelationResult, PlanNodeId nodeId)
+        {
             PlanNode decorrelatedChildNode = childDecorrelationResult.node;
+            Set<Symbol> constantSymbols = childDecorrelationResult.getConstantSymbols();
 
             if (constantSymbols.isEmpty() || !constantSymbols.containsAll(decorrelatedChildNode.getOutputSymbols())) {
                 return Optional.empty();
             }
 
-            // Rewrite limit to aggregation on constant symbols
+            // rewrite Limit to aggregation on constant symbols
             AggregationNode aggregationNode = new AggregationNode(
-                    idAllocator.getNextId(),
+                    nodeId,
                     decorrelatedChildNode,
                     ImmutableMap.of(),
                     singleGroupingSet(decorrelatedChildNode.getOutputSymbols()),
@@ -187,6 +217,143 @@ public class PlanNodeDecorrelator
                     childDecorrelationResult.correlatedPredicates,
                     childDecorrelationResult.correlatedSymbolsMapping,
                     true));
+        }
+
+        private Optional<DecorrelationResult> rewriteLimitWithRowCountGreaterThanOne(DecorrelationResult childDecorrelationResult, LimitNode node)
+        {
+            PlanNode decorrelatedChildNode = childDecorrelationResult.node;
+
+            // no rewrite needed (no symbols to partition by)
+            if (childDecorrelationResult.symbolsToPropagate.isEmpty()) {
+                return Optional.of(new DecorrelationResult(
+                        node.replaceChildren(ImmutableList.of(decorrelatedChildNode)),
+                        childDecorrelationResult.symbolsToPropagate,
+                        childDecorrelationResult.correlatedPredicates,
+                        childDecorrelationResult.correlatedSymbolsMapping,
+                        false));
+            }
+
+            Set<Symbol> constantSymbols = childDecorrelationResult.getConstantSymbols();
+            if (!constantSymbols.containsAll(childDecorrelationResult.symbolsToPropagate)) {
+                return Optional.empty();
+            }
+
+            // rewrite Limit to RowNumberNode partitioned by constant symbols
+            RowNumberNode rowNumberNode = new RowNumberNode(
+                    node.getId(),
+                    decorrelatedChildNode,
+                    ImmutableList.copyOf(childDecorrelationResult.symbolsToPropagate),
+                    symbolAllocator.newSymbol("row_number", BIGINT),
+                    Optional.of(toIntExact(node.getCount())),
+                    Optional.empty());
+
+            return Optional.of(new DecorrelationResult(
+                    rowNumberNode,
+                    childDecorrelationResult.symbolsToPropagate,
+                    childDecorrelationResult.correlatedPredicates,
+                    childDecorrelationResult.correlatedSymbolsMapping,
+                    false));
+        }
+
+        @Override
+        public Optional<DecorrelationResult> visitTopN(TopNNode node, Void context)
+        {
+            if (node.getCount() == 0) {
+                return Optional.empty();
+            }
+
+            Optional<DecorrelationResult> childDecorrelationResultOptional = lookup.resolve(node.getSource()).accept(this, null);
+            if (!childDecorrelationResultOptional.isPresent()) {
+                return Optional.empty();
+            }
+
+            DecorrelationResult childDecorrelationResult = childDecorrelationResultOptional.get();
+            if (childDecorrelationResult.atMostSingleRow) {
+                return childDecorrelationResultOptional;
+            }
+
+            PlanNode decorrelatedChildNode = childDecorrelationResult.node;
+            Set<Symbol> constantSymbols = childDecorrelationResult.getConstantSymbols();
+            Optional<OrderingScheme> decorrelatedOrderingScheme = decorrelateOrderingScheme(node.getOrderingScheme(), constantSymbols);
+
+            // no partitioning needed (no symbols to partition by)
+            if (childDecorrelationResult.symbolsToPropagate.isEmpty()) {
+                return decorrelatedOrderingScheme
+                        .map(orderingScheme -> Optional.of(new DecorrelationResult(
+                                // ordering symbols are present - return decorrelated TopNNode
+                                new TopNNode(node.getId(), decorrelatedChildNode, node.getCount(), orderingScheme, node.getStep()),
+                                childDecorrelationResult.symbolsToPropagate,
+                                childDecorrelationResult.correlatedPredicates,
+                                childDecorrelationResult.correlatedSymbolsMapping,
+                                node.getCount() == 1)))
+                        .orElseGet(() -> Optional.of(new DecorrelationResult(
+                                // no ordering symbols are left - convert to LimitNode
+                                new LimitNode(node.getId(), decorrelatedChildNode, node.getCount(), false),
+                                childDecorrelationResult.symbolsToPropagate,
+                                childDecorrelationResult.correlatedPredicates,
+                                childDecorrelationResult.correlatedSymbolsMapping,
+                                node.getCount() == 1)));
+            }
+
+            if (!constantSymbols.containsAll(childDecorrelationResult.symbolsToPropagate)) {
+                return Optional.empty();
+            }
+
+            return decorrelatedOrderingScheme
+                    .map(orderingScheme -> {
+                        // ordering symbols are present - rewrite TopN to TopNRowNumberNode partitioned by constant symbols
+                        TopNRowNumberNode topNRowNumberNode = new TopNRowNumberNode(
+                                node.getId(),
+                                decorrelatedChildNode,
+                                new Specification(
+                                        ImmutableList.copyOf(childDecorrelationResult.symbolsToPropagate),
+                                        Optional.of(orderingScheme)),
+                                symbolAllocator.newSymbol("row_number", BIGINT),
+                                toIntExact(node.getCount()),
+                                false,
+                                Optional.empty());
+
+                        return Optional.of(new DecorrelationResult(
+                                topNRowNumberNode,
+                                childDecorrelationResult.symbolsToPropagate,
+                                childDecorrelationResult.correlatedPredicates,
+                                childDecorrelationResult.correlatedSymbolsMapping,
+                                node.getCount() == 1));
+                    })
+                    .orElseGet(() -> {
+                        // no ordering symbols are left - rewrite TopN to RowNumberNode partitioned by constant symbols
+                        RowNumberNode rowNumberNode = new RowNumberNode(
+                                node.getId(),
+                                decorrelatedChildNode,
+                                ImmutableList.copyOf(childDecorrelationResult.symbolsToPropagate),
+                                symbolAllocator.newSymbol("row_number", BIGINT),
+                                Optional.of(toIntExact(node.getCount())),
+                                Optional.empty());
+
+                        return Optional.of(new DecorrelationResult(
+                                rowNumberNode,
+                                childDecorrelationResult.symbolsToPropagate,
+                                childDecorrelationResult.correlatedPredicates,
+                                childDecorrelationResult.correlatedSymbolsMapping,
+                                node.getCount() == 1));
+                    });
+        }
+
+        private Optional<OrderingScheme> decorrelateOrderingScheme(OrderingScheme orderingScheme, Set<Symbol> constantSymbols)
+        {
+            // remove local and remote constant sort symbols from the OrderingScheme
+            ImmutableList.Builder<Symbol> nonConstantOrderBy = ImmutableList.builder();
+            ImmutableMap.Builder<Symbol, SortOrder> nonConstantOrderings = ImmutableMap.builder();
+            for (Symbol symbol : orderingScheme.getOrderBy()) {
+                if (!constantSymbols.contains(symbol) && !correlation.contains(symbol)) {
+                    nonConstantOrderBy.add(symbol);
+                    nonConstantOrderings.put(symbol, orderingScheme.getOrdering(symbol));
+                }
+            }
+            if (nonConstantOrderBy.build().isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(new OrderingScheme(nonConstantOrderBy.build(), nonConstantOrderings.build()));
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -64,7 +64,7 @@ public class ScalarAggregationToJoinRewriter
         this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.lookup = requireNonNull(lookup, "lookup is null");
-        this.planNodeDecorrelator = new PlanNodeDecorrelator(idAllocator, lookup);
+        this.planNodeDecorrelator = new PlanNodeDecorrelator(idAllocator, symbolAllocator, lookup);
     }
 
     public PlanNode rewriteScalarAggregation(CorrelatedJoinNode correlatedJoinNode, AggregationNode aggregation)

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -118,6 +118,9 @@ public class TestSubqueries
                         "FROM (VALUES 1) t(cid)",
                 "VALUES true",
                 false);
+        assertions.assertFails(
+                "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a=t2.b ORDER BY a FETCH FIRST ROW WITH TIES) FROM (VALUES 1) t2(b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -96,10 +96,34 @@ public class TestSubqueries
         assertions.assertQuery(
                 "SELECT (SELECT t.a FROM (VALUES 1, 2) t(a) WHERE t.a=t2.b LIMIT 2) FROM (VALUES 1) t2(b)",
                 "VALUES 1");
-        // cannot enforce LIMIT on correlated subquery
+        assertions.assertQuery(
+                "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a = t2.b LIMIT 2) FROM (VALUES 1) t2(b)",
+                "VALUES 1");
         assertions.assertFails(
-                "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a=t2.b LIMIT 2) from (VALUES 1) t2(b)",
+                "SELECT (SELECT t.a FROM (VALUES 1, 1, 2, 3) t(a) WHERE t.a = t2.b LIMIT 2) FROM (VALUES 1) t2(b)",
+                "Scalar sub-query has returned multiple rows");
+        // Limit(1) and non-constant output symbol of the subquery
+        assertions.assertFails(
+                "SELECT (SELECT count(*) FROM (VALUES (1, 0), (1, 1)) t(a, b) WHERE a = c GROUP BY b LIMIT 1) FROM (VALUES (1)) t2(c)",
                 UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        // Limit(1) and non-constant output symbol of the subquery
+        assertions.assertFails(
+                "SELECT (SELECT a + b FROM (VALUES (1, 1), (1, 1)) t(a, b) WHERE a = c LIMIT 1) FROM (VALUES (1)) t2(c)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        // Limit and correlated non-equality predicate in the subquery
+        assertions.assertFails(
+                "SELECT (SELECT t.b FROM (VALUES (1, 2), (1, 3)) t(a, b) WHERE t.a = t2.a AND t.b > t2.b LIMIT 1) FROM (VALUES (1, 2)) t2(a, b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertions.assertQuery(
+                "SELECT (SELECT t.a FROM (VALUES (1, 2), (1, 3)) t(a, b) WHERE t.a = t2.a AND t2.b > 1 LIMIT 1) FROM (VALUES (1, 2)) t2(a, b)",
+                "VALUES 1");
+        // TopN and correlated non-equality predicate in the subquery
+        assertions.assertFails(
+                "SELECT (SELECT t.b FROM (VALUES (1, 2), (1, 3)) t(a, b) WHERE t.a = t2.a AND t.b > t2.b ORDER BY t.b LIMIT 1) FROM (VALUES (1, 2)) t2(a, b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertions.assertQuery(
+                "SELECT (SELECT t.b FROM (VALUES (1, 2), (1, 3)) t(a, b) WHERE t.a = t2.a AND t2.b > 1 ORDER BY t.b LIMIT 1) FROM (VALUES (1, 2)) t2(a, b)",
+                "VALUES 2");
         assertions.assertQuery(
                 "SELECT (SELECT sum(t.a) FROM (VALUES 1, 2) t(a) WHERE t.a=t2.b group by t.a LIMIT 2) FROM (VALUES 1) t2(b)",
                 "VALUES BIGINT '1'");
@@ -119,8 +143,113 @@ public class TestSubqueries
                 "VALUES true",
                 false);
         assertions.assertFails(
-                "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a=t2.b ORDER BY a FETCH FIRST ROW WITH TIES) FROM (VALUES 1) t2(b)",
+                "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a = t2.b ORDER BY a FETCH FIRST ROW WITH TIES) FROM (VALUES 1) t2(b)",
                 UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM " +
+                        "(VALUES " +
+                        "(1, 'a'), " +
+                        "(1, 'a'), " +
+                        "(1, 'a'), " +
+                        "(1, 'a'), " +
+                        "(2, 'b'), " +
+                        "(null, 'c')) inner_relation(id, value) " +
+                        "WHERE outer_relation.id = inner_relation.id " +
+                        "LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES " +
+                        "(1, 'a'), " +
+                        "(1, 'a'), " +
+                        "(2, 'b'), " +
+                        "(3, null), " +
+                        "(null, null)");
+        // TopN in correlated subquery
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM " +
+                        "(VALUES " +
+                        "(1, 'd'), " +
+                        "(1, 'c'), " +
+                        "(1, 'b'), " +
+                        "(1, 'a'), " +
+                        "(2, 'w'), " +
+                        "(null, 'x')) inner_relation(id, value) " +
+                        "WHERE outer_relation.id = inner_relation.id " +
+                        "ORDER BY inner_relation.value LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES " +
+                        "(1, 'a'), " +
+                        "(1, 'b'), " +
+                        "(2, 'w'), " +
+                        "(3, null), " +
+                        "(null, null)");
+        // correlated symbol in predicate not bound to inner relation + Limit
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES 'a', 'a', 'a') inner_relation(value) " +
+                        "   WHERE outer_relation.id = 3 LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 'a'), (3, 'a'), (null, null)");
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT 1 FROM (VALUES 'a', 'a', 'a') inner_relation(value) " +
+                        "   WHERE outer_relation.id = 3 LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 1), (3, 1), (null, null)");
+        // correlated symbol in predicate not bound to inner relation + TopN
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES 'c', 'a', 'b') inner_relation(value) " +
+                        "   WHERE outer_relation.id = 3 ORDER BY value LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 'a'), (3, 'b'), (null, null)");
+        // TopN with ordering not decorrelating
+        assertions.assertFails(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES 'c', 'a', 'b') inner_relation(value) " +
+                        "   WHERE outer_relation.id = 3 ORDER BY outer_relation.id LIMIT 2) " +
+                        "ON TRUE",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        // TopN with ordering only by constants
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES (3, 'b'), (3, 'a'), (null, 'b')) inner_relation(id, value) " +
+                        "   WHERE outer_relation.id = inner_relation.id ORDER BY id LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 'a'), (3, 'b'), (null, null)");
+        // TopN with ordering by constants and non-constant local symbols
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES (3, 'b'), (3, 'a'), (null, 'b')) inner_relation(id, value) " +
+                        "   WHERE outer_relation.id = inner_relation.id ORDER BY id, value LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 'a'), (3, 'b'), (null, null)");
+        // TopN with ordering by non-constant local symbols
+        assertions.assertQuery(
+                "SELECT * " +
+                        "FROM (VALUES 1, 2, 3, null) outer_relation(id) " +
+                        "LEFT JOIN LATERAL " +
+                        "(SELECT value FROM (VALUES (3, 'b'), (3, 'a'), (null, 'b')) inner_relation(id, value) " +
+                        "   WHERE outer_relation.id = inner_relation.id ORDER BY value LIMIT 2) " +
+                        "ON TRUE",
+                "VALUES (1, null), (2, null), (3, 'a'), (3, 'b'), (null, null)");
     }
 
     @Test

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -3420,6 +3420,7 @@ public abstract class AbstractTestQueries
 
         // explicit LIMIT in subquery
         assertQuery("SELECT (SELECT count(*) FROM (VALUES (7,1)) t(orderkey, value) WHERE orderkey = corr_key GROUP BY value LIMIT 1) FROM (values 7) t(corr_key)");
+        // Limit(1) and non-constant output symbol of the subquery (count)
         assertQueryFails("SELECT (SELECT count(*) FROM (VALUES (7,1), (7,2)) t(orderkey, value) WHERE orderkey = corr_key GROUP BY value LIMIT 1) FROM (values 7) t(corr_key)",
                 UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
     }
@@ -5173,6 +5174,21 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT * FROM (VALUES 1, 2) a(x) JOIN LATERAL(SELECT y FROM (VALUES 2, 3) b(y) WHERE y > x) c(z) ON z > 2*x",
                 "VALUES (1, 3)");
+
+        // TopN in correlated subquery
+        assertQuery(
+                "SELECT regionkey, n.name FROM region LEFT JOIN LATERAL (SELECT name FROM nation WHERE region.regionkey = regionkey ORDER BY nationkey LIMIT 2) n ON TRUE",
+                "VALUES " +
+                        "(0, 'ETHIOPIA'), " +
+                        "(0, 'ALGERIA'), " +
+                        "(1, 'BRAZIL'), " +
+                        "(1, 'ARGENTINA'), " +
+                        "(2, 'INDONESIA'), " +
+                        "(2, 'INDIA'), " +
+                        "(3, 'GERMANY'), " +
+                        "(3, 'FRANCE'), " +
+                        "(4, 'IRAN'), " +
+                        "(4, 'EGYPT')");
     }
 
     @Test


### PR DESCRIPTION
This change allows to decorrelate subqueries containing ORDER BY + LIMIT or LIMIT clause.
Refers to: https://github.com/prestosql/presto/issues/1358