### PR TITLE
Remove predicate sort by name

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/DomainTranslator.java
@@ -79,7 +79,6 @@ import static io.prestosql.sql.tree.ComparisonExpression.Operator.GREATER_THAN_O
 import static io.prestosql.sql.tree.ComparisonExpression.Operator.LESS_THAN;
 import static io.prestosql.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
 import static io.prestosql.sql.tree.ComparisonExpression.Operator.NOT_EQUAL;
-import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
@@ -101,7 +100,6 @@ public final class DomainTranslator
 
         Map<Symbol, Domain> domains = tupleDomain.getDomains().get();
         return domains.entrySet().stream()
-                .sorted(comparing(entry -> entry.getKey().getName()))
                 .map(entry -> toPredicate(entry.getValue(), entry.getKey().toSymbolReference()))
                 .collect(collectingAndThen(toImmutableList(), ExpressionUtils::combineConjuncts));
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDomainTranslator.java
@@ -1017,14 +1017,14 @@ public class TestDomainTranslator
         assertPredicateTranslates(
                 expression,
                 withColumnDomains(ImmutableMap.of(
-                        C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 0L)), false),
-                        C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, .0)), false))));
+                        C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, .0)), false),
+                        C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 0L)), false))));
 
         assertEquals(
                 toPredicate(fromPredicate(expression).getTupleDomain()),
                 and(
-                        comparison(GREATER_THAN, C_BIGINT.toSymbolReference(), bigintLiteral(0)),
-                        comparison(GREATER_THAN, C_DOUBLE.toSymbolReference(), doubleLiteral(0))));
+                        comparison(GREATER_THAN, C_DOUBLE.toSymbolReference(), doubleLiteral(0)),
+                        comparison(GREATER_THAN, C_BIGINT.toSymbolReference(), bigintLiteral(0))));
     }
 
     @Test


### PR DESCRIPTION
This change removes sorting predicates by name.

Presto's Parquet reader will lazily read column blocks as needed, so ordering predicates by column name has the side effect of potentially increasing the amount of data scanned.

Say a table has a high cardinality column `id` and a low cardinality column `country`, and the table is sorted on `id`. Given a query `select * from table where id=123 and country='US'`, Presto will order predicates by name, so `country` comes first. The Parquet reader will then load the `country` column block first, match many row groups, then load the `id` column block, where only a few match. Thus the `country` column block was unnecessarily loaded in most cases.

If the predicates are not sorted and are kept in the order defined in the query, then the Parquet reader will load the `id` column block first, skip most row groups, and only load the `country` column block if there is an id match.