### PR TITLE
No throw exception in Glue when isImpersonationEnabled is called.

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -915,6 +915,6 @@ public class GlueHiveMetastore
     @Override
     public boolean isImpersonationEnabled()
     {
-        throw new PrestoException(NOT_SUPPORTED, "isImpersonationEnabled is not supported by Glue");
+        return false;
     }
 }


### PR DESCRIPTION
Impersonation is not supported in Glue, should not return exception only false.

```
2019-10-08 17:26:01] [13] Query failed (#20191008_152601_00014_m5kjm): isImpersonationEnabled is not supported by Glue
[2019-10-08 17:26:01] java.lang.RuntimeException: io.prestosql.spi.PrestoException: isImpersonationEnabled is not supported by Glue
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.metastore.glue.GlueHiveMetastore.isImpersonationEnabled(GlueHiveMetastore.java:918)
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.isImpersonationEnabled(CachingHiveMetastore.java:810)
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.updateIdentity(CachingHiveMetastore.java:888)
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.getTable(CachingHiveMetastore.java:274)
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore.getTable(SemiTransactionalHiveMetastore.java:153)
[2019-10-08 17:26:01]   at io.prestosql.plugin.hive.HiveMetadata.getView(HiveMetadata.java:1659)
[2019-10-08 17:26:01]   at io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.getView(ClassLoaderSafeConnectorMetadata.java:442)
[2019-10-08 17:26:01]   at io.prestosql.metadata.MetadataManager.getView(MetadataManager.java:950)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:879)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:271)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.Table.accept(Table.java:53)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.AstVisitor.process(AstVisitor.java:27)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:286)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:1997)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:1091)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:271)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.QuerySpecification.accept(QuerySpecification.java:144)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.AstVisitor.process(AstVisitor.java:27)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:286)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:296)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:787)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:271)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.Query.accept(Query.java:107)
[2019-10-08 17:26:01]   at io.prestosql.sql.tree.AstVisitor.process(AstVisitor.java:27)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:286)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:263)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.Analyzer.analyze(Analyzer.java:82)
[2019-10-08 17:26:01]   at io.prestosql.sql.analyzer.Analyzer.analyze(Analyzer.java:74)
[2019-10-08 17:26:01]   at io.prestosql.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:218)
[2019-10-08 17:26:01]   at io.prestosql.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:177)
[2019-10-08 17:26:01]   at io.prestosql.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:94)
[2019-10-08 17:26:01]   at io.prestosql.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:713)
[2019-10-08 17:26:01]   at io.prestosql.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:118)
[2019-10-08 17:26:01]   at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
[2019-10-08 17:26:01]   at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
[2019-10-08 17:26:01]   at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
[2019-10-08 17:26:01]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2019-10-08 17:26:01]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2019-10-08 17:26:01]   at java.lang.Thread.run(Thread.java:748) (no stack trace)
```