### PR TITLE
Fix information_schema.table_privileges with table_name predicate

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -658,7 +658,16 @@ public class HiveMetadata
         if (!prefix.getTable().isPresent()) {
             return listTables(session, prefix.getSchema());
         }
-        return ImmutableList.of(prefix.toSchemaTableName());
+        SchemaTableName tableName = prefix.toSchemaTableName();
+        try {
+            if (!metastore.getTable(tableName.getSchemaName(), tableName.getTableName()).isPresent()) {
+                return ImmutableList.of();
+            }
+        }
+        catch (HiveViewNotSupportedException e) {
+            // exists, would be returned by listTables from schema
+        }
+        return ImmutableList.of(tableName);
     }
 
     /**

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
@@ -147,14 +147,19 @@ public class SqlStandardAccessControlMetadata
         boolean isAdminRoleSet = hasAdminRole(principals);
         ImmutableList.Builder<GrantInfo> result = ImmutableList.builder();
         for (SchemaTableName tableName : tableNames) {
-            if (isAdminRoleSet) {
-                result.addAll(buildGrants(tableName, null));
-            }
-            else {
-                for (HivePrincipal grantee : principals) {
-                    result.addAll(buildGrants(tableName, grantee));
-                }
-            }
+            result.addAll(buildGrants(principals, isAdminRoleSet, tableName));
+        }
+        return result.build();
+    }
+
+    private List<GrantInfo> buildGrants(Set<HivePrincipal> principals, boolean isAdminRoleSet, SchemaTableName tableName)
+    {
+        if (isAdminRoleSet) {
+            return buildGrants(tableName, null);
+        }
+        ImmutableList.Builder<GrantInfo> result = ImmutableList.builder();
+        for (HivePrincipal grantee : principals) {
+            result.addAll(buildGrants(tableName, grantee));
         }
         return result.build();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.security.GrantInfo;
 import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.PrivilegeInfo;
@@ -147,7 +148,12 @@ public class SqlStandardAccessControlMetadata
         boolean isAdminRoleSet = hasAdminRole(principals);
         ImmutableList.Builder<GrantInfo> result = ImmutableList.builder();
         for (SchemaTableName tableName : tableNames) {
-            result.addAll(buildGrants(principals, isAdminRoleSet, tableName));
+            try {
+                result.addAll(buildGrants(principals, isAdminRoleSet, tableName));
+            }
+            catch (TableNotFoundException e) {
+                // table disappeared during listing operation
+            }
         }
         return result.build();
     }


### PR DESCRIPTION
When `information_schema.table_privileges` is given a predicate on
`table_name` (but not on `table_schema`), it lists prefixes
`s.searched_table` for every schema.
`ConnectorMetadata#listTablePrivileges` needs to correctly handle (skip)
such prefixes