### PR TITLE
Rename H2 testing JdbcQueryRunner to H2QueryRunner

### DIFF
--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/H2QueryRunner.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/H2QueryRunner.java
@@ -30,19 +30,19 @@ import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static io.prestosql.tests.QueryAssertions.copyTpchTables;
 
-public final class JdbcQueryRunner
+public final class H2QueryRunner
 {
-    private JdbcQueryRunner() {}
+    private H2QueryRunner() {}
 
     private static final String TPCH_SCHEMA = "tpch";
 
-    public static DistributedQueryRunner createJdbcQueryRunner(TpchTable<?>... tables)
+    public static DistributedQueryRunner createH2QueryRunner(TpchTable<?>... tables)
             throws Exception
     {
-        return createJdbcQueryRunner(ImmutableList.copyOf(tables));
+        return createH2QueryRunner(ImmutableList.copyOf(tables));
     }
 
-    public static DistributedQueryRunner createJdbcQueryRunner(Iterable<TpchTable<?>> tables)
+    public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcDistributedQueries.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcDistributedQueries.java
@@ -16,14 +16,14 @@ package io.prestosql.plugin.jdbc;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.tests.AbstractTestQueries;
 
-import static io.prestosql.plugin.jdbc.JdbcQueryRunner.createJdbcQueryRunner;
+import static io.prestosql.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 
 public class TestJdbcDistributedQueries
         extends AbstractTestQueries
 {
     public TestJdbcDistributedQueries()
     {
-        super(() -> createJdbcQueryRunner(TpchTable.getTables()));
+        super(() -> createH2QueryRunner(TpchTable.getTables()));
     }
 
     @Override

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -16,13 +16,13 @@ package io.prestosql.plugin.jdbc;
 import io.prestosql.tests.AbstractTestIntegrationSmokeTest;
 
 import static io.airlift.tpch.TpchTable.ORDERS;
-import static io.prestosql.plugin.jdbc.JdbcQueryRunner.createJdbcQueryRunner;
+import static io.prestosql.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 
 public class TestJdbcIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
     public TestJdbcIntegrationSmokeTest()
     {
-        super(() -> createJdbcQueryRunner(ORDERS));
+        super(() -> createH2QueryRunner(ORDERS));
     }
 }


### PR DESCRIPTION
Rename H2 testing JdbcQueryRunner to H2QueryRunner
