### PR TITLE
Access insert-only tables when HMS compatibility check is enabled

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -18,6 +18,8 @@ import io.airlift.log.Logger;
 import io.prestosql.plugin.base.util.LoggingInvocationHandler;
 import io.prestosql.plugin.base.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
 import io.prestosql.plugin.base.util.LoggingInvocationHandler.ParameterNamesProvider;
+import org.apache.hadoop.hive.metastore.api.ClientCapabilities;
+import org.apache.hadoop.hive.metastore.api.ClientCapability;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -25,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeRoleRequest;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeRoleResponse;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeType;
@@ -154,6 +157,17 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         return client.get_table(databaseName, tableName);
+    }
+
+    @Override
+    public Table getTableWithCapabilities(String databaseName, String tableName)
+            throws TException
+    {
+        GetTableRequest request = new GetTableRequest();
+        request.setDbName(databaseName);
+        request.setTblName(tableName);
+        request.setCapabilities(new ClientCapabilities(ImmutableList.of(ClientCapability.INSERT_ONLY_TABLES)));
+        return client.get_table_req(request).getTable();
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -69,6 +69,9 @@ public interface ThriftMetastoreClient
     Table getTable(String databaseName, String tableName)
             throws TException;
 
+    Table getTableWithCapabilities(String databaseName, String tableName)
+            throws TException;
+
     List<FieldSchema> getFields(String databaseName, String tableName)
             throws TException;
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -138,6 +138,12 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public Table getTableWithCapabilities(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<FieldSchema> getFields(String databaseName, String tableName)
             throws TException
     {


### PR DESCRIPTION
When `metastore.client.capability.check` is true (on by default since
something around Hive 2.3, https://issues.apache.org/jira/browse/HIVE-15062
https://issues.apache.org/jira/browse/HIVE-14646), HMS throws `Your
client does not appear to support insert-only tables [...]` when
accessing metadata of an insert-only table.

Since we already explicitly fail when reading from/writing to an
insert-only table, we should pass HMS's compatibility check as we won't
destroy data in these tables.