### PR TITLE
Enable the Information Schema Connector to load data lazily

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
@@ -195,6 +195,10 @@ public class InformationSchemaMetadata
 
         Set<QualifiedTablePrefix> prefixes = getPrefixes(session, table, constraint);
 
+        if (prefixes.equals(table.getPrefixes())) {
+            return Optional.empty();
+        }
+
         table = new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), prefixes, table.getLimit());
 
         return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary()));

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
@@ -100,7 +100,7 @@ public class InformationSchemaMetadata
     {
         Optional<InformationSchemaTable> informationSchemaTable = InformationSchemaTable.of(tableName);
         if (informationSchemaTable.isPresent()) {
-            return new InformationSchemaTableHandle(catalogName, informationSchemaTable.get(), defaultPrefixes(), OptionalLong.empty());
+            return new InformationSchemaTableHandle(catalogName, informationSchemaTable.get(), defaultPrefixes(catalogName), OptionalLong.empty());
         }
         return null;
     }
@@ -189,7 +189,7 @@ public class InformationSchemaMetadata
     {
         InformationSchemaTableHandle table = (InformationSchemaTableHandle) handle;
 
-        if (!isTablesEnumeratingTable(table.getTable()) || !table.getPrefixes().equals(defaultPrefixes())) {
+        if (!isTablesEnumeratingTable(table.getTable()) || !table.getPrefixes().equals(defaultPrefixes(catalogName))) {
             return Optional.empty();
         }
 
@@ -204,7 +204,7 @@ public class InformationSchemaMetadata
         return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary()));
     }
 
-    private Set<QualifiedTablePrefix> defaultPrefixes()
+    public static Set<QualifiedTablePrefix> defaultPrefixes(String catalogName)
     {
         return ImmutableSet.of(new QualifiedTablePrefix(catalogName));
     }
@@ -229,13 +229,13 @@ public class InformationSchemaMetadata
         }
         if (prefixes.size() > MAX_PREFIXES_COUNT) {
             // in case of high number of prefixes it is better to populate all data and then filter
-            prefixes = defaultPrefixes();
+            prefixes = defaultPrefixes(catalogName);
         }
 
         return prefixes;
     }
 
