### PR TITLE
Offload TEST_OTHER_MODULES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
     - env: TEST_SPECIFIC_MODULES=presto-hive
     - env: TEST_SPECIFIC_MODULES=presto-main
     - env: TEST_SPECIFIC_MODULES=presto-orc,presto-parquet
-    - env: TEST_SPECIFIC_MODULES=presto-mongodb
+    - env: TEST_SPECIFIC_MODULES=presto-mongodb,presto-kafka,presto-elasticsearch
     - env: TEST_SPECIFIC_MODULES=presto-redis
     - env: TEST_SPECIFIC_MODULES=presto-sqlserver,presto-postgresql,presto-mysql
-    - env: TEST_SPECIFIC_MODULES=presto-phoenix
-    - env: TEST_OTHER_MODULES=!presto-tests,!presto-raptor-legacy,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-orc,!presto-parquet,!presto-mongodb,!presto-redis,!presto-sqlserver,!presto-postgresql,!presto-mysql,!presto-phoenix
+    - env: TEST_SPECIFIC_MODULES=presto-phoenix,presto-iceberg
+    - env: TEST_OTHER_MODULES=!presto-tests,!presto-raptor-legacy,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-orc,!presto-parquet,!presto-mongodb,!presto-kafka,!presto-elasticsearch,!presto-redis,!presto-sqlserver,!presto-postgresql,!presto-mysql,!presto-phoenix,!presto-iceberg
     - env: PRODUCT_TESTS_SUITE=suite-1
     - env: PRODUCT_TESTS_SUITE=suite-2
     - env: PRODUCT_TESTS_SUITE=suite-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ matrix:
     - env: TEST_SPECIFIC_MODULES=presto-raptor-legacy
     - env: TEST_SPECIFIC_MODULES=presto-accumulo
     - env: TEST_SPECIFIC_MODULES=presto-cassandra
-    - env: TEST_SPECIFIC_MODULES=presto-hive
+    - env: TEST_SPECIFIC_MODULES=presto-hive,presto-orc,presto-parquet
     - env: TEST_SPECIFIC_MODULES=presto-main
-    - env: TEST_SPECIFIC_MODULES=presto-orc,presto-parquet
     - env: TEST_SPECIFIC_MODULES=presto-mongodb,presto-kafka,presto-elasticsearch
     - env: TEST_SPECIFIC_MODULES=presto-redis
     - env: TEST_SPECIFIC_MODULES=presto-sqlserver,presto-postgresql,presto-mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ matrix:
   include:
     - env: MAVEN_CHECKS=true BUILD_PRESTO_DOCKER=true
     - env: WEBUI_CHECKS=true
+    - env: TEST_SPECIFIC_MODULES=presto-main
     - env: TEST_SPECIFIC_MODULES=presto-tests
     - env: TEST_SPECIFIC_MODULES=presto-tests TEST_FLAGS="-P ci-only"
     - env: TEST_SPECIFIC_MODULES=presto-raptor-legacy
     - env: TEST_SPECIFIC_MODULES=presto-accumulo
     - env: TEST_SPECIFIC_MODULES=presto-cassandra
     - env: TEST_SPECIFIC_MODULES=presto-hive,presto-orc,presto-parquet
-    - env: TEST_SPECIFIC_MODULES=presto-main
     - env: TEST_SPECIFIC_MODULES=presto-mongodb,presto-kafka,presto-elasticsearch
     - env: TEST_SPECIFIC_MODULES=presto-redis
     - env: TEST_SPECIFIC_MODULES=presto-sqlserver,presto-postgresql,presto-mysql
     - env: TEST_SPECIFIC_MODULES=presto-phoenix,presto-iceberg
-    - env: TEST_OTHER_MODULES=!presto-tests,!presto-raptor-legacy,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-orc,!presto-parquet,!presto-mongodb,!presto-kafka,!presto-elasticsearch,!presto-redis,!presto-sqlserver,!presto-postgresql,!presto-mysql,!presto-phoenix,!presto-iceberg
+    - env: TEST_OTHER_MODULES=!presto-main,!presto-tests,!presto-raptor-legacy,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-orc,!presto-parquet,!presto-mongodb,!presto-kafka,!presto-elasticsearch,!presto-redis,!presto-sqlserver,!presto-postgresql,!presto-mysql,!presto-phoenix,!presto-iceberg,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm
     - env: PRODUCT_TESTS_SUITE=suite-1
     - env: PRODUCT_TESTS_SUITE=suite-2
     - env: PRODUCT_TESTS_SUITE=suite-3


### PR DESCRIPTION
Move out
- `presto-kafka` (09:14 min)
- `presto-elasticsearch` (06:46 min)
- `presto-iceberg` (07:26 min)

(Times based on last Travis run)

Fixes https://github.com/prestosql/presto/issues/1504