### PR TITLE
Use class loader isolation for Hive and Iceberg connector instances

### DIFF
--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -14,7 +14,7 @@
 package io.prestosql.plugin.geospatial;
 
 import io.prestosql.Session;
-import io.prestosql.plugin.hive.HivePlugin;
+import io.prestosql.plugin.hive.TestingHivePlugin;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
@@ -24,7 +24,6 @@ import io.prestosql.tests.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Optional;
 
 import static io.prestosql.SystemSessionProperties.SPATIAL_PARTITIONING_TABLE_NAME;
 import static io.prestosql.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
@@ -82,7 +81,7 @@ public class TestSpatialJoins
                         .setOwnerName("public")
                         .setOwnerType(PrincipalType.ROLE)
                         .build());
-        queryRunner.installPlugin(new HivePlugin("hive", Optional.of(metastore)));
+        queryRunner.installPlugin(new TestingHivePlugin(metastore));
 
         queryRunner.createCatalog("hive", "hive");
         return queryRunner;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnector.java
@@ -19,6 +19,7 @@ import io.airlift.bootstrap.LifeCycleManager;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorAccessControl;
+import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorMetadata;
 import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
@@ -32,6 +33,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -93,6 +95,12 @@ public class HiveConnector
         this.analyzeProperties = ImmutableList.copyOf(requireNonNull(analyzeProperties, "analyzeProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public Optional<ConnectorHandleResolver> getHandleResolver()
+    {
+        return Optional.of(new HiveHandleResolver());
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConnectorFactory.java
@@ -38,7 +38,6 @@ import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.connector.ConnectorFactory;
-import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
@@ -78,12 +77,6 @@ public class HiveConnectorFactory
     public String getName()
     {
         return name;
-    }
-
-    @Override
-    public ConnectorHandleResolver getHandleResolver()
-    {
-        return new HiveHandleResolver();
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveConnectorFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
+import io.airlift.json.JsonModule;
+import io.prestosql.plugin.base.jmx.MBeanServerModule;
+import io.prestosql.plugin.hive.authentication.HiveAuthenticationModule;
+import io.prestosql.plugin.hive.gcs.HiveGcsModule;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
+import io.prestosql.plugin.hive.s3.HiveS3Module;
+import io.prestosql.plugin.hive.security.HiveSecurityModule;
+import io.prestosql.plugin.hive.security.SystemTableAwareAccessControl;
+import io.prestosql.spi.NodeManager;
+import io.prestosql.spi.PageIndexerFactory;
+import io.prestosql.spi.PageSorter;
+import io.prestosql.spi.VersionEmbedder;
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.connector.Connector;
+import io.prestosql.spi.connector.ConnectorAccessControl;
+import io.prestosql.spi.connector.ConnectorContext;
+import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorPageSourceProvider;
+import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorPageSinkProvider;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
+import io.prestosql.spi.procedure.Procedure;
+import io.prestosql.spi.type.TypeManager;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public final class InternalHiveConnectorFactory
+{
+    private InternalHiveConnectorFactory() {}
+
+    public static Connector createConnector(String catalogName, Map<String, String> config, ConnectorContext context, Optional<HiveMetastore> metastore)
+    {
+        requireNonNull(config, "config is null");
+
+        ClassLoader classLoader = InternalHiveConnectorFactory.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new EventModule(),
+                    new MBeanModule(),
+                    new ConnectorObjectNameGeneratorModule(catalogName),
+                    new JsonModule(),
+                    new HiveModule(),
+                    new HiveS3Module(),
+                    new HiveGcsModule(),
+                    new HiveMetastoreModule(metastore),
+                    new HiveSecurityModule(),
+                    new HiveAuthenticationModule(),
+                    new HiveProcedureModule(),
+                    new MBeanServerModule(),
+                    binder -> {
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
+                        binder.bind(VersionEmbedder.class).toInstance(context.getVersionEmbedder());
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
+                        binder.bind(PageSorter.class).toInstance(context.getPageSorter());
+                        binder.bind(HiveCatalogName.class).toInstance(new HiveCatalogName(catalogName));
+                    });
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+            HiveMetadataFactory metadataFactory = injector.getInstance(HiveMetadataFactory.class);
+            HiveTransactionManager transactionManager = injector.getInstance(HiveTransactionManager.class);
+            ConnectorSplitManager splitManager = injector.getInstance(ConnectorSplitManager.class);
+            ConnectorPageSourceProvider connectorPageSource = injector.getInstance(ConnectorPageSourceProvider.class);
+            ConnectorPageSinkProvider pageSinkProvider = injector.getInstance(ConnectorPageSinkProvider.class);
+            ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
+            HiveSessionProperties hiveSessionProperties = injector.getInstance(HiveSessionProperties.class);
+            HiveTableProperties hiveTableProperties = injector.getInstance(HiveTableProperties.class);
+            HiveAnalyzeProperties hiveAnalyzeProperties = injector.getInstance(HiveAnalyzeProperties.class);
+            ConnectorAccessControl accessControl = new SystemTableAwareAccessControl(injector.getInstance(ConnectorAccessControl.class));
+            Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
+
+            return new HiveConnector(
+                    lifeCycleManager,
+                    metadataFactory,
+                    transactionManager,
+                    new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),
+                    new ClassLoaderSafeConnectorPageSourceProvider(connectorPageSource, classLoader),
+                    new ClassLoaderSafeConnectorPageSinkProvider(pageSinkProvider, classLoader),
+                    new ClassLoaderSafeNodePartitioningProvider(connectorDistributionProvider, classLoader),
+                    ImmutableSet.of(),
+                    procedures,
+                    hiveSessionProperties.getSessionProperties(),
+                    HiveSchemaProperties.SCHEMA_PROPERTIES,
+                    hiveTableProperties.getTableProperties(),
+                    hiveAnalyzeProperties.getAnalyzeProperties(),
+                    accessControl,
+                    classLoader);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/TestingHiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/TestingHiveConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive;
 
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.connector.ConnectorFactory;
@@ -20,30 +21,33 @@ import io.prestosql.spi.connector.ConnectorFactory;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.prestosql.plugin.hive.InternalHiveConnectorFactory.createConnector;
+import static java.util.Objects.requireNonNull;
 
-public class HiveConnectorFactory
+public class TestingHiveConnectorFactory
         implements ConnectorFactory
 {
-    private final String name;
+    private final Optional<HiveMetastore> metastore;
 
-    public HiveConnectorFactory(String name)
+    public TestingHiveConnectorFactory()
     {
-        checkArgument(!isNullOrEmpty(name), "name is null or empty");
-        this.name = name;
+        this.metastore = Optional.empty();
+    }
+
+    public TestingHiveConnectorFactory(HiveMetastore metastore)
+    {
+        this.metastore = Optional.of(requireNonNull(metastore, "metastore is null"));
     }
 
     @Override
     public String getName()
     {
-        return name;
+        return "hive";
     }
 
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, Optional.empty());
+        return createConnector(catalogName, config, context, metastore);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/TestingHivePlugin.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/TestingHivePlugin.java
@@ -14,26 +14,25 @@
 package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
-public class HivePlugin
+public class TestingHivePlugin
         implements Plugin
 {
-    private final String name;
+    private final HiveMetastore metastore;
 
-    public HivePlugin(String name)
+    public TestingHivePlugin(HiveMetastore metastore)
     {
-        checkArgument(!isNullOrEmpty(name), "name is null or empty");
-        this.name = name;
+        this.metastore = requireNonNull(metastore, "metastore is null");
     }
 
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new HiveConnectorFactory(name));
+        return ImmutableList.of(new TestingHiveConnectorFactory(metastore));
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveBenchmarkQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveBenchmarkQueryRunner.java
@@ -27,7 +27,6 @@ import io.prestosql.testing.LocalQueryRunner;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -77,16 +76,11 @@ public final class HiveBenchmarkQueryRunner
                         .setOwnerType(PrincipalType.ROLE)
                         .build());
 
-        HiveConnectorFactory hiveConnectorFactory = new HiveConnectorFactory(
-                "hive",
-                HiveBenchmarkQueryRunner.class.getClassLoader(),
-                Optional.of(metastore));
-
         Map<String, String> hiveCatalogConfig = ImmutableMap.<String, String>builder()
                 .put("hive.max-split-size", "10GB")
                 .build();
 
-        localQueryRunner.createCatalog("hive", hiveConnectorFactory, hiveCatalogConfig);
+        localQueryRunner.createCatalog("hive", new TestingHiveConnectorFactory(metastore), hiveCatalogConfig);
 
         localQueryRunner.execute("CREATE TABLE orders AS SELECT * FROM tpch.sf1.orders");
         localQueryRunner.execute("CREATE TABLE lineitem AS SELECT * FROM tpch.sf1.lineitem");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
@@ -104,7 +104,7 @@ public final class HiveQueryRunner
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
             FileHiveMetastore metastore = new FileHiveMetastore(HDFS_ENVIRONMENT, baseDir.toURI().toString(), "test");
-            queryRunner.installPlugin(new HivePlugin(HIVE_CATALOG, Optional.of(metastore)));
+            queryRunner.installPlugin(new TestingHivePlugin(metastore));
 
             Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
                     .putAll(extraHiveProperties)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConnectorFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConnectorFactory.java
@@ -23,7 +23,6 @@ import io.prestosql.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertInstanceOf;
@@ -48,16 +47,11 @@ public class TestHiveConnectorFactory
 
     private static void assertCreateConnector(String metastoreUri)
     {
-        HiveConnectorFactory connectorFactory = new HiveConnectorFactory(
-                "hive-test",
-                HiveConnector.class.getClassLoader(),
-                Optional.empty());
-
         Map<String, String> config = ImmutableMap.<String, String>builder()
                 .put("hive.metastore.uri", metastoreUri)
                 .build();
 
-        Connector connector = connectorFactory.create("hive-test", config, new TestingConnectorContext());
+        Connector connector = new HiveConnectorFactory("hive").create("hive-test", config, new TestingConnectorContext());
         ConnectorTransactionHandle transaction = connector.beginTransaction(READ_UNCOMMITTED, true);
         assertInstanceOf(connector.getMetadata(transaction), ClassLoaderSafeConnectorMetadata.class);
         assertInstanceOf(connector.getSplitManager(), ClassLoaderSafeConnectorSplitManager.class);

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnector.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorCapabilities;
+import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorMetadata;
 import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
@@ -33,6 +34,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.immutableEnumSet;
@@ -83,6 +85,12 @@ public class IcebergConnector
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
+    @Override
+    public Optional<ConnectorHandleResolver> getHandleResolver()
+    {
+        return Optional.of(new IcebergHandleResolver());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
@@ -17,10 +17,11 @@ import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.connector.ConnectorFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.prestosql.plugin.iceberg.InternalIcebergConnectorFactory.createConnector;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 
 public class IcebergConnectorFactory
         implements ConnectorFactory
@@ -34,6 +35,19 @@ public class IcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, Optional.empty());
+        ClassLoader classLoader = context.duplicatePluginClassLoader();
+        try {
+            return (Connector) classLoader.loadClass(InternalIcebergConnectorFactory.class.getName())
+                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class)
+                    .invoke(null, catalogName, config, context, Optional.empty());
+        }
+        catch (InvocationTargetException e) {
+            Throwable targetException = e.getTargetException();
+            throwIfUnchecked(targetException);
+            throw new RuntimeException(targetException);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnectorFactory.java
@@ -33,7 +33,6 @@ import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.connector.ConnectorFactory;
-import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
@@ -64,12 +63,6 @@ public class IcebergConnectorFactory
     public String getName()
     {
         return "iceberg";
-    }
-
-    @Override
-    public ConnectorHandleResolver getHandleResolver()
-    {
-        return new IcebergHandleResolver();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPlugin.java
@@ -14,32 +14,15 @@
 package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
-import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
-
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
 
 public class IcebergPlugin
         implements Plugin
 {
-    private final Optional<HiveMetastore> metastore;
-
-    public IcebergPlugin()
-    {
-        this(Optional.empty());
-    }
-
-    public IcebergPlugin(Optional<HiveMetastore> metastore)
-    {
-        this.metastore = requireNonNull(metastore, "metastore is null");
-    }
-
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new IcebergConnectorFactory(metastore));
+        return ImmutableList.of(new IcebergConnectorFactory());
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
+import io.airlift.json.JsonModule;
+import io.prestosql.plugin.base.jmx.MBeanServerModule;
+import io.prestosql.plugin.base.security.AllowAllAccessControl;
+import io.prestosql.plugin.hive.HiveCatalogName;
+import io.prestosql.plugin.hive.NodeVersion;
+import io.prestosql.plugin.hive.authentication.HiveAuthenticationModule;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
+import io.prestosql.plugin.hive.s3.HiveS3Module;
+import io.prestosql.spi.NodeManager;
+import io.prestosql.spi.PageIndexerFactory;
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.connector.Connector;
+import io.prestosql.spi.connector.ConnectorContext;
+import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorPageSourceProvider;
+import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorPageSinkProvider;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
+import io.prestosql.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
+import io.prestosql.spi.type.TypeManager;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class InternalIcebergConnectorFactory
+{
+    private InternalIcebergConnectorFactory() {}
+
+    public static Connector createConnector(String catalogName, Map<String, String> config, ConnectorContext context, Optional<HiveMetastore> metastore)
+    {
+        ClassLoader classLoader = InternalIcebergConnectorFactory.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new EventModule(),
+                    new MBeanModule(),
+                    new JsonModule(),
+                    new IcebergModule(),
+                    new HiveS3Module(),
+                    new HiveAuthenticationModule(),
+                    new HiveMetastoreModule(metastore),
+                    new MBeanServerModule(),
+                    binder -> {
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
+                        binder.bind(HiveCatalogName.class).toInstance(new HiveCatalogName(catalogName));
+                    });
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+            IcebergTransactionManager transactionManager = injector.getInstance(IcebergTransactionManager.class);
+            IcebergMetadataFactory metadataFactory = injector.getInstance(IcebergMetadataFactory.class);
+            ConnectorSplitManager splitManager = injector.getInstance(ConnectorSplitManager.class);
+            ConnectorPageSourceProvider connectorPageSource = injector.getInstance(ConnectorPageSourceProvider.class);
+            ConnectorPageSinkProvider pageSinkProvider = injector.getInstance(ConnectorPageSinkProvider.class);
+            ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
+            IcebergSessionProperties icebergSessionProperties = injector.getInstance(IcebergSessionProperties.class);
+            IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
+
+            return new IcebergConnector(
+                    lifeCycleManager,
+                    transactionManager,
+                    metadataFactory,
+                    new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),
+                    new ClassLoaderSafeConnectorPageSourceProvider(connectorPageSource, classLoader),
+                    new ClassLoaderSafeConnectorPageSinkProvider(pageSinkProvider, classLoader),
+                    new ClassLoaderSafeNodePartitioningProvider(connectorDistributionProvider, classLoader),
+                    ImmutableSet.of(),
+                    icebergSessionProperties.getSessionProperties(),
+                    IcebergSchemaProperties.SCHEMA_PROPERTIES,
+                    icebergTableProperties.getTableProperties(),
+                    new AllowAllAccessControl());
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -21,7 +21,7 @@ import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
-import io.prestosql.plugin.hive.HivePlugin;
+import io.prestosql.plugin.hive.TestingHivePlugin;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
@@ -70,7 +70,7 @@ public class TestIcebergMetadataListing
 
         queryRunner.installPlugin(new IcebergPlugin(Optional.of(metastore)));
         queryRunner.createCatalog("iceberg", "iceberg");
-        queryRunner.installPlugin(new HivePlugin("hive", Optional.of(metastore)));
+        queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
 
         return queryRunner;

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -68,7 +68,7 @@ public class TestIcebergMetadataListing
 
         metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
 
-        queryRunner.installPlugin(new IcebergPlugin(Optional.of(metastore)));
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
         queryRunner.createCatalog("iceberg", "iceberg");
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestingIcebergConnectorFactory.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestingIcebergConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.iceberg;
 
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.connector.ConnectorFactory;
@@ -21,10 +22,18 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.prestosql.plugin.iceberg.InternalIcebergConnectorFactory.createConnector;
+import static java.util.Objects.requireNonNull;
 
-public class IcebergConnectorFactory
+public class TestingIcebergConnectorFactory
         implements ConnectorFactory
 {
+    private final Optional<HiveMetastore> metastore;
+
+    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore)
+    {
+        this.metastore = requireNonNull(metastore, "metastore is null");
+    }
+
     @Override
     public String getName()
     {
@@ -34,6 +43,6 @@ public class IcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, Optional.empty());
+        return createConnector(catalogName, config, context, metastore);
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestingIcebergPlugin.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestingIcebergPlugin.java
@@ -13,27 +13,33 @@
  */
 package io.prestosql.plugin.iceberg;
 
-import io.prestosql.spi.connector.Connector;
-import io.prestosql.spi.connector.ConnectorContext;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 
-import java.util.Map;
 import java.util.Optional;
 
-import static io.prestosql.plugin.iceberg.InternalIcebergConnectorFactory.createConnector;
+import static java.util.Objects.requireNonNull;
 
-public class IcebergConnectorFactory
-        implements ConnectorFactory
+public class TestingIcebergPlugin
+        implements Plugin
 {
-    @Override
-    public String getName()
+    private final Optional<HiveMetastore> metastore;
+
+    public TestingIcebergPlugin()
     {
-        return "iceberg";
+        this.metastore = Optional.empty();
+    }
+
+    public TestingIcebergPlugin(HiveMetastore metastore)
+    {
+        this.metastore = Optional.of(requireNonNull(metastore, "metastore is null"));
     }
 
     @Override
-    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return createConnector(catalogName, config, context, Optional.empty());
+        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore));
     }
 }

--- a/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/TestKinesisPlugin.java
+++ b/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/TestKinesisPlugin.java
@@ -70,7 +70,7 @@ public class TestKinesisPlugin
                 .put("kinesis.hide-internal-columns", "false")
                 .put("kinesis.access-key", TestUtils.noneToBlank(accessKey))
                 .put("kinesis.secret-key", TestUtils.noneToBlank(secretKey))
-                .build(), new TestingConnectorContext() {});
+                .build(), new TestingConnectorContext());
         assertNotNull(c);
 
         // Verify that the key objects have been created on the connector

