### PR TITLE
Do not enumerate all metadata objects when catalog is wrong

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
@@ -291,6 +291,11 @@ public class InformationSchemaMetadata
             return ImmutableSet.of();
         }
 
+        Optional<Set<String>> catalogs = filterString(constraint.getSummary(), CATALOG_COLUMN_HANDLE);
+        if (catalogs.isPresent() && !catalogs.get().contains(table.getCatalogName())) {
+            return ImmutableSet.of();
+        }
+
         SchemaTableName schemaTableName = handle.getSchemaTableName();
         Set<QualifiedTablePrefix> prefixes = calculatePrefixesWithSchemaName(schemaTableName, session, constraint.getSummary(), constraint.predicate());
         if (isTablesEnumeratingTable(handle.getSchemaTableName())) {

--- a/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
@@ -160,6 +160,17 @@ public class TestInformationSchemaConnector
                 new MetadataCallsCount()
                         .withListTablesCount(1)
                         .withGetColumnsCount(1));
+        assertNoMetadataCalls("SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'wrong'", "VALUES 0");
+        assertMetadataCalls(
+                "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'test_catalog' AND table_schema = 'table_schema1' AND table_name = 'test_table1'",
+                "VALUES 0",
+                new MetadataCallsCount()
+                        .withListTablesCount(1));
+        assertMetadataCalls(
+                "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog IN ('wrong', 'test_catalog') AND table_schema = 'table_schema1' AND table_name = 'test_table1'",
+                "VALUES 0",
+                new MetadataCallsCount()
+                        .withListTablesCount(1));
     }
 
     private static DistributedQueryRunner createQueryRunner()


### PR DESCRIPTION
Do enumerate all metadata objects when catalog is wrong
