### PR TITLE
Extract table predicates during planning

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -117,6 +117,7 @@ public final class SystemSessionProperties
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
     public static final String UNWRAP_CASTS = "unwrap_casts";
     public static final String SKIP_REDUNDANT_SORT = "skip_redundant_sort";
+    public static final String PREDICATE_PUSHDOWN_USE_TABLE_PROPERTIES = "predicate_pushdown_use_table_properties";
     public static final String WORK_PROCESSOR_PIPELINES = "work_processor_pipelines";
     public static final String ENABLE_DYNAMIC_FILTERING = "enable_dynamic_filtering";
     public static final String QUERY_MAX_MEMORY_PER_NODE = "query_max_memory_per_node";
@@ -505,6 +506,11 @@ public final class SystemSessionProperties
                         SKIP_REDUNDANT_SORT,
                         "Skip redundant sort operations",
                         featuresConfig.isSkipRedundantSort(),
+                        false),
+                booleanProperty(
+                        PREDICATE_PUSHDOWN_USE_TABLE_PROPERTIES,
+                        "Use table properties in predicate pushdown",
+                        featuresConfig.isPredicatePushdownUseTableProperties(),
                         false),
                 booleanProperty(
                         WORK_PROCESSOR_PIPELINES,
@@ -919,6 +925,11 @@ public final class SystemSessionProperties
     public static boolean isSkipRedundantSort(Session session)
     {
         return session.getSystemProperty(SKIP_REDUNDANT_SORT, Boolean.class);
+    }
+
+    public static boolean isPredicatePushdownUseTableProperties(Session session)
+    {
+        return session.getSystemProperty(PREDICATE_PUSHDOWN_USE_TABLE_PROPERTIES, Boolean.class);
     }
 
     public static boolean isWorkProcessorPipelines(Session session)

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -122,6 +122,7 @@ public class FeaturesConfig
     private boolean optimizeTopNRowNumber = true;
     private boolean workProcessorPipelines;
     private boolean skipRedundantSort = true;
+    private boolean predicatePushdownUseTableProperties = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private boolean enableDynamicFiltering;
@@ -943,6 +944,18 @@ public class FeaturesConfig
     public FeaturesConfig setSkipRedundantSort(boolean value)
     {
         this.skipRedundantSort = value;
+        return this;
+    }
+
+    public boolean isPredicatePushdownUseTableProperties()
+    {
+        return predicatePushdownUseTableProperties;
+    }
+
+    @Config("optimizer.predicate-pushdown-use-table-properties")
+    public FeaturesConfig setPredicatePushdownUseTableProperties(boolean predicatePushdownUseTableProperties)
+    {
+        this.predicatePushdownUseTableProperties = predicatePushdownUseTableProperties;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -275,7 +275,7 @@ public class PlanOptimizers
                         .addAll(new CanonicalizeExpressions(metadata, typeAnalyzer).rules())
                         .build());
 
-        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, typeAnalyzer));
+        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, typeAnalyzer, false));
 
         builder.add(
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -275,7 +275,7 @@ public class PlanOptimizers
                         .addAll(new CanonicalizeExpressions(metadata, typeAnalyzer).rules())
                         .build());
 
-        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, typeAnalyzer, false));
+        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, typeAnalyzer, true));
 
         builder.add(
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
@@ -399,7 +399,9 @@ public class PlanOptimizers
                                 new TransformCorrelatedSingleRowSubqueryToProject(),
                                 new RemoveAggregationInSemiJoin())),
                 new CheckSubqueryNodesAreRewritten(),
-                predicatePushDown,
+                new StatsRecordingPlanOptimizer(
+                        optimizerStats,
+                        new PredicatePushDown(metadata, typeAnalyzer, false)),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -79,6 +79,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.prestosql.SystemSessionProperties.isEnableDynamicFiltering;
+import static io.prestosql.SystemSessionProperties.isPredicatePushdownUseTableProperties;
 import static io.prestosql.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.prestosql.sql.ExpressionUtils.combineConjuncts;
 import static io.prestosql.sql.ExpressionUtils.extractConjuncts;
@@ -97,15 +98,15 @@ public class PredicatePushDown
 {
     private final Metadata metadata;
     private final LiteralEncoder literalEncoder;
-    private final EffectivePredicateExtractor effectivePredicateExtractor;
     private final TypeAnalyzer typeAnalyzer;
+    private final boolean useTableProperties;
 
     public PredicatePushDown(Metadata metadata, TypeAnalyzer typeAnalyzer, boolean useTableProperties)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.literalEncoder = new LiteralEncoder(metadata);
-        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder), metadata, useTableProperties);
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+        this.useTableProperties = useTableProperties;
     }
 
     @Override
