### PR TITLE
Enable TestAllDatatypesFromHiveConnector.testSelectAllDatatypesAvro

### DIFF
--- a/presto-product-tests/bin/product-tests-suite-1.sh
+++ b/presto-product-tests/bin/product-tests-suite-1.sh
@@ -2,6 +2,7 @@
 
 set -xeuo pipefail
 
+# TODO enable avro_schema_url when adding Metastore impersonation
 presto-product-tests/bin/run_on_docker.sh \
     multinode \
-    -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql_connector,postgresql_connector,mysql,kafka,avro,simba_jdbc
+    -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql_connector,postgresql_connector,mysql,kafka,avro_schema_url,simba_jdbc

--- a/presto-product-tests/bin/product-tests-suite-3.sh
+++ b/presto-product-tests/bin/product-tests-suite-3.sh
@@ -22,8 +22,8 @@ presto-product-tests/bin/run_on_docker.sh \
     singlenode-kerberos-kms-hdfs-no-impersonation \
     -g storage_formats
 
-# TODO enable avro when adding Metastore impersonation
+# TODO enable avro_schema_url when adding Metastore impersonation
 presto-product-tests/bin/run_on_docker.sh \
     singlenode-kerberos-kms-hdfs-impersonation \
     -g storage_formats \
-    -x avro
+    -x avro_schema_url

--- a/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
@@ -63,7 +63,8 @@ public final class TestGroups
     public static final String BIG_QUERY = "big_query";
     public static final String HIVE_TABLE_STATISTICS = "hive_table_statistics";
     public static final String KAFKA = "kafka";
-    public static final String AVRO = "avro";
+    // TODO remove avro_schema_url group when adding Metastore impersonation
+    public static final String AVRO_SCHEMA_URL = "avro_schema_url";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAllDatatypesFromHiveConnector.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAllDatatypesFromHiveConnector.java
@@ -39,7 +39,6 @@ import static io.prestosql.tempto.fulfillment.table.MutableTableRequirement.Stat
 import static io.prestosql.tempto.fulfillment.table.TableHandle.tableHandle;
 import static io.prestosql.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.prestosql.tempto.query.QueryExecutor.query;
-import static io.prestosql.tests.TestGroups.AVRO;
 import static io.prestosql.tests.TestGroups.JDBC;
 import static io.prestosql.tests.TestGroups.SKIP_ON_CDH;
 import static io.prestosql.tests.TestGroups.SMOKE;
@@ -216,7 +215,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(AvroRequirements.class)
-    @Test(groups = {JDBC, SKIP_ON_CDH, AVRO})
+    @Test(groups = {JDBC, SKIP_ON_CDH})
     public void testSelectAllDatatypesAvro()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_AVRO).getNameInDatabase();

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaEvolution.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaEvolution.java
@@ -23,7 +23,7 @@ import static io.prestosql.tempto.assertions.QueryAssert.Row.row;
 import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
 import static io.prestosql.tempto.context.ThreadLocalTestContextHolder.testContext;
 import static io.prestosql.tempto.query.QueryExecutor.query;
-import static io.prestosql.tests.TestGroups.AVRO;
+import static io.prestosql.tests.TestGroups.AVRO_SCHEMA_URL;
 import static java.lang.String.format;
 
 public class TestAvroSchemaEvolution
@@ -60,14 +60,14 @@ public class TestAvroSchemaEvolution
         query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testSelectTable()
     {
         assertThat(query(format("SELECT string_col FROM %s", TABLE_NAME)))
                 .containsExactly(row("string0"));
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testInsertAfterSchemaEvolution()
     {
         assertThat(query(SELECT_STAR))
@@ -81,7 +81,7 @@ public class TestAvroSchemaEvolution
                         row("string1", 1, 101));
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testSchemaEvolutionWithIncompatibleType()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -96,7 +96,7 @@ public class TestAvroSchemaEvolution
                 .failsWithMessage("Found int, expecting string");
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testSchemaEvolution()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -138,7 +138,7 @@ public class TestAvroSchemaEvolution
                 .containsExactly(row("string0", null));
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testSchemaWhenUrlIsUnset()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -154,7 +154,7 @@ public class TestAvroSchemaEvolution
                         row("dummy_col", "varchar", "", ""));
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testCreateTableLike()
     {
         String createTableLikeName = "test_avro_like";

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaUrl.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaUrl.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.prestosql.tempto.assertions.QueryAssert.Row.row;
 import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
-import static io.prestosql.tests.TestGroups.AVRO;
+import static io.prestosql.tests.TestGroups.AVRO_SCHEMA_URL;
 import static io.prestosql.tests.TestGroups.STORAGE_FORMATS;
 import static io.prestosql.tests.utils.QueryExecutors.onHive;
 import static io.prestosql.tests.utils.QueryExecutors.onPresto;
@@ -81,7 +81,7 @@ public class TestAvroSchemaUrl
         };
     }
 
-    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, STORAGE_FORMATS})
+    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO_SCHEMA_URL, STORAGE_FORMATS})
     public void testHiveCreatedTable(String schemaLocation)
     {
         onHive().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_hive");
@@ -101,7 +101,7 @@ public class TestAvroSchemaUrl
         onHive().executeQuery("DROP TABLE test_avro_schema_url_hive");
     }
 
-    @Test(groups = {AVRO})
+    @Test(groups = {AVRO_SCHEMA_URL})
     public void testAvroSchemaUrlInSerdeProperties()
             throws IOException
     {
@@ -143,7 +143,7 @@ public class TestAvroSchemaUrl
         onHive().executeQuery("DROP TABLE test_avro_schema_url_in_serde_properties");
     }
 
-    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, STORAGE_FORMATS})
+    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO_SCHEMA_URL, STORAGE_FORMATS})
     public void testPrestoCreatedTable(String schemaLocation)
     {
         onPresto().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_presto");
@@ -156,7 +156,7 @@ public class TestAvroSchemaUrl
         onPresto().executeQuery("DROP TABLE test_avro_schema_url_presto");
     }
 
-    @Test(groups = {AVRO, STORAGE_FORMATS})
+    @Test(groups = {AVRO_SCHEMA_URL, STORAGE_FORMATS})
     public void testTableWithLongColumnType()
     {
         onPresto().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_long_column");
@@ -185,7 +185,7 @@ public class TestAvroSchemaUrl
         onPresto().executeQuery("DROP TABLE test_avro_schema_url_long_column");
     }
 
-    @Test(groups = {AVRO, STORAGE_FORMATS})
+    @Test(groups = {AVRO_SCHEMA_URL, STORAGE_FORMATS})
     public void testPartitionedTableWithLongColumnType()
     {
         if (isOnHdp()) {


### PR DESCRIPTION
Previously this test was not run.

- Rename `avro` test group to `avro_schema_url`.
- Remove the group from `testSelectAllDatatypesAvro`, as this test does
  not need to be treated in any special way.