### PR TITLE
Pass table owner information to HiveMetastore:listTablePrivileges

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -100,9 +100,9 @@ public interface HiveMetastore
 
     Set<RoleGrant> listRoleGrants(HivePrincipal principal);
 
-    void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
+    void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
-    void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
+    void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
-    Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal);
+    Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal);
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -394,26 +394,26 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal)
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
     {
         return loadValue(
                 tablePrivilegesCache,
-                new UserTableKey(principal, databaseName, tableName),
-                () -> delegate.listTablePrivileges(databaseName, tableName, principal));
+                new UserTableKey(principal, databaseName, tableName, tableOwner),
+                () -> delegate.listTablePrivileges(databaseName, tableName, tableOwner, principal));
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         verifyRecordingMode();
-        delegate.grantTablePrivileges(databaseName, tableName, grantee, privileges);
+        delegate.grantTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         verifyRecordingMode();
-        delegate.revokeTablePrivileges(databaseName, tableName, grantee, privileges);
+        delegate.revokeTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
     }
 
     private Set<HivePartitionName> getHivePartitionNames(String databaseName, String tableName, Set<String> partitionNames)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/UserTableKey.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/UserTableKey.java
@@ -29,14 +29,20 @@ public class UserTableKey
     private final HivePrincipal principal;
     private final String database;
     private final String table;
+    private final String owner;
 
     @JsonCreator
-    public UserTableKey(@JsonProperty("principal") HivePrincipal principal, @JsonProperty("database") String database, @JsonProperty("table") String table)
+    public UserTableKey(
+            @JsonProperty("principal") HivePrincipal principal,
+            @JsonProperty("database") String database,
+            @JsonProperty("table") String table,
+            @JsonProperty("owner") String owner)
     {
         // principal can be null when we want to list all privileges for admins
         this.principal = principal;
         this.database = requireNonNull(database, "database is null");
         this.table = requireNonNull(table, "table is null");
+        this.owner = requireNonNull(owner, "owner is null");
     }
 
     @JsonProperty
@@ -57,6 +63,12 @@ public class UserTableKey
         return table;
     }
 
+    @JsonProperty
+    public String getOwner()
+    {
+        return owner;
+    }
+
     public boolean matches(String databaseName, String tableName)
     {
         return this.database.equals(databaseName) && this.table.equals(tableName);
@@ -74,13 +86,14 @@ public class UserTableKey
         UserTableKey that = (UserTableKey) o;
         return Objects.equals(principal, that.principal) &&
                 Objects.equals(table, that.table) &&
-                Objects.equals(database, that.database);
+                Objects.equals(database, that.database) &&
+                Objects.equals(owner, that.owner);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(principal, table, database);
+        return Objects.hash(principal, table, database, owner);
     }
 
     @Override
@@ -90,6 +103,7 @@ public class UserTableKey
                 .add("principal", principal)
                 .add("table", table)
                 .add("database", database)
+                .add("tableOwner", owner)
                 .toString();
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/UserTableKey.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/UserTableKey.java
@@ -103,7 +103,7 @@ public class UserTableKey
                 .add("principal", principal)
                 .add("table", table)
                 .add("database", database)
-                .add("tableOwner", owner)
+                .add("owner", owner)
                 .toString();
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -962,7 +962,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal)
+    public synchronized Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
     {
         Table table = getRequiredTable(databaseName, tableName);
         Path permissionsDirectory = getPermissionsDirectory(table);
@@ -978,15 +978,15 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public synchronized void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         setTablePrivileges(grantee, databaseName, tableName, privileges);
     }
 
     @Override
-    public synchronized void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public synchronized void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
-        Set<HivePrivilegeInfo> currentPrivileges = listTablePrivileges(databaseName, tableName, grantee);
+        Set<HivePrivilegeInfo> currentPrivileges = listTablePrivileges(databaseName, tableName, tableOwner, grantee);
         currentPrivileges.removeAll(privileges);
 
         setTablePrivileges(grantee, databaseName, tableName, currentPrivileges);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -870,19 +870,19 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new PrestoException(NOT_SUPPORTED, "grantTablePrivileges is not supported by Glue");
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new PrestoException(NOT_SUPPORTED, "revokeTablePrivileges is not supported by Glue");
     }
 
     @Override