--- a/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/util/TestUtils.java
+++ b/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/util/TestUtils.java
@@ -52,7 +52,7 @@ public class TestUtils
         ConnectorFactory factory = plugin.getConnectorFactories().iterator().next();
         assertNotNull(factory);
 
-        Connector connector = factory.create("kinesis", properties, new TestingConnectorContext() {});
+        Connector connector = factory.create("kinesis", properties, new TestingConnectorContext());
         return (KinesisConnector) connector;
     }
 

--- a/presto-main/src/main/java/io/prestosql/connector/ConnectorContextInstance.java
+++ b/presto-main/src/main/java/io/prestosql/connector/ConnectorContextInstance.java
@@ -20,6 +20,8 @@ import io.prestosql.spi.VersionEmbedder;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.type.TypeManager;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorContextInstance
@@ -30,19 +32,22 @@ public class ConnectorContextInstance
     private final TypeManager typeManager;
     private final PageSorter pageSorter;
     private final PageIndexerFactory pageIndexerFactory;
+    private final Supplier<ClassLoader> duplicatePluginClassLoaderFactory;
 
     public ConnectorContextInstance(
             NodeManager nodeManager,
             VersionEmbedder versionEmbedder,
             TypeManager typeManager,
             PageSorter pageSorter,
-            PageIndexerFactory pageIndexerFactory)
+            PageIndexerFactory pageIndexerFactory,
+            Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.versionEmbedder = requireNonNull(versionEmbedder, "versionEmbedder is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
+        this.duplicatePluginClassLoaderFactory = requireNonNull(duplicatePluginClassLoaderFactory, "duplicatePluginClassLoaderFactory is null");
     }
 
     @Override
