### PR TITLE
Extract BaseJdbcAuthenticationConfig

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcAuthenticationConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcAuthenticationConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.configuration.Config;
+import io.prestosql.plugin.jdbc.credential.CredentialProviderType;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
+import static java.util.Objects.requireNonNull;
+
+public class BaseJdbcAuthenticationConfig
+{
+    private String userCredentialName;
+    private String passwordCredentialName;
+    private CredentialProviderType credentialProviderType = INLINE;
+
+    @Nullable
+    public String getUserCredentialName()
+    {
+        return userCredentialName;
+    }
+
+    @Config("user-credential-name")
+    public BaseJdbcAuthenticationConfig setUserCredentialName(String userCredentialName)
+    {
+        this.userCredentialName = userCredentialName;
+        return this;
+    }
+
+    @Nullable
+    public String getPasswordCredentialName()
+    {
+        return passwordCredentialName;
+    }
+
+    @Config("password-credential-name")
+    public BaseJdbcAuthenticationConfig setPasswordCredentialName(String passwordCredentialName)
+    {
+        this.passwordCredentialName = passwordCredentialName;
+        return this;
+    }
+
+    @NotNull
+    public CredentialProviderType getCredentialProviderType()
+    {
+        return credentialProviderType;
+    }
+
+    @Config("credential-provider.type")
+    public BaseJdbcAuthenticationConfig setCredentialProviderType(CredentialProviderType credentialProviderType)
+    {
+        this.credentialProviderType = requireNonNull(credentialProviderType, "credentialProviderType is null");
+        return this;
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -18,26 +18,19 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
-import io.prestosql.plugin.jdbc.credential.CredentialProviderType;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
-import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class BaseJdbcConfig
 {
     private String connectionUrl;
-    private String userCredentialName;
-    private String passwordCredentialName;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
-    private CredentialProviderType credentialProviderType = INLINE;
     private Set<String> jdbcTypesMappedToVarchar = ImmutableSet.of();
 
     @NotNull
@@ -50,32 +43,6 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setConnectionUrl(String connectionUrl)
     {
         this.connectionUrl = connectionUrl;
-        return this;
-    }
-
-    @Nullable
-    public String getUserCredentialName()
-    {
-        return userCredentialName;
-    }
-
-    @Config("user-credential-name")
-    public BaseJdbcConfig setUserCredentialName(String userCredentialName)
-    {
-        this.userCredentialName = userCredentialName;
-        return this;
-    }
-
-    @Nullable
-    public String getPasswordCredentialName()
-    {
-        return passwordCredentialName;
-    }
-
-    @Config("password-credential-name")
-    public BaseJdbcConfig setPasswordCredentialName(String passwordCredentialName)
-    {
-        this.passwordCredentialName = passwordCredentialName;
         return this;
     }
 
@@ -102,19 +69,6 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
-        return this;
-    }
-
-    @NotNull
-    public CredentialProviderType getCredentialProviderType()
-    {
-        return credentialProviderType;
-    }
-
-    @Config("credential-provider.type")
-    public BaseJdbcConfig setCredentialProviderType(CredentialProviderType credentialProviderType)
-    {
-        this.credentialProviderType = requireNonNull(credentialProviderType, "credentialProviderType is null");
         return this;
     }
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/CredentialProviderModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.configuration.ConfigurationFactory;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.BaseJdbcAuthenticationConfig;
 import io.prestosql.plugin.jdbc.credential.file.ConfigFileBasedCredentialProviderConfig;
 import io.prestosql.plugin.jdbc.credential.keystore.KeyStoreBasedCredentialProviderConfig;
 
@@ -50,6 +50,7 @@ public class CredentialProviderModule
     @Override
     protected void setup(Binder binder)
     {
+        configBinder(binder).bindConfig(BaseJdbcAuthenticationConfig.class);
         bindCredentialProviderModule(
                 INLINE,
                 internalBinder -> {
@@ -74,7 +75,7 @@ public class CredentialProviderModule
     private void bindCredentialProviderModule(CredentialProviderType name, Module module)
     {
         install(installModuleIf(
-                BaseJdbcConfig.class,
+                BaseJdbcAuthenticationConfig.class,
                 config -> name.equals(config.getCredentialProviderType()),
                 module));
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ExtraCredentialProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/credential/ExtraCredentialProvider.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.plugin.jdbc.credential;
 
-import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.BaseJdbcAuthenticationConfig;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 
 import javax.inject.Inject;
@@ -31,9 +31,9 @@ public class ExtraCredentialProvider
     private final CredentialProvider delegate;
 
     @Inject
-    public ExtraCredentialProvider(BaseJdbcConfig baseJdbcConfig, @ForExtraCredentialProvider CredentialProvider delegate)
+    public ExtraCredentialProvider(BaseJdbcAuthenticationConfig config, @ForExtraCredentialProvider CredentialProvider delegate)
     {
-        this(Optional.ofNullable(baseJdbcConfig.getUserCredentialName()), Optional.ofNullable(baseJdbcConfig.getPasswordCredentialName()), delegate);
+        this(Optional.ofNullable(config.getUserCredentialName()), Optional.ofNullable(config.getPasswordCredentialName()), delegate);
     }
 
     public ExtraCredentialProvider(Optional<String> userCredentialName, Optional<String> passwordCredentialName, CredentialProvider delegate)

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcAuthenticationConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcAuthenticationConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.FILE;
+import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
+
+public class TestBaseJdbcAuthenticationConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(BaseJdbcAuthenticationConfig.class)
+                .setUserCredentialName(null)
+                .setPasswordCredentialName(null)
+                .setCredentialProviderType(INLINE));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("user-credential-name", "foo")
+                .put("password-credential-name", "bar")
+                .put("credential-provider.type", "FILE")
+                .build();
+
+        BaseJdbcAuthenticationConfig expected = new BaseJdbcAuthenticationConfig()
+                .setUserCredentialName("foo")
+                .setPasswordCredentialName("bar")
+                .setCredentialProviderType(FILE);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.FILE;
-import static io.prestosql.plugin.jdbc.credential.CredentialProviderType.INLINE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -36,11 +34,8 @@ public class TestBaseJdbcConfig
     {
         assertRecordedDefaults(recordDefaults(BaseJdbcConfig.class)
                 .setConnectionUrl(null)
-                .setUserCredentialName(null)
-                .setPasswordCredentialName(null)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
-                .setCredentialProviderType(INLINE)
                 .setJdbcTypesMappedToVarchar(null));
     }
 
@@ -49,21 +44,15 @@ public class TestBaseJdbcConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("connection-url", "jdbc:h2:mem:config")
-                .put("user-credential-name", "foo")
-                .put("password-credential-name", "bar")
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
-                .put("credential-provider.type", "FILE")
                 .put("jdbc-types-mapped-to-varchar", "mytype,struct_type1")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
-                .setUserCredentialName("foo")
-                .setPasswordCredentialName("bar")
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
-                .setCredentialProviderType(FILE)
                 .setJdbcTypesMappedToVarchar("mytype, struct_type1");
 
         assertFullMapping(properties, expected);

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
@@ -47,7 +47,7 @@ final class TestingDatabase
         jdbcClient = new BaseJdbcClient(
                 new BaseJdbcConfig(),
                 "\"",
-                new DriverConnectionFactory(new Driver(), connectionUrl, new Properties(), new ExtraCredentialProvider(new BaseJdbcConfig(), new ConfigFileBasedCredentialProvider(new CredentialConfig()))));
+                new DriverConnectionFactory(new Driver(), connectionUrl, new Properties(), new ExtraCredentialProvider(new BaseJdbcAuthenticationConfig(), new ConfigFileBasedCredentialProvider(new CredentialConfig()))));
 
         connection = DriverManager.getConnection(connectionUrl);
         connection.createStatement().execute("CREATE SCHEMA example");


### PR DESCRIPTION
Extract BaseJdbcAuthenticationConfig

Not every JDBC based connector is using user and password for
authentication. Hence allowing user to set user and password there is
incorrect.
