### PR TITLE
Decouple ParquetPageSource from HiveColumnHandle

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetColumnIOConverter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetColumnIOConverter.java
@@ -40,7 +40,7 @@ import static org.apache.parquet.io.ColumnIOUtil.columnDefinitionLevel;
 import static org.apache.parquet.io.ColumnIOUtil.columnRepetitionLevel;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 
-final class ParquetColumnIOConverter
+public final class ParquetColumnIOConverter
 {
     private ParquetColumnIOConverter() {}
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -16,8 +16,10 @@ package io.prestosql.plugin.hive.parquet;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import io.airlift.units.DataSize;
 import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.parquet.Field;
 import io.prestosql.parquet.ParquetCorruptionException;
 import io.prestosql.parquet.ParquetDataSource;
 import io.prestosql.parquet.RichColumnDescriptor;
@@ -33,6 +35,7 @@ import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -54,16 +57,18 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.parquet.ParquetTypeUtils.getColumnIO;
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
 import static io.prestosql.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static io.prestosql.parquet.ParquetTypeUtils.lookupColumnByName;
 import static io.prestosql.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.prestosql.parquet.predicate.PredicateUtils.predicateMatches;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
@@ -74,10 +79,10 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.getParquetMaxReadBl
 import static io.prestosql.plugin.hive.HiveSessionProperties.isFailOnCorruptedParquetStatistics;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isUseParquetColumnNames;
 import static io.prestosql.plugin.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static io.prestosql.plugin.hive.parquet.ParquetColumnIOConverter.constructField;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 
 public class ParquetPageSourceFactory
@@ -125,7 +130,6 @@ public class ParquetPageSourceFactory
                 start,
                 length,
                 fileSize,
-                schema,
                 columns,
                 isUseParquetColumnNames(session),
                 isFailOnCorruptedParquetStatistics(session),
@@ -143,7 +147,6 @@ public class ParquetPageSourceFactory
             long start,
             long length,
             long fileSize,
-            Properties schema,
             List<HiveColumnHandle> columns,
             boolean useParquetColumnNames,
             boolean failOnCorruptedParquetStatistics,
@@ -152,6 +155,10 @@ public class ParquetPageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             FileFormatDataSourceStats stats)
     {
+        for (HiveColumnHandle column : columns) {
+            checkArgument(column.getColumnType() == REGULAR, "column type must be REGULAR: %s", column);
+        }
+
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
         ParquetDataSource dataSource = null;
@@ -163,13 +170,16 @@ public class ParquetPageSourceFactory
             MessageType fileSchema = fileMetaData.getSchema();
             dataSource = buildHdfsParquetDataSource(inputStream, path, fileSize, stats);
 
-            List<org.apache.parquet.schema.Type> fields = columns.stream()
-                    .filter(column -> column.getColumnType() == REGULAR)
+            List<Optional<org.apache.parquet.schema.Type>> parquetFields = columns.stream()
                     .map(column -> getParquetType(column, fileSchema, useParquetColumnNames))
-                    .filter(Objects::nonNull)
-                    .collect(toList());
+                    .map(Optional::ofNullable)
+                    .collect(toImmutableList());
 
-            MessageType requestedSchema = new MessageType(fileSchema.getName(), fields);
+            MessageType requestedSchema = new MessageType(
+                    fileSchema.getName(),
+                    parquetFields.stream()
+                            .flatMap(Streams::stream)
+                            .collect(toImmutableList()));
 
             ImmutableList.Builder<BlockMetaData> footerBlocks = ImmutableList.builder();
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
@@ -197,13 +207,23 @@ public class ParquetPageSourceFactory
                     systemMemoryContext,
                     maxReadBlockSize);
 
