### PR TITLE
add PrestoS3ProfileCredentialsProvider

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ProfileCredentialsProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ProfileCredentialsProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoS3ProfileCredentialsProvider
+        implements AWSCredentialsProvider
+{
+    public static final String S3_PROFILE_CREDENTIALS_PROVIDER_PROFILE = "presto.s3.profile-credentials-provider-profile";
+
+    private final ProfileCredentialsProvider delegate;
+
+    public PrestoS3ProfileCredentialsProvider(URI uri, Configuration conf)
+    {
+        requireNonNull(uri, "uri is null");
+        requireNonNull(conf, "conf is null");
+        String profile = conf.get(S3_PROFILE_CREDENTIALS_PROVIDER_PROFILE);
+        delegate = new ProfileCredentialsProvider(profile);
+    }
+
+    @Override
+    public AWSCredentials getCredentials()
+    {
+        return delegate.getCredentials();
+    }
+
+    @Override
+    public void refresh()
+    {
+        delegate.refresh();
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
@@ -73,6 +73,7 @@ import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STAGING_DIRECTOR
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_PREFIX;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_SUFFIX;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
+import static io.prestosql.plugin.hive.s3.PrestoS3ProfileCredentialsProvider.S3_PROFILE_CREDENTIALS_PROVIDER_PROFILE;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -84,6 +85,21 @@ import static org.testng.Assert.assertTrue;
 public class TestPrestoS3FileSystem
 {
     private static final int HTTP_RANGE_NOT_SATISFIABLE = 416;
+
+    @Test
+    public void testPrestoS3ProfileCredentialsProvider()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3_PROFILE_CREDENTIALS_PROVIDER_PROFILE, "default");
+        config.set(S3_CREDENTIALS_PROVIDER, PrestoS3ProfileCredentialsProvider.class.getName());
+        config.setBoolean(S3_USE_INSTANCE_CREDENTIALS, false);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+            assertInstanceOf(getAwsCredentialsProvider(fs), PrestoS3ProfileCredentialsProvider.class);
+        }
+    }
 
     @Test
     public void testStaticCredentials()


### PR DESCRIPTION
I have only Temporary Security Credentials on my computer. This credentials provider is much easier to use than [TemporaryAWSCredentialsProvider](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/TemporaryAWSCredentialsProvider.java) IMO.