@@ -73,5 +78,11 @@ public class ConnectorContextInstance
     public PageIndexerFactory getPageIndexerFactory()
     {
         return pageIndexerFactory;
+    }
+
+    @Override
+    public ClassLoader duplicatePluginClassLoader()
+    {
+        return duplicatePluginClassLoaderFactory.get();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -101,7 +102,7 @@ public class ConnectorManager
     private final TransactionManager transactionManager;
 
     @GuardedBy("this")
-    private final ConcurrentMap<String, ConnectorFactory> connectorFactories = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InternalConnectorFactory> connectorFactories = new ConcurrentHashMap<>();
 
     @GuardedBy("this")
     private final ConcurrentMap<CatalogName, MaterializedConnector> connectors = new ConcurrentHashMap<>();
@@ -161,22 +162,26 @@ public class ConnectorManager
         }
     }
 
-    public synchronized void addConnectorFactory(ConnectorFactory connectorFactory)
+    public synchronized void addConnectorFactory(ConnectorFactory connectorFactory, Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
     {
+        requireNonNull(connectorFactory, "connectorFactory is null");
+        requireNonNull(duplicatePluginClassLoaderFactory, "duplicatePluginClassLoaderFactory is null");
         checkState(!stopped.get(), "ConnectorManager is stopped");
-        ConnectorFactory existingConnectorFactory = connectorFactories.putIfAbsent(connectorFactory.getName(), connectorFactory);
+        InternalConnectorFactory existingConnectorFactory = connectorFactories.putIfAbsent(
+                connectorFactory.getName(),
+                new InternalConnectorFactory(connectorFactory, duplicatePluginClassLoaderFactory));
         checkArgument(existingConnectorFactory == null, "Connector '%s' is already registered", connectorFactory.getName());
     }
 
     public synchronized CatalogName createCatalog(String catalogName, String connectorName, Map<String, String> properties)
     {
         requireNonNull(connectorName, "connectorName is null");
-        ConnectorFactory connectorFactory = connectorFactories.get(connectorName);
+        InternalConnectorFactory connectorFactory = connectorFactories.get(connectorName);
         checkArgument(connectorFactory != null, "No factory for connector '%s'.  Available factories: %s", connectorName, connectorFactories.keySet());
         return createCatalog(catalogName, connectorFactory, properties);
     }
 
-    private synchronized CatalogName createCatalog(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties)
+    private synchronized CatalogName createCatalog(String catalogName, InternalConnectorFactory connectorFactory, Map<String, String> properties)
     {
         checkState(!stopped.get(), "ConnectorManager is stopped");
         requireNonNull(catalogName, "catalogName is null");
@@ -192,14 +197,14 @@ public class ConnectorManager
         return catalog;
     }
 
-    private synchronized void createCatalog(CatalogName catalogName, ConnectorFactory factory, Map<String, String> properties)
+    private synchronized void createCatalog(CatalogName catalogName, InternalConnectorFactory factory, Map<String, String> properties)
     {
         // create all connectors before adding, so a broken connector does not leave the system half updated
         MaterializedConnector connector = new MaterializedConnector(catalogName, createConnector(catalogName, factory, properties));
 
         ConnectorHandleResolver connectorHandleResolver = connector.getConnector().getHandleResolver()
-                .orElseGet(factory::getHandleResolver);
-        checkArgument(connectorHandleResolver != null, "Connector %s does not have a handle resolver", factory.getName());
+                .orElseGet(factory.getConnectorFactory()::getHandleResolver);
+        checkArgument(connectorHandleResolver != null, "Connector %s does not have a handle resolver", factory);
 
         MaterializedConnector informationSchemaConnector = new MaterializedConnector(
                 createInformationSchemaCatalogName(catalogName),
@@ -322,17 +327,46 @@ public class ConnectorManager
         }
     }
 
-    private Connector createConnector(CatalogName catalogName, ConnectorFactory factory, Map<String, String> properties)
+    private Connector createConnector(CatalogName catalogName, InternalConnectorFactory factory, Map<String, String> properties)
     {
         ConnectorContext context = new ConnectorContextInstance(
                 new ConnectorAwareNodeManager(nodeManager, nodeInfo.getEnvironment(), catalogName),
                 versionEmbedder,
                 new InternalTypeManager(metadataManager),
                 pageSorter,
-                pageIndexerFactory);
+                pageIndexerFactory,
+                factory.getDuplicatePluginClassLoaderFactory());
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
-            return factory.create(catalogName.getCatalogName(), properties, context);
+            return factory.getConnectorFactory().create(catalogName.getCatalogName(), properties, context);
+        }
+    }
+
+    private static class InternalConnectorFactory
+    {
+        private final ConnectorFactory connectorFactory;
+        private final Supplier<ClassLoader> duplicatePluginClassLoaderFactory;
+
+        public InternalConnectorFactory(ConnectorFactory connectorFactory, Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
+        {
+            this.connectorFactory = connectorFactory;
+            this.duplicatePluginClassLoaderFactory = duplicatePluginClassLoaderFactory;
+        }
+
+        public ConnectorFactory getConnectorFactory()
+        {
+            return connectorFactory;
+        }
+
+        public Supplier<ClassLoader> getDuplicatePluginClassLoaderFactory()
+        {
+            return duplicatePluginClassLoaderFactory;
+        }
+
+        @Override
+        public String toString()
+        {
+            return connectorFactory.getName();
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/io/prestosql/connector/ConnectorManager.java
@@ -165,7 +165,6 @@ public class ConnectorManager
         checkState(!stopped.get(), "ConnectorManager is stopped");
         ConnectorFactory existingConnectorFactory = connectorFactories.putIfAbsent(connectorFactory.getName(), connectorFactory);
         checkArgument(existingConnectorFactory == null, "Connector '%s' is already registered", connectorFactory.getName());
-        handleResolver.addConnectorName(connectorFactory.getName(), connectorFactory.getHandleResolver());
     }
 
     public synchronized CatalogName createCatalog(String catalogName, String connectorName, Map<String, String> properties)
@@ -173,6 +172,7 @@ public class ConnectorManager
         requireNonNull(connectorName, "connectorName is null");
         ConnectorFactory connectorFactory = connectorFactories.get(connectorName);
         checkArgument(connectorFactory != null, "No factory for connector '%s'.  Available factories: %s", connectorName, connectorFactories.keySet());
+        handleResolver.addCatalogHandleResolver(catalogName, connectorFactory.getHandleResolver());
         return createCatalog(catalogName, connectorFactory, properties);
     }
 

--- a/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
@@ -89,7 +89,7 @@ public class SystemConnectorModule
         @Inject
         public SystemConnectorRegistrar(ConnectorManager manager, GlobalSystemConnectorFactory globalSystemConnectorFactory)
         {
-            manager.addConnectorFactory(globalSystemConnectorFactory);
+            manager.addConnectorFactory(globalSystemConnectorFactory, globalSystemConnectorFactory.getClass()::getClassLoader);
             manager.createCatalog(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());
         }
     }

