### PR TITLE
Add join type and filter to UnnestNode

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionExtractor.java
@@ -23,6 +23,7 @@ import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.UnnestNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.tree.Expression;
 
@@ -122,6 +123,13 @@ public final class ExpressionExtractor
         {
             node.getFilter().ifPresent(consumer);
             return super.visitJoin(node, context);
+        }
+
+        @Override
+        public Void visitUnnest(UnnestNode node, Void context)
+        {
+            node.getFilter().ifPresent(consumer);
+            return super.visitUnnest(node, context);
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -261,6 +261,7 @@ import static io.prestosql.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.RIGHT;
 import static io.prestosql.sql.planner.plan.TableWriterNode.CreateTarget;
 import static io.prestosql.sql.planner.plan.TableWriterNode.InsertTarget;
@@ -1361,6 +1362,7 @@ public class LocalExecutionPlanner
                 outputMappings.put(ordinalitySymbol.get(), channel);
                 channel++;
             }
+            boolean outer = node.getJoinType() == LEFT || node.getJoinType() == FULL;
             OperatorFactory operatorFactory = new UnnestOperatorFactory(
                     context.getNextOperatorId(),
                     node.getId(),
@@ -1369,7 +1371,7 @@ public class LocalExecutionPlanner
                     unnestChannels,
                     unnestTypes.build(),
                     ordinalityType.isPresent(),
-                    node.isOuter());
+                    outer);
             return new PhysicalOperation(operatorFactory, outputMappings.build(), context, source);
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -563,7 +563,7 @@ class RelationPlanner
         else {
             JoinCriteria criteria = join.getCriteria().get();
             if (criteria instanceof JoinUsing || criteria instanceof NaturalJoin) {
-                throw notSupportedException(join, "Lateral join with criteria other than ON");
+                throw notSupportedException(join, "Correlated join with criteria other than ON");
             }
             filterExpression = (Expression) getOnlyElement(criteria.getNodes());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -28,6 +28,7 @@ import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.planner.plan.SimplePlanRewriter;
+import io.prestosql.sql.planner.plan.UnnestNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.tree.DefaultExpressionTraversalVisitor;
 import io.prestosql.sql.tree.DereferenceExpression;
@@ -580,6 +581,20 @@ class SubqueryPlanner
         {
             FilterNode rewrittenNode = (FilterNode) context.defaultRewrite(node);
             return new FilterNode(node.getId(), rewrittenNode.getSource(), replaceExpression(rewrittenNode.getPredicate(), mapping));
+        }
+
+        @Override
+        public PlanNode visitUnnest(UnnestNode node, RewriteContext<Void> context)
+        {
+            UnnestNode rewrittenNode = (UnnestNode) context.defaultRewrite(node);
+            return new UnnestNode(
+                    node.getId(),
+                    rewrittenNode.getSource(),
+                    rewrittenNode.getReplicateSymbols(),
+                    rewrittenNode.getUnnestSymbols(),
+                    rewrittenNode.getOrdinalitySymbol(),
+                    rewrittenNode.getJoinType(),
+                    rewrittenNode.getFilter().map(expression -> replaceExpression(expression, mapping)));
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -605,7 +605,8 @@ public class ExtractSpatialJoins
                 node.getOutputSymbols(),
                 ImmutableMap.of(partitionsSymbol, ImmutableList.of(partitionSymbol)),
                 Optional.empty(),
-                false);
+                INNER,
+                Optional.empty());
     }
 
     private static boolean containsNone(Collection<Symbol> values, Collection<Symbol> testValues)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -662,7 +662,8 @@ public class HashGenerationOptimizer
                                     .build(),
                             node.getUnnestSymbols(),
                             node.getOrdinalitySymbol(),
