### PR TITLE
Rename ThriftHiveMetastoreConfig to ThriftMetastoreConfig

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -134,7 +134,7 @@ public class ThriftHiveMetastore
     private static final Pattern TABLE_PARAMETER_SAFE_VALUE_PATTERN = Pattern.compile("^[a-zA-Z0-9]*$");
 
     @Inject
-    public ThriftHiveMetastore(MetastoreLocator metastoreLocator, ThriftHiveMetastoreConfig thriftConfig, HiveAuthenticationConfig authenticationConfig)
+    public ThriftHiveMetastore(MetastoreLocator metastoreLocator, ThriftMetastoreConfig thriftConfig, HiveAuthenticationConfig authenticationConfig)
     {
         this.clientProvider = requireNonNull(metastoreLocator, "metastoreLocator is null");
         this.backoffScaleFactor = thriftConfig.getBackoffScaleFactor();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
@@ -46,7 +46,7 @@ public class ThriftMetastoreClientFactory
     }
 
     @Inject
-    public ThriftMetastoreClientFactory(ThriftHiveMetastoreConfig config, HiveMetastoreAuthentication metastoreAuthentication)
+    public ThriftMetastoreClientFactory(ThriftMetastoreConfig config, HiveMetastoreAuthentication metastoreAuthentication)
     {
         this(Optional.empty(), Optional.ofNullable(config.getSocksProxy()), config.getMetastoreTimeout(), metastoreAuthentication);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.NotNull;
 
 import java.util.concurrent.TimeUnit;
 
-public class ThriftHiveMetastoreConfig
+public class ThriftMetastoreConfig
 {
     private Duration metastoreTimeout = new Duration(10, TimeUnit.SECONDS);
     private HostAndPort socksProxy;
@@ -42,7 +42,7 @@ public class ThriftHiveMetastoreConfig
     }
 
     @Config("hive.metastore-timeout")
-    public ThriftHiveMetastoreConfig setMetastoreTimeout(Duration metastoreTimeout)
+    public ThriftMetastoreConfig setMetastoreTimeout(Duration metastoreTimeout)
     {
         this.metastoreTimeout = metastoreTimeout;
         return this;
@@ -54,7 +54,7 @@ public class ThriftHiveMetastoreConfig
     }
 
     @Config("hive.metastore.thrift.client.socks-proxy")
-    public ThriftHiveMetastoreConfig setSocksProxy(HostAndPort socksProxy)
+    public ThriftMetastoreConfig setSocksProxy(HostAndPort socksProxy)
     {
         this.socksProxy = socksProxy;
         return this;
@@ -68,7 +68,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.max-retries")
     @ConfigDescription("Maximum number of retry attempts for metastore requests")
-    public ThriftHiveMetastoreConfig setMaxRetries(int maxRetries)
+    public ThriftMetastoreConfig setMaxRetries(int maxRetries)
     {
         this.maxRetries = maxRetries;
         return this;
@@ -81,7 +81,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.backoff-scale-factor")
     @ConfigDescription("Scale factor for metastore request retry delay")
-    public ThriftHiveMetastoreConfig setBackoffScaleFactor(double backoffScaleFactor)
+    public ThriftMetastoreConfig setBackoffScaleFactor(double backoffScaleFactor)
     {
         this.backoffScaleFactor = backoffScaleFactor;
         return this;
@@ -95,7 +95,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.max-retry-time")
     @ConfigDescription("Total time limit for a metastore request to be retried")
-    public ThriftHiveMetastoreConfig setMaxRetryTime(Duration maxRetryTime)
+    public ThriftMetastoreConfig setMaxRetryTime(Duration maxRetryTime)
     {
         this.maxRetryTime = maxRetryTime;
         return this;
@@ -108,7 +108,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.min-backoff-delay")
     @ConfigDescription("Minimum delay between metastore request retries")
-    public ThriftHiveMetastoreConfig setMinBackoffDelay(Duration minBackoffDelay)
+    public ThriftMetastoreConfig setMinBackoffDelay(Duration minBackoffDelay)
     {
         this.minBackoffDelay = minBackoffDelay;
         return this;
@@ -121,7 +121,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.max-backoff-delay")
     @ConfigDescription("Maximum delay between metastore request retries")
-    public ThriftHiveMetastoreConfig setMaxBackoffDelay(Duration maxBackoffDelay)
+    public ThriftMetastoreConfig setMaxBackoffDelay(Duration maxBackoffDelay)
     {
         this.maxBackoffDelay = maxBackoffDelay;
         return this;
@@ -134,7 +134,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.impersonation.enabled")
     @ConfigDescription("Should end user be impersonated when communicating with metastore")
-    public ThriftHiveMetastoreConfig setImpersonationEnabled(boolean impersonationEnabled)
+    public ThriftMetastoreConfig setImpersonationEnabled(boolean impersonationEnabled)
     {
         this.impersonationEnabled = impersonationEnabled;
         return this;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -39,7 +39,7 @@ public class ThriftMetastoreModule
         binder.bind(ThriftMetastoreClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(MetastoreLocator.class).to(StaticMetastoreLocator.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticMetastoreConfig.class);
-        configBinder(binder).bindConfig(ThriftHiveMetastoreConfig.class);
+        configBinder(binder).bindConfig(ThriftMetastoreConfig.class);
 
         binder.bind(ThriftMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ThriftMetastore.class)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -47,7 +47,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
-import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.orc.OrcPageSource;
 import io.prestosql.plugin.hive.parquet.ParquetPageSource;
 import io.prestosql.plugin.hive.rcfile.RcFilePageSource;
@@ -703,7 +703,7 @@ public abstract class AbstractTestHive
         MetastoreLocator metastoreLocator = new TestingMetastoreLocator(proxy, HostAndPort.fromParts(host, port));
 
         HiveMetastore metastore = new CachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new ThriftHiveMetastoreConfig(), new HiveAuthenticationConfig())),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new ThriftMetastoreConfig(), new HiveAuthenticationConfig())),
                 executor,
                 Duration.valueOf("1m"),
                 Duration.valueOf("15s"),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -38,7 +38,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
-import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.security.SqlStandardAccessControlMetadata;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
@@ -163,7 +163,7 @@ public abstract class AbstractTestHiveFileSystem
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, new HdfsConfig(), new NoHdfsAuthentication());
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new ThriftHiveMetastoreConfig(), new HiveAuthenticationConfig())),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new ThriftMetastoreConfig(), new HiveAuthenticationConfig())),
                 executor,
                 getBasePath(),
                 hdfsEnvironment);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -24,8 +24,8 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