--- a/presto-main/src/main/java/io/prestosql/metadata/HandleResolver.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/HandleResolver.java
@@ -63,6 +63,11 @@ public final class HandleResolver
         checkState(existingResolver == null, "Catalog '%s' is already assigned to resolver: %s", catalogName, existingResolver);
     }
 
+    public void removeCatalogHandleResolver(String catalogName)
+    {
+        handleResolvers.remove(catalogName);
+    }
+
     public String getId(ConnectorTableHandle tableHandle)
     {
         return getId(tableHandle, MaterializedHandleResolver::getTableHandleClass);

--- a/presto-main/src/main/java/io/prestosql/metadata/HandleResolver.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/HandleResolver.java
@@ -42,26 +42,25 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.operator.ExchangeOperator.REMOTE_CONNECTOR_ID;
 import static java.util.Objects.requireNonNull;
 
-public class HandleResolver
+public final class HandleResolver
 {
     private final ConcurrentMap<String, MaterializedHandleResolver> handleResolvers = new ConcurrentHashMap<>();
 
     @Inject
     public HandleResolver()
     {
-        handleResolvers.put(REMOTE_CONNECTOR_ID.toString(), new MaterializedHandleResolver(new RemoteHandleResolver()));
-        handleResolvers.put("$system", new MaterializedHandleResolver(new SystemHandleResolver()));
-        handleResolvers.put("$info_schema", new MaterializedHandleResolver(new InformationSchemaHandleResolver()));
-        handleResolvers.put("$empty", new MaterializedHandleResolver(new EmptySplitHandleResolver()));
+        addCatalogHandleResolver(REMOTE_CONNECTOR_ID.toString(), new RemoteHandleResolver());
+        addCatalogHandleResolver("$system", new SystemHandleResolver());
+        addCatalogHandleResolver("$info_schema", new InformationSchemaHandleResolver());
+        addCatalogHandleResolver("$empty", new EmptySplitHandleResolver());
     }
 
-    public void addConnectorName(String name, ConnectorHandleResolver resolver)
+    public void addCatalogHandleResolver(String catalogName, ConnectorHandleResolver resolver)
     {
-        requireNonNull(name, "name is null");
+        requireNonNull(catalogName, "catalogName is null");
         requireNonNull(resolver, "resolver is null");
-        MaterializedHandleResolver existingResolver = handleResolvers.putIfAbsent(name, new MaterializedHandleResolver(resolver));
-        checkState(existingResolver == null || existingResolver.equals(resolver),
-                "Connector '%s' is already assigned to resolver: %s", name, existingResolver);
+        MaterializedHandleResolver existingResolver = handleResolvers.putIfAbsent(catalogName, new MaterializedHandleResolver(resolver));
+        checkState(existingResolver == null, "Catalog '%s' is already assigned to resolver: %s", catalogName, existingResolver);
     }
 
     public String getId(ConnectorTableHandle tableHandle)

--- a/presto-main/src/main/java/io/prestosql/server/PluginClassLoader.java
+++ b/presto-main/src/main/java/io/prestosql/server/PluginClassLoader.java
@@ -59,6 +59,11 @@ class PluginClassLoader
         this.spiResources = ImmutableList.copyOf(spiResources);
     }
 
+    public PluginClassLoader duplicate()
+    {
+        return new PluginClassLoader(ImmutableList.copyOf(getURLs()), spiClassLoader, spiPackages, spiResources);
+    }
+
     @Override
     protected Class<?> loadClass(String name, boolean resolve)
             throws ClassNotFoundException

--- a/presto-main/src/main/java/io/prestosql/server/PluginManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/PluginManager.java
@@ -44,7 +44,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,6 +51,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.metadata.FunctionExtractor.extractFunctions;
@@ -144,25 +144,25 @@ public class PluginManager
             throws Exception
     {
         log.info("-- Loading plugin %s --", plugin);
-        URLClassLoader pluginClassLoader = buildClassLoader(plugin);
+        PluginClassLoader pluginClassLoader = buildClassLoader(plugin);
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader)) {
             loadPlugin(pluginClassLoader);
         }
         log.info("-- Finished loading plugin %s --", plugin);
     }
 
