### PR TITLE
Deprecate SqlTimeWithTimeZone constructor with j.u.TimeZone

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimeWithTimeZone.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimeWithTimeZone.java
@@ -45,6 +45,10 @@ public final class SqlTimeWithTimeZone
         this.timeZoneKey = timeZoneKey;
     }
 
+    /**
+     * @deprecated Use {@link #SqlTimeWithTimeZone(long, TimeZoneKey)} instead.
+     */
+    @Deprecated
     public SqlTimeWithTimeZone(long millisUtc, TimeZone timeZone)
     {
         this.millisUtc = millisUtc;


### PR DESCRIPTION
This is currently used in tests only. If such a constructor is needed,
it should take `java.time.ZoneId` rather than `java.util.TimeZone`.