### PR TITLE
Add scroll bar for query-list ui component

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/presto.css
+++ b/presto-main/src/main/resources/webapp/assets/presto.css
@@ -425,6 +425,11 @@ pre {
     padding: 0;
 }
 
+.query-navigation {
+    max-height: 400px;
+    overflow-y: scroll; 
+}
+
 /** Query List Toolbar **/
 /** ================== **/
 

--- a/presto-main/src/main/resources/webapp/src/components/QueryList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryList.jsx
@@ -201,7 +201,7 @@ class DisplayedQueriesList extends React.Component {
             );
         }.bind(this));
         return (
-            <div>
+            <div className="query-navigation">
                 {queryNodes}
             </div>
         );


### PR DESCRIPTION
Limit max-height of query-list component with scroll bar
so that user could navigate within component instead of
web page.