### PR TITLE
Forbid hive.metastore.username when connecting to metastore with authentication

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -27,6 +27,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class StaticMetastoreConfig
 {
+    public static final String HIVE_METASTORE_USERNAME = "hive.metastore.username";
+
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<URI> metastoreUris;
@@ -59,7 +61,7 @@ public class StaticMetastoreConfig
         return metastoreUsername;
     }
 
-    @Config("hive.metastore.username")
+    @Config(HIVE_METASTORE_USERNAME)
     @ConfigDescription("Optional username for accessing the Hive metastore")
     public StaticMetastoreConfig setMetastoreUsername(String metastoreUsername)
     {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -14,6 +14,8 @@
 package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.net.HostAndPort;
+import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
+import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
 import org.apache.thrift.TException;
 
 import javax.inject.Inject;
@@ -26,6 +28,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.prestosql.plugin.hive.metastore.thrift.StaticMetastoreConfig.HIVE_METASTORE_USERNAME;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -37,9 +40,15 @@ public class StaticMetastoreLocator
     private final String metastoreUsername;
 
     @Inject
-    public StaticMetastoreLocator(StaticMetastoreConfig config, ThriftMetastoreClientFactory clientFactory)
+    public StaticMetastoreLocator(StaticMetastoreConfig config, HiveAuthenticationConfig hiveAuthenticationConfig, ThriftMetastoreClientFactory clientFactory)
     {
         this(config.getMetastoreUris(), config.getMetastoreUsername(), clientFactory);
+
+        checkArgument(
+                isNullOrEmpty(metastoreUsername) || hiveAuthenticationConfig.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.NONE,
+                "%s cannot be used together with %s authentication",
+                HIVE_METASTORE_USERNAME,
+                hiveAuthenticationConfig.getHiveMetastoreAuthenticationType());
     }
 
     public StaticMetastoreLocator(List<URI> metastoreUris, String metastoreUsername, ThriftMetastoreClientFactory clientFactory)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -18,6 +18,7 @@ import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
 import org.apache.thrift.TException;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.net.URI;
@@ -51,7 +52,7 @@ public class StaticMetastoreLocator
                 hiveAuthenticationConfig.getHiveMetastoreAuthenticationType());
     }
 
-    public StaticMetastoreLocator(List<URI> metastoreUris, String metastoreUsername, ThriftMetastoreClientFactory clientFactory)
+    public StaticMetastoreLocator(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory)
     {
         requireNonNull(metastoreUris, "metastoreUris is null");
         checkArgument(!metastoreUris.isEmpty(), "metastoreUris must specify at least one URI");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.hive.metastore.thrift;
 
 import io.airlift.units.Duration;
+import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
@@ -99,7 +100,7 @@ public class TestStaticMetastoreLocator
 
     private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, List<ThriftMetastoreClient> clients)
     {
-        return new StaticMetastoreLocator(config, new MockThriftMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
+        return new StaticMetastoreLocator(config, new HiveAuthenticationConfig(), new MockThriftMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
     }
 
     private static ThriftMetastoreClient createFakeMetastoreClient()


### PR DESCRIPTION
https://github.com/prestosql/presto/issues/1585 showed that `setUGI` is
ineffective when metastore is kerberized.