-                            node.isOuter()),
+                            node.getJoinType(),
+                            node.getFilter()),
                     hashSymbols);
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
@@ -682,12 +682,25 @@ public final class PropertyDerivations
         {
             Set<Symbol> passThroughInputs = ImmutableSet.copyOf(node.getReplicateSymbols());
 
-            return Iterables.getOnlyElement(inputProperties).translate(column -> {
+            ActualProperties translatedProperties = Iterables.getOnlyElement(inputProperties).translate(column -> {
                 if (passThroughInputs.contains(column)) {
                     return Optional.of(column);
                 }
                 return Optional.empty();
             });
+
+            switch (node.getJoinType()) {
+                case INNER:
+                case LEFT:
+                    return translatedProperties;
+                case RIGHT:
+                case FULL:
+                    return ActualProperties.builderFrom(translatedProperties)
+                            .local(ImmutableList.of())
+                            .build();
+                default:
+                    throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
+            }
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -524,9 +524,15 @@ public class PruneUnreferencedOutputs
             ImmutableSet.Builder<Symbol> expectedInputs = ImmutableSet.<Symbol>builder()
                     .addAll(replicateSymbols)
                     .addAll(unnestSymbols.keySet());
+            ImmutableSet.Builder<Symbol> unnestedSymbols = ImmutableSet.builder();
+            for (List<Symbol> symbols : unnestSymbols.values()) {
+                unnestedSymbols.addAll(symbols);
+            }
+            Set<Symbol> expectedFilterSymbols = Sets.difference(SymbolsExtractor.extractUnique(node.getFilter().orElse(TRUE_LITERAL)), unnestedSymbols.build());
+            expectedInputs.addAll(expectedFilterSymbols);
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
-            return new UnnestNode(node.getId(), source, replicateSymbols, unnestSymbols, ordinalitySymbol, node.isOuter());
+            return new UnnestNode(node.getId(), source, replicateSymbols, unnestSymbols, ordinalitySymbol, node.getJoinType(), node.getFilter());
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -430,12 +430,23 @@ public final class StreamPropertyDerivations
 
             // We can describe properties in terms of inputs that are projected unmodified (i.e., not the unnested symbols)
             Set<Symbol> passThroughInputs = ImmutableSet.copyOf(node.getReplicateSymbols());
-            return properties.translate(column -> {
+            StreamProperties translatedProperties = properties.translate(column -> {
                 if (passThroughInputs.contains(column)) {
                     return Optional.of(column);
                 }
                 return Optional.empty();
             });
+
+            switch (node.getJoinType()) {
+                case INNER:
+                case LEFT:
+                    return translatedProperties;
+                case RIGHT:
+                case FULL:
+                    return translatedProperties.unordered(true);
+                default:
+                    throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
+            }
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -183,7 +183,14 @@ public class UnaliasSymbolReferences
             for (Map.Entry<Symbol, List<Symbol>> entry : node.getUnnestSymbols().entrySet()) {
                 builder.put(canonicalize(entry.getKey()), entry.getValue());
             }
-            return new UnnestNode(node.getId(), source, canonicalizeAndDistinct(node.getReplicateSymbols()), builder.build(), node.getOrdinalitySymbol(), node.isOuter());
+            return new UnnestNode(
+                    node.getId(),
+                    source,
+                    canonicalizeAndDistinct(node.getReplicateSymbols()),
+                    builder.build(),
+                    node.getOrdinalitySymbol(),
+                    node.getJoinType(),
+                    node.getFilter().map(this::canonicalize));
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/UnnestNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/UnnestNode.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.JoinNode.Type;
+import io.prestosql.sql.tree.Expression;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -37,7 +39,8 @@ public class UnnestNode
     private final List<Symbol> replicateSymbols;
     private final Map<Symbol, List<Symbol>> unnestSymbols;
     private final Optional<Symbol> ordinalitySymbol;
-    private final boolean outer;
+    private final Type joinType;
+    private final Optional<Expression> filter;
 
     @JsonCreator
     public UnnestNode(
@@ -46,7 +49,8 @@ public class UnnestNode
             @JsonProperty("replicateSymbols") List<Symbol> replicateSymbols,
             @JsonProperty("unnestSymbols") Map<Symbol, List<Symbol>> unnestSymbols,
             @JsonProperty("ordinalitySymbol") Optional<Symbol> ordinalitySymbol,
-            @JsonProperty("outer") boolean outer)
+            @JsonProperty("joinType") Type joinType,
+            @JsonProperty("filter") Optional<Expression> filter)
     {
         super(id);
         this.source = requireNonNull(source, "source is null");
@@ -60,7 +64,8 @@ public class UnnestNode
         }
         this.unnestSymbols = builder.build();
         this.ordinalitySymbol = requireNonNull(ordinalitySymbol, "ordinalitySymbol is null");
-        this.outer = outer;
+        this.joinType = requireNonNull(joinType, "type is null");
+        this.filter = requireNonNull(filter, "filter is null");
     }
 
     @Override
@@ -98,9 +103,15 @@ public class UnnestNode
     }
 
     @JsonProperty
-    public boolean isOuter()
+    public Type getJoinType()
     {
-        return outer;
+        return joinType;
+    }
+
+    @JsonProperty
+    public Optional<Expression> getFilter()
+    {
+        return filter;
     }
 
     @Override
@@ -118,6 +129,6 @@ public class UnnestNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, unnestSymbols, ordinalitySymbol, outer);
+        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, unnestSymbols, ordinalitySymbol, joinType, filter);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -851,9 +851,21 @@ public class PlanPrinter
         @Override
         public Void visitUnnest(UnnestNode node, Void context)
         {
-            addNode(node,
-                    "Unnest",
-                    format("[replicate=%s, unnest=%s]", formatOutputs(types, node.getReplicateSymbols()), formatOutputs(types, node.getUnnestSymbols().keySet())));
+            String name;
+            if (node.getFilter().isPresent()) {
+                name = node.getJoinType().getJoinLabel() + " Unnest";
+            }
+            else if (!node.getReplicateSymbols().isEmpty()) {
+                name = "CrossJoin Unnest";
+            }
+            else {
+                name = "Unnest";
+            }
+            addNode(
+                    node,
+                    name,
+                    format("[replicate=%s, unnest=%s", formatOutputs(types, node.getReplicateSymbols()), formatOutputs(types, node.getUnnestSymbols().keySet()))
+                            + (node.getFilter().isPresent() ? format(", filter=%s]", node.getFilter().get().toString()) : "]"));
             return processChildren(node, context);
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -15,6 +15,7 @@ package io.prestosql.sql.planner.sanity;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.prestosql.Session;
 import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.metadata.Metadata;
@@ -78,6 +79,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
+import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 /**
  * Ensures that all dependencies (i.e., symbols in expressions) for a plan node are provided by its source nodes
@@ -484,12 +486,16 @@ public final class ValidateDependenciesChecker
             PlanNode source = node.getSource();
             source.accept(this, boundSymbols);
 
-            Set<Symbol> required = ImmutableSet.<Symbol>builder()
+            ImmutableSet.Builder<Symbol> required = ImmutableSet.<Symbol>builder()
                     .addAll(node.getReplicateSymbols())
-                    .addAll(node.getUnnestSymbols().keySet())
-                    .build();
-
-            checkDependencies(source.getOutputSymbols(), required, "Invalid node. Dependencies (%s) not in source plan output (%s)", required, source.getOutputSymbols());
+                    .addAll(node.getUnnestSymbols().keySet());
+            ImmutableSet.Builder<Symbol> unnestedSymbols = ImmutableSet.builder();
+            for (List<Symbol> symbols : node.getUnnestSymbols().values()) {
+                unnestedSymbols.addAll(symbols);
+            }
+            Set<Symbol> expectedFilterSymbols = Sets.difference(SymbolsExtractor.extractUnique(node.getFilter().orElse(TRUE_LITERAL)), unnestedSymbols.build());
+            required.addAll(expectedFilterSymbols);
+            checkDependencies(source.getOutputSymbols(), required.build(), "Invalid node. Dependencies (%s) not in source plan output (%s)", required, source.getOutputSymbols());
 
             return null;
         }

--- a/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
@@ -387,12 +387,23 @@ public final class GraphvizPrinter
         @Override
         public Void visitUnnest(UnnestNode node, Void context)
         {
-            if (!node.getOrdinalitySymbol().isPresent()) {
-                printNode(node, format("Unnest[%s]", node.getUnnestSymbols().keySet()), NODE_COLORS.get(NodeType.UNNEST));
+            StringBuilder label = new StringBuilder();
+            if (node.getFilter().isPresent()) {
+                label.append(node.getJoinType().getJoinLabel())
+                        .append(" Unnest");
+            }
+            else if (!node.getReplicateSymbols().isEmpty()) {
+                label.append("CrossJoin Unnest");
             }
             else {
-                printNode(node, format("Unnest[%s (ordinality)]", node.getUnnestSymbols().keySet()), NODE_COLORS.get(NodeType.UNNEST));
+                label.append("Unnest");
             }
+            label.append(format(" [%s", node.getUnnestSymbols().keySet()))
+                    .append(node.getOrdinalitySymbol().isPresent() ? " (ordinality)]" : "]");
+
+            String details = node.getFilter().isPresent() ? " filter " + node.getFilter().get().toString() : "";
+
+            printNode(node, label.toString(), details, NODE_COLORS.get(NodeType.UNNEST));
             return node.getSource().accept(this, context);
         }
 


### PR DESCRIPTION
First step to support `LEFT`, `RIGHT`, `FULL` and `INNER` `JOIN` involving `UNNEST` on non-trivial conditions. 