### PR TITLE
Remove duplicate configuration

### DIFF
--- a/presto-hive-hadoop2/bin/run_hive_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_tests.sh
@@ -18,7 +18,6 @@ HADOOP_MASTER_IP=$(hadoop_master_ip)
 pushd ${PROJECT_ROOT}
 set +e
 ./mvnw -B -pl presto-hive-hadoop2 test -P test-hive-hadoop2 \
-  -Dhive.hadoop2.timeZone=UTC \
   -DHADOOP_USER_NAME=hive \
   -Dhive.hadoop2.metastoreHost=localhost \
   -Dhive.hadoop2.metastorePort=9083 \


### PR DESCRIPTION
There is a second `-Dhive.hadoop2.timeZone` on the same invocation.