### PR TITLE
Fix bug in Planner

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/ReferenceAwareExpressionNodeInliner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ReferenceAwareExpressionNodeInliner.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.ExpressionRewriter;
+import io.prestosql.sql.tree.ExpressionTreeRewriter;
+import io.prestosql.sql.tree.NodeRef;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class ReferenceAwareExpressionNodeInliner
+        extends ExpressionRewriter<Void>
+{
+    public static Expression replaceExpression(Expression expression, Map<NodeRef<Expression>, Expression> mappings)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ReferenceAwareExpressionNodeInliner(mappings), expression);
+    }
+
+    private final Map<NodeRef<Expression>, Expression> mappings;
+
+    public ReferenceAwareExpressionNodeInliner(Map<NodeRef<Expression>, Expression> mappings)
+    {
+        this.mappings = ImmutableMap.copyOf(requireNonNull(mappings, "mappings is null"));
+    }
+
+    @Override
+    public Expression rewriteExpression(Expression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        return mappings.get(NodeRef.of(node));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -58,7 +58,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.sql.analyzer.SemanticExceptions.notSupportedException;
-import static io.prestosql.sql.planner.ExpressionNodeInliner.replaceExpression;
+import static io.prestosql.sql.planner.ReferenceAwareExpressionNodeInliner.replaceExpression;
 import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.prestosql.sql.tree.ComparisonExpression.Operator.EQUAL;
@@ -233,7 +233,7 @@ class SubqueryPlanner
     public PlanBuilder appendCorrelatedJoin(PlanBuilder subPlan, PlanBuilder subqueryPlan, Query query, boolean correlationAllowed, CorrelatedJoinNode.Type type, Expression filterCondition)
     {
         PlanNode subqueryNode = subqueryPlan.getRoot();
-        Map<Expression, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
+        Map<NodeRef<Expression>, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
         if (!correlationAllowed && !correlation.isEmpty()) {
             throw notSupportedException(query, "Correlated subquery in given context");
         }
@@ -431,11 +431,14 @@ class SubqueryPlanner
             Assignments subqueryAssignments,
             boolean correlationAllowed)
     {
-        Map<Expression, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
+        Map<NodeRef<Expression>, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
         if (!correlationAllowed && !correlation.isEmpty()) {
             throw notSupportedException(subquery, "Correlated subquery in given context");
         }
-        subPlan = subPlan.appendProjections(correlation.keySet(), symbolAllocator, idAllocator);
+        subPlan = subPlan.appendProjections(
+                correlation.keySet().stream().map(NodeRef::getNode).collect(toImmutableSet()),
+                symbolAllocator,
+                idAllocator);
         subqueryNode = replaceExpressionsWithSymbols(subqueryNode, correlation);
 
         TranslationMap translations = subPlan.copyTranslations();
@@ -449,14 +452,14 @@ class SubqueryPlanner
                         subquery));
     }
 
