### PR TITLE
Allow treating forwarded HTTPS requests over HTTP as secure

### DIFF
--- a/presto-docs/src/main/sphinx/develop/password-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/password-authenticator.rst
@@ -42,4 +42,4 @@ Example configuration file:
     custom-property2=custom-value2
 
 Additionally, the coordinator must be configured to use password authentication
-and have HTTPS enabled.
+and have HTTPS enabled (or HTTPS forwarding enabled).

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -89,6 +89,10 @@ Property                                                Description
                                                         used to secure TLS.
 ``http-server.https.keystore.key``                      The password for the keystore. This must match the
                                                         password you specified when creating the keystore.
+``http-server.authentication.allow-forwarded-https``    Enable treating forwarded HTTPS requests over HTTP
+                                                        as secure.  Requires the ``X-Forwarded-Proto`` header
+                                                        to be set to ``https`` on forwarded requests.
+                                                        Default value is ``false``.
 ======================================================= ======================================================
 
 Password Authenticator Configuration

--- a/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
+    private boolean enableForwardingHttps;
 
     public enum AuthenticationType
     {
@@ -65,6 +66,19 @@ public class SecurityConfig
         authenticationTypes = stream(SPLITTER.split(types))
                 .map(AuthenticationType::valueOf)
                 .collect(toImmutableList());
+        return this;
+    }
+
+    public boolean getEnableForwardingHttps()
+    {
+        return enableForwardingHttps;
+    }
+
+    @Config("http-server.authentication.allow-forwarded-https")
+    @ConfigDescription("Enable forwarding HTTPS requests")
+    public SecurityConfig setEnableForwardingHttps(boolean enableForwardingHttps)
+    {
+        this.enableForwardingHttps = enableForwardingHttps;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
@@ -31,6 +31,7 @@ public class TestSecurityConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SecurityConfig.class)
+                .setEnableForwardingHttps(false)
                 .setAuthenticationTypes(""));
     }
 
@@ -39,9 +40,11 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
+                .put("http-server.authentication.allow-forwarded-https", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
+                .setEnableForwardingHttps(true)
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD));
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
* If `http-server.authentication.allow-forwarded-https` is set to `true`,
  HTTP requests with the `X-Forwarded-Proto` header will be treated as secure and can be authenticated
* Configuration defaults to `false`
* Addresses https://github.com/prestosql/presto/issues/1246