### PR TITLE
Change default hive metastore refresh interval

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class CachingHiveMetastoreConfig
 {
     private Duration metastoreCacheTtl = new Duration(0, TimeUnit.SECONDS);
-    private Duration metastoreRefreshInterval = new Duration(0, TimeUnit.SECONDS);
+    private Duration metastoreRefreshInterval = new Duration(Integer.MAX_VALUE, TimeUnit.DAYS);
     private long metastoreCacheMaximumSize = 10000;
     private int maxMetastoreRefreshThreads = 100;
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -31,7 +31,7 @@ public class TestCachingHiveMetastoreConfig
     {
         assertRecordedDefaults(recordDefaults(CachingHiveMetastoreConfig.class)
                 .setMetastoreCacheTtl(new Duration(0, TimeUnit.SECONDS))
-                .setMetastoreRefreshInterval(new Duration(0, TimeUnit.SECONDS))
+                .setMetastoreRefreshInterval(new Duration(Integer.MAX_VALUE, TimeUnit.DAYS))
                 .setMetastoreCacheMaximumSize(10000)
                 .setMaxMetastoreRefreshThreads(100));
     }


### PR DESCRIPTION
With previous configuration, whenever someone was setting up
a ttl, refresh-interval default was used as 0, which is an invalid
configuration option for cache, which in turn has caused PrestoServer
startup failure. Changing it to Duration(Integer.MAX_VALUE, DAYS)
makes it disabled by default as well, but allows configuration
with ttl only, as refresh interval is not applied when it's greater than ttl.