### PR TITLE
Microoptimizations in CachingHiveMetastore

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -832,11 +832,13 @@ public class CachingHiveMetastore
     {
         private final HiveIdentity identity;
         private final T key;
+        private final int hashCode;
 
         public WithIdentity(HiveIdentity identity, T key)
         {
             this.identity = requireNonNull(identity, "identity is null");
             this.key = requireNonNull(key, "key is null");
+            this.hashCode = Objects.hash(identity, key);
         }
 
         public HiveIdentity getIdentity()
@@ -859,14 +861,15 @@ public class CachingHiveMetastore
                 return false;
             }
             WithIdentity<?> other = (WithIdentity<?>) o;
-            return Objects.equals(identity, other.identity) &&
-                   Objects.equals(key, other.key);
+            return hashCode == other.hashCode &&
+                    Objects.equals(identity, other.identity) &&
+                    Objects.equals(key, other.key);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(identity, key);
+            return hashCode;
         }
 
         @Override


### PR DESCRIPTION
Three parts here:
1. Adds a benchmark for baseline. This commit will be discarded because it's not generally useful, only necessary to show the benchmark code used. The benchmark itself is set up to fetch twice as many partitions per iteration than the cache allows. This guarantees that some large proportion of cache churn per iteration.
1. Refactors the code in CachingHiveMetastore to prefer re-using the WithIdentity<HivePartitionName> keys to recreating them. The effect is that partition values need not be re-parsed from the partition name string, fewer objects are allocated, and the returned keys are alias equals to the stored cache key.
1. Adds a cached hashCode field to `WithIdentity`. Since these classes are only used in cache key form, the work is never wasted and can be used to speed up equals at the same time. However, this adds 8 bytes (4 bytes from `int`, 4 bytes waste from alignment) per instance. I've included it in this PR for consideration comparing the results below, but am interested to hear how others feel about the trade-off of CPU time vs memory consumption. I'm happy to drop this commit too if others think the memory overhead isn't worth the performance gain.

Below, benchmark runs from my laptop. TL;DR:
- Refactored code achieves ~1.25x better throughput than baseline
- Refactored code with cached hashCode achieves ~1.7x better throughput than baseline

### Baseline Benchmark Run
```
Benchmark                                                 (cacheSize)  (databaseCount)  (identityCount)  (partitionColumnCount)  (partitionsPerCall)  (partitionsPerTableCount)  (tableCount)   Mode  Cnt     Score     Error  Units
BenchmarkCachingHiveMetastore.benchmarkGetPartitionStats           50                1                3                       5                  100                       1000            10  thrpt   10  4836.039 ± 532.213  ops/s
BenchmarkCachingHiveMetastore.benchmarkGetPartitions               50                1                3                       5                  100                       1000            10  thrpt   10  5803.520 ± 311.179  ops/s
```

### Refactor Only, no precomputed hashCode
```
Benchmark                                                 (cacheSize)  (databaseCount)  (identityCount)  (partitionColumnCount)  (partitionsPerCall)  (partitionsPerTableCount)  (tableCount)   Mode  Cnt     Score     Error  Units
BenchmarkCachingHiveMetastore.benchmarkGetPartitionStats           50                1                3                       5                  100                       1000            10  thrpt   10  5808.788 ± 222.566  ops/s
BenchmarkCachingHiveMetastore.benchmarkGetPartitions               50                1                3                       5                  100                       1000            10  thrpt   10  7699.901 ± 125.262  ops/s
```

### Refactored Code, with precomputed hashCode
```
Benchmark                                                 (cacheSize)  (databaseCount)  (identityCount)  (partitionColumnCount)  (partitionsPerCall)  (partitionsPerTableCount)  (tableCount)   Mode  Cnt     Score     Error  Units
BenchmarkCachingHiveMetastore.benchmarkGetPartitionStats           50                1                3                       5                  100                       1000            10  thrpt   10  8419.244 ±  74.695  ops/s
BenchmarkCachingHiveMetastore.benchmarkGetPartitions               50                1                3                       5                  100                       1000            10  thrpt   10  9835.061 ± 203.398  ops/s
```
