### PR TITLE
Update gcs jars to v2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
         <dep.jmxutils.version>1.21</dep.jmxutils.version>
-        <dep.gcs.version>1.9.17</dep.gcs.version>
+        <dep.gcs.version>2.0.0</dep.gcs.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -1232,6 +1232,8 @@
                                     <!-- TODO: fix this in Airlift resolver -->
                                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                                     <exclude>com.google.guava:guava</exclude>
+                                    <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                                    <exclude>com.google.j2objc:j2objc-annotations</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>
                         </rules>


### PR DESCRIPTION
There are a lot of improvements in the new cloud storage connector for hadoop: https://cloud.google.com/blog/products/data-analytics/new-release-of-cloud-storage-connector-for-hadoop-improving-performance-throughput-and-more