### PR TITLE
Remove obsoleted partitionChunk wording

### DIFF
--- a/presto-google-sheets/src/main/java/io/prestosql/plugin/google/sheets/SheetsRecordSetProvider.java
+++ b/presto-google-sheets/src/main/java/io/prestosql/plugin/google/sheets/SheetsRecordSetProvider.java
@@ -32,7 +32,7 @@ public class SheetsRecordSetProvider
     @Override
     public RecordSet getRecordSet(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<? extends ColumnHandle> columns)
     {
-        requireNonNull(split, "partitionChunk is null");
+        requireNonNull(split, "split is null");
         SheetsSplit sheetsSplit = (SheetsSplit) split;
 
         List<SheetsColumnHandle> handles = columns.stream().map(c -> (SheetsColumnHandle) c).collect(Collectors.toList());


### PR DESCRIPTION
PartitionChunk was removed in https://github.com/prestosql/presto/commit/ba91c67c748d66b653d0a0d41c188680e65c49ec