### PR TITLE
Consolidate and bump the snappy-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1000,7 +1000,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.1</version>
+                <version>1.1.7.3</version>
             </dependency>
 
             <dependency>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.2.6</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
While updating the Avro dependency I've noticed that we're using different versions of the snappy compression codec. I would propose to pin it to one version.