### PR TITLE
Remove empty files left behind after mounting with different name

### DIFF
--- a/presto-product-tests/bin/lib.sh
+++ b/presto-product-tests/bin/lib.sh
@@ -2,6 +2,11 @@
 
 source "${BASH_SOURCE%/*}/locations.sh"
 
+# docker-compose leaves behind empty files on host corresponding to volume targets
+function remove_empty_property_files() {
+  find "${BASH_SOURCE%/*}/../conf/presto/etc" -type f -size 0 -delete
+}
+
 # docker-compose down is not good enough because it's ignores services created with "run" command
 function stop_all_containers() {
   local ENVIRONMENT

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -99,6 +99,7 @@ docker-compose version
 docker version
 
 stop_all_containers
+remove_empty_property_files
 
 if [[ ${CONTINUOUS_INTEGRATION:-false} = true ]]; then
     environment_compose pull --quiet


### PR DESCRIPTION
Docker-compose leaves behind empty files corresponding to volume targets
if the file is mounted with a different name.