### PR TITLE
Add ST_Length(SphericalGeography)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -292,6 +292,11 @@ Accessors
     Returns the length of a linestring or multi-linestring using Euclidean measurement on a
     two dimensional plane (based on spatial ref) in projected units.
 
+.. function:: ST_Length(SphericalGeography) -> double
+
+    Returns the length of a linestring or multi-linestring on a spherical model of the Earth.
+    This is equivalent to the sum of great-circle distances between adjacent points on the linestring.
+
 .. function:: ST_PointN(LineString, index) -> Point
 
     Returns the vertex of a linestring at a given index (indices start at 1).

--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
@@ -542,6 +542,41 @@ public final class GeoFunctions
     }
 
     @SqlNullable
+    @Description("Returns the great-circle length in meters of a linestring or multi-linestring on Earth's surface")
+    @ScalarFunction("ST_Length")
+    @SqlType(DOUBLE)
+    public static Double stSphericalLength(@SqlType(SPHERICAL_GEOGRAPHY_TYPE_NAME) Slice input)
+    {
+        OGCGeometry geometry = deserialize(input);
+        if (geometry.isEmpty()) {
+            return null;
+        }
+
+        validateSphericalType("ST_Length", geometry, EnumSet.of(LINE_STRING, MULTI_LINE_STRING));
+        MultiPath lineString = (MultiPath) geometry.getEsriGeometry();
+
+        double sum = 0;
+
+        // sum up paths on (multi)linestring
+        for (int path = 0; path < lineString.getPathCount(); path++) {
+            if (lineString.getPathSize(path) < 2) {
+                continue;
+            }
+
+            // sum up distances between adjacent points on this path
+            int pathStart = lineString.getPathStart(path);
+            Point prev = lineString.getPoint(pathStart);
+            for (int i = pathStart + 1; i < lineString.getPathEnd(path); i++) {
+                Point next = lineString.getPoint(i);
+                sum += greatCircleDistance(prev.getY(), prev.getX(), next.getY(), next.getX());
+                prev = next;
+            }
+        }
+
+        return sum * 1000;
+    }
+
+    @SqlNullable
     @Description("Returns a float between 0 and 1 representing the location of the closest point on the LineString to the given Point, as a fraction of total 2d line length.")
     @ScalarFunction("line_locate_point")
     @SqlType(DOUBLE)

--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
@@ -565,11 +565,11 @@ public final class GeoFunctions
 
             // sum up distances between adjacent points on this path
             int pathStart = lineString.getPathStart(path);
-            Point prev = lineString.getPoint(pathStart);
+            Point previous = lineString.getPoint(pathStart);
             for (int i = pathStart + 1; i < lineString.getPathEnd(path); i++) {
                 Point next = lineString.getPoint(i);
-                sum += greatCircleDistance(prev.getY(), prev.getX(), next.getY(), next.getX());
-                prev = next;
+                sum += greatCircleDistance(previous.getY(), previous.getX(), next.getY(), next.getX());
+                previous = next;
             }
         }
 

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
@@ -403,6 +403,54 @@ public class TestGeoFunctions
     }
 
     @Test
+    public void testSTLengthSphericalGeography()
+    {
+        // Empty linestring returns null
+        assertSTLengthSphericalGeography("LINESTRING EMPTY", null);
+
+        // Linestring with one point has length 0
+        assertSTLengthSphericalGeography("LINESTRING (0 0)", 0.0);
+
+        // Linestring with only one distinct point has length 0
+        assertSTLengthSphericalGeography("LINESTRING (0 0, 0 0, 0 0)", 0.0);
+
+        double length = 4350866.6362;
+
+        // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
+        assertSTLengthSphericalGeography("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", length);
+
+        // Linestring has same length as its reverse
+        assertSTLengthSphericalGeography("LINESTRING (-122.41 37.77, -87.62 41.87, -71.05 42.36)", length);
+
+        // Path north pole -> south pole -> north pole should be roughly the circumference of the Earth
+        assertSTLengthSphericalGeography("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", 4.003e7);
+
+        // Empty multi-linestring returns null
+        assertSTLengthSphericalGeography("MULTILINESTRING (EMPTY)", null);
+
+        // Multi-linestring with one path is equivalent to a single linestring
+        assertSTLengthSphericalGeography("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77))", length);
+
+        // Multi-linestring with two disjoint paths has length equal to sum of lengths of lines
+        assertSTLengthSphericalGeography("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77), (-73.05 42.36, -89.62 41.87, -124.41 37.77))", 2 * length);
+
+        // Multi-linestring with adjacent paths is equivalent to a single linestring
+        assertSTLengthSphericalGeography("MULTILINESTRING ((-71.05 42.36, -87.62 41.87), (-87.62 41.87, -122.41 37.77))", length);
+    }
+
+    private void assertSTLengthSphericalGeography(String lineString, Double expectedLength)
+    {
+        String function = format("ST_Length(to_spherical_geography(ST_GeometryFromText('%s')))", lineString);
+
+        if (expectedLength == null || expectedLength == 0.0) {
+            assertFunction(function, DOUBLE, expectedLength);
+        }
+        else {
+            assertFunction(format("ROUND(ABS((%s / %f) - 1.0) / %f, 0)", function, expectedLength, 1e-4), DOUBLE, 0.0);
+        }
+    }
+
+    @Test
     public void testLineLocatePoint()
     {
         assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1)'), ST_Point(0, 0.2))", DOUBLE, 0.2);


### PR DESCRIPTION
Adds ST_Length(SphericalGeography) which computes the length of a LINESTRING on the surface of a spherical model of Earth's surface, i.e. the sum of great-circle distances between adjacent points along the linestring.

Based on https://github.com/prestodb/presto/pull/12552