### PR TITLE
Add support for Elasticsearch query string syntax

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -181,3 +181,15 @@ _id     The Elasticsearch document ID
 _score  The document score returned by the Elasticsearch query
 _source The source of the original document
 ======= =======================================================
+
+Full Text Queries
+-----------------
+
+Presto SQL queries can be combined with Elasticsearch queries by providing the `full text query`_
+as part of the table name, separated by a colon. For example:
+
+.. code-block:: sql
+
+    SELECT * FROM "tweets: +presto SQL^2"
+
+.. _full text query: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchErrorCode.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchErrorCode.java
@@ -18,13 +18,15 @@ import io.prestosql.spi.ErrorCodeSupplier;
 import io.prestosql.spi.ErrorType;
 
 import static io.prestosql.spi.ErrorType.EXTERNAL;
+import static io.prestosql.spi.ErrorType.USER_ERROR;
 
 public enum ElasticsearchErrorCode
         implements ErrorCodeSupplier
 {
     ELASTICSEARCH_CONNECTION_ERROR(0, EXTERNAL),
     ELASTICSEARCH_INVALID_RESPONSE(1, EXTERNAL),
-    ELASTICSEARCH_SSL_INITIALIZATION_FAILURE(2, EXTERNAL);
+    ELASTICSEARCH_SSL_INITIALIZATION_FAILURE(2, EXTERNAL),
+    ELASTICSEARCH_QUERY_FAILURE(3, USER_ERROR);
 
     private final ErrorCode errorCode;
 

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
@@ -81,8 +81,15 @@ public class ElasticsearchMetadata
         requireNonNull(tableName, "tableName is null");
 
         if (tableName.getSchemaName().equals(schemaName)) {
-            if (listTables(session, Optional.of(schemaName)).contains(tableName)) {
-                return new ElasticsearchTableHandle(schemaName, tableName.getTableName());
+            String[] parts = tableName.getTableName().split(":", 2);
+            String table = parts[0];
+            Optional<String> query = Optional.empty();
+            if (parts.length == 2) {
+                query = Optional.of(parts[1]);
+            }
+
+            if (listTables(session, Optional.of(schemaName)).contains(new SchemaTableName(schemaName, table))) {
+                return new ElasticsearchTableHandle(schemaName, table, query);
             }
         }
 
@@ -245,7 +252,8 @@ public class ElasticsearchMetadata
         handle = new ElasticsearchTableHandle(
                 handle.getSchema(),
                 handle.getIndex(),
-                handle.getConstraint());
+                handle.getConstraint(),
+                handle.getQuery());
 
         return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary()));
     }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
@@ -124,7 +124,7 @@ public class ElasticsearchPageSource
         SearchResponse searchResponse = client.beginSearch(
                 table.getIndex(),
                 split.getShard(),
-                buildSearchQuery(table.getConstraint(), columns),
+                buildSearchQuery(table.getConstraint(), columns, table.getQuery()),
                 needAllFields ? Optional.empty() : Optional.of(requiredFields),
                 documentFields);
         readTimeNanos += System.nanoTime() - start;

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -23,11 +23,13 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -43,7 +45,7 @@ public class ElasticsearchQueryBuilder
 {
     private ElasticsearchQueryBuilder() {}
 
-    public static QueryBuilder buildSearchQuery(TupleDomain<ColumnHandle> constraint, List<ElasticsearchColumnHandle> columns)
+    public static QueryBuilder buildSearchQuery(TupleDomain<ColumnHandle> constraint, List<ElasticsearchColumnHandle> columns, Optional<String> query)
     {
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         for (ElasticsearchColumnHandle column : columns) {
@@ -57,6 +59,10 @@ public class ElasticsearchQueryBuilder
             }
             boolQueryBuilder.must(columnQueryBuilder);
         }
+
+        query.map(QueryStringQueryBuilder::new)
+                .ifPresent(boolQueryBuilder::must);
+
         if (boolQueryBuilder.hasClauses()) {
             return boolQueryBuilder;
         }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,11 +30,13 @@ public final class ElasticsearchTableHandle
     private final String schema;
     private final String index;
     private final TupleDomain<ColumnHandle> constraint;
+    private final Optional<String> query;
 
-    public ElasticsearchTableHandle(String schema, String index)
+    public ElasticsearchTableHandle(String schema, String index, Optional<String> query)
     {
         this.schema = requireNonNull(schema, "schema is null");
         this.index = requireNonNull(index, "index is null");
+        this.query = requireNonNull(query, "query is null");
 
         constraint = TupleDomain.all();
     }
@@ -42,11 +45,13 @@ public final class ElasticsearchTableHandle
     public ElasticsearchTableHandle(
             @JsonProperty("schema") String schema,
             @JsonProperty("index") String index,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("query") Optional<String> query)
     {
         this.schema = requireNonNull(schema, "schema is null");
         this.index = requireNonNull(index, "index is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.query = requireNonNull(query, "query is null");
     }
 
     @JsonProperty
@@ -67,6 +72,12 @@ public final class ElasticsearchTableHandle
         return constraint;
     }
 
+    @JsonProperty
+    public Optional<String> getQuery()
+    {
+        return query;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -79,12 +90,13 @@ public final class ElasticsearchTableHandle
         ElasticsearchTableHandle that = (ElasticsearchTableHandle) o;
         return schema.equals(that.schema) &&
                 index.equals(that.index) &&
-                constraint.equals(that.constraint);
+                constraint.equals(that.constraint) &&
+                query.equals(that.query);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schema, index, constraint);
+        return Objects.hash(schema, index, constraint, query);
     }
 }


### PR DESCRIPTION
The connector now supports queries of the form:

    SELECT * FROM "t: <elasticsearch query string>"

The language is described here:

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html