### PR TITLE
Add at_timezone and with_timezone functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -69,6 +69,14 @@ Date and Time Functions
 
     Parses the ISO 8601 formatted ``string`` into a ``date``.
 
+.. function:: at_timezone(timestamp with time zone, zone) -> timestamp with time zone
+
+    Change the time zone component of a TIMESTAMP WITH TIME ZONE while preserving the instant in time.
+
+.. function:: with_timezone(timestamp, zone) -> timestamp with time zone
+
+    Make a TIMESTAMP WITH TIME ZONE from a TIMESTAMP and a time zone.
+
 .. function:: from_unixtime(unixtime) -> timestamp
 
     Returns the UNIX timestamp ``unixtime`` as a timestamp. ``unixtime`` is the number of seconds since ``1970-01-01 00:00:00``.


### PR DESCRIPTION
Addresses https://github.com/prestosql/presto/issues/135

This makes the `at_timezone` function that changes the timezone of a timestamp with time zone public, and adds a `with_timezone` function that makes a timestamp with time zone from a time stamp and time zone.