-    private void loadPlugin(URLClassLoader pluginClassLoader)
+    private void loadPlugin(PluginClassLoader pluginClassLoader)
     {
         ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, pluginClassLoader);
         List<Plugin> plugins = ImmutableList.copyOf(serviceLoader);
         checkState(!plugins.isEmpty(), "No service providers of type %s", Plugin.class.getName());
         for (Plugin plugin : plugins) {
             log.info("Installing %s", plugin.getClass().getName());
-            installPlugin(plugin);
+            installPlugin(plugin, pluginClassLoader::duplicate);
         }
     }
 
-    public void installPlugin(Plugin plugin)
+    public void installPlugin(Plugin plugin, Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
     {
         for (BlockEncoding blockEncoding : plugin.getBlockEncodings()) {
             log.info("Registering block encoding %s", blockEncoding.getName());
@@ -181,7 +181,7 @@ public class PluginManager
 
         for (ConnectorFactory connectorFactory : plugin.getConnectorFactories()) {
             log.info("Registering connector %s", connectorFactory.getName());
-            connectorManager.addConnectorFactory(connectorFactory);
+            connectorManager.addConnectorFactory(connectorFactory, duplicatePluginClassLoaderFactory);
         }
 
         for (Class<?> functionClass : plugin.getFunctions()) {
@@ -215,7 +215,7 @@ public class PluginManager
         }
     }
 
-    private URLClassLoader buildClassLoader(String plugin)
+    private PluginClassLoader buildClassLoader(String plugin)
             throws Exception
     {
         File file = new File(plugin);
@@ -228,11 +228,11 @@ public class PluginManager
         return buildClassLoaderFromCoordinates(plugin);
     }
 
-    private URLClassLoader buildClassLoaderFromPom(File pomFile)
+    private PluginClassLoader buildClassLoaderFromPom(File pomFile)
             throws Exception
     {
         List<Artifact> artifacts = resolver.resolvePom(pomFile);
-        URLClassLoader classLoader = createClassLoader(artifacts, pomFile.getPath());
+        PluginClassLoader classLoader = createClassLoader(artifacts, pomFile.getPath());
 
         Artifact artifact = artifacts.get(0);
         Set<String> plugins = discoverPlugins(artifact, classLoader);
@@ -243,7 +243,7 @@ public class PluginManager
         return classLoader;
     }
 
-    private URLClassLoader buildClassLoaderFromDirectory(File dir)
+    private PluginClassLoader buildClassLoaderFromDirectory(File dir)
             throws Exception
     {
         log.info("Classpath for %s:", dir.getName());
@@ -255,7 +255,7 @@ public class PluginManager
         return createClassLoader(urls);
     }
 
-    private URLClassLoader buildClassLoaderFromCoordinates(String coordinates)
+    private PluginClassLoader buildClassLoaderFromCoordinates(String coordinates)
             throws Exception
     {
         Artifact rootArtifact = new DefaultArtifact(coordinates);
@@ -263,7 +263,7 @@ public class PluginManager
         return createClassLoader(artifacts, rootArtifact.toString());
     }
 
-    private URLClassLoader createClassLoader(List<Artifact> artifacts, String name)
+    private PluginClassLoader createClassLoader(List<Artifact> artifacts, String name)
             throws IOException
     {
         log.info("Classpath for %s:", name);
@@ -279,7 +279,7 @@ public class PluginManager
         return createClassLoader(urls);
     }
 
-    private URLClassLoader createClassLoader(List<URL> urls)
+    private PluginClassLoader createClassLoader(List<URL> urls)
     {
         ClassLoader parent = getClass().getClassLoader();
         return new PluginClassLoader(urls, parent, SPI_PACKAGES);

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -326,7 +326,7 @@ public class TestingPrestoServer
 
     public void installPlugin(Plugin plugin)
     {
-        pluginManager.installPlugin(plugin);
+        pluginManager.installPlugin(plugin, plugin.getClass()::getClassLoader);
     }
 
     public DispatchManager getDispatchManager()

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -361,7 +361,7 @@ public class LocalQueryRunner
                 new EventListenerManager(),
                 new SessionPropertyDefaults(nodeInfo));
 
-        connectorManager.addConnectorFactory(globalSystemConnectorFactory);
+        connectorManager.addConnectorFactory(globalSystemConnectorFactory, globalSystemConnectorFactory.getClass()::getClassLoader);
         connectorManager.createCatalog(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());
 
         // add bogus connector for testing session properties
@@ -528,14 +528,14 @@ public class LocalQueryRunner
     public void createCatalog(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties)
     {
         nodeManager.addCurrentNodeConnector(new CatalogName(catalogName));
-        connectorManager.addConnectorFactory(connectorFactory);
+        connectorManager.addConnectorFactory(connectorFactory, connectorFactory.getClass()::getClassLoader);
         connectorManager.createCatalog(catalogName, connectorFactory.getName(), properties);
     }
 
     @Override
     public void installPlugin(Plugin plugin)
     {
-        pluginManager.installPlugin(plugin);
+        pluginManager.installPlugin(plugin, plugin.getClass()::getClassLoader);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorContext.java
@@ -33,7 +33,7 @@ import io.prestosql.version.EmbedVersion;
 
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 
-public class TestingConnectorContext
+public final class TestingConnectorContext
         implements ConnectorContext
 {
     private final NodeManager nodeManager = new ConnectorAwareNodeManager(new InMemoryNodeManager(), "testenv", new CatalogName("test"));

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorContext.java
@@ -78,4 +78,10 @@ public final class TestingConnectorContext
     {
         return pageIndexerFactory;
     }
+
+    @Override
+    public ClassLoader duplicatePluginClassLoader()
+    {
+        return getClass().getClassLoader();
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/io/prestosql/server/remotetask/TestHttpRemoteTask.java
@@ -257,7 +257,7 @@ public class TestHttpRemoteTask
                 .quiet()
                 .initialize();
         HandleResolver handleResolver = injector.getInstance(HandleResolver.class);
-        handleResolver.addConnectorName("test", new TestingHandleResolver());
+        handleResolver.addCatalogHandleResolver("test", new TestingHandleResolver());
         return injector.getInstance(HttpRemoteTaskFactory.class);
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/Connector.java
@@ -18,6 +18,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
@@ -25,6 +26,15 @@ import static java.util.Collections.emptySet;
 
 public interface Connector
 {
+    /**
+     * Get handle resolver for this connector instance. If {@code Optional.empty()} is returned,
+     * {@link ConnectorFactory#getHandleResolver()} is used instead.
+     */
+    default Optional<ConnectorHandleResolver> getHandleResolver()
+    {
+        return Optional.empty();
+    }
+
     ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly);
 
     /**

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorContext.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorContext.java
@@ -45,4 +45,9 @@ public interface ConnectorContext
     {
         throw new UnsupportedOperationException();
     }
+
+    default ClassLoader duplicatePluginClassLoader()
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorFactory.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorFactory.java
@@ -19,7 +19,15 @@ public interface ConnectorFactory
 {
     String getName();
 
-    ConnectorHandleResolver getHandleResolver();
+    /**
+     * Gets the default handle resolver for connectors created by this factory.
+     * Must return a non-null result when {@link Connector#getHandleResolver()}
+     * is not implemented (or it returns empty result).
+     */
+    default ConnectorHandleResolver getHandleResolver()
+    {
+        throw new UnsupportedOperationException();
+    }
 
     Connector create(String catalogName, Map<String, String> config, ConnectorContext context);
 }


### PR DESCRIPTION
Relates to #760
Fixes  #978
Fixes prestosql/presto-hadoop-apache#10