-    private boolean isTablesEnumeratingTable(InformationSchemaTable table)
+    public static boolean isTablesEnumeratingTable(InformationSchemaTable table)
     {
         return ImmutableSet.of(COLUMNS, VIEWS, TABLES, TABLE_PRIVILEGES).contains(table);
     }

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSource.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSource.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.connector.informationschema;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.QualifiedTablePrefix;
+import io.prestosql.security.AccessControl;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorViewDefinition;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.GrantInfo;
+import io.prestosql.spi.security.PrestoPrincipal;
+import io.prestosql.spi.security.RoleGrant;
+import io.prestosql.spi.type.Type;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.union;
+import static io.prestosql.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
+import static io.prestosql.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
+import static io.prestosql.metadata.MetadataListing.listSchemas;
+import static io.prestosql.metadata.MetadataListing.listTableColumns;
+import static io.prestosql.metadata.MetadataListing.listTablePrivileges;
+import static io.prestosql.metadata.MetadataListing.listTables;
+import static io.prestosql.metadata.MetadataListing.listViews;
+import static io.prestosql.spi.security.PrincipalType.USER;
+import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
+import static java.util.Objects.requireNonNull;
+
+public class InformationSchemaPageSource
+        implements ConnectorPageSource
+{
+    private final Session session;
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    private final String catalogName;
+    private final InformationSchemaTable table;
+    private final Supplier<Iterator<QualifiedTablePrefix>> prefixIterator;
+    private final OptionalLong limit;
+
+    private final List<Type> types;
+    private final Queue<Page> pages = new ArrayDeque<>();
+    private final PageBuilder pageBuilder;
+    private final Function<Page, Page> projection;
+
+    private long recordCount;
+    private long completedBytes;
+    private long memoryUsageBytes;
+    private boolean closed;
+
+    public InformationSchemaPageSource(
+            Session session,
+            Metadata metadata,
+            AccessControl accessControl,
+            InformationSchemaTableHandle tableHandle,
+            List<ColumnHandle> columns)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(columns, "columns is null");
+
+        catalogName = tableHandle.getCatalogName();
+        table = tableHandle.getTable();
+        prefixIterator = Suppliers.memoize(() -> {
+            Set<QualifiedTablePrefix> prefixes = tableHandle.getPrefixes();
+            if (isTablesEnumeratingTable(table)) {
+                if (prefixes.equals(defaultPrefixes(catalogName))) {
+                    prefixes = metadata.listSchemaNames(session, catalogName).stream()
+                            .map(schema -> new QualifiedTablePrefix(catalogName, schema))
+                            .collect(toImmutableSet());
+                }
+            }
+            else {
+                checkArgument(prefixes.equals(defaultPrefixes(catalogName)), "Catalog-wise tables have prefixes other than the default one");
+            }
+            return prefixes.iterator();
+        });
+        limit = tableHandle.getLimit();
+
+        List<ColumnMetadata> columnMetadata = table.getTableMetadata().getColumns();
+
+        types = columnMetadata.stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList());
+
+        pageBuilder = new PageBuilder(types);
+
+        Map<String, Integer> columnNameToChannel = IntStream.range(0, columnMetadata.size())
+                .boxed()
+                .collect(toImmutableMap(i -> columnMetadata.get(i).getName(), Function.identity()));
+
+        List<Integer> channels = columns.stream()
+                .map(columnHandle -> (InformationSchemaColumnHandle) columnHandle)
+                .map(columnHandle -> columnNameToChannel.get(columnHandle.getColumnName()))
+                .collect(toImmutableList());
+
+        projection = page -> {
+            Block[] blocks = new Block[channels.size()];
+            for (int i = 0; i < blocks.length; i++) {
+                blocks[i] = page.getBlock(channels.get(i));
+            }
+            return new Page(page.getPositionCount(), blocks);
+        };
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed ||
+                (pages.isEmpty() && (!prefixIterator.get().hasNext() || isLimitExhausted()));
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+
+        if (pages.isEmpty()) {
+            buildPages();
+        }
+
+        Page page = pages.poll();
+
+        if (page == null) {
+            return null;
+        }
+
+        memoryUsageBytes -= page.getRetainedSizeInBytes();
+        Page outputPage = projection.apply(page);
+        completedBytes += outputPage.getSizeInBytes();
+        return outputPage;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return memoryUsageBytes + pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closed = true;
+    }
+
+    private void buildPages()
+    {
+        while (pages.isEmpty() && prefixIterator.get().hasNext() && !closed && !isLimitExhausted()) {
+            QualifiedTablePrefix prefix = prefixIterator.get().next();
+            switch (table) {
+                case COLUMNS:
+                    addColumnsRecords(prefix);
+                    break;
+                case TABLES:
+                    addTablesRecords(prefix);
+                    break;
+                case VIEWS:
+                    addViewsRecords(prefix);
+                    break;
+                case SCHEMATA:
+                    addSchemataRecords();
+                    break;
+                case TABLE_PRIVILEGES:
+                    addTablePrivilegesRecords(prefix);
+                    break;
+                case ROLES:
+                    addRolesRecords();
+                    break;
+                case APPLICABLE_ROLES:
+                    addApplicableRolesRecords();
+                    break;
+                case ENABLED_ROLES:
+                    addEnabledRolesRecords();
+                    break;
+            }
+        }
+        if (!prefixIterator.get().hasNext() || isLimitExhausted()) {
+            flushPageBuilder();
+        }
+    }
+
+    private void addColumnsRecords(QualifiedTablePrefix prefix)
+    {
+        for (Map.Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+            SchemaTableName tableName = entry.getKey();
+            int ordinalPosition = 1;
+            for (ColumnMetadata column : entry.getValue()) {
+                if (column.isHidden()) {
+                    continue;
+                }
+                addRecord(
+                        prefix.getCatalogName(),
+                        tableName.getSchemaName(),
+                        tableName.getTableName(),
+                        column.getName(),
+                        ordinalPosition,
+                        null,
+                        "YES",
+                        column.getType().getDisplayName(),
+                        column.getComment(),
+                        column.getExtraInfo(),
+                        column.getComment());
+                ordinalPosition++;
+                if (isLimitExhausted()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void addTablesRecords(QualifiedTablePrefix prefix)
+    {
+        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
+        Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
+
+        for (SchemaTableName name : union(tables, views)) {
+            // if table and view names overlap, the view wins
+            String type = views.contains(name) ? "VIEW" : "BASE TABLE";
+            addRecord(
+                    prefix.getCatalogName(),
+                    name.getSchemaName(),
+                    name.getTableName(),
+                    type,
+                    null);
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addViewsRecords(QualifiedTablePrefix prefix)
+    {
+        for (Map.Entry<QualifiedObjectName, ConnectorViewDefinition> entry : metadata.getViews(session, prefix).entrySet()) {
+            addRecord(
+                    entry.getKey().getCatalogName(),
+                    entry.getKey().getSchemaName(),
+                    entry.getKey().getObjectName(),
+                    entry.getValue().getOriginalSql());
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addSchemataRecords()
+    {
+        for (String schema : listSchemas(session, metadata, accessControl, catalogName)) {
+            addRecord(catalogName, schema);
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addTablePrivilegesRecords(QualifiedTablePrefix prefix)
+    {
+        List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
+        for (GrantInfo grant : grants) {
+            addRecord(
+                    grant.getGrantor().map(PrestoPrincipal::getName).orElse(null),
+                    grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
+                    grant.getGrantee().getName(),
+                    grant.getGrantee().getType().toString(),
+                    prefix.getCatalogName(),
+                    grant.getSchemaTableName().getSchemaName(),
+                    grant.getSchemaTableName().getTableName(),
+                    grant.getPrivilegeInfo().getPrivilege().name(),
+                    grant.getPrivilegeInfo().isGrantOption() ? "YES" : "NO",
+                    grant.getWithHierarchy().map(withHierarchy -> withHierarchy ? "YES" : "NO").orElse(null));
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addRolesRecords()
+    {
+        try {
+            accessControl.checkCanShowRoles(session.toSecurityContext(), catalogName);
+        }
+        catch (AccessDeniedException exception) {
+            return;
+        }
+
+        for (String role : metadata.listRoles(session, catalogName)) {
+            addRecord(role);
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addApplicableRolesRecords()
+    {
+        for (RoleGrant grant : metadata.listApplicableRoles(session, new PrestoPrincipal(USER, session.getUser()), catalogName)) {
+            PrestoPrincipal grantee = grant.getGrantee();
+            addRecord(
+                    grantee.getName(),
+                    grantee.getType().toString(),
+                    grant.getRoleName(),
+                    grant.isGrantable() ? "YES" : "NO");
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addEnabledRolesRecords()
+    {
+        for (String role : metadata.listEnabledRoles(session, catalogName)) {
+            addRecord(role);
+            if (isLimitExhausted()) {
+                return;
+            }
+        }
+    }
+
+    private void addRecord(Object... values)
+    {
+        pageBuilder.declarePosition();
+        for (int i = 0; i < types.size(); i++) {
+            writeNativeValue(types.get(i), pageBuilder.getBlockBuilder(i), values[i]);
+        }
+        if (pageBuilder.isFull()) {
+            flushPageBuilder();
+        }
+        recordCount++;
+    }
+
+    private void flushPageBuilder()
+    {
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+            memoryUsageBytes += pageBuilder.getRetainedSizeInBytes();
+            pageBuilder.reset();
+        }
+    }
+
+    private boolean isLimitExhausted()
+    {
+        return limit.isPresent() && recordCount >= limit.getAsLong();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaPageSourceProvider.java
@@ -13,62 +13,24 @@
  */
 package io.prestosql.connector.informationschema;
 
-import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
 import io.prestosql.FullConnectorSession;
-import io.prestosql.Session;
-import io.prestosql.metadata.InternalTable;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.metadata.QualifiedObjectName;
-import io.prestosql.metadata.QualifiedTablePrefix;
 import io.prestosql.security.AccessControl;
-import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ColumnHandle;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
-import io.prestosql.spi.connector.ConnectorViewDefinition;
-import io.prestosql.spi.connector.FixedPageSource;
-import io.prestosql.spi.connector.SchemaTableName;
-import io.prestosql.spi.security.AccessDeniedException;
-import io.prestosql.spi.security.GrantInfo;
-import io.prestosql.spi.security.PrestoPrincipal;
-import io.prestosql.spi.security.RoleGrant;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.OptionalLong;
-import java.util.Set;
 
-import static com.google.common.collect.Sets.union;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.APPLICABLE_ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.COLUMNS;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.ENABLED_ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.ROLES;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.SCHEMATA;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.TABLES;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.TABLE_PRIVILEGES;
-import static io.prestosql.connector.informationschema.InformationSchemaTable.VIEWS;
-import static io.prestosql.metadata.MetadataListing.listSchemas;
-import static io.prestosql.metadata.MetadataListing.listTableColumns;
-import static io.prestosql.metadata.MetadataListing.listTablePrivileges;
-import static io.prestosql.metadata.MetadataListing.listTables;
-import static io.prestosql.metadata.MetadataListing.listViews;
-import static io.prestosql.spi.security.PrincipalType.USER;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class InformationSchemaPageSourceProvider
         implements ConnectorPageSourceProvider
 {
-    private static final Logger log = Logger.get(InformationSchemaPageSourceProvider.class);
-
     private final Metadata metadata;
     private final AccessControl accessControl;
 
@@ -86,218 +48,11 @@ public class InformationSchemaPageSourceProvider
             ConnectorTableHandle tableHandle,
             List<ColumnHandle> columns)
     {
-        InternalTable table = getInternalTable(session, tableHandle);
-
-        List<Integer> channels = new ArrayList<>();
-        for (ColumnHandle column : columns) {
-            String columnName = ((InformationSchemaColumnHandle) column).getColumnName();
-            int columnIndex = table.getColumnIndex(columnName);
-            channels.add(columnIndex);
-        }
-
-        ImmutableList.Builder<Page> pages = ImmutableList.builder();
-        for (Page page : table.getPages()) {
-            Block[] blocks = new Block[channels.size()];
-            for (int index = 0; index < blocks.length; index++) {
-                blocks[index] = page.getBlock(channels.get(index));
-            }
-            pages.add(new Page(page.getPositionCount(), blocks));
-        }
-        return new FixedPageSource(pages.build());
-    }
-
-    private InternalTable getInternalTable(ConnectorSession connectorSession, ConnectorTableHandle tablehandle)
-    {
-        Session session = ((FullConnectorSession) connectorSession).getSession();
-        InformationSchemaTableHandle handle = (InformationSchemaTableHandle) tablehandle;
-        Set<QualifiedTablePrefix> prefixes = handle.getPrefixes();
-
-        return getInformationSchemaTable(session, handle.getCatalogName(), handle.getTable(), prefixes, handle.getLimit());
-    }
-
-    private InternalTable getInformationSchemaTable(Session session, String catalog, InformationSchemaTable table, Set<QualifiedTablePrefix> prefixes, OptionalLong limit)
-    {
-        log.debug("Building information schema table (queryId=%s; catalog=%s; table=%s; prefixes=%s, limit=%s)", session.getQueryId(), catalog, table, prefixes, limit);
-
-        switch (table) {
-            case COLUMNS:
-                return buildColumns(session, prefixes, limit);
-            case TABLES:
-                return buildTables(session, prefixes, limit);
-            case VIEWS:
-                return buildViews(session, prefixes, limit);
-            case SCHEMATA:
-                return buildSchemata(session, catalog, limit);
-            case TABLE_PRIVILEGES:
-                return buildTablePrivileges(session, prefixes, limit);
-            case ROLES:
-                return buildRoles(session, catalog, limit);
-            case APPLICABLE_ROLES:
-                return buildApplicableRoles(session, catalog, limit);
-            case ENABLED_ROLES:
-                return buildEnabledRoles(session, catalog, limit);
-        }
-        throw new IllegalArgumentException(format("table does not exist: %s", table.getSchemaTableName()));
-    }
-
-    private InternalTable buildColumns(Session session, Set<QualifiedTablePrefix> prefixes, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(COLUMNS.getTableMetadata().getColumns());
-        for (QualifiedTablePrefix prefix : prefixes) {
-            for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
-                SchemaTableName tableName = entry.getKey();
-                int ordinalPosition = 1;
-                for (ColumnMetadata column : entry.getValue()) {
-                    if (column.isHidden()) {
-                        continue;
-                    }
-                    table.add(
-                            prefix.getCatalogName(),
-                            tableName.getSchemaName(),
-                            tableName.getTableName(),
-                            column.getName(),
-                            ordinalPosition,
-                            null,
-                            "YES",
-                            column.getType().getDisplayName(),
-                            column.getComment(),
-                            column.getExtraInfo(),
-                            column.getComment());
-                    ordinalPosition++;
-                    if (table.atLimit(limit)) {
-                        return table.build();
-                    }
-                }
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildTables(Session session, Set<QualifiedTablePrefix> prefixes, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(TABLES.getTableMetadata().getColumns());
-        for (QualifiedTablePrefix prefix : prefixes) {
-            Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
-            Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
-
-            for (SchemaTableName name : union(tables, views)) {
-                // if table and view names overlap, the view wins
-                String type = views.contains(name) ? "VIEW" : "BASE TABLE";
-                table.add(
-                        prefix.getCatalogName(),
-                        name.getSchemaName(),
-                        name.getTableName(),
-                        type,
-                        null);
-                if (table.atLimit(limit)) {
-                    return table.build();
-                }
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildTablePrivileges(Session session, Set<QualifiedTablePrefix> prefixes, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(TABLE_PRIVILEGES.getTableMetadata().getColumns());
-        for (QualifiedTablePrefix prefix : prefixes) {
-            List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
-            for (GrantInfo grant : grants) {
-                table.add(
-                        grant.getGrantor().map(PrestoPrincipal::getName).orElse(null),
-                        grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
-                        grant.getGrantee().getName(),
-                        grant.getGrantee().getType().toString(),
-                        prefix.getCatalogName(),
-                        grant.getSchemaTableName().getSchemaName(),
-                        grant.getSchemaTableName().getTableName(),
-                        grant.getPrivilegeInfo().getPrivilege().name(),
-                        grant.getPrivilegeInfo().isGrantOption() ? "YES" : "NO",
-                        grant.getWithHierarchy().map(withHierarchy -> withHierarchy ? "YES" : "NO").orElse(null));
-                if (table.atLimit(limit)) {
-                    return table.build();
-                }
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildViews(Session session, Set<QualifiedTablePrefix> prefixes, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(VIEWS.getTableMetadata().getColumns());
-        for (QualifiedTablePrefix prefix : prefixes) {
-            for (Entry<QualifiedObjectName, ConnectorViewDefinition> entry : metadata.getViews(session, prefix).entrySet()) {
-                table.add(
-                        entry.getKey().getCatalogName(),
-                        entry.getKey().getSchemaName(),
-                        entry.getKey().getObjectName(),
-                        entry.getValue().getOriginalSql());
-                if (table.atLimit(limit)) {
-                    return table.build();
-                }
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildSchemata(Session session, String catalogName, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(SCHEMATA.getTableMetadata().getColumns());
-        for (String schema : listSchemas(session, metadata, accessControl, catalogName)) {
-            table.add(catalogName, schema);
-            if (table.atLimit(limit)) {
-                return table.build();
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildRoles(Session session, String catalog, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(ROLES.getTableMetadata().getColumns());
-
-        try {
-            accessControl.checkCanShowRoles(session.toSecurityContext(), catalog);
-        }
-        catch (AccessDeniedException exception) {
-            return table.build();
-        }
-
-        for (String role : metadata.listRoles(session, catalog)) {
-            table.add(role);
-            if (table.atLimit(limit)) {
-                return table.build();
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildApplicableRoles(Session session, String catalog, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(APPLICABLE_ROLES.getTableMetadata().getColumns());
-        for (RoleGrant grant : metadata.listApplicableRoles(session, new PrestoPrincipal(USER, session.getUser()), catalog)) {
-            PrestoPrincipal grantee = grant.getGrantee();
-            table.add(
-                    grantee.getName(),
-                    grantee.getType().toString(),
-                    grant.getRoleName(),
-                    grant.isGrantable() ? "YES" : "NO");
-            if (table.atLimit(limit)) {
-                return table.build();
-            }
-        }
-        return table.build();
-    }
-
-    private InternalTable buildEnabledRoles(Session session, String catalog, OptionalLong limit)
-    {
-        InternalTable.Builder table = InternalTable.builder(ENABLED_ROLES.getTableMetadata().getColumns());
-        for (String role : metadata.listEnabledRoles(session, catalog)) {
-            table.add(role);
-            if (table.atLimit(limit)) {
-                return table.build();
-            }
-        }
-        return table.build();
+        return new InformationSchemaPageSource(
+                ((FullConnectorSession) session).getSession(),
+                metadata,
+                accessControl,
+                (InformationSchemaTableHandle) tableHandle,
+                columns);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
@@ -167,9 +167,14 @@ public class MockConnectorFactory
             @Override
             public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
             {
-                return listTables.apply(session, schemaName.orElse(null)).stream()
-                        .filter(schemaTableName -> !schemaName.isPresent() || schemaTableName.getSchemaName().equals(schemaName.get()))
-                        .collect(toImmutableList());
+                if (schemaName.isPresent()) {
+                    return listTables.apply(session, schemaName.get());
+                }
+                ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
+                for (String schema : listSchemaNames(session)) {
+                    tableNames.addAll(listTables.apply(session, schema));
+                }
+                return tableNames.build();
             }
 
             @Override

--- a/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/io/prestosql/connector/informationschema/BenchmarkInformationSchema.java
@@ -67,9 +67,10 @@ public class BenchmarkInformationSchema
         private final Map<String, String> queries = ImmutableMap.of(
                 "FULL_SCAN", "SELECT count(*) FROM information_schema.columns",
                 "LIKE_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema LIKE 'schema_0'",
-                "MIXED_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema = 'schema_0'");
+                "MIXED_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema = 'schema_0'",
+                "LIMIT_SCAN", "SELECT column_name FROM information_schema.columns LIMIT 100");
 
-        @Param({"FULL_SCAN", "LIKE_PREDICATE", "MIXED_PREDICATE"})
+        @Param({"FULL_SCAN", "LIKE_PREDICATE", "MIXED_PREDICATE", "LIMIT_SCAN"})
         private String queryId = "LIKE_PREDICATE";
         @Param("200")
         private String schemasCount = "200";

--- a/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
@@ -59,6 +59,7 @@ public class TestInformationSchemaConnector
         assertQuery("SELECT * FROM tpch.information_schema.schemata ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('tpch', 'tiny')");
         assertQuery("SELECT * FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'BASE TABLE')");
         assertQuery("SELECT * FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'suppkey', 1, NULL, 'YES', 'bigint', NULL, NULL)");
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.columns", "VALUES 3000800");
     }
 
     @Test
@@ -106,7 +107,6 @@ public class TestInformationSchemaConnector
         assertQuery("SELECT table_name, table_type FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('views', 'BASE TABLE')");
         assertQuery("SELECT column_name, data_type FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('with_hierarchy', 'varchar')");
     }
-
 
     @Test
     public void testLimit()
@@ -189,15 +189,15 @@ public class TestInformationSchemaConnector
                 "VALUES 1",
                 new MetadataCallsCount()
                         .withListSchemasCount(1)
-                        .withListTablesCount(2)
-                        .withGetColumnsCount(30000));
+                        .withListTablesCount(0)
+                        .withGetColumnsCount(8));
         assertMetadataCalls(
                 "SELECT count(*) FROM (SELECT * from test_catalog.information_schema.columns LIMIT 10000)",
                 "VALUES 10000",
                 new MetadataCallsCount()
                         .withListSchemasCount(1)
-                        .withListTablesCount(2)
-                        .withGetColumnsCount(30000));
+                        .withListTablesCount(1)
+                        .withGetColumnsCount(10008));
     }
 
     private static DistributedQueryRunner createQueryRunner()


### PR DESCRIPTION
Supersedes #1121 and closes #1046 #998 

Before: Information Schema Connector builds all the pages beforehand and returns a `FixedPageSource`.
After: It builds pages lazily. Downstream operators can process data as soon as it's ready.

cc: @kokosing @wagnermarkd @findepi 