### PR TITLE
Populate QueryStatistics wallTime using QueryStats elapsedTime 

### DIFF
--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -224,7 +224,7 @@ public class QueryMonitor
         QueryStats queryStats = queryInfo.getQueryStats();
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
-                ofMillis(queryStats.getTotalScheduledTime().toMillis()),
+                ofMillis(queryStats.getElapsedTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
                 Optional.of(ofMillis(queryStats.getResourceWaitingTime().toMillis())),
                 Optional.of(ofMillis(queryStats.getAnalysisTime().toMillis())),


### PR DESCRIPTION
Noticed that QueryStatistics wallTime was populated using `queryStats.getTotalScheduledTime()` instead of `queryStats.getElapsedTime()`. This PR is to correct that.