### PR TITLE
Upgrade MySQL driver to 5.1.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -722,7 +722,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.47</version>
+                <version>5.1.48</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Summary
---

* Among other things, fixes annoying driver bug/interaction with Java 11 which creates unnecessary log noise for anything using MySQL (MySQL catalogs and Raptor shard management)
  * https://bugs.mysql.com/bug.php?id=93590
  * as the official Presto Docker image uses Java 11, this will cleanup logging for anyone using the official image with either MySQL or Raptor catalogs

Example of Log Noise
---

```
2019-09-03T00:41:48.429Z	INFO	shard-compaction-discovery	stderr	Tue Sep 03 00:41:48 UTC 2019 WARN: Caught while disconnecting...

EXCEPTION STACK TRACE:



** BEGIN NESTED EXCEPTION **

javax.net.ssl.SSLException
MESSAGE: closing inbound before receiving peer's close_notify

STACKTRACE:

javax.net.ssl.SSLException: closing inbound before receiving peer's close_notify
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:133)
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:308)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:264)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:255)
	at java.base/sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:645)
	at java.base/sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:624)
	at com.mysql.jdbc.MysqlIO.quit(MysqlIO.java:2249)
	at com.mysql.jdbc.ConnectionImpl.realClose(ConnectionImpl.java:4232)
	at com.mysql.jdbc.ConnectionImpl.close(ConnectionImpl.java:1472)
	at com.mysql.jdbc.jdbc2.optional.MysqlPooledConnection.close(MysqlPooledConnection.java:183)
	at com.mysql.jdbc.jdbc2.optional.JDBC4MysqlPooledConnection.close(JDBC4MysqlPooledConnection.java:48)
	at io.airlift.dbpool.ManagedDataSource.connectionReturned(ManagedDataSource.java:121)
	at io.airlift.dbpool.ManagedDataSource$NoPoolConnectionEventListener.connectionClosed(ManagedDataSource.java:291)
	at com.mysql.jdbc.jdbc2.optional.MysqlPooledConnection.callConnectionEventListeners(MysqlPooledConnection.java:223)
	at com.mysql.jdbc.jdbc2.optional.ConnectionWrapper.close(ConnectionWrapper.java:772)
	at com.mysql.jdbc.jdbc2.optional.ConnectionWrapper.close(ConnectionWrapper.java:435)
	at com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper.close(JDBC4ConnectionWrapper.java:69)
	at io.prestosql.plugin.raptor.legacy.storage.organization.ShardOrganizerUtil.getOrganizationEligibleShards(ShardOrganizerUtil.java:127)
	at io.prestosql.plugin.raptor.legacy.storage.organization.ShardCompactionManager.filterAndCreateCompactionSets(ShardCompactionManager.java:206)
	at io.prestosql.plugin.raptor.legacy.storage.organization.ShardCompactionManager.discoverShards(ShardCompactionManager.java:181)
	at io.prestosql.plugin.raptor.legacy.storage.organization.ShardCompactionManager.lambda$startDiscovery$0(ShardCompactionManager.java:158)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)


** END NESTED EXCEPTION **
```