-            return new ParquetPageSource(
-                    parquetReader,
-                    fileSchema,
-                    messageColumnIO,
-                    typeManager,
-                    columns,
-                    useParquetColumnNames);
+            ImmutableList.Builder<Type> prestoTypes = ImmutableList.builder();
+            ImmutableList.Builder<Optional<Field>> internalFields = ImmutableList.builder();
+            for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+                HiveColumnHandle column = columns.get(columnIndex);
+                Optional<org.apache.parquet.schema.Type> parquetField = parquetFields.get(columnIndex);
+
+                Type prestoType = typeManager.getType(column.getTypeSignature());
+
+                prestoTypes.add(prestoType);
+
+                internalFields.add(parquetField.map(field -> {
+                    String columnName = useParquetColumnNames ? column.getName() : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
+                    return constructField(prestoType, lookupColumnByName(messageColumnIO, columnName)).orElse(null);
+                }));
+            }
+
+            return new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build());
         }
         catch (Exception e) {
             try {
@@ -253,7 +273,7 @@ public class ParquetPageSourceFactory
         return TupleDomain.withColumnDomains(predicate.build());
     }
 
-    public static org.apache.parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
+    private static org.apache.parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
     {
         if (useParquetColumnNames) {
             return getParquetTypeByName(column.getName(), messageType);

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.parquet.Field;
 import io.prestosql.parquet.ParquetCorruptionException;
 import io.prestosql.parquet.ParquetDataSource;
 import io.prestosql.parquet.RichColumnDescriptor;
@@ -40,6 +41,7 @@ import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -53,7 +55,6 @@ import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
@@ -65,12 +66,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.parquet.ParquetTypeUtils.getColumnIO;
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
+import static io.prestosql.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static io.prestosql.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.prestosql.parquet.predicate.PredicateUtils.predicateMatches;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
@@ -79,8 +83,8 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
 import static io.prestosql.plugin.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static io.prestosql.plugin.hive.parquet.ParquetColumnIOConverter.constructField;
 import static io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory.getParquetTupleDomain;
-import static io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory.getParquetType;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getParquetMaxReadBlockSize;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.isFailOnCorruptedParquetStatistics;
 import static java.lang.String.format;
@@ -127,7 +131,6 @@ public class IcebergPageSourceProvider
                 length,
                 hiveColumns,
                 split.getNameToId(),
-                false,
                 typeManager,
                 getParquetMaxReadBlockSize(session),
                 isFailOnCorruptedParquetStatistics(session),
@@ -136,7 +139,6 @@ public class IcebergPageSourceProvider
                 fileFormatDataSourceStats);
     }
 
-    // TODO: move column rename handling out and reuse ParquetPageSourceFactory.createPageSource()
     private static ConnectorPageSource createParquetPageSource(
             HdfsEnvironment hdfsEnvironment,
             String user,
@@ -146,7 +148,6 @@ public class IcebergPageSourceProvider
             long length,
             List<HiveColumnHandle> columns,
             Map<String, Integer> icebergNameToId,
-            boolean useParquetColumnNames,
             TypeManager typeManager,
             DataSize maxReadBlockSize,
             boolean failOnCorruptedStatistics,
@@ -167,20 +168,32 @@ public class IcebergPageSourceProvider
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 
-            // We need to transform columns so they have the parquet column name and not table column name.
-            // In order to make that transformation we need to pass the iceberg schema (not the hive schema)
-            // in split and use that here to map from iceberg schema column name to ID, lookup parquet column
-            // with same ID and all of its children and use the index of all those columns as requested schema.
-
-            Map<String, HiveColumnHandle> parquetColumns = convertToParquetNames(columns, icebergNameToId, fileSchema);
-
-            List<Type> fields = parquetColumns.values().stream()
+            List<HiveColumnHandle> regularColumns = columns.stream()
                     .filter(column -> column.getColumnType() == REGULAR)
-                    .map(column -> getParquetType(column, fileSchema, true)) // we always use parquet column names in case of iceberg.
-                    .filter(Objects::nonNull)
+                    .collect(toImmutableList());
+
+            // Mapping from Iceberg field ID to Parquet fields.
+            Map<Integer, org.apache.parquet.schema.Type> parquetIdToField = fileSchema.getFields().stream()
+                    .filter(field -> field.getId() != null)
+                    .collect(toImmutableMap(field -> field.getId().intValue(), Function.identity()));
+
+            List<org.apache.parquet.schema.Type> parquetFields = regularColumns.stream()
+                    .map(column -> {
+                        String columnName = column.getName();
+                        Integer id = icebergNameToId.get(columnName);
+                        checkArgument(id != null, "column name not in ID map: %s", columnName);
+
+                        org.apache.parquet.schema.Type parquetField;
+                        if (parquetIdToField.isEmpty()) {
+                            // This is a migrated table
+                            return getParquetTypeByName(columnName, fileSchema);
+                        }
+
+                        return parquetIdToField.get(id);
+                    })
                     .collect(toList());
 
-            MessageType requestedSchema = new MessageType(fileSchema.getName(), fields);
+            MessageType requestedSchema = new MessageType(fileSchema.getName(), parquetFields.stream().filter(Objects::nonNull).collect(toImmutableList()));
             Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, requestedSchema);
             TupleDomain<ColumnDescriptor> parquetTupleDomain = getParquetTupleDomain(descriptorsByPath, effectivePredicate);
             Predicate parquetPredicate = buildPredicate(requestedSchema, parquetTupleDomain, descriptorsByPath);
@@ -214,23 +227,25 @@ public class IcebergPageSourceProvider
                     fileSize,
                     fileStatus.getModificationTime());
 
