### PR TITLE
Rename record_count to row_count in Iceberg partitions table

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
@@ -124,7 +124,7 @@ public class PartitionTable
                 .filter(column -> !identityPartitionIds.contains(column.fieldId()) && column.type().isPrimitiveType())
                 .collect(toImmutableList());
 
-        ImmutableList.of("record_count", "file_count", "total_size")
+        ImmutableList.of("row_count", "file_count", "total_size")
                 .forEach(metric -> columnMetadataBuilder.add(new ColumnMetadata(metric, BIGINT)));
 
         List<ColumnMetadata> columnMetricsMetadata = getColumnMetadata(nonPartitionPrimitiveColumns);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -231,14 +231,14 @@ public class TestIcebergSmoke
                 .collect(toImmutableMap(row -> (LocalDate) row.getField(0), Function.identity()));
 
         // Test if record counts are computed correctly
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(1), Long.valueOf(1));
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(1), Long.valueOf(3));
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1), Long.valueOf(2));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(1), 1L);
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(1), 3L);
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1), 2L);
 
         // Test if min/max values and null value count are computed correctly.
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(0), Long.valueOf(0), Long.valueOf(0)));
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(1), Long.valueOf(3), Long.valueOf(0)));
-        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(4), new MaterializedRow(DEFAULT_PRECISION, Long.valueOf(4), Long.valueOf(5), Long.valueOf(0)));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 0L, 0L, 0L));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 1L, 3L, 0L));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 4L, 5L, 0L));
 
         dropTable(session, "test_partition_table_basic");
     }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -219,7 +219,7 @@ public class TestIcebergSmoke
 
         assertQuery(session, "SHOW COLUMNS FROM \"test_partition_table_basic$partitions\"",
                 "VALUES ('_date', 'date', '', '')," +
-                        "('record_count', 'bigint', '', '')," +
+                        "('row_count', 'bigint', '', '')," +
                         "('file_count', 'bigint', '', '')," +
                         "('total_size', 'bigint', '', '')," +
                         "('_bigint', 'row(min bigint, max bigint, null_count bigint)', '', '')");
@@ -230,7 +230,7 @@ public class TestIcebergSmoke
         Map<LocalDate, MaterializedRow> rowsByPartition = result.getMaterializedRows().stream()
                 .collect(toImmutableMap(row -> (LocalDate) row.getField(0), Function.identity()));
 
-        // Test if record counts are computed correctly
+        // Test if row counts are computed correctly
         assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(1), 1L);
         assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(1), 3L);
         assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1), 2L);


### PR DESCRIPTION
This better matches the nomenclature used elsewhere.