-    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal)
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
     {
         throw new PrestoException(NOT_SUPPORTED, "listTablePrivileges is not supported by Glue");
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -359,20 +359,20 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
-        delegate.grantTablePrivileges(databaseName, tableName, grantee, privileges);
+        delegate.grantTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
-        delegate.revokeTablePrivileges(databaseName, tableName, grantee, privileges);
+        delegate.revokeTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
     }
 
     @Override
-    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal)
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
     {
-        return delegate.listTablePrivileges(databaseName, tableName, principal);
+        return delegate.listTablePrivileges(databaseName, tableName, tableOwner, principal);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -102,13 +102,6 @@ public interface ThriftMetastore
 
     Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal);
 
-    default boolean isTableOwner(String user, String databaseName, String tableName)
-    {
-        // a table can only be owned by a user
-        Optional<Table> table = getTable(databaseName, tableName);
-        return table.isPresent() && user.equals(table.get().getOwner());
-    }
-
     default Optional<List<FieldSchema>> getFields(String databaseName, String tableName)
     {
         Optional<Table> table = getTable(databaseName, tableName);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -96,11 +96,18 @@ public interface ThriftMetastore
 
     Set<RoleGrant> listRoleGrants(HivePrincipal principal);
 
-    void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
+    void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
-    void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
+    void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
-    Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal);
+    Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal);
+
+    default boolean isTableOwner(String user, String databaseName, String tableName)
+    {
+        // a table can only be owned by a user
+        Optional<Table> table = getTable(databaseName, tableName);
+        return table.isPresent() && user.equals(table.get().getOwner());
+    }
 
     default Optional<List<FieldSchema>> getFields(String databaseName, String tableName)
     {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -136,7 +136,7 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.getPartitionNames("database", "table"), Optional.of(ImmutableList.of("value")));
         assertEquals(hiveMetastore.getPartitionNamesByParts("database", "table", ImmutableList.of("value")), Optional.of(ImmutableList.of("value")));
         assertEquals(hiveMetastore.getPartitionsByNames("database", "table", ImmutableList.of("value")), ImmutableMap.of("value", Optional.of(PARTITION)));
-        assertEquals(hiveMetastore.listTablePrivileges("database", "table", new HivePrincipal(USER, "user")), ImmutableSet.of(PRIVILEGE_INFO));
+        assertEquals(hiveMetastore.listTablePrivileges("database", "table", "owner", new HivePrincipal(USER, "user")), ImmutableSet.of(PRIVILEGE_INFO));
         assertEquals(hiveMetastore.listRoles(), ImmutableSet.of("role"));
         assertEquals(hiveMetastore.listRoleGrants(new HivePrincipal(USER, "user")), ImmutableSet.of(ROLE_GRANT));
     }
@@ -263,9 +263,9 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public Set<HivePrivilegeInfo> listTablePrivileges(String database, String table, HivePrincipal prestoPrincipal)
+        public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
         {
-            if (database.equals("database") && table.equals("table") && prestoPrincipal.getType() == USER && prestoPrincipal.getName().equals("user")) {
+            if (databaseName.equals("database") && tableName.equals("table") && principal.getType() == USER && principal.getName().equals("user")) {
                 return ImmutableSet.of(PRIVILEGE_INFO);
             }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -197,19 +197,19 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal prestoPrincipal)
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal prestoPrincipal)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -486,19 +486,19 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, HivePrincipal principal)
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal principal)
     {
         return ImmutableSet.of();
     }
 
     @Override
-    public void grantTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void revokeTablePrivileges(String databaseName, String tableName, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Pass table owner information to HiveMetastore:listTablePrivileges

Information about table owner can be easily accessed (from cache) in
SemiTransactionalHiveMetastore, while in ThriftHiveMetastore it required
additional call to HMS.