@@ -116,6 +117,10 @@ public class PredicatePushDown
         requireNonNull(types, "types is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
+        EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(
+                new DomainTranslator(literalEncoder),
+                metadata,
+                useTableProperties && isPredicatePushdownUseTableProperties(session));
         return SimplePlanRewriter.rewriteWith(
                 new Rewriter(symbolAllocator, idAllocator, metadata, literalEncoder, effectivePredicateExtractor, typeAnalyzer, session, types),
                 plan,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -100,11 +100,11 @@ public class PredicatePushDown
     private final EffectivePredicateExtractor effectivePredicateExtractor;
     private final TypeAnalyzer typeAnalyzer;
 
-    public PredicatePushDown(Metadata metadata, TypeAnalyzer typeAnalyzer)
+    public PredicatePushDown(Metadata metadata, TypeAnalyzer typeAnalyzer, boolean useTableProperties)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.literalEncoder = new LiteralEncoder(metadata);
-        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder), metadata);
+        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder), metadata, useTableProperties);
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -107,6 +107,7 @@ public class TestFeaturesConfig
                 .setMaxGroupingSets(2048)
                 .setWorkProcessorPipelines(false)
                 .setSkipRedundantSort(true)
+                .setPredicatePushdownUseTableProperties(true)
                 .setEnableDynamicFiltering(false)
                 .setDynamicFilteringMaxPerDriverRowCount(100)
                 .setDynamicFilteringMaxPerDriverSize(new DataSize(10, KILOBYTE)));
@@ -176,6 +177,7 @@ public class TestFeaturesConfig
                 .put("analyzer.max-grouping-sets", "2047")
                 .put("experimental.work-processor-pipelines", "true")
                 .put("optimizer.skip-redundant-sort", "false")
+                .put("optimizer.predicate-pushdown-use-table-properties", "false")
                 .put("experimental.enable-dynamic-filtering", "true")
                 .put("experimental.dynamic-filtering-max-per-driver-row-count", "256")
                 .put("experimental.dynamic-filtering-max-per-driver-size", "64kB")
@@ -242,6 +244,7 @@ public class TestFeaturesConfig
                 .setDefaultFilterFactorEnabled(true)
                 .setWorkProcessorPipelines(true)
                 .setSkipRedundantSort(false)
+                .setPredicatePushdownUseTableProperties(false)
                 .setEnableDynamicFiltering(true)
                 .setDynamicFilteringMaxPerDriverRowCount(256)
                 .setDynamicFilteringMaxPerDriverSize(new DataSize(64, KILOBYTE));

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
@@ -168,7 +168,8 @@ public class TestEffectivePredicateExtractor
     };
 
     private final TypeAnalyzer typeAnalyzer = new TypeAnalyzer(new SqlParser(), metadata);
-    private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(new LiteralEncoder(metadata)), metadata);
+    private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(new LiteralEncoder(metadata)), metadata, true);
+    private final EffectivePredicateExtractor effectivePredicateExtractorWithoutTableProperties = new EffectivePredicateExtractor(new DomainTranslator(new LiteralEncoder(metadata)), metadata, false);
 
     private Map<Symbol, ColumnHandle> scanAssignments;
     private TableScanNode baseTableScan;
@@ -427,10 +428,30 @@ public class TestEffectivePredicateExtractor
                 scanAssignments.get(B), Domain.singleValue(BIGINT, 2L)));
         node = new TableScanNode(
                 newId(),
-                makeTableHandle(predicate),
+                makeTableHandle(TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L)))),
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 predicate);
+        effectivePredicate = effectivePredicateExtractorWithoutTableProperties.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
+
+        node = new TableScanNode(
+                newId(),
+                makeTableHandle(predicate),
+                ImmutableList.copyOf(assignments.keySet()),
+                assignments,
+                TupleDomain.all());
+        effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
+        assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
+
+        node = new TableScanNode(
+                newId(),
+                makeTableHandle(predicate),
+                ImmutableList.copyOf(assignments.keySet()),
+                assignments,
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        scanAssignments.get(A), Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L, 3L)),
+                        scanAssignments.get(B), Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L, 3L)))));
         effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestPredicatePushdown.java
@@ -503,4 +503,22 @@ public class TestPredicatePushdown
                                 anyTree(
                                         values("COL")))));
     }
+
+    @Test
+    public void testTablePredicateIsExtracted()
+    {
+        assertPlan(
+                "SELECT * FROM orders, nation WHERE orderstatus = CAST(nation.name AS varchar(1)) AND orderstatus BETWEEN 'A' AND 'O'",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        tableScan(
+                                                "orders",
+                                                ImmutableMap.of("ORDERSTATUS", "orderstatus"))),
+                                anyTree(
+                                        filter("CAST(NAME AS varchar(1)) IN ('F', 'O')",
+                                                tableScan(
+                                                        "nation",
+                                                        ImmutableMap.of("NAME", "name")))))));
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
@@ -323,7 +323,7 @@ public class TestReorderWindows
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),
-                new PredicatePushDown(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata())),
+                new PredicatePushDown(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata()), false),
                 new IterativeOptimizer(
                         new RuleStatsRecorder(),
                         getQueryRunner().getStatsCalculator(),


### PR DESCRIPTION
The observation is that `getTableProperties` is being used in `PushPredicateIntoTableScan`. Therefore we can use `getTableProperties` in effective predicate extractor after `PushPredicateIntoTableScan` is fired