### PR TITLE
Fix create table error for file based Hive metastore with S3

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -1031,8 +1031,8 @@ public class FileHiveMetastore
 
             Path permissionsDirectory = getPermissionsDirectory(table);
 
-            metadataFileSystem.mkdirs(permissionsDirectory);
-            if (!metadataFileSystem.isDirectory(permissionsDirectory)) {
+            boolean created = metadataFileSystem.mkdirs(permissionsDirectory);
+            if (!created && !metadataFileSystem.isDirectory(permissionsDirectory)) {
                 throw new PrestoException(HIVE_METASTORE_ERROR, "Could not create permissions directory");
             }
 


### PR DESCRIPTION
S3FileSystem mkdirs doesn't actually do anything since S3 doesn't have the concept of directories. Therefore, trying to create an empty directory and check if it exists would fail since the current directory check for S3FileSystem is checking if any object keys exist under that path. This can be shortcircuited by just checking if the mkdirs call is successful.