-            // This transformation is solely done so columns that are renames can be read.
-            // ParquetPageSource tries to get column type from column name and because the
-            // name in Parquet file is different than the Iceberg column name it gets a
-            // null back. When it can't find a field it assumes that field is missing and
-            // just assigns a null block for the whole field.
-            List<HiveColumnHandle> columnNameReplaced = columns.stream()
-                    .filter(column -> column.getColumnType() == REGULAR)
-                    .map(column -> parquetColumns.getOrDefault(column.getName(), column))
-                    .collect(toImmutableList());
+            ImmutableList.Builder<Type> prestoTypes = ImmutableList.builder();
+            ImmutableList.Builder<Optional<Field>> internalFields = ImmutableList.builder();
+            for (int columnIndex = 0; columnIndex < regularColumns.size(); columnIndex++) {
+                HiveColumnHandle column = regularColumns.get(columnIndex);
+                org.apache.parquet.schema.Type parquetField = parquetFields.get(columnIndex);
 
-            ParquetPageSource parquetPageSource = new ParquetPageSource(
-                    parquetReader,
-                    fileSchema,
-                    messageColumnIO,
-                    typeManager,
-                    columnNameReplaced,
-                    useParquetColumnNames);
+                Type prestoType = typeManager.getType(column.getTypeSignature());
+
+                prestoTypes.add(prestoType);
+
+                if (parquetField == null) {
+                    internalFields.add(Optional.empty());
+                }
+                else {
+                    internalFields.add(constructField(prestoType, messageColumnIO.getChild(parquetField.getName())));
+                }
+            }
+
+            ParquetPageSource parquetPageSource = new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build());
 
             return new HivePageSource(
                     columnMappings,
@@ -261,54 +276,5 @@ public class IcebergPageSourceProvider
             }
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
         }
-    }
-
-    /**
-     * This method maps the Iceberg column names to corresponding parquet column names
-     * by matching their IDs rather than relying on name or index.
-     *
-     * If no Parquet fields have an ID, this is a case of migrated table and the method
-     * just returns the same column name as the Hive column name.
-     *
-     * If any Parquet field has an ID, it returns a column name that has the same Iceberg ID.
-     *
-     * If no Iceberg ID matches the given parquet ID, it assumes the column must have been
-     * added to table later and does not return any column name for that column.
-     *
-     * @param columns iceberg columns
-     * @param icebergNameToId column name to id
-     * @param parquetSchema parquet file schema
-     * @return Map from iceberg column names to column handles with replace column names.
-     */
-    private static Map<String, HiveColumnHandle> convertToParquetNames(List<HiveColumnHandle> columns, Map<String, Integer> icebergNameToId, MessageType parquetSchema)
-    {
-        List<Type> fields = parquetSchema.getFields();
-        ImmutableMap.Builder<String, HiveColumnHandle> builder = ImmutableMap.builder();
-        Map<Integer, String> parquetIdToName = fields.stream()
-                .filter(field -> field.getId() != null)
-                .collect(Collectors.toMap((x) -> x.getId().intValue(), Type::getName));
-
-        for (HiveColumnHandle column : columns) {
-            if (!column.isHidden()) {
-                String name = column.getName();
-                Integer id = icebergNameToId.get(name);
-                if (parquetIdToName.containsKey(id)) {
-                    String parquetName = parquetIdToName.get(id);
-                    HiveColumnHandle columnHandle = new HiveColumnHandle(parquetName, column.getHiveType(), column.getTypeSignature(), column.getHiveColumnIndex(), column.getColumnType(), column.getComment());
-                    builder.put(name, columnHandle);
-                }
-                else {
-                    if (parquetIdToName.isEmpty()) {
-                        // a case of migrated tables so we just add the column as is.
-                        builder.put(name, column);
-                    }
-                    else {
-                        // this is not a migrated table but not parquet id matches. This could mean the column was added after this parquet file was created
-                        // so we should ignore this column
-                    }
-                }
-            }
-        }
-        return builder.build();
     }
 }


### PR DESCRIPTION
This is preparatory work for removing `HiveColumnHandle` in Iceberg Connector (#1324 ). Doing this decoupling also helps simplify logic in `IcebergPageSourceProvider`.

Tests done: `TestIcebergDistributed` passed.