-import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreClient;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreStats;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -78,7 +78,7 @@ public class TestCachingHiveMetastore
     private ThriftHiveMetastore createThriftHiveMetastore()
     {
         MetastoreLocator metastoreLocator = new MockMetastoreLocator(mockClient);
-        return new ThriftHiveMetastore(metastoreLocator, new ThriftHiveMetastoreConfig(), new HiveAuthenticationConfig());
+        return new ThriftHiveMetastore(metastoreLocator, new ThriftMetastoreConfig(), new HiveAuthenticationConfig());
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
@@ -26,12 +26,12 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class TestThriftHiveMetastoreConfig
+public class TestThriftMetastoreConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(ThriftHiveMetastoreConfig.class)
+        assertRecordedDefaults(recordDefaults(ThriftMetastoreConfig.class)
                 .setMetastoreTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setSocksProxy(null)
                 .setMaxRetries(9)
@@ -56,7 +56,7 @@ public class TestThriftHiveMetastoreConfig
                 .put("hive.metastore.thrift.impersonation.enabled", "true")
                 .build();
 
-        ThriftHiveMetastoreConfig expected = new ThriftHiveMetastoreConfig()
+        ThriftMetastoreConfig expected = new ThriftMetastoreConfig()
                 .setMetastoreTimeout(new Duration(20, TimeUnit.SECONDS))
                 .setSocksProxy(HostAndPort.fromParts("localhost", 1234))
                 .setMaxRetries(15)


### PR DESCRIPTION
This is consistent with e.g. `ThriftMetastoreModule`.