-    private Map<Expression, Expression> extractCorrelation(PlanBuilder subPlan, PlanNode subquery)
+    private Map<NodeRef<Expression>, Expression> extractCorrelation(PlanBuilder subPlan, PlanNode subquery)
     {
-        Set<Expression> missingReferences = extractOuterColumnReferences(subquery);
-        ImmutableMap.Builder<Expression, Expression> correlation = ImmutableMap.builder();
-        for (Expression missingReference : missingReferences) {
+        Set<NodeRef<Expression>> missingReferences = extractOuterColumnReferences(subquery);
+        ImmutableMap.Builder<NodeRef<Expression>, Expression> correlation = ImmutableMap.builder();
+        for (NodeRef<Expression> missingReference : missingReferences) {
             // missing reference expression can be solved within current subPlan,
             // or within outer plans in case of multiple nesting levels of subqueries.
-            tryResolveMissingExpression(subPlan, missingReference)
+            tryResolveMissingExpression(subPlan, missingReference.getNode())
                     .ifPresent(symbolReference -> correlation.put(missingReference, symbolReference));
         }
         return correlation.build();
@@ -495,7 +498,7 @@ class SubqueryPlanner
      * @return a set of reference expressions which cannot be resolved within this plan. For plan representing:
      * SELECT a, b FROM (VALUES 1) T(a). It will return a set containing single expression reference to 'b'.
      */
-    private Set<Expression> extractOuterColumnReferences(PlanNode planNode)
+    private Set<NodeRef<Expression>> extractOuterColumnReferences(PlanNode planNode)
     {
         // at this point all the column references are already rewritten to SymbolReference
         // when reference expression is not rewritten that means it cannot be satisfied within given PlanNode
@@ -505,14 +508,14 @@ class SubqueryPlanner
                 .collect(toImmutableSet());
     }
 
-    private static Set<Expression> extractColumnReferences(Expression expression, Set<NodeRef<Expression>> columnReferences)
+    private static Set<NodeRef<Expression>> extractColumnReferences(Expression expression, Set<NodeRef<Expression>> columnReferences)
     {
-        ImmutableSet.Builder<Expression> expressionColumnReferences = ImmutableSet.builder();
+        ImmutableSet.Builder<NodeRef<Expression>> expressionColumnReferences = ImmutableSet.builder();
         new ColumnReferencesExtractor(columnReferences).process(expression, expressionColumnReferences);
         return expressionColumnReferences.build();
     }
 
-    private PlanNode replaceExpressionsWithSymbols(PlanNode planNode, Map<Expression, Expression> mapping)
+    private PlanNode replaceExpressionsWithSymbols(PlanNode planNode, Map<NodeRef<Expression>, Expression> mapping)
     {
         if (mapping.isEmpty()) {
             return planNode;
@@ -522,7 +525,7 @@ class SubqueryPlanner
     }
 
     private static class ColumnReferencesExtractor
-            extends DefaultExpressionTraversalVisitor<Void, ImmutableSet.Builder<Expression>>
+            extends DefaultExpressionTraversalVisitor<Void, ImmutableSet.Builder<NodeRef<Expression>>>
     {
         private final Set<NodeRef<Expression>> columnReferences;
 
@@ -532,10 +535,10 @@ class SubqueryPlanner
         }
 
         @Override
-        protected Void visitDereferenceExpression(DereferenceExpression node, ImmutableSet.Builder<Expression> builder)
+        protected Void visitDereferenceExpression(DereferenceExpression node, ImmutableSet.Builder<NodeRef<Expression>> builder)
         {
             if (columnReferences.contains(NodeRef.<Expression>of(node))) {
-                builder.add(node);
+                builder.add(NodeRef.of(node));
             }
             else {
                 process(node.getBase(), builder);
@@ -544,9 +547,9 @@ class SubqueryPlanner
         }
 
         @Override
-        protected Void visitIdentifier(Identifier node, ImmutableSet.Builder<Expression> builder)
+        protected Void visitIdentifier(Identifier node, ImmutableSet.Builder<NodeRef<Expression>> builder)
         {
-            builder.add(node);
+            builder.add(NodeRef.of(node));
             return null;
         }
     }
@@ -555,9 +558,9 @@ class SubqueryPlanner
             extends SimplePlanRewriter<Void>
     {
         private final PlanNodeIdAllocator idAllocator;
-        private final Map<Expression, Expression> mapping;
+        private final Map<NodeRef<Expression>, Expression> mapping;
 
-        public ExpressionReplacer(PlanNodeIdAllocator idAllocator, Map<Expression, Expression> mapping)
+        public ExpressionReplacer(PlanNodeIdAllocator idAllocator, Map<NodeRef<Expression>, Expression> mapping)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.mapping = requireNonNull(mapping, "mapping is null");

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -463,7 +463,7 @@ class SubqueryPlanner
     }
 
     /**
-     * Checks if give reference expression can resolved within given plan.
+     * Checks if given reference expression can be resolved within given plan.
      */
     private static Optional<Expression> tryResolveMissingExpression(PlanBuilder subPlan, Expression expression)
     {


### PR DESCRIPTION
Produced plans are incorrect in the case when:
there are multiple references to a correlated symbol in a correlated subquery
and different occurrences of the symbol require different coercions.
In the resulting plan all occurrences of the symbol are coerced in the way that was appropriate for the first occurrence.
This behavior is caused by `SubqueryPlanner` who collects correlated symbols using equality comparison, and as a result equates different occurrences of the symbols.
Solution: identify them by `NodeRef` instead of `Expression`.
