### PR TITLE
Update HiveTableHandle equals

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableHandle.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableHandle.java
@@ -237,13 +237,31 @@ public class HiveTableHandle
         }
         HiveTableHandle that = (HiveTableHandle) o;
         return Objects.equals(schemaName, that.schemaName) &&
-                Objects.equals(tableName, that.tableName);
+                Objects.equals(tableName, that.tableName) &&
+                Objects.equals(tableParameters, that.tableParameters) &&
+                Objects.equals(partitionColumns, that.partitionColumns) &&
+                Objects.equals(partitions, that.partitions) &&
+                Objects.equals(compactEffectivePredicate, that.compactEffectivePredicate) &&
+                Objects.equals(enforcedConstraint, that.enforcedConstraint) &&
+                Objects.equals(bucketHandle, that.bucketHandle) &&
+                Objects.equals(bucketFilter, that.bucketFilter) &&
+                Objects.equals(analyzePartitionValues, that.analyzePartitionValues);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(
+                schemaName,
+                tableName,
+                tableParameters,
+                partitionColumns,
+                partitions,
+                compactEffectivePredicate,
+                enforcedConstraint,
+                bucketHandle,
+                bucketFilter,
+                analyzePartitionValues);
     }
 
     @Override


### PR DESCRIPTION
`HiveTableHandle.equals()` got simplified in
a389636715d2b7d2fdfd9d3a5fe113f175926c3c.