### PR TITLE
Remove angle brackets support in type signature parsing

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/MapUnionAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/MapUnionAggregation.java
@@ -53,7 +53,7 @@ public class MapUnionAggregation
 
     public MapUnionAggregation()
     {
-        super(NAME, ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), parseTypeSignature("map<K,V>"), ImmutableList.of(parseTypeSignature("map<K,V>")));
+        super(NAME, ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")), ImmutableList.of(), parseTypeSignature("map(K,V)"), ImmutableList.of(parseTypeSignature("map(K,V)")));
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/ImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/ImplementationDependency.java
@@ -73,7 +73,7 @@ public interface ImplementationDependency
 
     static void checkTypeParameters(TypeSignature typeSignature, Set<String> typeParameterNames, AnnotatedElement element)
     {
-        // Check recursively if `typeSignature` contains something like `T<bigint>`
+        // Check recursively if `typeSignature` contains something like `T(bigint)`
         if (typeParameterNames.contains(typeSignature.getBase())) {
             checkArgument(typeSignature.getParameters().isEmpty(), "Expected type parameter not to take parameters, but got %s on method [%s]", typeSignature.getBase(), element);
             return;

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/Re2JRegexpFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/Re2JRegexpFunctions.java
@@ -66,7 +66,7 @@ public final class Re2JRegexpFunctions
     @Description("string(s) extracted using the given pattern")
     @ScalarFunction
     @LiteralParameters("x")
-    @SqlType("array<varchar(x)>")
+    @SqlType("array(varchar(x))")
     public static Block regexpExtractAll(@SqlType("varchar(x)") Slice source, @SqlType(Re2JRegexpType.NAME) Re2JRegexp pattern)
     {
         return regexpExtractAll(source, pattern, 0);
@@ -75,7 +75,7 @@ public final class Re2JRegexpFunctions
     @Description("group(s) extracted using the given pattern")
     @ScalarFunction
     @LiteralParameters("x")
-    @SqlType("array<varchar(x)>")
+    @SqlType("array(varchar(x))")
     public static Block regexpExtractAll(@SqlType("varchar(x)") Slice source, @SqlType(Re2JRegexpType.NAME) Re2JRegexp pattern, @SqlType(StandardTypes.BIGINT) long groupIndex)
     {
         return pattern.extractAll(source, groupIndex);
@@ -104,7 +104,7 @@ public final class Re2JRegexpFunctions
     @ScalarFunction
     @Description("returns array of strings split by pattern")
     @LiteralParameters("x")
-    @SqlType("array<varchar(x)>")
+    @SqlType("array(varchar(x))")
     public static Block regexpSplit(@SqlType("varchar(x)") Slice source, @SqlType(Re2JRegexpType.NAME) Re2JRegexp pattern)
     {
         return pattern.split(source);

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/SplitToMapFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/SplitToMapFunction.java
@@ -41,13 +41,13 @@ public class SplitToMapFunction
 {
     private final PageBuilder pageBuilder;
 
-    public SplitToMapFunction(@TypeParameter("map<varchar,varchar>") Type mapType)
+    public SplitToMapFunction(@TypeParameter("map(varchar,varchar)") Type mapType)
     {
         pageBuilder = new PageBuilder(ImmutableList.of(mapType));
     }
 
-    @SqlType("map<varchar,varchar>")
-    public Block splitToMap(@TypeParameter("map<varchar,varchar>") Type mapType, @SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice entryDelimiter, @SqlType(StandardTypes.VARCHAR) Slice keyValueDelimiter)
+    @SqlType("map(varchar,varchar)")
+    public Block splitToMap(@TypeParameter("map(varchar,varchar)") Type mapType, @SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice entryDelimiter, @SqlType(StandardTypes.VARCHAR) Slice keyValueDelimiter)
     {
         checkCondition(entryDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "entryDelimiter is empty");
         checkCondition(keyValueDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "keyValueDelimiter is empty");

--- a/presto-main/src/main/java/io/prestosql/type/FunctionType.java
+++ b/presto-main/src/main/java/io/prestosql/type/FunctionType.java
@@ -86,7 +86,7 @@ public class FunctionType
         ImmutableList<String> names = getTypeParameters().stream()
                 .map(Type::getDisplayName)
                 .collect(toImmutableList());
-        return "function<" + Joiner.on(",").join(names) + ">";
+        return "function(" + Joiner.on(",").join(names) + ")";
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/type/setdigest/SetDigestFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/type/setdigest/SetDigestFunctions.java
@@ -85,7 +85,7 @@ public final class SetDigestFunctions
 
     @ScalarFunction
     @SqlType("map(bigint,smallint)")
-    public static Block hashCounts(@TypeParameter("map<bigint,smallint>") Type mapType, @SqlType(SetDigestType.NAME) Slice slice)
+    public static Block hashCounts(@TypeParameter("map(bigint,smallint)") Type mapType, @SqlType(SetDigestType.NAME) Slice slice)
     {
         SetDigest digest = SetDigest.newInstance(slice);
 

--- a/presto-main/src/test/java/io/prestosql/metadata/TestSignatureBinder.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/TestSignatureBinder.java
@@ -1068,9 +1068,7 @@ public class TestSignatureBinder
         assertThat("T2", boundVariables, "bigint");
         assertThat("array(T1)", boundVariables, "array(double)");
         assertThat("array(T3)", boundVariables, "array(decimal(5,3))");
-        assertThat("array<T1>", boundVariables, "array(double)");
         assertThat("map(T1,T2)", boundVariables, "map(double,bigint)");
-        assertThat("map<T1,T2>", boundVariables, "map(double,bigint)");
         assertThat("bla(T1,42,T2)", boundVariables, "bla(double,42,bigint)");
         assertThat("varchar(p)", boundVariables, "varchar(1)");
         assertThat("char(p)", boundVariables, "char(1)");

--- a/presto-main/src/test/java/io/prestosql/type/TestFunctionType.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestFunctionType.java
@@ -25,7 +25,7 @@ public class TestFunctionType
     @Test
     public void testDisplayName()
     {
-        Type function = createTestMetadataManager().getType(TypeSignature.parseTypeSignature("function<row(field double),bigint>"));
-        assertEquals(function.getDisplayName(), "function<row(field double),bigint>");
+        Type function = createTestMetadataManager().getType(TypeSignature.parseTypeSignature("function(row(field double),bigint)"));
+        assertEquals(function.getDisplayName(), "function(row(field double),bigint)");
     }
 }

--- a/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnClassifierAggregation.java
+++ b/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnClassifierAggregation.java
@@ -55,7 +55,7 @@ public final class LearnClassifierAggregation
         throw new UnsupportedOperationException("LEARN must run on a single machine");
     }
 
-    @OutputFunction("Classifier<bigint>")
+    @OutputFunction("Classifier(bigint)")
     public static void output(@AggregationState LearnState state, BlockBuilder out)
     {
         LearnLibSvmClassifierAggregation.output(state, out);

--- a/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnLibSvmClassifierAggregation.java
+++ b/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnLibSvmClassifierAggregation.java
@@ -65,7 +65,7 @@ public final class LearnLibSvmClassifierAggregation
         throw new UnsupportedOperationException("LEARN must run on a single machine");
     }
 
-    @OutputFunction("Classifier<bigint>")
+    @OutputFunction("Classifier(bigint)")
     public static void output(@AggregationState LearnState state, BlockBuilder out)
     {
         Dataset dataset = new Dataset(state.getLabels(), state.getFeatureVectors(), state.getLabelEnumeration().inverse());

--- a/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnLibSvmVarcharClassifierAggregation.java
+++ b/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnLibSvmVarcharClassifierAggregation.java
@@ -51,7 +51,7 @@ public final class LearnLibSvmVarcharClassifierAggregation
         throw new UnsupportedOperationException("LEARN must run on a single machine");
     }
 
-    @OutputFunction("Classifier<varchar>")
+    @OutputFunction("Classifier(varchar)")
     public static void output(@AggregationState LearnState state, BlockBuilder out)
     {
         Dataset dataset = new Dataset(state.getLabels(), state.getFeatureVectors(), state.getLabelEnumeration().inverse());

--- a/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnVarcharClassifierAggregation.java
+++ b/presto-ml/src/main/java/io/prestosql/plugin/ml/LearnVarcharClassifierAggregation.java
@@ -46,7 +46,7 @@ public final class LearnVarcharClassifierAggregation
         throw new UnsupportedOperationException("LEARN must run on a single machine");
     }
 
-    @OutputFunction("Classifier<varchar>")
+    @OutputFunction("Classifier(varchar)")
     public static void output(@AggregationState LearnState state, BlockBuilder out)
     {
         LearnLibSvmVarcharClassifierAggregation.output(state, out);

--- a/presto-ml/src/main/java/io/prestosql/plugin/ml/MLFunctions.java
+++ b/presto-ml/src/main/java/io/prestosql/plugin/ml/MLFunctions.java
@@ -40,22 +40,22 @@ public final class MLFunctions
 
     @ScalarFunction("classify")
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice varcharClassify(@SqlType(MAP_BIGINT_DOUBLE) Block featuresMap, @SqlType("Classifier<varchar>") Slice modelSlice)
+    public static Slice varcharClassify(@SqlType(MAP_BIGINT_DOUBLE) Block featuresMap, @SqlType("Classifier(varchar)") Slice modelSlice)
     {
         FeatureVector features = ModelUtils.toFeatures(featuresMap);
         Model model = getOrLoadModel(modelSlice);
-        checkArgument(model.getType().equals(VARCHAR_CLASSIFIER), "model is not a classifier<varchar>");
+        checkArgument(model.getType().equals(VARCHAR_CLASSIFIER), "model is not a Classifier(varchar)");
         Classifier<String> varcharClassifier = (Classifier<String>) model;
         return Slices.utf8Slice(varcharClassifier.classify(features));
     }
 
     @ScalarFunction
     @SqlType(StandardTypes.BIGINT)
-    public static long classify(@SqlType(MAP_BIGINT_DOUBLE) Block featuresMap, @SqlType("Classifier<bigint>") Slice modelSlice)
+    public static long classify(@SqlType(MAP_BIGINT_DOUBLE) Block featuresMap, @SqlType("Classifier(bigint)") Slice modelSlice)
     {
         FeatureVector features = ModelUtils.toFeatures(featuresMap);
         Model model = getOrLoadModel(modelSlice);
-        checkArgument(model.getType().equals(BIGINT_CLASSIFIER), "model is not a classifier<bigint>");
+        checkArgument(model.getType().equals(BIGINT_CLASSIFIER), "model is not a Classifier(bigint)");
         Classifier<Integer> classifier = (Classifier<Integer>) model;
         return classifier.classify(features);
     }

--- a/presto-product-tests/conf/presto/etc/catalog/kafka/structural_datatype_avro.json
+++ b/presto-product-tests/conf/presto/etc/catalog/kafka/structural_datatype_avro.json
@@ -8,12 +8,12 @@
     "fields": [
       {
         "name": "c_array",
-        "type": "ARRAY<BIGINT>",
+        "type": "ARRAY(BIGINT)",
         "mapping": "a_array"
       },
       {
         "name": "c_map",
-        "type": "MAP<VARCHAR, VARCHAR>",
+        "type": "MAP(VARCHAR, VARCHAR)",
         "mapping": "a_map"
       }
     ]

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableMetadataSystemTable.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableMetadataSystemTable.java
@@ -78,7 +78,7 @@ public class TableMetadataSystemTable
         this.dao = onDemandDao(dbi, MetadataDao.class);
         requireNonNull(typeManager, "typeManager is null");
 
-        Type arrayOfVarchar = typeManager.getType(parseTypeSignature("array<varchar>"));
+        Type arrayOfVarchar = typeManager.getType(parseTypeSignature("array(varchar)"));
         this.tableMetadata = new ConnectorTableMetadata(
                 new SchemaTableName("system", "tables"),
                 ImmutableList.of(

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
@@ -77,9 +77,9 @@ public class TestAvroDecoder
     private static final AvroRowDecoderFactory DECODER_FACTORY = new AvroRowDecoderFactory();
 
     private static final Metadata METADATA = createTestMetadataManager();
-    private static final Type VACHAR_MAP_TYPE = METADATA.getType(parseTypeSignature("map<varchar,varchar>"));
-    private static final Type DOUBLE_MAP_TYPE = METADATA.getType(parseTypeSignature("map<varchar,double>"));
-    private static final Type REAL_MAP_TYPE = METADATA.getType(parseTypeSignature("map<varchar,real>"));
+    private static final Type VACHAR_MAP_TYPE = METADATA.getType(parseTypeSignature("map(varchar,varchar)"));
+    private static final Type DOUBLE_MAP_TYPE = METADATA.getType(parseTypeSignature("map(varchar,double)"));
+    private static final Type REAL_MAP_TYPE = METADATA.getType(parseTypeSignature("map(varchar,real)"));
 
     private static String getAvroSchema(String name, String dataType)
     {

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TypeSignature.java
@@ -126,10 +126,7 @@ public class TypeSignature
 
         for (int i = 0; i < signature.length(); i++) {
             char c = signature.charAt(i);
-            // TODO: remove angle brackets support once ROW<TYPE>(name) will be dropped
-            // Angle brackets here are checked not for the support of ARRAY<> and MAP<>
-            // but to correctly parse ARRAY(row<BIGINT, BIGINT>('a','b'))
-            if (c == '(' || c == '<') {
+            if (c == '(') {
                 if (bracketCount == 0) {
                     verify(baseName == null, "Expected baseName to be null");
                     verify(parameterStart == -1, "Expected parameter start to be -1");
@@ -139,7 +136,7 @@ public class TypeSignature
                 }
                 bracketCount++;
             }
-            else if (c == ')' || c == '>') {
+            else if (c == ')') {
                 bracketCount--;
                 checkArgument(bracketCount >= 0, "Bad type signature: '%s'", signature);
                 if (bracketCount == 0) {


### PR DESCRIPTION
Remove angle brackets support now that ROW<TYPE>(name) legacy row type signature is no longer supported (removed by 8759d8c).