### PR TITLE
Dereference projections and predicate pushdown in Hive

### DIFF
--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
@@ -211,6 +211,12 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testApplyProjection()
+    {
+        // Alluxio metastore does not support create/delete operations
+    }
+
+    @Override
     public void testPreferredInsertLayout()
     {
         // Alluxio metastore does not support insert layout operations

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -248,6 +248,13 @@
         <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveApplyProjectionUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveApplyProjectionUtil.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.expression.FieldDereference;
+import io.prestosql.spi.expression.Variable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+final class HiveApplyProjectionUtil
+{
+    private HiveApplyProjectionUtil() {}
+
+    public static List<ConnectorExpression> extractSupportedProjectedColumns(ConnectorExpression expression)
+    {
+        requireNonNull(expression, "expression is null");
+        ImmutableList.Builder<ConnectorExpression> supportedSubExpressions = ImmutableList.builder();
+        fillSupportedProjectedColumns(expression, supportedSubExpressions);
+        return supportedSubExpressions.build();
+    }
+
+    private static void fillSupportedProjectedColumns(ConnectorExpression expression, ImmutableList.Builder<ConnectorExpression> supportedSubExpressions)
+    {
+        if (isPushDownSupported(expression)) {
+            supportedSubExpressions.add(expression);
+            return;
+        }
+
+        // If the whole expression is not supported, look for a partially supported projection
+        if (expression instanceof FieldDereference) {
+            fillSupportedProjectedColumns(((FieldDereference) expression).getTarget(), supportedSubExpressions);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isPushDownSupported(ConnectorExpression expression)
+    {
+        return expression instanceof Variable ||
+            (expression instanceof FieldDereference && isPushDownSupported(((FieldDereference) expression).getTarget()));
+    }
+
+    public static ProjectedColumnRepresentation createProjectedColumnRepresentation(ConnectorExpression expression)
+    {
+        ImmutableList.Builder<Integer> ordinals = ImmutableList.builder();
+
+        Variable target;
+        while (true) {
+            if (expression instanceof Variable) {
+                target = (Variable) expression;
+                break;
+            }
+            else if (expression instanceof FieldDereference) {
+                FieldDereference dereference = (FieldDereference) expression;
+                ordinals.add(dereference.getField());
+                expression = dereference.getTarget();
+            }
+            else {
+                throw new IllegalArgumentException("expression is not a valid dereference chain");
+            }
+        }
+
+        return new ProjectedColumnRepresentation(target, ordinals.build().reverse());
+    }
+
+    /**
+     * Replace all connector expressions with variables as given by {@param expressionToVariableMappings} in a top down manner.
+     * i.e. if the replacement occurs for the parent, the children will not be visited.
+     */
+    public static ConnectorExpression replaceWithNewVariables(ConnectorExpression expression, Map<ConnectorExpression, Variable> expressionToVariableMappings)
+    {
+        if (expressionToVariableMappings.containsKey(expression)) {
+            return expressionToVariableMappings.get(expression);
+        }
+
+        if (expression instanceof FieldDereference) {
+            ConnectorExpression newTarget = replaceWithNewVariables(((FieldDereference) expression).getTarget(), expressionToVariableMappings);
+            return new FieldDereference(expression.getType(), newTarget, ((FieldDereference) expression).getField());
+        }
+
+        return expression;
+    }
+
+    /**
+     * Returns the assignment key corresponding to the column represented by {@param projectedColumn} in the {@param assignments}, if one exists.
+     * The variable in the {@param projectedColumn} can itself be a representation of another projected column. For example,
+     * say a projected column representation has variable "x" and a dereferenceIndices=[0]. "x" can in-turn map to a projected
+     * column handle with base="a" and [1, 2] as dereference indices. Then the method searches for a column handle in
+     * {@param assignments} with base="a" and dereferenceIndices=[1, 2, 0].
+     */
+    public static Optional<String> find(Map<String, ColumnHandle> assignments, ProjectedColumnRepresentation projectedColumn)
+    {
+        HiveColumnHandle variableColumn = (HiveColumnHandle) assignments.get(projectedColumn.getVariable().getName());
+
+        if (variableColumn == null) {
+            return Optional.empty();
+        }
+
+        String baseColumnName = variableColumn.getBaseColumnName();
+
+        List<Integer> variableColumnIndices = variableColumn.getHiveColumnProjectionInfo()
+                .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                .orElse(ImmutableList.of());
+
+        List<Integer> projectionIndices = ImmutableList.<Integer>builder()
+                .addAll(variableColumnIndices)
+                .addAll(projectedColumn.getDereferenceIndices())
+                .build();
+
+        for (Map.Entry<String, ColumnHandle> entry : assignments.entrySet()) {
+            HiveColumnHandle column = (HiveColumnHandle) entry.getValue();
+            if (column.getBaseColumnName().equals(baseColumnName) &&
+                    column.getHiveColumnProjectionInfo()
+                        .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                        .orElse(ImmutableList.of())
+                        .equals(projectionIndices)) {
+                return Optional.of(entry.getKey());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static class ProjectedColumnRepresentation
+    {
+        private final Variable variable;
+        private final List<Integer> dereferenceIndices;
+
+        public ProjectedColumnRepresentation(Variable variable, List<Integer> dereferenceIndices)
+        {
+            this.variable = requireNonNull(variable, "variable is null");
+            this.dereferenceIndices = ImmutableList.copyOf(requireNonNull(dereferenceIndices, "dereferenceIndices is null"));
+        }
+
+        public Variable getVariable()
+        {
+            return variable;
+        }
+
+        public List<Integer> getDereferenceIndices()
+        {
+            return dereferenceIndices;
+        }
+
+        public boolean isVariable()
+        {
+            return dereferenceIndices.isEmpty();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+            ProjectedColumnRepresentation that = (ProjectedColumnRepresentation) obj;
+            return Objects.equals(variable, that.variable) &&
+                    Objects.equals(dereferenceIndices, that.dereferenceIndices);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(variable, dereferenceIndices);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveBucketHandle.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveBucketHandle.java
@@ -20,6 +20,8 @@ import io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -41,6 +43,7 @@ public class HiveBucketHandle
             @JsonProperty("readBucketCount") int readBucketCount)
     {
         this.columns = requireNonNull(columns, "columns is null");
+        columns.forEach(column -> checkArgument(column.isBaseColumn(), format("projected column %s is not allowed for bucketing", column)));
         this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
         this.tableBucketCount = tableBucketCount;
         this.readBucketCount = readBucketCount;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveCoercionRecordCursor.java
@@ -74,8 +74,8 @@ public class HiveCoercionRecordCursor
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
 
-            if (columnMapping.getCoercionFrom().isPresent()) {
-                coercers[columnIndex] = createCoercer(typeManager, columnMapping.getCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType(), bridgingRecordCursor);
+            if (columnMapping.getBaseTypeCoercionFrom().isPresent()) {
+                coercers[columnIndex] = createCoercer(typeManager, columnMapping.getBaseTypeCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType(), bridgingRecordCursor);
             }
         }
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveColumnProjectionInfo.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveColumnProjectionInfo.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class HiveColumnProjectionInfo
+{
+    private final List<Integer> dereferenceIndices;
+    private final List<String> dereferenceNames;
+    private final HiveType hiveType;
+    private final Type type;
+    private final String partialName;
+
+    @JsonCreator
+    public HiveColumnProjectionInfo(
+            @JsonProperty("dereferenceIndices") List<Integer> dereferenceIndices,
+            @JsonProperty("dereferenceNames") List<String> dereferenceNames,
+            @JsonProperty("hiveType") HiveType hiveType,
+            @JsonProperty("type") Type type)
+    {
+        this.dereferenceIndices = requireNonNull(dereferenceIndices, "dereferenceIndices is null");
+        this.dereferenceNames = requireNonNull(dereferenceNames, "dereferenceNames is null");
+        checkArgument(dereferenceIndices.size() > 0, "dereferenceIndices should not be empty");
+        checkArgument(dereferenceIndices.size() == dereferenceNames.size(), "dereferenceIndices and dereferenceNames should have the same sizes");
+
+        this.hiveType = requireNonNull(hiveType, "hiveType is null");
+        this.type = requireNonNull(type, "type is null");
+
+        this.partialName = generatePartialName(dereferenceNames);
+    }
+
+    public String getPartialName()
+    {
+        return partialName;
+    }
+
+    @JsonProperty
+    public List<Integer> getDereferenceIndices()
+    {
+        return dereferenceIndices;
+    }
+
+    @JsonProperty
+    public List<String> getDereferenceNames()
+    {
+        return dereferenceNames;
+    }
+
+    @JsonProperty
+    public HiveType getHiveType()
+    {
+        return hiveType;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(dereferenceIndices, dereferenceNames, hiveType, type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        HiveColumnProjectionInfo other = (HiveColumnProjectionInfo) obj;
+        return Objects.equals(this.dereferenceIndices, other.dereferenceIndices) &&
+                Objects.equals(this.dereferenceNames, other.dereferenceNames) &&
+                Objects.equals(this.hiveType, other.hiveType) &&
+                Objects.equals(this.type, other.type);
+    }
+
+    public static String generatePartialName(List<String> dereferenceNames)
+    {
+        return dereferenceNames.stream()
+                .map(name -> "#" + name)
+                .collect(Collectors.joining());
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -29,6 +29,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.HiveApplyProjectionUtil.ProjectedColumnRepresentation;
 import io.prestosql.plugin.hive.LocationService.WriteInfo;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.Column;
@@ -65,11 +66,15 @@ import io.prestosql.spi.connector.Constraint;
 import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.DiscretePredicates;
 import io.prestosql.spi.connector.InMemoryRecordSet;
+import io.prestosql.spi.connector.ProjectionApplicationResult;
+import io.prestosql.spi.connector.ProjectionApplicationResult.Assignment;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.connector.ViewNotFoundException;
+import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.expression.Variable;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.NullableValue;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -101,6 +106,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -126,6 +132,9 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Streams.stream;
 import static io.prestosql.plugin.hive.HiveAnalyzeProperties.getColumnNames;
 import static io.prestosql.plugin.hive.HiveAnalyzeProperties.getPartitionList;
+import static io.prestosql.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.prestosql.plugin.hive.HiveApplyProjectionUtil.find;
+import static io.prestosql.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariables;
 import static io.prestosql.plugin.hive.HiveBasicStatistics.createEmptyStatistics;
 import static io.prestosql.plugin.hive.HiveBasicStatistics.createZeroStatistics;
 import static io.prestosql.plugin.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
@@ -1915,6 +1924,100 @@ public class HiveMetadata
                 }
             }
         }
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle handle,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        // Create projected column representations for supported sub expressions. Simple column references and chain of
+        // dereferences on a variable are supported right now.
+        Set<ConnectorExpression> projectedExpressions = projections.stream()
+                .flatMap(expression -> extractSupportedProjectedColumns(expression).stream())
+                .collect(toImmutableSet());
+
+        Map<ConnectorExpression, ProjectedColumnRepresentation> columnProjections = projectedExpressions.stream()
+                .collect(toImmutableMap(Function.identity(), HiveApplyProjectionUtil::createProjectedColumnRepresentation));
+
+        // No pushdown required if all references are simple variables
+        if (columnProjections.values().stream().allMatch(ProjectedColumnRepresentation::isVariable)) {
+            return Optional.empty();
+        }
+
+        Map<String, Assignment> newAssignments = new HashMap<>();
+        ImmutableMap.Builder<ConnectorExpression, Variable> expressionToVariableMappings = ImmutableMap.builder();
+
+        for (Map.Entry<ConnectorExpression, ProjectedColumnRepresentation> entry : columnProjections.entrySet()) {
+            ConnectorExpression expression = entry.getKey();
+            ProjectedColumnRepresentation projectedColumn = entry.getValue();
+
+            ColumnHandle projectedColumnHandle;
+            String projectedColumnName;
+
+            // See if input already contains a columnhandle for this projected column, avoid creating duplicates.
+            Optional<String> existingColumn = find(assignments, projectedColumn);
+
+            if (existingColumn.isPresent()) {
+                projectedColumnName = existingColumn.get();
+                projectedColumnHandle = assignments.get(projectedColumnName);
+            }
+            else {
+                // Create a new column handle
+                HiveColumnHandle oldColumnHandle = (HiveColumnHandle) assignments.get(projectedColumn.getVariable().getName());
+                projectedColumnHandle = createProjectedColumnHandle(oldColumnHandle, projectedColumn.getDereferenceIndices());
+                projectedColumnName = ((HiveColumnHandle) projectedColumnHandle).getName();
+            }
+
+            Variable projectedColumnVariable = new Variable(projectedColumnName, expression.getType());
+            Assignment newAssignment = new Assignment(projectedColumnName, projectedColumnHandle, expression.getType());
+            newAssignments.put(projectedColumnName, newAssignment);
+
+            expressionToVariableMappings.put(expression, projectedColumnVariable);
+        }
+
+        // Modify projections to refer to new variables
+        List<ConnectorExpression> newProjections = projections.stream()
+                .map(expression -> replaceWithNewVariables(expression, expressionToVariableMappings.build()))
+                .collect(toImmutableList());
+
+        List<Assignment> outputAssignments = newAssignments.values().stream().collect(toImmutableList());
+        return Optional.of(new ProjectionApplicationResult<>(handle, newProjections, outputAssignments));
+    }
+
+    private HiveColumnHandle createProjectedColumnHandle(HiveColumnHandle column, List<Integer> indices)
+    {
+        HiveType oldHiveType = column.getHiveType();
+        HiveType newHiveType = oldHiveType.getHiveTypeForDereferences(indices).get();
+
+        HiveColumnProjectionInfo columnProjectionInfo = new HiveColumnProjectionInfo(
+                // Merge indices
+                ImmutableList.<Integer>builder()
+                    .addAll(column.getHiveColumnProjectionInfo()
+                        .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                        .orElse(ImmutableList.of()))
+                    .addAll(indices)
+                    .build(),
+                // Merge names
+                ImmutableList.<String>builder()
+                    .addAll(column.getHiveColumnProjectionInfo()
+                        .map(HiveColumnProjectionInfo::getDereferenceNames)
+                        .orElse(ImmutableList.of()))
+                    .addAll(oldHiveType.getHiveDereferenceNames(indices))
+                    .build(),
+                newHiveType,
+                newHiveType.getType(typeManager));
+
+        return new HiveColumnHandle(
+                column.getBaseColumnName(),
+                column.getBaseHiveColumnIndex(),
+                column.getBaseHiveType(),
+                column.getBaseType(),
+                Optional.of(columnProjectionInfo),
+                column.getColumnType(),
+                column.getComment());
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -135,6 +135,7 @@ import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static io.prestosql.plugin.hive.HiveColumnHandle.FILE_MODIFIED_TIME_COLUMN_NAME;
 import static io.prestosql.plugin.hive.HiveColumnHandle.FILE_SIZE_COLUMN_NAME;
 import static io.prestosql.plugin.hive.HiveColumnHandle.PATH_COLUMN_NAME;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveColumnHandle.updateRowIdHandle;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DETECTED;
@@ -2336,11 +2337,11 @@ public class HiveMetadata
             else {
                 columnType = REGULAR;
             }
-            columnHandles.add(new HiveColumnHandle(
+            columnHandles.add(createBaseColumn(
                     column.getName(),
+                    ordinal,
                     toHiveType(typeTranslator, column.getType()),
                     column.getType(),
-                    ordinal,
                     columnType,
                     Optional.ofNullable(column.getComment())));
             ordinal++;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import static java.util.Objects.requireNonNull;
+
 public interface HivePageSourceFactory
 {
-    Optional<? extends ConnectorPageSource> createPageSource(
+    Optional<ReaderPageSourceWithProjections> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -38,4 +40,39 @@ public interface HivePageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<DeleteDeltaLocations> deleteDeltaLocations);
+
+    /**
+     * A wrapper class for
+     * - delegate reader page source and
+     * - projection information for columns to be returned by the delegate
+     *
+     * Empty {@param projectedReaderColumns} indicates that the delegate page source reads the exact same columns provided to
+     * it in {@link HivePageSourceFactory#createPageSource}
+     */
+    class ReaderPageSourceWithProjections
+    {
+        private final ConnectorPageSource connectorPageSource;
+        private final Optional<ReaderProjections> projectedReaderColumns;
+
+        public ReaderPageSourceWithProjections(ConnectorPageSource connectorPageSource, Optional<ReaderProjections> projectedReaderColumns)
+        {
+            this.connectorPageSource = requireNonNull(connectorPageSource, "connectorPageSource is null");
+            this.projectedReaderColumns = requireNonNull(projectedReaderColumns, "projectedReaderColumns is null");
+        }
+
+        public ConnectorPageSource getConnectorPageSource()
+        {
+            return connectorPageSource;
+        }
+
+        public Optional<ReaderProjections> getProjectedReaderColumns()
+        {
+            return projectedReaderColumns;
+        }
+
+        public static ReaderPageSourceWithProjections noProjectionAdaptation(ConnectorPageSource connectorPageSource)
+        {
+            return new ReaderPageSourceWithProjections(connectorPageSource, Optional.empty());
+        }
+    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -16,6 +16,8 @@ package io.prestosql.plugin.hive;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
+import io.prestosql.plugin.hive.HiveRecordCursorProvider.ReaderRecordCursorWithProjections;
 import io.prestosql.plugin.hive.HiveSplit.BucketConversion;
 import io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -37,6 +39,7 @@ import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +142,7 @@ public class HivePageSourceProvider
             long fileModifiedTime,
             Properties schema,
             TupleDomain<HiveColumnHandle> effectivePredicate,
-            List<HiveColumnHandle> hiveColumns,
+            List<HiveColumnHandle> columns,
             List<HivePartitionKey> partitionKeys,
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager,
@@ -154,7 +157,7 @@ public class HivePageSourceProvider
 
         List<ColumnMapping> columnMappings = ColumnMapping.buildColumnMappings(
                 partitionKeys,
-                hiveColumns,
+                columns,
                 bucketConversion.map(BucketConversion::getBucketColumnHandles).orElse(ImmutableList.of()),
                 tableToPartitionMapping,
                 path,
@@ -163,25 +166,12 @@ public class HivePageSourceProvider
                 fileModifiedTime);
         List<ColumnMapping> regularAndInterimColumnMappings = ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);
 
-        Optional<BucketAdaptation> bucketAdaptation = bucketConversion.map(conversion -> {
-            Map<Integer, ColumnMapping> hiveIndexToBlockIndex = uniqueIndex(regularAndInterimColumnMappings, columnMapping -> columnMapping.getHiveColumnHandle().getHiveColumnIndex());
-            int[] bucketColumnIndices = conversion.getBucketColumnHandles().stream()
-                    .mapToInt(columnHandle -> hiveIndexToBlockIndex.get(columnHandle.getHiveColumnIndex()).getIndex())
-                    .toArray();
-            List<HiveType> bucketColumnHiveTypes = conversion.getBucketColumnHandles().stream()
-                    .map(columnHandle -> hiveIndexToBlockIndex.get(columnHandle.getHiveColumnIndex()).getHiveColumnHandle().getHiveType())
-                    .collect(toImmutableList());
-            return new BucketAdaptation(
-                    bucketColumnIndices,
-                    bucketColumnHiveTypes,
-                    conversion.getBucketingVersion(),
-                    conversion.getTableBucketCount(),
-                    conversion.getPartitionBucketCount(),
-                    bucketNumber.getAsInt());
-        });
+        Optional<BucketAdaptation> bucketAdaptation = createBucketAdaptation(bucketConversion, bucketNumber, regularAndInterimColumnMappings);
 
         for (HivePageSourceFactory pageSourceFactory : pageSourceFactories) {
-            Optional<? extends ConnectorPageSource> pageSource = pageSourceFactory.createPageSource(
+            List<HiveColumnHandle> desiredColumns = toColumnHandles(regularAndInterimColumnMappings, true, typeManager);
+
+            Optional<ReaderPageSourceWithProjections> readerWithProjections = pageSourceFactory.createPageSource(
                     configuration,
                     session,
                     path,
@@ -189,18 +179,27 @@ public class HivePageSourceProvider
                     length,
                     fileSize,
                     schema,
-                    toColumnHandles(regularAndInterimColumnMappings, true, typeManager),
+                    desiredColumns,
                     effectivePredicate,
                     hiveStorageTimeZone,
                     deleteDeltaLocations);
-            if (pageSource.isPresent()) {
-                return Optional.of(
-                        new HivePageSource(
-                                columnMappings,
-                                bucketAdaptation,
-                                hiveStorageTimeZone,
-                                typeManager,
-                                pageSource.get()));
+
+            if (readerWithProjections.isPresent()) {
+                ConnectorPageSource pageSource = readerWithProjections.get().getConnectorPageSource();
+
+                Optional<ReaderProjections> readerProjections = readerWithProjections.get().getProjectedReaderColumns();
+                Optional<ReaderProjectionsAdapter> adapter = Optional.empty();
+                if (readerProjections.isPresent()) {
+                    adapter = Optional.of(new ReaderProjectionsAdapter(desiredColumns, readerProjections.get()));
+                }
+
+                return Optional.of(new HivePageSource(
+                        columnMappings,
+                        bucketAdaptation,
+                        adapter,
+                        hiveStorageTimeZone,
+                        typeManager,
+                        pageSource));
             }
         }
 
@@ -208,7 +207,8 @@ public class HivePageSourceProvider
             // GenericHiveRecordCursor will automatically do the coercion without HiveCoercionRecordCursor
             boolean doCoercion = !(provider instanceof GenericHiveRecordCursorProvider);
 
-            Optional<RecordCursor> cursor = provider.createRecordCursor(
+            List<HiveColumnHandle> desiredColumns = toColumnHandles(regularAndInterimColumnMappings, doCoercion, typeManager);
+            Optional<ReaderRecordCursorWithProjections> readerWithProjections = provider.createRecordCursor(
                     configuration,
                     session,
                     path,
@@ -216,14 +216,20 @@ public class HivePageSourceProvider
                     length,
                     fileSize,
                     schema,
-                    toColumnHandles(regularAndInterimColumnMappings, doCoercion, typeManager),
+                    desiredColumns,
                     effectivePredicate,
                     hiveStorageTimeZone,
                     typeManager,
                     s3SelectPushdownEnabled);
 
-            if (cursor.isPresent()) {
-                RecordCursor delegate = cursor.get();
+            if (readerWithProjections.isPresent()) {
+                RecordCursor delegate = readerWithProjections.get().getRecordCursor();
+                Optional<ReaderProjections> projections = readerWithProjections.get().getProjectedReaderColumns();
+
+                if (projections.isPresent()) {
+                    ReaderProjectionsAdapter projectionsAdapter = new ReaderProjectionsAdapter(desiredColumns, projections.get());
+                    delegate = new HiveReaderProjectionsAdaptingRecordCursor(delegate, projectionsAdapter);
+                }
 
                 checkArgument(!deleteDeltaLocations.isPresent(), "Delete delta is not supported");
 
@@ -248,7 +254,7 @@ public class HivePageSourceProvider
                         columnMappings,
                         hiveStorageTimeZone,
                         delegate);
-                List<Type> columnTypes = hiveColumns.stream()
+                List<Type> columnTypes = columns.stream()
                         .map(HiveColumnHandle::getType)
                         .collect(toList());
 
@@ -268,33 +274,45 @@ public class HivePageSourceProvider
          * ordinal of this column in the underlying page source or record cursor
          */
         private final OptionalInt index;
-        private final Optional<HiveType> coercionFrom;
+        private final Optional<HiveType> baseTypeCoercionFrom;
 
-        public static ColumnMapping regular(HiveColumnHandle hiveColumnHandle, int index, Optional<HiveType> coerceFrom)
+        public static ColumnMapping regular(HiveColumnHandle hiveColumnHandle, int index, Optional<HiveType> baseTypeCoercionFrom)
         {
             checkArgument(hiveColumnHandle.getColumnType() == REGULAR);
-            return new ColumnMapping(ColumnMappingKind.REGULAR, hiveColumnHandle, Optional.empty(), OptionalInt.of(index), coerceFrom);
+            return new ColumnMapping(ColumnMappingKind.REGULAR, hiveColumnHandle, Optional.empty(), OptionalInt.of(index), baseTypeCoercionFrom);
         }
 
-        public static ColumnMapping prefilled(HiveColumnHandle hiveColumnHandle, String prefilledValue, Optional<HiveType> coerceFrom)
+        public static ColumnMapping prefilled(HiveColumnHandle hiveColumnHandle, String prefilledValue, Optional<HiveType> baseTypeCoercionFrom)
         {
             checkArgument(hiveColumnHandle.getColumnType() == PARTITION_KEY || hiveColumnHandle.getColumnType() == SYNTHESIZED);
-            return new ColumnMapping(ColumnMappingKind.PREFILLED, hiveColumnHandle, Optional.of(prefilledValue), OptionalInt.empty(), coerceFrom);
+            checkArgument(hiveColumnHandle.isBaseColumn(), "prefilled values not supported for projected columns");
+            return new ColumnMapping(ColumnMappingKind.PREFILLED, hiveColumnHandle, Optional.of(prefilledValue), OptionalInt.empty(), baseTypeCoercionFrom);
         }
 
-        public static ColumnMapping interim(HiveColumnHandle hiveColumnHandle, int index)
+        public static ColumnMapping interim(HiveColumnHandle hiveColumnHandle, int index, Optional<HiveType> baseTypeCoercionFrom)
         {
             checkArgument(hiveColumnHandle.getColumnType() == REGULAR);
-            return new ColumnMapping(ColumnMappingKind.INTERIM, hiveColumnHandle, Optional.empty(), OptionalInt.of(index), Optional.empty());
+            return new ColumnMapping(ColumnMappingKind.INTERIM, hiveColumnHandle, Optional.empty(), OptionalInt.of(index), baseTypeCoercionFrom);
         }
 
-        private ColumnMapping(ColumnMappingKind kind, HiveColumnHandle hiveColumnHandle, Optional<String> prefilledValue, OptionalInt index, Optional<HiveType> coerceFrom)
+        public static ColumnMapping empty(HiveColumnHandle hiveColumnHandle)
+        {
+            checkArgument(hiveColumnHandle.getColumnType() == REGULAR);
+            return new ColumnMapping(ColumnMappingKind.EMPTY, hiveColumnHandle, Optional.empty(), OptionalInt.empty(), Optional.empty());
+        }
+
+        private ColumnMapping(
+                ColumnMappingKind kind,
+                HiveColumnHandle hiveColumnHandle,
+                Optional<String> prefilledValue,
+                OptionalInt index,
+                Optional<HiveType> baseTypeCoercionFrom)
         {
             this.kind = requireNonNull(kind, "kind is null");
             this.hiveColumnHandle = requireNonNull(hiveColumnHandle, "hiveColumnHandle is null");
             this.prefilledValue = requireNonNull(prefilledValue, "prefilledValue is null");
             this.index = requireNonNull(index, "index is null");
-            this.coercionFrom = requireNonNull(coerceFrom, "coerceFrom is null");
+            this.baseTypeCoercionFrom = requireNonNull(baseTypeCoercionFrom, "baseTypeCoercionFrom is null");
         }
 
         public ColumnMappingKind getKind()
@@ -319,9 +337,9 @@ public class HivePageSourceProvider
             return index.getAsInt();
         }
 
-        public Optional<HiveType> getCoercionFrom()
+        public Optional<HiveType> getBaseTypeCoercionFrom()
         {
-            return coercionFrom;
+            return baseTypeCoercionFrom;
         }
 
         public static List<ColumnMapping> buildColumnMappings(
@@ -335,35 +353,70 @@ public class HivePageSourceProvider
                 long fileModifiedTime)
         {
             Map<String, HivePartitionKey> partitionKeysByName = uniqueIndex(partitionKeys, HivePartitionKey::getName);
-            int regularIndex = 0;
-            Set<Integer> regularColumnIndices = new HashSet<>();
+
+            // Maintain state about hive columns added to the mapping as we iterate (for validation)
+            Set<Integer> baseColumnHiveIndices = new HashSet<>();
+            Map<Integer, Set<Optional<HiveColumnProjectionInfo>>> projectionsForColumn = new HashMap<>();
+
             ImmutableList.Builder<ColumnMapping> columnMappings = ImmutableList.builder();
+            int regularIndex = 0;
+
             for (HiveColumnHandle column : columns) {
-                Optional<HiveType> coercionFrom = tableToPartitionMapping.getCoercion(column.getHiveColumnIndex());
+                Optional<HiveType> baseTypeCoercionFrom = tableToPartitionMapping.getCoercion(column.getBaseHiveColumnIndex());
+
                 if (column.getColumnType() == REGULAR) {
-                    checkArgument(regularColumnIndices.add(column.getHiveColumnIndex()), "duplicate hiveColumnIndex in columns list");
-                    columnMappings.add(regular(column, regularIndex, coercionFrom));
-                    regularIndex++;
+                    if (column.isBaseColumn()) {
+                        baseColumnHiveIndices.add(column.getBaseHiveColumnIndex());
+                    }
+
+                    checkArgument(
+                            projectionsForColumn.computeIfAbsent(column.getBaseHiveColumnIndex(), HashSet::new).add(column.getHiveColumnProjectionInfo()),
+                            "duplicate column in columns list");
+
+                    // Add regular mapping if projection is valid for partition schema, otherwise add an empty mapping
+                    if (!baseTypeCoercionFrom.isPresent()
+                            || projectionValidForType(baseTypeCoercionFrom.get(), column.getHiveColumnProjectionInfo())) {
+                        columnMappings.add(regular(column, regularIndex, baseTypeCoercionFrom));
+                        regularIndex++;
+                    }
+                    else {
+                        columnMappings.add(empty(column));
+                    }
                 }
                 else {
                     columnMappings.add(prefilled(
                             column,
                             getPrefilledColumnValue(column, partitionKeysByName.get(column.getName()), path, bucketNumber, fileSize, fileModifiedTime),
-                            coercionFrom));
+                            baseTypeCoercionFrom));
                 }
             }
+
             for (HiveColumnHandle column : requiredInterimColumns) {
                 checkArgument(column.getColumnType() == REGULAR);
-                if (regularColumnIndices.contains(column.getHiveColumnIndex())) {
+                checkArgument(column.isBaseColumn(), "bucketed columns should be base columns");
+                if (baseColumnHiveIndices.contains(column.getBaseHiveColumnIndex())) {
                     continue; // This column exists in columns. Do not add it again.
                 }
-                // If coercion does not affect bucket number calculation, coercion doesn't need to be applied here.
-                // Otherwise, read of this partition should not be allowed.
-                // (Alternatively, the partition could be read as an unbucketed partition. This is not implemented.)
-                columnMappings.add(interim(column, regularIndex));
+
+                if (projectionsForColumn.containsKey(column.getBaseHiveColumnIndex())) {
+                    columnMappings.add(interim(column, regularIndex, tableToPartitionMapping.getCoercion(column.getBaseHiveColumnIndex())));
+                }
+                else {
+                    // If coercion does not affect bucket number calculation, coercion doesn't need to be applied here.
+                    // Otherwise, read of this partition should not be allowed.
+                    // (Alternatively, the partition could be read as an unbucketed partition. This is not implemented.)
+                    columnMappings.add(interim(column, regularIndex, Optional.empty()));
+                }
                 regularIndex++;
             }
             return columnMappings.build();
+        }
+
+        private static boolean projectionValidForType(HiveType baseType, Optional<HiveColumnProjectionInfo> projection)
+        {
+            List<Integer> dereferences = projection.map(HiveColumnProjectionInfo::getDereferenceIndices).orElse(ImmutableList.of());
+            Optional<HiveType> targetType = baseType.getHiveTypeForDereferences(dereferences);
+            return targetType.isPresent();
         }
 
         public static List<ColumnMapping> extractRegularAndInterimColumnMappings(List<ColumnMapping> columnMappings)
@@ -378,16 +431,28 @@ public class HivePageSourceProvider
             return regularColumnMappings.stream()
                     .map(columnMapping -> {
                         HiveColumnHandle columnHandle = columnMapping.getHiveColumnHandle();
-                        if (!doCoercion || !columnMapping.getCoercionFrom().isPresent()) {
+                        if (!doCoercion || !columnMapping.getBaseTypeCoercionFrom().isPresent()) {
                             return columnHandle;
                         }
+                        HiveType fromHiveTypeBase = columnMapping.getBaseTypeCoercionFrom().get();
+
+                        Optional<HiveColumnProjectionInfo> newColumnProjectionInfo = columnHandle.getHiveColumnProjectionInfo().map(projectedColumn -> {
+                            HiveType fromHiveType = fromHiveTypeBase.getHiveTypeForDereferences(projectedColumn.getDereferenceIndices()).get();
+                            return new HiveColumnProjectionInfo(
+                                    projectedColumn.getDereferenceIndices(),
+                                    projectedColumn.getDereferenceNames(),
+                                    fromHiveType,
+                                    fromHiveType.getType(typeManager));
+                        });
+
                         return new HiveColumnHandle(
-                                columnHandle.getName(),
-                                columnMapping.getCoercionFrom().get(),
-                                columnMapping.getCoercionFrom().get().getType(typeManager),
-                                columnHandle.getHiveColumnIndex(),
+                                columnHandle.getBaseColumnName(),
+                                columnHandle.getBaseHiveColumnIndex(),
+                                fromHiveTypeBase,
+                                fromHiveTypeBase.getType(typeManager),
+                                newColumnProjectionInfo,
                                 columnHandle.getColumnType(),
-                                Optional.empty());
+                                columnHandle.getComment());
                     })
                     .collect(toList());
         }
@@ -398,6 +463,31 @@ public class HivePageSourceProvider
         REGULAR,
         PREFILLED,
         INTERIM,
+        EMPTY
+    }
+
+    private static Optional<BucketAdaptation> createBucketAdaptation(Optional<BucketConversion> bucketConversion, OptionalInt bucketNumber, List<ColumnMapping> columnMappings)
+    {
+        return bucketConversion.map(conversion -> {
+            List<ColumnMapping> baseColumnMapping = columnMappings.stream()
+                    .filter(mapping -> mapping.getHiveColumnHandle().isBaseColumn())
+                    .collect(toList());
+            Map<Integer, ColumnMapping> baseHiveColumnToBlockIndex = uniqueIndex(baseColumnMapping, mapping -> mapping.getHiveColumnHandle().getBaseHiveColumnIndex());
+
+            int[] bucketColumnIndices = conversion.getBucketColumnHandles().stream()
+                    .mapToInt(columnHandle -> baseHiveColumnToBlockIndex.get(columnHandle.getBaseHiveColumnIndex()).getIndex())
+                    .toArray();
+            List<HiveType> bucketColumnHiveTypes = conversion.getBucketColumnHandles().stream()
+                    .map(columnHandle -> baseHiveColumnToBlockIndex.get(columnHandle.getBaseHiveColumnIndex()).getHiveColumnHandle().getHiveType())
+                    .collect(toImmutableList());
+            return new BucketAdaptation(
+                    bucketColumnIndices,
+                    bucketColumnHiveTypes,
+                    conversion.getBucketingVersion(),
+                    conversion.getTableBucketCount(),
+                    conversion.getPartitionBucketCount(),
+                    bucketNumber.getAsInt());
+        });
     }
 
     public static class BucketAdaptation

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveReaderProjectionsAdaptingRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveReaderProjectionsAdaptingRecordCursor.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.Iterables;
+import io.airlift.slice.Slice;
+import io.prestosql.plugin.hive.ReaderProjectionsAdapter.ChannelMapping;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.connector.RecordCursor;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Applies projections on delegate fields provided by {@link ChannelMapping} to produce fields expected from this cursor.
+ */
+public class HiveReaderProjectionsAdaptingRecordCursor
+        implements RecordCursor
+{
+    private final RecordCursor delegate;
+    private final ChannelMapping[] channelMappings;
+    private final Type[] outputTypes;
+    private final Type[] inputTypes;
+
+    private final Type[] baseTypes;
+
+    public HiveReaderProjectionsAdaptingRecordCursor(RecordCursor delegate, ReaderProjectionsAdapter projectionsAdapter)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        requireNonNull(projectionsAdapter, "projectionsAdapter is null");
+
+        this.channelMappings = new ChannelMapping[projectionsAdapter.getOutputToInputMapping().size()];
+        projectionsAdapter.getOutputToInputMapping().toArray(channelMappings);
+
+        this.outputTypes = new Type[projectionsAdapter.getOutputTypes().size()];
+        projectionsAdapter.getOutputTypes().toArray(outputTypes);
+
+        this.inputTypes = new Type[projectionsAdapter.getInputTypes().size()];
+        projectionsAdapter.getInputTypes().toArray(inputTypes);
+
+        this.baseTypes = new Type[outputTypes.length];
+        for (int i = 0; i < baseTypes.length; i++) {
+            Type type = inputTypes[channelMappings[i].getInputChannelIndex()];
+            List<Integer> dereferences = channelMappings[i].getDereferenceSequence();
+            for (int j = 0; j < dereferences.size(); j++) {
+                type = type.getTypeParameters().get(dereferences.get(j));
+            }
+            baseTypes[i] = type;
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return outputTypes[field];
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        return delegate.advanceNextPosition();
+    }
+
+    private Block applyDereferences(Block baseObject, List<Integer> dereferences, int length)
+    {
+        checkArgument(length <= dereferences.size());
+        Block current = baseObject;
+        for (int i = 0; i < length; i++) {
+            current = current.getObject(dereferences.get(i), Block.class);
+        }
+        return current;
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.getBoolean(inputFieldIndex);
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block elementBlock = (Block) delegate.getObject(inputFieldIndex);
+
+        // Apply dereferences except for the last one, which is type dependent
+        Block baseObject = applyDereferences(elementBlock, dereferences, dereferences.size() - 1);
+
+        return baseTypes[field].getBoolean(baseObject, Iterables.getLast(dereferences));
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.getLong(inputFieldIndex);
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block elementBlock = (Block) delegate.getObject(inputFieldIndex);
+
+        // Apply dereferences except for the last one, which is type dependent
+        Block baseObject = applyDereferences(elementBlock, dereferences, dereferences.size() - 1);
+
+        return baseTypes[field].getLong(baseObject, Iterables.getLast(dereferences));
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.getDouble(inputFieldIndex);
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block elementBlock = (Block) delegate.getObject(inputFieldIndex);
+
+        // Apply dereferences except for the last one, which is type dependent
+        Block baseObject = applyDereferences(elementBlock, dereferences, dereferences.size() - 1);
+
+        return baseTypes[field].getDouble(baseObject, Iterables.getLast(dereferences));
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.getSlice(inputFieldIndex);
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block elementBlock = (Block) delegate.getObject(inputFieldIndex);
+
+        // Apply dereferences except for the last one, which is type dependent
+        Block baseObject = applyDereferences(elementBlock, dereferences, dereferences.size() - 1);
+
+        return baseTypes[field].getSlice(baseObject, Iterables.getLast(dereferences));
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.getObject(inputFieldIndex);
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block elementBlock = (Block) delegate.getObject(inputFieldIndex);
+
+        // Apply dereferences except for the last one, which is type dependent
+        Block baseObject = applyDereferences(elementBlock, dereferences, dereferences.size() - 1);
+
+        return baseTypes[field].getObject(baseObject, Iterables.getLast(dereferences));
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        int inputFieldIndex = channelMappings[field].getInputChannelIndex();
+        List<Integer> dereferences = channelMappings[field].getDereferenceSequence();
+
+        if (dereferences.isEmpty()) {
+            return delegate.isNull(inputFieldIndex);
+        }
+
+        if (delegate.isNull(inputFieldIndex)) {
+            return true;
+        }
+
+        // Get SingleRowBlock corresponding to the element at current position
+        Block baseObject = (Block) delegate.getObject(inputFieldIndex);
+
+        for (int j = 0; j < dereferences.size() - 1; j++) {
+            int dereferenceIndex = dereferences.get(j);
+            if (baseObject.isNull(dereferenceIndex)) {
+                return true;
+            }
+            baseObject = baseObject.getObject(dereferenceIndex, Block.class);
+        }
+
+        int finalDereference = Iterables.getLast(dereferences);
+        return baseObject.isNull(finalDereference);
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegate.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
@@ -25,6 +25,7 @@ import org.joda.time.DateTimeZone;
 
 import java.util.List;
 
+import static io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMappingKind.EMPTY;
 import static io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
 import static io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMappingKind.REGULAR;
 import static io.prestosql.plugin.hive.util.HiveUtil.bigintPartitionKey;
@@ -99,6 +100,9 @@ public class HiveRecordCursor
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
 
+            if (columnMapping.getKind() == EMPTY) {
+                nulls[columnIndex] = true;
+            }
             if (columnMapping.getKind() == PREFILLED) {
                 String columnValue = columnMapping.getPrefilledValue();
                 byte[] bytes = columnValue.getBytes(UTF_8);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursorProvider.java
@@ -25,9 +25,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import static java.util.Objects.requireNonNull;
+
 public interface HiveRecordCursorProvider
 {
-    Optional<RecordCursor> createRecordCursor(
+    Optional<ReaderRecordCursorWithProjections> createRecordCursor(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -40,4 +42,34 @@ public interface HiveRecordCursorProvider
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager,
             boolean s3SelectPushdownEnabled);
+
+    /**
+     * A wrapper class for
+     * - delegate reader record cursor and
+     * - projection information for columns to be returned by the delegate
+     *
+     * Empty {@param projectedReaderColumns} indicates that the delegate cursor reads the exact same columns provided to
+     * it in {@link HiveRecordCursorProvider#createRecordCursor}
+     */
+    class ReaderRecordCursorWithProjections
+    {
+        private final RecordCursor recordCursor;
+        private final Optional<ReaderProjections> projectedReaderColumns;
+
+        public ReaderRecordCursorWithProjections(RecordCursor recordCursor, Optional<ReaderProjections> projectedReaderColumns)
+        {
+            this.recordCursor = requireNonNull(recordCursor, "recordCursor is null");
+            this.projectedReaderColumns = requireNonNull(projectedReaderColumns, "projectedReaderColumns is null");
+        }
+
+        public RecordCursor getRecordCursor()
+        {
+            return recordCursor;
+        }
+
+        public Optional<ReaderProjections> getProjectedReaderColumns()
+        {
+            return projectedReaderColumns;
+        }
+    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/IonSqlQueryBuilder.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/IonSqlQueryBuilder.java
@@ -62,6 +62,11 @@ public class IonSqlQueryBuilder
 
     public String buildSql(List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> tupleDomain)
     {
+        columns.forEach(column -> checkArgument(column.isBaseColumn(), "%s is not a base column", column));
+        tupleDomain.getDomains().ifPresent(domains -> {
+            domains.keySet().forEach(column -> checkArgument(column.isBaseColumn(), "%s is not a base column", column));
+        });
+
         StringBuilder sql = new StringBuilder("SELECT ");
 
         if (columns.isEmpty()) {
@@ -69,7 +74,7 @@ public class IonSqlQueryBuilder
         }
         else {
             String columnNames = columns.stream()
-                    .map(column -> format("s._%d", column.getHiveColumnIndex() + 1))
+                    .map(column -> format("s._%d", column.getBaseHiveColumnIndex() + 1))
                     .collect(joining(", "));
             sql.append(columnNames);
         }
@@ -94,7 +99,7 @@ public class IonSqlQueryBuilder
             if (tupleDomain.getDomains().isPresent() && isSupported(type)) {
                 Domain domain = tupleDomain.getDomains().get().get(column);
                 if (domain != null) {
-                    builder.add(toPredicate(domain, type, column.getHiveColumnIndex()));
+                    builder.add(toPredicate(domain, type, column.getBaseHiveColumnIndex()));
                 }
             }
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjections.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjections.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Stores a mapping of the projected columns required by {@link HivePageSource} to the columns supplied by format-specific
+ * page sources or record cursors.
+ */
+public class ReaderProjections
+{
+    // columns to be read by the reader (ordered)
+    private final List<HiveColumnHandle> readerColumns;
+    // indices for mapping expected hive column handles to the reader's column handles
+    private final List<Integer> readerBlockIndices;
+
+    private ReaderProjections(List<HiveColumnHandle> readerColumns, List<Integer> readerBlockIndices)
+    {
+        this.readerColumns = ImmutableList.copyOf(requireNonNull(readerColumns, "readerColumns is null"));
+
+        readerBlockIndices.forEach(value -> checkArgument(value >= 0 && value < readerColumns.size(), "block index out of bounds"));
+        this.readerBlockIndices = ImmutableList.copyOf(requireNonNull(readerBlockIndices, "readerBlockIndices is null"));
+    }
+
+    /**
+     * For a column required by the {@link HivePageSource}, returns the column read by the delegate page source or record cursor.
+     */
+    public HiveColumnHandle readerColumnForHiveColumnAt(int index)
+    {
+        checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is not valid");
+        int readerIndex = readerBlockIndices.get(index);
+        return readerColumns.get(readerIndex);
+    }
+
+    /**
+     * For a channel expected by {@link HivePageSource}, returns the channel index in the underlying page source or record cursor.
+     */
+    public int readerColumnPositionForHiveColumnAt(int index)
+    {
+        checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is invalid");
+        return readerBlockIndices.get(index);
+    }
+
+    /**
+     * returns the actual list of columns being read by underlying page source or record cursor in order.
+     */
+    public List<HiveColumnHandle> getReaderColumns()
+    {
+        return readerColumns;
+    }
+
+    /**
+     * Creates a mapping between the input {@param columns} and base columns if required.
+     */
+    public static Optional<ReaderProjections> projectBaseColumns(List<HiveColumnHandle> columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        // No projection is required if all columns are base columns
+        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<HiveColumnHandle> projectedColumns = ImmutableList.builder();
+        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
+        Map<Integer, Integer> mappedHiveColumnIndices = new HashMap<>();
+        int projectedColumnCount = 0;
+
+        for (HiveColumnHandle column : columns) {
+            int hiveColumnIndex = column.getBaseHiveColumnIndex();
+            Integer mapped = mappedHiveColumnIndices.get(hiveColumnIndex);
+
+            if (mapped == null) {
+                projectedColumns.add(column.getBaseColumn());
+                mappedHiveColumnIndices.put(hiveColumnIndex, projectedColumnCount);
+                outputColumnMapping.add(projectedColumnCount);
+                projectedColumnCount++;
+            }
+            else {
+                outputColumnMapping.add(mapped);
+            }
+        }
+
+        return Optional.of(new ReaderProjections(projectedColumns.build(), outputColumnMapping.build()));
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjections.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjections.java
@@ -13,14 +13,19 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -102,5 +107,116 @@ public class ReaderProjections
         }
 
         return Optional.of(new ReaderProjections(projectedColumns.build(), outputColumnMapping.build()));
+    }
+
+    /**
+     * Creates a set of sufficient columns for the input projected columns and prepares a mapping between the two. For example,
+     * if input {@param columns} include columns "a.b" and "a.b.c", then they will be projected from a single column "a.b".
+     */
+    public static Optional<ReaderProjections> projectSufficientColumns(List<HiveColumnHandle> columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
+            return Optional.empty();
+        }
+
+        ImmutableBiMap.Builder<DereferenceChain, HiveColumnHandle> dereferenceChainsBuilder = ImmutableBiMap.builder();
+
+        for (HiveColumnHandle column : columns) {
+            List<Integer> indices = column.getHiveColumnProjectionInfo()
+                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                    .orElse(ImmutableList.of());
+
+            DereferenceChain dereferenceChain = new DereferenceChain(column.getBaseColumnName(), indices);
+            dereferenceChainsBuilder.put(dereferenceChain, column);
+        }
+
+        BiMap<DereferenceChain, HiveColumnHandle> dereferenceChains = dereferenceChainsBuilder.build();
+
+        List<HiveColumnHandle> sufficientColumns = new ArrayList<>();
+        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
+
+        Map<DereferenceChain, Integer> pickedColumns = new HashMap<>();
+
+        // Pick a covering column for every column
+        for (HiveColumnHandle columnHandle : columns) {
+            DereferenceChain column = dereferenceChains.inverse().get(columnHandle);
+            List<DereferenceChain> orderedPrefixes = column.getOrderedPrefixes();
+            DereferenceChain chosenColumn = null;
+
+            // Shortest existing prefix is chosen as the input.
+            for (DereferenceChain prefix : orderedPrefixes) {
+                if (dereferenceChains.containsKey(prefix)) {
+                    chosenColumn = prefix;
+                    break;
+                }
+            }
+
+            checkState(chosenColumn != null, "chosenColumn is null");
+            int inputBlockIndex;
+
+            if (pickedColumns.containsKey(chosenColumn)) {
+                // Use already picked column
+                inputBlockIndex = pickedColumns.get(chosenColumn);
+            }
+            else {
+                // Add a new column for the reader
+                sufficientColumns.add(dereferenceChains.get(chosenColumn));
+                pickedColumns.put(chosenColumn, sufficientColumns.size() - 1);
+                inputBlockIndex = sufficientColumns.size() - 1;
+            }
+
+            outputColumnMapping.add(inputBlockIndex);
+        }
+
+        return Optional.of(new ReaderProjections(sufficientColumns, outputColumnMapping.build()));
+    }
+
+    private static class DereferenceChain
+    {
+        private final String name;
+        private final List<Integer> indices;
+
+        public DereferenceChain(String name, List<Integer> indices)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.indices = ImmutableList.copyOf(requireNonNull(indices, "indices is null"));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DereferenceChain that = (DereferenceChain) o;
+            return Objects.equals(name, that.name) &&
+                    Objects.equals(indices, that.indices);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, indices);
+        }
+
+        /**
+         * Get Prefixes of this Dereference chain in increasing order of lengths
+         */
+        public List<DereferenceChain> getOrderedPrefixes()
+        {
+            ImmutableList.Builder<DereferenceChain> prefixes = ImmutableList.builder();
+
+            for (int prefixLen = 0; prefixLen <= indices.size(); prefixLen++) {
+                prefixes.add(new DereferenceChain(name, indices.subList(0, prefixLen)));
+            }
+
+            return prefixes.build();
+        }
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.ColumnarRow;
+import io.prestosql.spi.block.LazyBlock;
+import io.prestosql.spi.block.LazyBlockLoader;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.ReaderProjectionsAdapter.ChannelMapping.createChannelMapping;
+import static io.prestosql.spi.block.ColumnarRow.toColumnarRow;
+import static java.util.Objects.requireNonNull;
+
+public class ReaderProjectionsAdapter
+{
+    private final List<ChannelMapping> outputToInputMapping;
+    private final List<Type> outputTypes;
+    private final List<Type> inputTypes;
+
+    public ReaderProjectionsAdapter(List<HiveColumnHandle> expectedHiveColumns, ReaderProjections readerProjections)
+    {
+        requireNonNull(expectedHiveColumns, "expectedHiveColumns is null");
+        requireNonNull(readerProjections, "readerProjections is null");
+
+        ImmutableList.Builder<ChannelMapping> mappingBuilder = ImmutableList.builder();
+
+        for (int i = 0; i < expectedHiveColumns.size(); i++) {
+            HiveColumnHandle projectedColumnHandle = readerProjections.readerColumnForHiveColumnAt(i);
+            int inputChannel = readerProjections.readerColumnPositionForHiveColumnAt(i);
+            ChannelMapping mapping = createChannelMapping(expectedHiveColumns.get(i), projectedColumnHandle, inputChannel);
+            mappingBuilder.add(mapping);
+        }
+
+        outputToInputMapping = mappingBuilder.build();
+
+        outputTypes = expectedHiveColumns.stream()
+                .map(HiveColumnHandle::getType)
+                .collect(toImmutableList());
+
+        inputTypes = readerProjections.getReaderColumns().stream()
+                .map(HiveColumnHandle::getType)
+                .collect(toImmutableList());
+    }
+
+    public Page adaptPage(Page input)
+    {
+        if (input == null) {
+            return null;
+        }
+
+        Block[] blocks = new Block[outputToInputMapping.size()];
+
+        // Prepare adaptations to extract dereferences
+        for (int i = 0; i < outputToInputMapping.size(); i++) {
+            ChannelMapping mapping = outputToInputMapping.get(i);
+
+            Block inputBlock = input.getBlock(mapping.getInputChannelIndex());
+            blocks[i] = createAdaptedLazyBlock(inputBlock, mapping.getDereferenceSequence(), outputTypes.get(i));
+        }
+
+        return new Page(input.getPositionCount(), blocks);
+    }
+
+    private static Block createAdaptedLazyBlock(Block inputBlock, List<Integer> dereferenceSequence, Type type)
+    {
+        if (dereferenceSequence.size() == 0) {
+            return inputBlock;
+        }
+
+        if (inputBlock == null) {
+            return null;
+        }
+
+        return new LazyBlock(inputBlock.getPositionCount(), new DereferenceBlockLoader(inputBlock, dereferenceSequence, type));
+    }
+
+    private static class DereferenceBlockLoader
+            implements LazyBlockLoader
+    {
+        private final List<Integer> dereferenceSequence;
+        private final Type type;
+        private boolean loaded;
+        private Block inputBlock;
+
+        DereferenceBlockLoader(Block inputBlock, List<Integer> dereferenceSequence, Type type)
+        {
+            this.inputBlock = requireNonNull(inputBlock, "inputBlock is null");
+            this.dereferenceSequence = requireNonNull(dereferenceSequence, "dereferenceSequence is null");
+            this.type = type;
+        }
+
+        @Override
+        public Block load()
+        {
+            checkState(!loaded, "Already loaded");
+            Block loadedBlock = loadInternalBlock(dereferenceSequence, inputBlock);
+            inputBlock = null;
+            loaded = true;
+            return loadedBlock;
+        }
+
+        /**
+         * Applies dereference operations on the input block to extract the required internal block. If the input block is lazy
+         * in a nested manner, this implementation avoids loading the entire input block.
+         */
+        private Block loadInternalBlock(List<Integer> dereferences, Block parentBlock)
+        {
+            if (dereferences.size() == 0) {
+                return parentBlock.getLoadedBlock();
+            }
+
+            ColumnarRow columnarRow = toColumnarRow(parentBlock);
+
+            int dereferenceIndex = dereferences.get(0);
+            List<Integer> remainingDereferences = dereferences.subList(1, dereferences.size());
+
+            Block fieldBlock = columnarRow.getField(dereferenceIndex);
+            Block loadedInternalBlock = loadInternalBlock(remainingDereferences, fieldBlock);
+
+            // Field blocks provided by ColumnarRow can have a smaller position count, because they do not store nulls.
+            // The following step adds null elements (when required) to the loaded block.
+            return adaptNulls(columnarRow, loadedInternalBlock);
+        }
+
+        private Block adaptNulls(ColumnarRow columnarRow, Block loadedInternalBlock)
+        {
+            // TODO: The current implementation copies over data to a new block builder when a null row element is found.
+            //  We can optimize this by using a Block implementation that uses a null vector of the parent row block and
+            //  the block for the field.
+
+            BlockBuilder newlyCreatedBlock = null;
+            int fieldBlockPosition = 0;
+
+            for (int i = 0; i < columnarRow.getPositionCount(); i++) {
+                boolean isRowNull = columnarRow.isNull(i);
+
+                if (isRowNull) {
+                    // A new block is only created when a null is encountered for the first time.
+                    if (newlyCreatedBlock == null) {
+                        newlyCreatedBlock = type.createBlockBuilder(null, columnarRow.getPositionCount());
+
+                        // Copy over all elements encountered so far to the new block
+                        for (int j = 0; j < i; j++) {
+                            type.appendTo(loadedInternalBlock, j, newlyCreatedBlock);
+                        }
+                    }
+                    newlyCreatedBlock.appendNull();
+                }
+                else {
+                    if (newlyCreatedBlock != null) {
+                        type.appendTo(loadedInternalBlock, fieldBlockPosition, newlyCreatedBlock);
+                    }
+                    fieldBlockPosition++;
+                }
+            }
+
+            if (newlyCreatedBlock == null) {
+                // If there was no need to create a null, return the original block
+                return loadedInternalBlock;
+            }
+
+            return newlyCreatedBlock.build();
+        }
+    }
+
+    List<ChannelMapping> getOutputToInputMapping()
+    {
+        return outputToInputMapping;
+    }
+
+    List<Type> getOutputTypes()
+    {
+        return outputTypes;
+    }
+
+    List<Type> getInputTypes()
+    {
+        return inputTypes;
+    }
+
+    @VisibleForTesting
+    static class ChannelMapping
+    {
+        private final int inputChannelIndex;
+        private final List<Integer> dereferenceSequence;
+
+        private ChannelMapping(int inputBlockIndex, List<Integer> dereferenceSequence)
+        {
+            checkArgument(inputBlockIndex >= 0, "inputBlockIndex cannot be negative");
+            this.inputChannelIndex = inputBlockIndex;
+            this.dereferenceSequence = ImmutableList.copyOf(requireNonNull(dereferenceSequence, "dereferences is null"));
+        }
+
+        public int getInputChannelIndex()
+        {
+            return inputChannelIndex;
+        }
+
+        public List<Integer> getDereferenceSequence()
+        {
+            return dereferenceSequence;
+        }
+
+        static ChannelMapping createChannelMapping(HiveColumnHandle expected, HiveColumnHandle delegate, int inputBlockIndex)
+        {
+            List<Integer> dereferences = validateProjectionAndExtractDereferences(expected, delegate);
+            return new ChannelMapping(inputBlockIndex, dereferences);
+        }
+
+        private static List<Integer> validateProjectionAndExtractDereferences(HiveColumnHandle expectedColumn, HiveColumnHandle readerColumn)
+        {
+            checkArgument(expectedColumn.getBaseColumn().equals(readerColumn.getBaseColumn()), "reader column is not valid for expected column");
+
+            List<Integer> expectedDereferences = expectedColumn.getHiveColumnProjectionInfo()
+                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                    .orElse(ImmutableList.of());
+
+            List<Integer> readerDereferences = readerColumn.getHiveColumnProjectionInfo()
+                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                    .orElse(ImmutableList.of());
+
+            checkArgument(readerDereferences.size() <= expectedDereferences.size(), "Field returned by the reader should include expected field");
+            checkArgument(expectedDereferences.subList(0, readerDereferences.size()).equals(readerDereferences), "Field returned by the reader should be a prefix of expected field");
+
+            return expectedDereferences.subList(readerDereferences.size(), expectedDereferences.size());
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSource.java
@@ -79,7 +79,7 @@ public class RcFilePageSource
             typesBuilder.add(column.getType());
             hiveTypesBuilder.add(column.getHiveType());
 
-            hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
+            hiveColumnIndexes[columnIndex] = column.getBaseHiveColumnIndex();
 
             if (hiveColumnIndexes[columnIndex] >= rcFileReader.getColumnCount()) {
                 // this file may contain fewer fields than what's declared in the schema
@@ -135,9 +135,7 @@ public class RcFilePageSource
                 }
             }
 
-            Page page = new Page(currentPageSize, blocks);
-
-            return page;
+            return new Page(currentPageSize, blocks);
         }
         catch (PrestoException e) {
             closeWithSuppression(e);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.rcfile.AircompressorCodecFactory;
 import io.prestosql.rcfile.HadoopCodecFactory;
 import io.prestosql.rcfile.RcFileCorruptionException;
@@ -59,6 +60,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
+import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.prestosql.rcfile.text.TextRcFileEncoding.DEFAULT_NULL_SEQUENCE;
 import static io.prestosql.rcfile.text.TextRcFileEncoding.DEFAULT_SEPARATORS;
@@ -93,7 +95,7 @@ public class RcFilePageSourceFactory
     }
 
     @Override
-    public Optional<? extends ConnectorPageSource> createPageSource(
+    public Optional<ReaderPageSourceWithProjections> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -124,6 +126,12 @@ public class RcFilePageSourceFactory
             throw new PrestoException(HIVE_BAD_DATA, "RCFile is empty: " + path);
         }
 
+        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+
+        List<HiveColumnHandle> projectedReaderColumns = readerProjections
+                .map(ReaderProjections::getReaderColumns)
+                .orElse(columns);
+
         FSDataInputStream inputStream;
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
@@ -139,8 +147,8 @@ public class RcFilePageSourceFactory
 
         try {
             ImmutableMap.Builder<Integer, Type> readColumns = ImmutableMap.builder();
-            for (HiveColumnHandle column : columns) {
-                readColumns.put(column.getHiveColumnIndex(), column.getHiveType().getType(typeManager));
+            for (HiveColumnHandle column : projectedReaderColumns) {
+                readColumns.put(column.getBaseHiveColumnIndex(), column.getHiveType().getType(typeManager));
             }
 
             RcFileReader rcFileReader = new RcFileReader(
@@ -152,7 +160,8 @@ public class RcFilePageSourceFactory
                     length,
                     DataSize.of(8, Unit.MEGABYTE));
 
-            return Optional.of(new RcFilePageSource(rcFileReader, columns));
+            ConnectorPageSource pageSource = new RcFilePageSource(rcFileReader, projectedReaderColumns);
+            return Optional.of(new ReaderPageSourceWithProjections(pageSource, readerProjections));
         }
         catch (Throwable e) {
             try {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -182,6 +182,7 @@ import static io.prestosql.plugin.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.bucketColumnHandle;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
 import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
@@ -640,11 +641,11 @@ public abstract class AbstractTestHive
 
         invalidTableHandle = new HiveTableHandle(database, INVALID_TABLE, ImmutableMap.of(), ImmutableList.of(), Optional.empty());
 
-        dsColumn = new HiveColumnHandle("ds", HIVE_STRING, VARCHAR, -1, PARTITION_KEY, Optional.empty());
-        fileFormatColumn = new HiveColumnHandle("file_format", HIVE_STRING, VARCHAR, -1, PARTITION_KEY, Optional.empty());
-        dummyColumn = new HiveColumnHandle("dummy", HIVE_INT, INTEGER, -1, PARTITION_KEY, Optional.empty());
-        intColumn = new HiveColumnHandle("t_int", HIVE_INT, INTEGER, -1, PARTITION_KEY, Optional.empty());
-        invalidColumnHandle = new HiveColumnHandle(INVALID_COLUMN, HIVE_STRING, VARCHAR, 0, REGULAR, Optional.empty());
+        dsColumn = createBaseColumn("ds", -1, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+        fileFormatColumn = createBaseColumn("file_format", -1, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+        dummyColumn = createBaseColumn("dummy", -1, HIVE_INT, INTEGER, PARTITION_KEY, Optional.empty());
+        intColumn = createBaseColumn("t_int", -1, HIVE_INT, INTEGER, PARTITION_KEY, Optional.empty());
+        invalidColumnHandle = createBaseColumn(INVALID_COLUMN, 0, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
 
         List<ColumnHandle> partitionColumns = ImmutableList.of(dsColumn, fileFormatColumn, dummyColumn);
         tablePartitionFormatPartitions = ImmutableList.<HivePartition>builder()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -85,6 +85,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.prestosql.plugin.hive.HiveColumnProjectionInfo.generatePartialName;
 import static io.prestosql.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static io.prestosql.plugin.hive.HiveTestUtils.SESSION;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
@@ -473,13 +475,47 @@ public abstract class AbstractTestHiveFileFormats
     protected List<HiveColumnHandle> getColumnHandles(List<TestColumn> testColumns)
     {
         List<HiveColumnHandle> columns = new ArrayList<>();
+        Map<String, Integer> hiveColumnIndexes = new HashMap<>();
+
         int nextHiveColumnIndex = 0;
         for (int i = 0; i < testColumns.size(); i++) {
             TestColumn testColumn = testColumns.get(i);
-            int columnIndex = testColumn.isPartitionKey() ? -1 : nextHiveColumnIndex++;
 
-            HiveType hiveType = HiveType.valueOf(testColumn.getObjectInspector().getTypeName());
-            columns.add(new HiveColumnHandle(testColumn.getName(), hiveType, hiveType.getType(TYPE_MANAGER), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
+            int columnIndex;
+            if (testColumn.isPartitionKey()) {
+                columnIndex = -1;
+            }
+            else {
+                if (hiveColumnIndexes.get(testColumn.getBaseName()) != null) {
+                    columnIndex = hiveColumnIndexes.get(testColumn.getBaseName());
+                }
+                else {
+                    columnIndex = nextHiveColumnIndex++;
+                    hiveColumnIndexes.put(testColumn.getBaseName(), columnIndex);
+                }
+            }
+
+            if (testColumn.getDereferenceNames().size() == 0) {
+                HiveType hiveType = HiveType.valueOf(testColumn.getObjectInspector().getTypeName());
+                columns.add(createBaseColumn(testColumn.getName(), columnIndex, hiveType, hiveType.getType(TYPE_MANAGER), testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
+            }
+            else {
+                HiveType baseHiveType = HiveType.valueOf(testColumn.getBaseObjectInspector().getTypeName());
+                HiveType partialHiveType = baseHiveType.getHiveTypeForDereferences(testColumn.getDereferenceIndices()).get();
+                HiveColumnHandle hiveColumnHandle = new HiveColumnHandle(
+                        testColumn.getBaseName(),
+                        columnIndex,
+                        baseHiveType,
+                        baseHiveType.getType(TYPE_MANAGER),
+                        Optional.of(new HiveColumnProjectionInfo(
+                                testColumn.getDereferenceIndices(),
+                                testColumn.getDereferenceNames(),
+                                partialHiveType,
+                                partialHiveType.getType(TYPE_MANAGER))),
+                        testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR,
+                        Optional.empty());
+                columns.add(hiveColumnHandle);
+            }
         }
         return columns;
     }
@@ -817,6 +853,10 @@ public abstract class AbstractTestHiveFileFormats
 
     public static final class TestColumn
     {
+        private final String baseName;
+        private final ObjectInspector baseObjectInspector;
+        private final List<String> dereferenceNames;
+        private final List<Integer> dereferenceIndices;
         private final String name;
         private final ObjectInspector objectInspector;
         private final Object writeValue;
@@ -830,11 +870,30 @@ public abstract class AbstractTestHiveFileFormats
 
         public TestColumn(String name, ObjectInspector objectInspector, Object writeValue, Object expectedValue, boolean partitionKey)
         {
-            this.name = requireNonNull(name, "name is null");
+            this(name, objectInspector, ImmutableList.of(), ImmutableList.of(), objectInspector, writeValue, expectedValue, partitionKey);
+        }
+
+        public TestColumn(
+                String baseName,
+                ObjectInspector baseObjectInspector,
+                List<String> dereferenceNames,
+                List<Integer> dereferenceIndices,
+                ObjectInspector objectInspector,
+                Object writeValue,
+                Object expectedValue,
+                boolean partitionKey)
+        {
+            this.baseName = requireNonNull(baseName, "baseName is null");
+            this.baseObjectInspector = requireNonNull(baseObjectInspector, "baseObjectInspector is null");
+            this.dereferenceNames = requireNonNull(dereferenceNames, "dereferenceNames is null");
+            this.dereferenceIndices = requireNonNull(dereferenceIndices, "dereferenceIndices is null");
+            checkArgument(dereferenceIndices.size() == dereferenceNames.size(), "dereferenceIndices and dereferenceNames should have the same size");
+            this.name = baseName + generatePartialName(dereferenceNames);
             this.objectInspector = requireNonNull(objectInspector, "objectInspector is null");
             this.writeValue = writeValue;
             this.expectedValue = expectedValue;
             this.partitionKey = partitionKey;
+            checkArgument(dereferenceNames.size() == 0 || partitionKey == false, "partial column cannot be a partition key");
         }
 
         public String getName()
@@ -842,9 +901,29 @@ public abstract class AbstractTestHiveFileFormats
             return name;
         }
 
+        public String getBaseName()
+        {
+            return baseName;
+        }
+
+        public List<String> getDereferenceNames()
+        {
+            return dereferenceNames;
+        }
+
+        public List<Integer> getDereferenceIndices()
+        {
+            return dereferenceIndices;
+        }
+
         public String getType()
         {
             return objectInspector.getTypeName();
+        }
+
+        public ObjectInspector getBaseObjectInspector()
+        {
+            return baseObjectInspector;
         }
 
         public ObjectInspector getObjectInspector()
@@ -871,7 +950,9 @@ public abstract class AbstractTestHiveFileFormats
         public String toString()
         {
             StringBuilder sb = new StringBuilder("TestColumn{");
-            sb.append("name='").append(name).append('\'');
+            sb.append("baseName='").append(baseName).append("'");
+            sb.append("dereferenceNames=").append("[").append(dereferenceNames.stream().collect(Collectors.joining(","))).append("]");
+            sb.append("name=").append(name);
             sb.append(", objectInspector=").append(objectInspector);
             sb.append(", writeValue=").append(writeValue);
             sb.append(", expectedValue=").append(expectedValue);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -76,6 +76,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
 import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.getBucketNumber;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveColumnHandle.pathColumnHandle;
 import static io.prestosql.plugin.hive.HiveStorageFormat.CSV;
 import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -124,7 +125,7 @@ public class TestBackgroundHiveSplitLoader
     private static final List<Column> PARTITION_COLUMNS = ImmutableList.of(
             new Column("partitionColumn", HIVE_INT, Optional.empty()));
     private static final List<HiveColumnHandle> BUCKET_COLUMN_HANDLES = ImmutableList.of(
-            new HiveColumnHandle("col1", HIVE_INT, INTEGER, 0, ColumnType.REGULAR, Optional.empty()));
+            createBaseColumn("col1", 0, HIVE_INT, INTEGER, ColumnType.REGULAR, Optional.empty()));
 
     private static final Optional<HiveBucketProperty> BUCKET_PROPERTY = Optional.of(
             new HiveBucketProperty(ImmutableList.of("col1"), BUCKETING_V1, BUCKET_COUNT, ImmutableList.of()));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveApplyProjectionUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveApplyProjectionUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.expression.Constant;
+import io.prestosql.spi.expression.FieldDereference;
+import io.prestosql.spi.expression.Variable;
+import org.testng.annotations.Test;
+
+import static io.prestosql.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.prestosql.plugin.hive.HiveApplyProjectionUtil.isPushDownSupported;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.spi.type.RowType.rowType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveApplyProjectionUtil
+{
+    private static final ConnectorExpression ROW_OF_ROW_VARIABLE = new Variable("a", rowType(field("b", rowType(field("c", INTEGER)))));
+
+    private static final ConnectorExpression ONE_LEVEL_DEREFERENCE = new FieldDereference(
+            rowType(field("c", INTEGER)),
+            ROW_OF_ROW_VARIABLE,
+            0);
+
+    private static final ConnectorExpression TWO_LEVEL_DEREFERENCE = new FieldDereference(
+            INTEGER,
+            ONE_LEVEL_DEREFERENCE,
+            0);
+
+    private static final ConnectorExpression INT_VARIABLE = new Variable("a", INTEGER);
+    private static final ConnectorExpression CONSTANT = new Constant(5, INTEGER);
+
+    @Test
+    public void testIsProjectionSupported()
+    {
+        assertTrue(isPushDownSupported(ONE_LEVEL_DEREFERENCE));
+        assertTrue(isPushDownSupported(TWO_LEVEL_DEREFERENCE));
+        assertTrue(isPushDownSupported(INT_VARIABLE));
+        assertFalse(isPushDownSupported(CONSTANT));
+    }
+
+    @Test
+    public void testExtractSupportedProjectionColumns()
+    {
+        assertEquals(extractSupportedProjectedColumns(ONE_LEVEL_DEREFERENCE), ImmutableList.of(ONE_LEVEL_DEREFERENCE));
+        assertEquals(extractSupportedProjectedColumns(TWO_LEVEL_DEREFERENCE), ImmutableList.of(TWO_LEVEL_DEREFERENCE));
+        assertEquals(extractSupportedProjectedColumns(INT_VARIABLE), ImmutableList.of(INT_VARIABLE));
+        assertEquals(extractSupportedProjectedColumns(CONSTANT), ImmutableList.of());
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveColumnHandle.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveColumnHandle.java
@@ -13,19 +13,28 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
-import io.prestosql.spi.type.TestingTypeManager;
+import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.type.InternalTypeManager;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.prestosql.plugin.hive.HiveType.toHiveType;
+import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveColumnHandle
@@ -40,29 +49,60 @@ public class TestHiveColumnHandle
     @Test
     public void testRegularColumn()
     {
-        HiveColumnHandle expectedPartitionColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, DOUBLE, 88, PARTITION_KEY, Optional.empty());
+        HiveColumnHandle expectedPartitionColumn = createBaseColumn("name", 88, HiveType.HIVE_FLOAT, DOUBLE, PARTITION_KEY, Optional.empty());
         testRoundTrip(expectedPartitionColumn);
     }
 
     @Test
     public void testPartitionKeyColumn()
     {
-        HiveColumnHandle expectedRegularColumn = new HiveColumnHandle("name", HiveType.HIVE_FLOAT, DOUBLE, 88, REGULAR, Optional.empty());
+        HiveColumnHandle expectedRegularColumn = createBaseColumn("name", 88, HiveType.HIVE_FLOAT, DOUBLE, REGULAR, Optional.empty());
         testRoundTrip(expectedRegularColumn);
+    }
+
+    @Test
+    public void testProjectedColumn()
+    {
+        Type baseType = RowType.from(asList(field("a", VARCHAR), field("b", BIGINT)));
+        HiveType baseHiveType = toHiveType(new HiveTypeTranslator(), baseType);
+
+        HiveColumnProjectionInfo columnProjectionInfo = new HiveColumnProjectionInfo(
+                ImmutableList.of(1),
+                ImmutableList.of("b"),
+                HiveType.HIVE_LONG,
+                BIGINT);
+
+        HiveColumnHandle projectedColumn = new HiveColumnHandle(
+                "struct_col",
+                88,
+                baseHiveType,
+                baseType,
+                Optional.of(columnProjectionInfo),
+                REGULAR,
+                Optional.empty());
+
+        testRoundTrip(projectedColumn);
     }
 
     private void testRoundTrip(HiveColumnHandle expected)
     {
         ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
-        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new HiveModule.TypeDeserializer(new TestingTypeManager())));
+        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new HiveModule.TypeDeserializer(new InternalTypeManager(createTestMetadataManager()))));
         JsonCodec<HiveColumnHandle> codec = new JsonCodecFactory(objectMapperProvider).jsonCodec(HiveColumnHandle.class);
 
         String json = codec.toJson(expected);
         HiveColumnHandle actual = codec.fromJson(json);
 
+        assertEquals(actual.getBaseColumnName(), expected.getBaseColumnName());
+        assertEquals(actual.getBaseHiveColumnIndex(), expected.getBaseHiveColumnIndex());
+        assertEquals(actual.getBaseType(), expected.getBaseType());
+        assertEquals(actual.getBaseHiveType(), expected.getBaseHiveType());
+
         assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getType(), expected.getType());
         assertEquals(actual.getHiveType(), expected.getHiveType());
-        assertEquals(actual.getHiveColumnIndex(), expected.getHiveColumnIndex());
+
+        assertEquals(actual.getHiveColumnProjectionInfo(), expected.getHiveColumnProjectionInfo());
         assertEquals(actual.isPartitionKey(), expected.isPartitionKey());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -34,6 +34,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.RecordCursor;
 import io.prestosql.spi.connector.RecordPageSource;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.Type;
 import io.prestosql.testing.TestingConnectorSession;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -55,14 +56,18 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.plugin.hive.HiveStorageFormat.AVRO;
@@ -80,10 +85,12 @@ import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveTestUtils.createGenericHiveRecordCursorProvider;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.prestosql.plugin.hive.HiveTestUtils.getTypes;
+import static io.prestosql.testing.StructuralTestUtil.rowBlockOf;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.FILE_INPUT_FORMAT;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 import static org.testng.Assert.assertEquals;
@@ -523,6 +530,254 @@ public class TestHiveFileFormats
                 .isReadableByRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
     }
 
+    @Test(dataProvider = "rowCount")
+    public void testAvroProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = getTestColumnsSupportedByAvro();
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(AVRO)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByRecordCursorPageSource(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testParquetProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = getTestColumnsSupportedByParquet();
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(PARQUET)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .withSession(PARQUET_SESSION)
+                .isReadableByPageSource(new ParquetPageSourceFactory(HDFS_ENVIRONMENT, STATS, new ParquetReaderConfig()));
+
+        assertThatFileFormat(PARQUET)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .withSession(PARQUET_SESSION_USE_NAME)
+                .isReadableByPageSource(new ParquetPageSourceFactory(HDFS_ENVIRONMENT, STATS, new ParquetReaderConfig()));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testORCProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = TEST_COLUMNS;
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        ConnectorSession session = getHiveSession(new HiveConfig(), new OrcReaderConfig().setUseColumnNames(true));
+        assertThatFileFormat(ORC)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .withSession(session)
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_ENVIRONMENT, STATS));
+
+        assertThatFileFormat(ORC)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_ENVIRONMENT, STATS));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testSequenceFileProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = TEST_COLUMNS.stream()
+                .filter(column -> !column.getName().equals("t_map_null_key_complex_key_value"))
+                .collect(toList());
+
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(SEQUENCEFILE)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByRecordCursorPageSource(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testTextFileProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = TEST_COLUMNS.stream()
+                .filter(column -> !column.getName().equals("t_map_null_key_complex_key_value"))
+                .collect(toList());
+
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(TEXTFILE)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByRecordCursorPageSource(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testRCTextProjectedColumns(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = TEST_COLUMNS.stream()
+                .filter(testColumn -> {
+                    // TODO: This is a bug in the RC text reader
+                    // RC file does not support complex type as key of a map
+                    return !testColumn.getName().equals("t_struct_null")
+                        && !testColumn.getName().equals("t_map_null_key_complex_key_value");
+                })
+                .collect(toImmutableList());
+
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(RCTEXT)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByRecordCursorPageSource(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testRCTextProjectedColumnsPageSource(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> supportedColumns = TEST_COLUMNS;
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(RCTEXT)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testRCBinaryProjectedColumns(int rowCount)
+            throws Exception
+    {
+        // RCBinary does not support complex type as key of a map and interprets empty VARCHAR as nulls
+        List<TestColumn> supportedColumns = TEST_COLUMNS.stream()
+                .filter(testColumn -> {
+                    String name = testColumn.getName();
+                    return !name.equals("t_map_null_key_complex_key_value") && !name.equals("t_empty_varchar");
+                })
+                .collect(toList());
+
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(RCBINARY)
+            .withWriteColumns(writeColumns)
+            .withReadColumns(readColumns)
+            .withRowsCount(rowCount)
+            .isReadableByRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
+    }
+
+    @Test(dataProvider = "rowCount")
+    public void testRCBinaryProjectedColumnsPageSource(int rowCount)
+            throws Exception
+    {
+        // RCBinary does not support complex type as key of a map and interprets empty VARCHAR as nulls
+        List<TestColumn> supportedColumns = TEST_COLUMNS.stream()
+                .filter(testColumn -> !testColumn.getName().equals("t_empty_varchar"))
+                .collect(toList());
+
+        List<TestColumn> regularColumns = getRegularColumns(supportedColumns);
+        List<TestColumn> partitionColumns = getPartitionColumns(supportedColumns);
+
+        // Created projected columns for all regular supported columns
+        ImmutableList.Builder<TestColumn> writeColumnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<TestColumn> readeColumnsBuilder = ImmutableList.builder();
+        generateProjectedColumns(regularColumns, writeColumnsBuilder, readeColumnsBuilder);
+
+        List<TestColumn> writeColumns = writeColumnsBuilder.addAll(partitionColumns).build();
+        List<TestColumn> readColumns = readeColumnsBuilder.addAll(partitionColumns).build();
+
+        assertThatFileFormat(RCBINARY)
+                .withWriteColumns(writeColumns)
+                .withReadColumns(readColumns)
+                .withRowsCount(rowCount)
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS));
+    }
+
     @Test
     public void testFailForLongVarcharPartitionColumn()
             throws Exception
@@ -563,42 +818,81 @@ public class TestHiveFileFormats
                 .isFailingForRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT), expectedErrorCode, expectedMessage);
     }
 
+    private void testRecordPageSource(
+            HiveRecordCursorProvider cursorProvider,
+            FileSplit split,
+            HiveStorageFormat storageFormat,
+            List<TestColumn> testReadColumns,
+            ConnectorSession session,
+            int rowCount)
+                throws Exception
+    {
+        Properties splitProperties = new Properties();
+        splitProperties.setProperty(FILE_INPUT_FORMAT, storageFormat.getInputFormat());
+        splitProperties.setProperty(SERIALIZATION_LIB, storageFormat.getSerDe());
+        ConnectorPageSource pageSource = createPageSourceFromCursorProvider(cursorProvider, split, splitProperties, testReadColumns, session);
+        checkPageSource(pageSource, testReadColumns, getTypes(getColumnHandles(testReadColumns)), rowCount);
+    }
+
     private void testCursorProvider(
             HiveRecordCursorProvider cursorProvider,
             FileSplit split,
             HiveStorageFormat storageFormat,
-            List<TestColumn> testColumns,
+            List<TestColumn> testReadColumns,
             ConnectorSession session,
             int rowCount)
     {
         Properties splitProperties = new Properties();
         splitProperties.setProperty(FILE_INPUT_FORMAT, storageFormat.getInputFormat());
         splitProperties.setProperty(SERIALIZATION_LIB, storageFormat.getSerDe());
-        testCursorProvider(cursorProvider, split, splitProperties, testColumns, session, rowCount);
+        testCursorProvider(cursorProvider, split, splitProperties, testReadColumns, session, rowCount);
     }
 
     private void testCursorProvider(
             HiveRecordCursorProvider cursorProvider,
             FileSplit split,
             Properties splitProperties,
-            List<TestColumn> testColumns,
+            List<TestColumn> testReadColumns,
             ConnectorSession session,
             int rowCount)
     {
+        ConnectorPageSource pageSource = createPageSourceFromCursorProvider(cursorProvider, split, splitProperties, testReadColumns, session);
+        RecordCursor cursor = ((RecordPageSource) pageSource).getCursor();
+        checkCursor(cursor, testReadColumns, rowCount);
+    }
+
+    private ConnectorPageSource createPageSourceFromCursorProvider(
+            HiveRecordCursorProvider cursorProvider,
+            FileSplit split,
+            Properties splitProperties,
+            List<TestColumn> testReadColumns,
+            ConnectorSession session)
+    {
+        // Use full columns in split properties
+        ImmutableList.Builder<String> splitPropertiesColumnNames = ImmutableList.builder();
+        ImmutableList.Builder<String> splitPropertiesColumnTypes = ImmutableList.builder();
+        Set<String> baseColumnNames = new HashSet<>();
+
+        for (TestColumn testReadColumn : testReadColumns) {
+            String name = testReadColumn.getBaseName();
+            if (!baseColumnNames.contains(name) && !testReadColumn.isPartitionKey()) {
+                baseColumnNames.add(name);
+                splitPropertiesColumnNames.add(name);
+                splitPropertiesColumnTypes.add(testReadColumn.getBaseObjectInspector().getTypeName());
+            }
+        }
+
         splitProperties.setProperty(
                 "columns",
-                testColumns.stream()
-                        .filter(column -> !column.isPartitionKey())
-                        .map(TestColumn::getName)
-                        .collect(Collectors.joining(",")));
+                splitPropertiesColumnNames.build().stream()
+                    .collect(Collectors.joining(",")));
+
         splitProperties.setProperty(
                 "columns.types",
-                testColumns.stream()
-                        .filter(column -> !column.isPartitionKey())
-                        .map(TestColumn::getType)
-                        .collect(Collectors.joining(",")));
+                splitPropertiesColumnTypes.build().stream()
+                    .collect(Collectors.joining(",")));
 
-        List<HivePartitionKey> partitionKeys = testColumns.stream()
+        List<HivePartitionKey> partitionKeys = testReadColumns.stream()
                 .filter(TestColumn::isPartitionKey)
                 .map(input -> new HivePartitionKey(input.getName(), (String) input.getWriteValue()))
                 .collect(toList());
@@ -618,7 +912,7 @@ public class TestHiveFileFormats
                 Instant.now().toEpochMilli(),
                 splitProperties,
                 TupleDomain.all(),
-                getColumnHandles(testColumns),
+                getColumnHandles(testReadColumns),
                 partitionKeys,
                 DateTimeZone.getDefault(),
                 TYPE_MANAGER,
@@ -627,16 +921,14 @@ public class TestHiveFileFormats
                 false,
                 Optional.empty());
 
-        RecordCursor cursor = ((RecordPageSource) pageSource.get()).getCursor();
-
-        checkCursor(cursor, testColumns, rowCount);
+        return pageSource.get();
     }
 
     private void testPageSourceFactory(
             HivePageSourceFactory sourceFactory,
             FileSplit split,
             HiveStorageFormat storageFormat,
-            List<TestColumn> testColumns,
+            List<TestColumn> testReadColumns,
             ConnectorSession session,
             int rowCount)
             throws IOException
@@ -644,25 +936,30 @@ public class TestHiveFileFormats
         Properties splitProperties = new Properties();
         splitProperties.setProperty(FILE_INPUT_FORMAT, storageFormat.getInputFormat());
         splitProperties.setProperty(SERIALIZATION_LIB, storageFormat.getSerDe());
-        splitProperties.setProperty(
-                "columns",
-                testColumns.stream()
-                        .filter(column -> !column.isPartitionKey())
-                        .map(TestColumn::getName)
-                        .collect(Collectors.joining(",")));
-        splitProperties.setProperty(
-                "columns.types",
-                testColumns.stream()
-                        .filter(column -> !column.isPartitionKey())
-                        .map(TestColumn::getType)
-                        .collect(Collectors.joining(",")));
 
-        List<HivePartitionKey> partitionKeys = testColumns.stream()
+        // Use full columns in split properties
+        ImmutableList.Builder<String> splitPropertiesColumnNames = ImmutableList.builder();
+        ImmutableList.Builder<String> splitPropertiesColumnTypes = ImmutableList.builder();
+        Set<String> baseColumnNames = new HashSet<>();
+
+        for (TestColumn testReadColumn : testReadColumns) {
+            String name = testReadColumn.getBaseName();
+            if (!baseColumnNames.contains(name) && !testReadColumn.isPartitionKey()) {
+                baseColumnNames.add(name);
+                splitPropertiesColumnNames.add(name);
+                splitPropertiesColumnTypes.add(testReadColumn.getBaseObjectInspector().getTypeName());
+            }
+        }
+
+        splitProperties.setProperty("columns", splitPropertiesColumnNames.build().stream().collect(Collectors.joining(",")));
+        splitProperties.setProperty("columns.types", splitPropertiesColumnTypes.build().stream().collect(Collectors.joining(",")));
+
+        List<HivePartitionKey> partitionKeys = testReadColumns.stream()
                 .filter(TestColumn::isPartitionKey)
                 .map(input -> new HivePartitionKey(input.getName(), (String) input.getWriteValue()))
                 .collect(toList());
 
-        List<HiveColumnHandle> columnHandles = getColumnHandles(testColumns);
+        List<HiveColumnHandle> columnHandles = getColumnHandles(testReadColumns);
 
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(sourceFactory),
@@ -688,7 +985,7 @@ public class TestHiveFileFormats
 
         assertTrue(pageSource.isPresent());
 
-        checkPageSource(pageSource.get(), testColumns, getTypes(columnHandles), rowCount);
+        checkPageSource(pageSource.get(), testReadColumns, getTypes(columnHandles), rowCount);
     }
 
     public static boolean hasType(ObjectInspector objectInspector, PrimitiveCategory... types)
@@ -741,6 +1038,51 @@ public class TestHiveFileFormats
     {
         return new HiveConfig()
                 .setUseParquetColumnNames(useParquetColumnNames);
+    }
+
+    private void generateProjectedColumns(List<TestColumn> childColumns, ImmutableList.Builder<TestColumn> testFullColumnsBuilder, ImmutableList.Builder<TestColumn> testDereferencedColumnsBuilder)
+    {
+        for (int i = 0; i < childColumns.size(); i++) {
+            TestColumn childColumn = childColumns.get(i);
+            checkState(childColumn.getDereferenceIndices().size() == 0);
+            ObjectInspector newObjectInspector = getStandardStructObjectInspector(
+                    ImmutableList.of("field0"),
+                    ImmutableList.of(childColumn.getObjectInspector()));
+
+            HiveType hiveType = (HiveType.valueOf(childColumn.getObjectInspector().getTypeName()));
+            Type prestoType = hiveType.getType(TYPE_MANAGER);
+
+            List<Object> list = new ArrayList<>();
+            list.add(childColumn.getWriteValue());
+
+            TestColumn newProjectedColumn = new TestColumn(
+                    "new_col" + i, newObjectInspector,
+                    ImmutableList.of("field0"),
+                    ImmutableList.of(0),
+                    childColumn.getObjectInspector(),
+                    childColumn.getWriteValue(),
+                    childColumn.getExpectedValue(),
+                    false);
+
+            TestColumn newFullColumn = new TestColumn("new_col" + i, newObjectInspector, list, rowBlockOf(ImmutableList.of(prestoType), childColumn.getExpectedValue()));
+
+            testFullColumnsBuilder.add(newFullColumn);
+            testDereferencedColumnsBuilder.add(newProjectedColumn);
+        }
+    }
+
+    private final List<TestColumn> getRegularColumns(List<TestColumn> columns)
+    {
+        return columns.stream()
+                .filter(column -> !column.isPartitionKey())
+                .collect(toImmutableList());
+    }
+
+    private final List<TestColumn> getPartitionColumns(List<TestColumn> columns)
+    {
+        return columns.stream()
+                .filter(column -> column.isPartitionKey())
+                .collect(toImmutableList());
     }
 
     private class FileFormatAssertion
@@ -811,32 +1153,39 @@ public class TestHiveFileFormats
         public FileFormatAssertion isReadableByPageSource(HivePageSourceFactory pageSourceFactory)
                 throws Exception
         {
-            assertRead(Optional.of(pageSourceFactory), Optional.empty());
+            assertRead(Optional.of(pageSourceFactory), Optional.empty(), false);
+            return this;
+        }
+
+        public FileFormatAssertion isReadableByRecordCursorPageSource(HiveRecordCursorProvider cursorProvider)
+                throws Exception
+        {
+            assertRead(Optional.empty(), Optional.of(cursorProvider), true);
             return this;
         }
 
         public FileFormatAssertion isReadableByRecordCursor(HiveRecordCursorProvider cursorProvider)
                 throws Exception
         {
-            assertRead(Optional.empty(), Optional.of(cursorProvider));
+            assertRead(Optional.empty(), Optional.of(cursorProvider), false);
             return this;
         }
 
         public FileFormatAssertion isFailingForPageSource(HivePageSourceFactory pageSourceFactory, HiveErrorCode expectedErrorCode, String expectedMessage)
                 throws Exception
         {
-            assertFailure(Optional.of(pageSourceFactory), Optional.empty(), expectedErrorCode, expectedMessage);
+            assertFailure(Optional.of(pageSourceFactory), Optional.empty(), expectedErrorCode, expectedMessage, false);
             return this;
         }
 
         public FileFormatAssertion isFailingForRecordCursor(HiveRecordCursorProvider cursorProvider, HiveErrorCode expectedErrorCode, String expectedMessage)
                 throws Exception
         {
-            assertFailure(Optional.empty(), Optional.of(cursorProvider), expectedErrorCode, expectedMessage);
+            assertFailure(Optional.empty(), Optional.of(cursorProvider), expectedErrorCode, expectedMessage, false);
             return this;
         }
 
-        private void assertRead(Optional<HivePageSourceFactory> pageSourceFactory, Optional<HiveRecordCursorProvider> cursorProvider)
+        private void assertRead(Optional<HivePageSourceFactory> pageSourceFactory, Optional<HiveRecordCursorProvider> cursorProvider, boolean withRecordPageSource)
                 throws Exception
         {
             assertNotNull(storageFormat, "storageFormat must be specified");
@@ -866,11 +1215,17 @@ public class TestHiveFileFormats
                 else {
                     split = createTestFile(file.getAbsolutePath(), storageFormat, compressionCodec, writeColumns, rowsCount);
                 }
+
                 if (pageSourceFactory.isPresent()) {
                     testPageSourceFactory(pageSourceFactory.get(), split, storageFormat, readColumns, session, rowsCount);
                 }
                 if (cursorProvider.isPresent()) {
-                    testCursorProvider(cursorProvider.get(), split, storageFormat, readColumns, session, rowsCount);
+                    if (withRecordPageSource) {
+                        testRecordPageSource(cursorProvider.get(), split, storageFormat, readColumns, session, rowsCount);
+                    }
+                    else {
+                        testCursorProvider(cursorProvider.get(), split, storageFormat, readColumns, session, rowsCount);
+                    }
                 }
             }
             finally {
@@ -883,11 +1238,12 @@ public class TestHiveFileFormats
                 Optional<HivePageSourceFactory> pageSourceFactory,
                 Optional<HiveRecordCursorProvider> cursorProvider,
                 HiveErrorCode expectedErrorCode,
-                String expectedMessage)
+                String expectedMessage,
+                boolean withRecordPageSource)
                 throws Exception
         {
             try {
-                assertRead(pageSourceFactory, cursorProvider);
+                assertRead(pageSourceFactory, cursorProvider, withRecordPageSource);
                 fail("failure is expected");
             }
             catch (PrestoException prestoException) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -1192,7 +1192,7 @@ public class TestHiveFileFormats
             assertNotNull(writeColumns, "writeColumns must be specified");
             assertNotNull(readColumns, "readColumns must be specified");
             assertNotNull(session, "session must be specified");
-            assertTrue(rowsCount >= 0, "rowsCount must be greater than zero");
+            assertTrue(rowsCount >= 0, "rowsCount must be non-negative");
 
             String compressionSuffix = compressionCodec.getCodec()
                     .map(codec -> {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -2916,12 +2916,30 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testRows()
+    public void testRowsWithAllFormats()
     {
-        assertUpdate("CREATE TABLE tmp_row1 AS SELECT cast(row(CAST(1 as BIGINT), CAST(NULL as BIGINT)) AS row(col0 bigint, col1 bigint)) AS a", 1);
-        assertQuery(
-                "SELECT a.col0, a.col1 FROM tmp_row1",
-                "SELECT 1, cast(null as bigint)");
+        testWithAllStorageFormats(this::testRows);
+    }
+
+    private void testRows(Session session, HiveStorageFormat format)
+    {
+        String tableName = "test_dereferences";
+        @Language("SQL") String createTable = "" +
+                "CREATE TABLE " + tableName +
+                " WITH (" +
+                "format = '" + format + "'" +
+                ") " +
+                "AS SELECT " +
+                "CAST(row(CAST(1 as BIGINT), CAST(NULL as BIGINT)) AS row(col0 bigint, col1 bigint)) AS a, " +
+                "CAST(row(row(CAST('abc' as VARCHAR), CAST(5 as BIGINT)), CAST(3.0 AS DOUBLE)) AS row(field0 row(col0 varchar, col1 bigint), field1 double)) AS b";
+
+        assertUpdate(session, createTable, 1);
+
+        assertQuery(session,
+                "SELECT a.col0, a.col1, b.field0.col0, b.field0.col1, b.field1 FROM " + tableName,
+                "SELECT 1, cast(null as bigint), CAST('abc' as VARCHAR), CAST(5 as BIGINT), CAST(3.0 AS DOUBLE)");
+
+        assertUpdate(session, "DROP TABLE " + tableName);
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveMetadata.java
@@ -22,16 +22,17 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveMetadata.createPredicate;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 
 public class TestHiveMetadata
 {
-    private static final HiveColumnHandle TEST_COLUMN_HANDLE = new HiveColumnHandle(
+    private static final HiveColumnHandle TEST_COLUMN_HANDLE = createBaseColumn(
             "test",
+            0,
             HiveType.HIVE_STRING,
             VARCHAR,
-            0,
             HiveColumnHandle.ColumnType.PARTITION_KEY,
             Optional.empty());
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -60,6 +60,7 @@ import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.testing.Assertions.assertGreaterThan;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveCompressionCodec.NONE;
 import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.prestosql.plugin.hive.HiveTestUtils.PAGE_SORTER;
@@ -291,7 +292,7 @@ public class TestHivePageSink
         for (int i = 0; i < columns.size(); i++) {
             LineItemColumn column = columns.get(i);
             HiveType hiveType = getHiveType(column.getType());
-            handles.add(new HiveColumnHandle(column.getColumnName(), hiveType, hiveType.getType(TYPE_MANAGER), i, REGULAR, Optional.empty()));
+            handles.add(createBaseColumn(column.getColumnName(), i, hiveType, hiveType.getType(TYPE_MANAGER), REGULAR, Optional.empty()));
         }
         return handles.build();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -66,7 +66,7 @@ public class TestHiveReaderProjectionsUtil
         return hiveColumns.build();
     }
 
-    static HiveColumnHandle createProjectedColumnHandle(HiveColumnHandle column, List<Integer> indices)
+    public static HiveColumnHandle createProjectedColumnHandle(HiveColumnHandle column, List<Integer> indices)
     {
         checkArgument(column.isBaseColumn(), "base column is expected here");
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.type.NamedTypeSignature;
+import io.prestosql.spi.type.RowFieldName;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.TypeManager;
+import io.prestosql.type.InternalTypeManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
+import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.prestosql.plugin.hive.HiveTestUtils.rowType;
+import static io.prestosql.plugin.hive.HiveType.toHiveType;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+
+public class TestHiveReaderProjectionsUtil
+{
+    private TestHiveReaderProjectionsUtil() {}
+
+    public static final RowType ROWTYPE_OF_PRIMITIVES = rowType(ImmutableList.of(
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint_0")), BIGINT.getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint_1")), BIGINT.getTypeSignature())));
+
+    public static final RowType ROWTYPE_OF_ROW_AND_PRIMITIVES = rowType(ImmutableList.of(
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_row_0")), ROWTYPE_OF_PRIMITIVES.getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint_0")), BIGINT.getTypeSignature())));
+
+    public static final TypeManager TYPE_MANAGER = new InternalTypeManager(createTestMetadataManager());
+
+    public static final HiveTypeTranslator HIVE_TYPE_TRANSLATOR = new HiveTypeTranslator();
+
+    public static Map<String, HiveColumnHandle> createTestFullColumns(List<String> names, Map<String, Type> types)
+    {
+        checkArgument(names.size() == types.size());
+
+        ImmutableMap.Builder<String, HiveColumnHandle> hiveColumns = ImmutableMap.builder();
+
+        int regularColumnHiveIndex = 0;
+        for (String name : names) {
+            HiveType hiveType = toHiveType(HIVE_TYPE_TRANSLATOR, types.get(name));
+            hiveColumns.put(name, createBaseColumn(name, regularColumnHiveIndex, hiveType, types.get(name), REGULAR, Optional.empty()));
+            regularColumnHiveIndex++;
+        }
+
+        return hiveColumns.build();
+    }
+
+    static HiveColumnHandle createProjectedColumnHandle(HiveColumnHandle column, List<Integer> indices)
+    {
+        checkArgument(column.isBaseColumn(), "base column is expected here");
+
+        if (indices.size() == 0) {
+            return column;
+        }
+
+        HiveType baseHiveType = column.getHiveType();
+        List<String> names = baseHiveType.getHiveDereferenceNames(indices);
+        HiveType hiveType = baseHiveType.getHiveTypeForDereferences(indices).get();
+
+        HiveColumnProjectionInfo columnProjection = new HiveColumnProjectionInfo(indices, names, hiveType, hiveType.getType(TYPE_MANAGER));
+
+        return new HiveColumnHandle(
+                column.getBaseColumnName(),
+                column.getBaseHiveColumnIndex(),
+                column.getBaseHiveType(),
+                column.getBaseType(),
+                Optional.of(columnProjection),
+                column.getColumnType(),
+                column.getComment());
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveType.HIVE_LONG;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -75,7 +76,7 @@ public class TestHiveSplit
                         BUCKETING_V1,
                         32,
                         16,
-                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT, 5, ColumnType.REGULAR, Optional.of("comment"))))),
+                        ImmutableList.of(createBaseColumn("col", 5, HIVE_LONG, BIGINT, ColumnType.REGULAR, Optional.of("comment"))))),
                 false,
                 Optional.of(deleteDeltaLocations));
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveTestUtils.longDecimal;
 import static io.prestosql.plugin.hive.HiveTestUtils.shortDecimal;
 import static io.prestosql.plugin.hive.HiveType.HIVE_DATE;
@@ -56,9 +57,9 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("n_nationkey", HIVE_INT, INTEGER, 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("n_name", HIVE_STRING, VARCHAR, 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("n_regionkey", HIVE_INT, INTEGER, 2, REGULAR, Optional.empty()));
+                createBaseColumn("n_nationkey", 0, HIVE_INT, INTEGER, REGULAR, Optional.empty()),
+                createBaseColumn("n_name", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty()),
+                createBaseColumn("n_regionkey", 2, HIVE_INT, INTEGER, REGULAR, Optional.empty()));
 
         assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s",
                 queryBuilder.buildSql(columns, TupleDomain.all()));
@@ -81,9 +82,9 @@ public class TestIonSqlQueryBuilder
         TypeManager typeManager = this.typeManager;
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("quantity", HiveType.valueOf("decimal(20,0)"), DecimalType.createDecimalType(), 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("extendedprice", HiveType.valueOf("decimal(20,2)"), DecimalType.createDecimalType(), 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("discount", HiveType.valueOf("decimal(10,2)"), DecimalType.createDecimalType(), 2, REGULAR, Optional.empty()));
+                createBaseColumn("quantity", 0, HiveType.valueOf("decimal(20,0)"), DecimalType.createDecimalType(), REGULAR, Optional.empty()),
+                createBaseColumn("extendedprice", 1, HiveType.valueOf("decimal(20,2)"), DecimalType.createDecimalType(), REGULAR, Optional.empty()),
+                createBaseColumn("discount", 2, HiveType.valueOf("decimal(10,2)"), DecimalType.createDecimalType(), REGULAR, Optional.empty()));
         DecimalType decimalType = DecimalType.createDecimalType(10, 2);
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
                 ImmutableMap.of(
@@ -101,8 +102,8 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("t1", HIVE_TIMESTAMP, TIMESTAMP, 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("t2", HIVE_DATE, DATE, 1, REGULAR, Optional.empty()));
+                createBaseColumn("t1", 0, HIVE_TIMESTAMP, TIMESTAMP, REGULAR, Optional.empty()),
+                createBaseColumn("t2", 1, HIVE_DATE, DATE, REGULAR, Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 columns.get(1), Domain.create(SortedRangeSet.copyOf(DATE, ImmutableList.of(Range.equal(DATE, (long) DateTimeUtils.parseDate("2001-08-22")))), false)));
 
@@ -114,9 +115,9 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle("quantity", HIVE_INT, INTEGER, 0, REGULAR, Optional.empty()),
-                new HiveColumnHandle("extendedprice", HIVE_DOUBLE, DOUBLE, 1, REGULAR, Optional.empty()),
-                new HiveColumnHandle("discount", HIVE_DOUBLE, DOUBLE, 2, REGULAR, Optional.empty()));
+                createBaseColumn("quantity", 0, HIVE_INT, INTEGER, REGULAR, Optional.empty()),
+                createBaseColumn("extendedprice", 1, HIVE_DOUBLE, DOUBLE, REGULAR, Optional.empty()),
+                createBaseColumn("discount", 2, HIVE_DOUBLE, DOUBLE, REGULAR, Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
                 ImmutableMap.of(
                         columns.get(0), Domain.create(ofRanges(Range.lessThan(BIGINT, 50L)), false),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -101,6 +101,7 @@ import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.orc.OrcReader.MAX_BATCH_SIZE;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.prestosql.plugin.hive.HiveTestUtils.SESSION;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
@@ -454,7 +455,7 @@ public class TestOrcPageSourceMemoryTracking
                 HiveType hiveType = HiveType.valueOf(inspector.getTypeName());
                 Type type = hiveType.getType(TYPE_MANAGER);
 
-                columnsBuilder.add(new HiveColumnHandle(testColumn.getName(), hiveType, type, columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
+                columnsBuilder.add(createBaseColumn(testColumn.getName(), columnIndex, hiveType, type, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
                 typesBuilder.add(type);
             }
             columns = columnsBuilder.build();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
-import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile.WriterOptions;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
@@ -461,7 +460,7 @@ public class TestOrcPageSourceMemoryTracking
             columns = columnsBuilder.build();
             types = typesBuilder.build();
 
-            fileSplit = createTestFile(tempFilePath, new OrcOutputFormat(), serde, null, testColumns, numRows, stripeRows);
+            fileSplit = createTestFile(tempFilePath, serde, null, testColumns, numRows, stripeRows);
         }
 
         public ConnectorPageSource newPageSource()
@@ -554,7 +553,6 @@ public class TestOrcPageSourceMemoryTracking
 
     public static FileSplit createTestFile(
             String filePath,
-            HiveOutputFormat<?, ?> outputFormat,
             Serializer serializer,
             String compressionCodec,
             List<TestColumn> testColumns,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -274,7 +274,7 @@ public class TestOrcPageSourceMemoryTracking
                 .add(new TestColumn("p_empty_string", javaStringObjectInspector, () -> "", true));
         GrowingTestColumn[] dataColumns = new GrowingTestColumn[numColumns];
         for (int i = 0; i < numColumns; i++) {
-            dataColumns[i] = new GrowingTestColumn("p_string", javaStringObjectInspector, () -> Long.toHexString(random.nextLong()), false, step * (i + 1));
+            dataColumns[i] = new GrowingTestColumn("p_string" + "_" + i, javaStringObjectInspector, () -> Long.toHexString(random.nextLong()), false, step * (i + 1));
             columnBuilder.add(dataColumns[i]);
         }
         List<TestColumn> testColumns = columnBuilder.build();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjections.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjections.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_PRIMITIVES;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createTestFullColumns;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestReaderProjections
+{
+    private static final List<String> TEST_COLUMN_NAMES = ImmutableList.of(
+            "col_bigint",
+            "col_struct_of_primitives",
+            "col_struct_of_non_primitives",
+            "col_partition_key_1",
+            "col_partition_key_2");
+
+    private static final Map<String, Type> TEST_COLUMN_TYPES = ImmutableMap.<String, Type>builder()
+            .put("col_bigint", BIGINT)
+            .put("col_struct_of_primitives", ROWTYPE_OF_PRIMITIVES)
+            .put("col_struct_of_non_primitives", ROWTYPE_OF_ROW_AND_PRIMITIVES)
+            .put("col_partition_key_1", BIGINT)
+            .put("col_partition_key_2", BIGINT)
+            .build();
+
+    private static final Map<String, HiveColumnHandle> TEST_FULL_COLUMNS = createTestFullColumns(TEST_COLUMN_NAMES, TEST_COLUMN_TYPES);
+
+    @Test
+    public void testNoProjections()
+    {
+        List<HiveColumnHandle> columns = new ArrayList<>(TEST_FULL_COLUMNS.values());
+        Optional<ReaderProjections> mapping = projectBaseColumns(columns);
+        assertTrue(!mapping.isPresent(), "Full columns should not require any adaptation");
+    }
+
+    @Test
+    public void testBaseColumnsProjection()
+    {
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_primitives"), ImmutableList.of(0)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_primitives"), ImmutableList.of(1)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_bigint"), ImmutableList.of()),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0, 1)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0)));
+
+        Optional<ReaderProjections> mapping = projectBaseColumns(columns);
+        assertTrue(mapping.isPresent(), "Full columns should be created for corresponding projected columns");
+
+        List<HiveColumnHandle> readerColumns = mapping.get().getReaderColumns();
+
+        for (int i = 0; i < columns.size(); i++) {
+            HiveColumnHandle column = columns.get(i);
+            int readerIndex = mapping.get().readerColumnPositionForHiveColumnAt(i);
+            HiveColumnHandle readerColumn = mapping.get().readerColumnForHiveColumnAt(i);
+            assertEquals(column.getBaseColumn(), readerColumn);
+            assertEquals(readerColumns.get(readerIndex), readerColumn);
+        }
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjections.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjections.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderProjections.projectSufficientColumns;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
@@ -55,7 +56,12 @@ public class TestReaderProjections
     public void testNoProjections()
     {
         List<HiveColumnHandle> columns = new ArrayList<>(TEST_FULL_COLUMNS.values());
-        Optional<ReaderProjections> mapping = projectBaseColumns(columns);
+        Optional<ReaderProjections> mapping;
+
+        mapping = projectBaseColumns(columns);
+        assertTrue(!mapping.isPresent(), "Full columns should not require any adaptation");
+
+        mapping = projectSufficientColumns(columns);
         assertTrue(!mapping.isPresent(), "Full columns should not require any adaptation");
     }
 
@@ -81,5 +87,37 @@ public class TestReaderProjections
             assertEquals(column.getBaseColumn(), readerColumn);
             assertEquals(readerColumns.get(readerIndex), readerColumn);
         }
+    }
+
+    @Test
+    public void testProjectSufficientColumns()
+    {
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_primitives"), ImmutableList.of(0)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_primitives"), ImmutableList.of(1)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_bigint"), ImmutableList.of()),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0, 1)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0)));
+
+        Optional<ReaderProjections> readerProjections = projectSufficientColumns(columns);
+        assertTrue(readerProjections.isPresent(), "expected readerProjections to be present");
+
+        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(0), columns.get(0));
+        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(1), columns.get(1));
+        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(2), columns.get(2));
+        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(3), columns.get(4));
+        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(4), columns.get(4));
+
+        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(0), 0);
+        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(1), 1);
+        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(2), 2);
+        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(3), 3);
+        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(4), 3);
+
+        List<HiveColumnHandle> readerColumns = readerProjections.get().getReaderColumns();
+        assertEquals(readerColumns.get(0), columns.get(0));
+        assertEquals(readerColumns.get(1), columns.get(1));
+        assertEquals(readerColumns.get(2), columns.get(2));
+        assertEquals(readerColumns.get(3), columns.get(4));
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjectionsAdapter.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.ColumnarRow;
+import io.prestosql.spi.block.LazyBlock;
+import io.prestosql.spi.block.RowBlock;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.block.BlockAssertions.assertBlockEquals;
+import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createTestFullColumns;
+import static io.prestosql.plugin.hive.TestReaderProjectionsAdapter.RowData.rowData;
+import static io.prestosql.spi.block.ColumnarRow.toColumnarRow;
+import static io.prestosql.spi.block.RowBlock.fromFieldBlocks;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestReaderProjectionsAdapter
+{
+    private static final String TEST_COLUMN_NAME = "col";
+    private static final Type TEST_COLUMN_TYPE = ROWTYPE_OF_ROW_AND_PRIMITIVES;
+
+    private static final Map<String, HiveColumnHandle> TEST_FULL_COLUMNS = createTestFullColumns(
+            ImmutableList.of(TEST_COLUMN_NAME),
+            ImmutableMap.of(TEST_COLUMN_NAME, TEST_COLUMN_TYPE));
+
+    @Test
+    public void testAdaptPage()
+    {
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col"), ImmutableList.of(0, 0)),
+                createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col"), ImmutableList.of(0)));
+
+        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+
+        List<Object> inputBlockData = new ArrayList<>();
+        inputBlockData.add(rowData(rowData(11L, 12L, 13L), 1L));
+        inputBlockData.add(rowData(null, 2L));
+        inputBlockData.add(null);
+        inputBlockData.add(rowData(rowData(31L, 32L, 33L), 3L));
+
+        ReaderProjectionsAdapter adapter = new ReaderProjectionsAdapter(columns, readerProjections.get());
+        verifyPageAdaptation(adapter, ImmutableList.of(inputBlockData));
+    }
+
+    @Test
+    public void testLazyDereferenceProjectionLoading()
+    {
+        List<HiveColumnHandle> columns = ImmutableList.of(createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col"), ImmutableList.of(0, 0)));
+
+        List<Object> inputBlockData = new ArrayList<>();
+        inputBlockData.add(rowData(rowData(11L, 12L, 13L), 1L));
+        inputBlockData.add(rowData(null, 2L));
+        inputBlockData.add(null);
+        inputBlockData.add(rowData(rowData(31L, 32L, 33L), 3L));
+
+        // Produce an output page by applying adaptation
+        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+        ReaderProjectionsAdapter adapter = new ReaderProjectionsAdapter(columns, readerProjections.get());
+        Page inputPage = createPage(ImmutableList.of(inputBlockData), adapter.getInputTypes());
+        Page outputPage = adapter.adaptPage(inputPage).getLoadedPage();
+
+        // Verify that only the block corresponding to subfield "col.f_row_0.f_bigint_0" should be completely loaded, others are not.
+
+        // Assertion for "col"
+        Block lazyBlockLevel1 = inputPage.getBlock(0);
+        assertTrue(lazyBlockLevel1 instanceof LazyBlock);
+        assertFalse(lazyBlockLevel1.isLoaded());
+        RowBlock rowBlockLevel1 = ((RowBlock) (((LazyBlock) lazyBlockLevel1).getBlock()));
+        assertFalse(rowBlockLevel1.isLoaded());
+
+        // Assertion for "col.f_row_0" and col.f_bigint_0"
+        ColumnarRow columnarRowLevel1 = toColumnarRow(rowBlockLevel1);
+        assertFalse(columnarRowLevel1.getField(0).isLoaded());
+        assertFalse(columnarRowLevel1.getField(1).isLoaded());
+
+        Block lazyBlockLevel2 = columnarRowLevel1.getField(0);
+        assertTrue(lazyBlockLevel2 instanceof LazyBlock);
+        RowBlock rowBlockLevel2 = ((RowBlock) (((LazyBlock) lazyBlockLevel2).getBlock()));
+        assertFalse(rowBlockLevel2.isLoaded());
+        ColumnarRow columnarRowLevel2 = toColumnarRow(rowBlockLevel2);
+        // Assertion for "col.f_row_0.f_bigint_0" and "col.f_row_0.f_bigint_1"
+        assertTrue(columnarRowLevel2.getField(0).isLoaded());
+        assertFalse(columnarRowLevel2.getField(1).isLoaded());
+    }
+
+    private void verifyPageAdaptation(ReaderProjectionsAdapter adapter, List<List<Object>> inputPageData)
+    {
+        List<ReaderProjectionsAdapter.ChannelMapping> columnMapping = adapter.getOutputToInputMapping();
+        List<Type> outputTypes = adapter.getOutputTypes();
+        List<Type> inputTypes = adapter.getInputTypes();
+
+        Page inputPage = createPage(inputPageData, inputTypes);
+        Page outputPage = adapter.adaptPage(inputPage).getLoadedPage();
+
+        // Verify output block values
+        for (int i = 0; i < columnMapping.size(); i++) {
+            ReaderProjectionsAdapter.ChannelMapping mapping = columnMapping.get(i);
+            int inputBlockIndex = mapping.getInputChannelIndex();
+            verifyBlock(
+                    outputPage.getBlock(i),
+                    outputTypes.get(i),
+                    inputPage.getBlock(inputBlockIndex),
+                    inputTypes.get(inputBlockIndex),
+                    mapping.getDereferenceSequence());
+        }
+    }
+
+    private static Page createPage(List<List<Object>> pageData, List<Type> types)
+    {
+        Block[] inputPageBlocks = new Block[pageData.size()];
+        for (int i = 0; i < inputPageBlocks.length; i++) {
+            inputPageBlocks[i] = createInputBlock(pageData.get(i), types.get(i));
+        }
+
+        return new Page(inputPageBlocks);
+    }
+
+    private static Block createInputBlock(List<Object> data, Type type)
+    {
+        int positionCount = data.size();
+
+        if (type instanceof RowType) {
+            return new LazyBlock(data.size(), () -> createRowBlockWithLazyNestedBlocks(data, (RowType) type));
+        }
+        else if (BIGINT.equals(type)) {
+            return new LazyBlock(positionCount, () -> createLongArrayBlock(data));
+        }
+        else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static Block createRowBlockWithLazyNestedBlocks(List<Object> data, RowType rowType)
+    {
+        int positionCount = data.size();
+
+        boolean[] isNull = new boolean[positionCount];
+        int fieldCount = rowType.getFields().size();
+
+        List<List<Object>> fieldsData = new ArrayList<>();
+        for (int i = 0; i < fieldCount; i++) {
+            fieldsData.add(new ArrayList<>());
+        }
+
+        // Extract data to generate fieldBlocks
+        for (int position = 0; position < data.size(); position++) {
+            RowData row = (RowData) data.get(position);
+            if (row == null) {
+                isNull[position] = true;
+            }
+            else {
+                for (int field = 0; field < fieldCount; field++) {
+                    fieldsData.get(field).add(row.getField(field));
+                }
+            }
+        }
+
+        Block[] fieldBlocks = new Block[fieldCount];
+        for (int field = 0; field < fieldCount; field++) {
+            fieldBlocks[field] = createInputBlock(fieldsData.get(field), rowType.getFields().get(field).getType());
+        }
+
+        return fromFieldBlocks(positionCount, Optional.of(isNull), fieldBlocks);
+    }
+
+    private static Block createLongArrayBlock(List<Object> data)
+    {
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, data.size());
+        for (int i = 0; i < data.size(); i++) {
+            Long value = (Long) data.get(i);
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                builder.writeLong(value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static void verifyBlock(Block actualBlock, Type outputType, Block input, Type inputType, List<Integer> dereferences)
+    {
+        Block expectedOutputBlock = createProjectedColumnBlock(input, outputType, inputType, dereferences);
+        assertBlockEquals(outputType, actualBlock, expectedOutputBlock);
+    }
+
+    private static Block createProjectedColumnBlock(Block data, Type finalType, Type blockType, List<Integer> dereferences)
+    {
+        if (dereferences.size() == 0) {
+            return data;
+        }
+
+        BlockBuilder builder = finalType.createBlockBuilder(null, data.getPositionCount());
+
+        for (int i = 0; i < data.getPositionCount(); i++) {
+            Type sourceType = blockType;
+
+            Block currentData = null;
+            boolean isNull = data.isNull(i);
+
+            if (!isNull) {
+                // Get SingleRowBlock corresponding to element at position i
+                currentData = data.getObject(i, Block.class);
+            }
+
+            // Apply all dereferences except for the last one, because the type can be different
+            for (int j = 0; j < dereferences.size() - 1; j++) {
+                if (isNull) {
+                    // If null element is discovered at any dereferencing step, break
+                    break;
+                }
+
+                checkArgument(sourceType instanceof RowType);
+                if (currentData.isNull(dereferences.get(j))) {
+                    currentData = null;
+                }
+                else {
+                    sourceType = ((RowType) sourceType).getFields().get(dereferences.get(j)).getType();
+                    currentData = currentData.getObject(dereferences.get(j), Block.class);
+                }
+
+                isNull = isNull || (currentData == null);
+            }
+
+            if (isNull) {
+                // Append null if any of the elements in the dereference chain were null
+                builder.appendNull();
+            }
+            else {
+                int lastDereference = dereferences.get(dereferences.size() - 1);
+
+                if (currentData.isNull(lastDereference)) {
+                    // Append null if the last dereference is null
+                    builder.appendNull();
+                }
+                else {
+                    // Append actual values otherwise
+                    if (finalType.equals(BIGINT)) {
+                        Long value = currentData.getLong(lastDereference, 0);
+                        builder.writeLong(value);
+                    }
+                    else if (finalType instanceof RowType) {
+                        Block block = currentData.getObject(lastDereference, Block.class);
+                        builder.appendStructure(block);
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+            }
+        }
+
+        return builder.build();
+    }
+
+    static class RowData
+    {
+        private final List<? extends Object> data;
+
+        private RowData(Object... data)
+        {
+            this.data = requireNonNull(Arrays.asList(data), "data is null");
+        }
+
+        static RowData rowData(Object... data)
+        {
+            return new RowData(data);
+        }
+
+        List<? extends Object> getData()
+        {
+            return data;
+        }
+
+        Object getField(int field)
+        {
+            checkArgument(field >= 0 && field < data.size());
+            return data.get(field);
+        }
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import io.prestosql.Session;
+import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveColumnHandle;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.Database;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.plugin.hive.testing.TestingHiveConnectorFactory;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.security.PrincipalType;
+import io.prestosql.sql.planner.assertions.BasePushdownPlanTest;
+import io.prestosql.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.any;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveProjectionPushdownIntoTableScan
+        extends BasePushdownPlanTest
+{
+    private static final String HIVE_CATALOG_NAME = "hive";
+    private static final String SCHEMA_NAME = "test_schema";
+
+    private static final Session HIVE_SESSION = testSessionBuilder()
+            .setCatalog(HIVE_CATALOG_NAME)
+            .setSchema(SCHEMA_NAME)
+            .build();
+
+    private File baseDir;
+
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
+    {
+        baseDir = Files.createTempDir();
+        HdfsConfig config = new HdfsConfig();
+        HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
+        HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
+
+        HiveMetastore metastore = new FileHiveMetastore(environment, baseDir.toURI().toString(), "test");
+        Database database = Database.builder()
+                .setDatabaseName(SCHEMA_NAME)
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build();
+
+        metastore.createDatabase(new HiveIdentity(HIVE_SESSION.toConnectorSession()), database);
+
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(HIVE_SESSION);
+        queryRunner.createCatalog(HIVE_CATALOG_NAME, new TestingHiveConnectorFactory(metastore), ImmutableMap.of());
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testProjectionPushdown()
+    {
+        String testTable = "test_simple_projection_pushdown";
+        QualifiedObjectName completeTableName = new QualifiedObjectName(HIVE_CATALOG_NAME, SCHEMA_NAME, testTable);
+
+        String tableName = HIVE_CATALOG_NAME + "." + SCHEMA_NAME + "." + testTable;
+        getQueryRunner().execute("CREATE TABLE " + tableName + " " + "(col0) AS" +
+                " SELECT cast(row(5, 6) as row(a bigint, b bigint)) as col0 where false");
+
+        Session session = getQueryRunner().getDefaultSession();
+
+        Optional<TableHandle> tableHandle = getTableHandle(session, completeTableName);
+        assertTrue(tableHandle.isPresent(), "expected the table handle to be present");
+
+        Map<String, ColumnHandle> columns = getColumnHandles(session, completeTableName);
+        assertTrue(columns.containsKey("col0"), "expected column not found");
+
+        HiveColumnHandle baseColumnHandle = (HiveColumnHandle) columns.get("col0");
+
+        assertPlan(
+                "SELECT col0.a expr_a, col0.b expr_b FROM " + tableName,
+                any(tableScan(
+                    equalTo(tableHandle.get().getConnectorHandle()),
+                    TupleDomain.all(),
+                    ImmutableMap.of(
+                        "col0#a", equalTo(createProjectedColumnHandle(baseColumnHandle, ImmutableList.of(0))),
+                        "col0#b", equalTo(createProjectedColumnHandle(baseColumnHandle, ImmutableList.of(1)))))));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws Exception
+    {
+        if (baseDir != null) {
+            deleteRecursively(baseDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestPushProjectionRuleWithHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestPushProjectionRuleWithHive.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import io.prestosql.Session;
+import io.prestosql.connector.CatalogName;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveColumnHandle;
+import io.prestosql.plugin.hive.HiveColumnProjectionInfo;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.HiveTableHandle;
+import io.prestosql.plugin.hive.HiveTransactionHandle;
+import io.prestosql.plugin.hive.HiveTypeTranslator;
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.Database;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.plugin.hive.testing.TestingHiveConnectorFactory;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.security.PrincipalType;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.iterative.rule.PushProjectionIntoTableScan;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.tree.DereferenceExpression;
+import io.prestosql.sql.tree.Identifier;
+import io.prestosql.sql.tree.SymbolReference;
+import io.prestosql.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.plugin.hive.HiveType.toHiveType;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.Arrays.asList;
+
+public class TestPushProjectionRuleWithHive
+        extends BaseRuleTest
+{
+    private static final String HIVE_CATALOG_NAME = "hive";
+    private static final String SCHEMA_NAME = "test_schema";
+    private static final String TABLE_NAME = "test_table";
+
+    private static final Type ROW_TYPE = RowType.from(asList(field("a", BIGINT), field("b", BIGINT)));
+
+    private File baseDir;
+
+    private static final Session HIVE_SESSION = testSessionBuilder()
+            .setCatalog(HIVE_CATALOG_NAME)
+            .setSchema(SCHEMA_NAME)
+            .build();
+
+    @Override
+    protected Optional<LocalQueryRunner> createLocalQueryRunner()
+    {
+        baseDir = Files.createTempDir();
+        HdfsConfig config = new HdfsConfig();
+        HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
+        HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
+
+        HiveMetastore metastore = new FileHiveMetastore(environment, baseDir.toURI().toString(), "test");
+        Database database = Database.builder()
+                .setDatabaseName(SCHEMA_NAME)
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build();
+
+        metastore.createDatabase(new HiveIdentity(SESSION), database);
+
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(HIVE_SESSION);
+        queryRunner.createCatalog(HIVE_CATALOG_NAME, new TestingHiveConnectorFactory(metastore), ImmutableMap.of());
+
+        return Optional.of(queryRunner);
+    }
+
+    @Test
+    public void testProjectionPushdown()
+    {
+        PushProjectionIntoTableScan pushProjectionIntoTableScan = new PushProjectionIntoTableScan(tester().getMetadata(), tester().getTypeAnalyzer());
+
+        tester().getQueryRunner().execute("CREATE TABLE " + TABLE_NAME + "(struct_of_int) AS " +
+                "SELECT cast(row(5, 6) as row(a bigint, b bigint)) as struct_of_int where false");
+
+        Type baseType = ROW_TYPE;
+
+        HiveColumnHandle partialColumn = new HiveColumnHandle(
+                "struct_of_int",
+                0,
+                toHiveType(new HiveTypeTranslator(), baseType),
+                baseType,
+                Optional.of(new HiveColumnProjectionInfo(
+                    ImmutableList.of(0),
+                    ImmutableList.of("a"),
+                    toHiveType(new HiveTypeTranslator(), BIGINT),
+                    BIGINT)),
+                HiveColumnHandle.ColumnType.REGULAR,
+                Optional.empty());
+
+        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), Optional.empty());
+        TableHandle table = new TableHandle(new CatalogName(HIVE_CATALOG_NAME), hiveTable, new HiveTransactionHandle(), Optional.empty());
+
+        HiveColumnHandle fullColumn = partialColumn.getBaseColumn();
+
+        // Test No pushdown in case of full column references
+        tester().assertThat(pushProjectionIntoTableScan)
+                .on(p ->
+                        p.project(
+                                Assignments.of(p.symbol("struct_of_int", baseType), p.symbol("struct_of_int", baseType).toSymbolReference()),
+                                p.tableScan(
+                                    table,
+                                    ImmutableList.of(p.symbol("struct_of_int", baseType)),
+                                    ImmutableMap.of(p.symbol("struct_of_int", baseType), fullColumn))))
+                .withSession(HIVE_SESSION)
+                .doesNotFire();
+
+        // Test Dereference pushdown
+        tester().assertThat(pushProjectionIntoTableScan)
+                .on(p ->
+                        p.project(
+                                Assignments.of(
+                                    p.symbol("expr_deref", BIGINT), new DereferenceExpression(p.symbol("struct_of_int", baseType).toSymbolReference(), new Identifier("a"))),
+                                p.tableScan(
+                                        table,
+                                        ImmutableList.of(p.symbol("struct_of_int", baseType)),
+                                        ImmutableMap.of(p.symbol("struct_of_int", baseType), fullColumn))))
+                .withSession(HIVE_SESSION)
+                .matches(project(
+                        ImmutableMap.of("expr_deref", expression(new SymbolReference("struct_of_int#a"))),
+                        tableScan(
+                                equalTo(table.getConnectorHandle()),
+                                TupleDomain.all(),
+                                ImmutableMap.of("struct_of_int#a", equalTo(partialColumn)))));
+    }
+
+    @AfterClass(alwaysRun = true)
+    protected void cleanup()
+            throws IOException
+    {
+        if (baseDir != null) {
+            deleteRecursively(baseDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory.getParquetTupleDomain;
 import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
 import static io.prestosql.spi.predicate.TupleDomain.withColumnDomains;
@@ -55,7 +56,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainPrimitiveArray()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array", HiveType.valueOf("array<int>"), new ArrayType(INTEGER), 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn("my_array", 0, HiveType.valueOf("array<int>"), new ArrayType(INTEGER), REGULAR, Optional.empty());
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(INTEGER))));
 
         MessageType fileSchema = new MessageType("hive_schema",
@@ -73,7 +74,8 @@ public class TestParquetPredicateUtils
         RowType.Field rowField = new RowType.Field(Optional.of("a"), INTEGER);
         RowType rowType = RowType.from(ImmutableList.of(rowField));
 
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array_struct", HiveType.valueOf("array<struct<a:int>>"), rowType, 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn("my_array_struct", 0, HiveType.valueOf("array<struct<a:int>>"), rowType, REGULAR, Optional.empty());
+
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(rowType))));
 
         MessageType fileSchema = new MessageType("hive_schema",
@@ -89,7 +91,7 @@ public class TestParquetPredicateUtils
     @Test
     public void testParquetTupleDomainPrimitive()
     {
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_primitive", HiveType.valueOf("bigint"), BIGINT, 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn("my_primitive", 0, HiveType.valueOf("bigint"), BIGINT, REGULAR, Optional.empty());
         Domain singleValueDomain = Domain.singleValue(BIGINT, 123L);
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, singleValueDomain));
 
@@ -114,7 +116,7 @@ public class TestParquetPredicateUtils
                 RowType.field("a", INTEGER),
                 RowType.field("b", INTEGER));
 
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_struct", HiveType.valueOf("struct<a:int,b:int>"), rowType, 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn("my_struct", 0, HiveType.valueOf("struct<a:int,b:int>"), rowType, REGULAR, Optional.empty());
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(rowType)));
 
         MessageType fileSchema = new MessageType("hive_schema",
@@ -137,7 +139,7 @@ public class TestParquetPredicateUtils
                 methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
                 methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"));
 
-        HiveColumnHandle columnHandle = new HiveColumnHandle("my_map", HiveType.valueOf("map<int,int>"), mapType, 0, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn("my_map", 0, HiveType.valueOf("map<int,int>"), mapType, REGULAR, Optional.empty());
 
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(mapType)));
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3select/TestS3SelectRecordCursor.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3select/TestS3SelectRecordCursor.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.stream.Stream;
 
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveType.HIVE_INT;
 import static io.prestosql.plugin.hive.HiveType.HIVE_STRING;
 import static io.prestosql.plugin.hive.s3select.S3SelectRecordCursor.updateSplitSchema;
@@ -43,10 +44,10 @@ public class TestS3SelectRecordCursor
 {
     private static final String LAZY_SERDE_CLASS_NAME = LazySimpleSerDe.class.getName();
 
-    private static final HiveColumnHandle ARTICLE_COLUMN = new HiveColumnHandle("article", HIVE_STRING, VARCHAR, 1, REGULAR, Optional.empty());
-    private static final HiveColumnHandle AUTHOR_COLUMN = new HiveColumnHandle("author", HIVE_STRING, VARCHAR, 1, REGULAR, Optional.empty());
-    private static final HiveColumnHandle DATE_ARTICLE_COLUMN = new HiveColumnHandle("date_pub", HIVE_INT, DATE, 1, REGULAR, Optional.empty());
-    private static final HiveColumnHandle QUANTITY_COLUMN = new HiveColumnHandle("quantity", HIVE_INT, INTEGER, 1, REGULAR, Optional.empty());
+    private static final HiveColumnHandle ARTICLE_COLUMN = createBaseColumn("article", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+    private static final HiveColumnHandle AUTHOR_COLUMN = createBaseColumn("author", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+    private static final HiveColumnHandle DATE_ARTICLE_COLUMN = createBaseColumn("date_pub", 1, HIVE_INT, DATE, REGULAR, Optional.empty());
+    private static final HiveColumnHandle QUANTITY_COLUMN = createBaseColumn("quantity", 1, HIVE_INT, INTEGER, REGULAR, Optional.empty());
     private static final HiveColumnHandle[] DEFAULT_TEST_COLUMNS = {ARTICLE_COLUMN, AUTHOR_COLUMN, DATE_ARTICLE_COLUMN, QUANTITY_COLUMN};
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid Thrift DDL struct article \\{ \\}")

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -45,6 +45,7 @@ import java.util.OptionalLong;
 
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CORRUPTED_COLUMN_STATISTICS;
 import static io.prestosql.plugin.hive.HivePartition.UNPARTITIONED_ID;
 import static io.prestosql.plugin.hive.HivePartitionManager.parsePartition;
@@ -93,8 +94,8 @@ public class TestMetastoreHiveStatisticsProvider
     private static final String COLUMN = "column";
     private static final DecimalType DECIMAL = createDecimalType(5, 3);
 
-    private static final HiveColumnHandle PARTITION_COLUMN_1 = new HiveColumnHandle("p1", HIVE_STRING, VARCHAR, 0, PARTITION_KEY, Optional.empty());
-    private static final HiveColumnHandle PARTITION_COLUMN_2 = new HiveColumnHandle("p2", HIVE_LONG, BIGINT, 1, PARTITION_KEY, Optional.empty());
+    private static final HiveColumnHandle PARTITION_COLUMN_1 = createBaseColumn("p1", 0, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+    private static final HiveColumnHandle PARTITION_COLUMN_2 = createBaseColumn("p2", 1, HIVE_LONG, BIGINT, PARTITION_KEY, Optional.empty());
 
     @Test
     public void testGetPartitionsSample()
@@ -609,7 +610,7 @@ public class TestMetastoreHiveStatisticsProvider
                 .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
                 .build();
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(partitionName, statistics));
-        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT, 2, REGULAR, Optional.empty());
+        HiveColumnHandle columnHandle = createBaseColumn(COLUMN, 2, HIVE_LONG, BIGINT, REGULAR, Optional.empty());
         TableStatistics expected = TableStatistics.builder()
                 .setRowCount(Estimate.of(1000))
                 .setColumnStatistics(
@@ -658,7 +659,9 @@ public class TestMetastoreHiveStatisticsProvider
                 .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
                 .build();
         MetastoreHiveStatisticsProvider statisticsProvider = new MetastoreHiveStatisticsProvider((session, table, hivePartitions) -> ImmutableMap.of(UNPARTITIONED_ID, statistics));
-        HiveColumnHandle columnHandle = new HiveColumnHandle(COLUMN, HIVE_LONG, BIGINT, 2, REGULAR, Optional.empty());
+
+        HiveColumnHandle columnHandle = createBaseColumn(COLUMN, 2, HIVE_LONG, BIGINT, REGULAR, Optional.empty());
+
         TableStatistics expected = TableStatistics.builder()
                 .setRowCount(Estimate.of(1000))
                 .setColumnStatistics(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -495,7 +495,7 @@ public class PlanOptimizers
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
 
                 // Because ReorderJoins runs only once,
-                // PredicatePushDown, PruneUnreferenedOutputpus and RemoveRedundantIdentityProjections
+                // PredicatePushDown, PruneUnreferencedOutputs and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order
                 // It also needs to run after EliminateCrossJoins so that its chosen order doesn't get undone.
                 new IterativeOptimizer(

--- a/presto-main/src/test/java/io/prestosql/util/StructuralTestUtil.java
+++ b/presto-main/src/test/java/io/prestosql/util/StructuralTestUtil.java
@@ -28,6 +28,7 @@ import io.prestosql.spi.type.StandardTypes;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignatureParameter;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
@@ -125,6 +126,9 @@ public final class StructuralTestUtil
             }
             else if (element instanceof SqlDecimal) {
                 type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(((SqlDecimal) element).getUnscaledValue()));
+            }
+            else if (element instanceof BigDecimal) {
+                type.writeSlice(blockBuilder, Decimals.encodeScaledValue((BigDecimal) element));
             }
             else {
                 type.writeSlice(blockBuilder, (Slice) element);


### PR DESCRIPTION
(required by #1953)

This PR includes the following major changes:

**1. Add support for projected columns in Hive**

* Page sources need to be supplied projected columns representing internal fields from a struct column. We modify `HiveColumnHandle` to include this information about column subfield access. Right now, the `HiveColumnProjectionInfo` simply stores a chain of dereferences, but that can later be extended to support other types of partial columns (eg. subscripts)

* Internal page sources in Hive Connector may or may not be able to push down projected column reads, depending on the formats. Reader page sources or record cursor can provide the partial projections they'll apply, and the rest is "adapted" by the HivePageSource or HiveReaderProjectionsAdaptingRecordCursor.

* By default, the readers only read base columns for projected columns. For example, column "a" will be read for a projection "a.x".  This is implemented through `ReaderProjections#projectBaseColumns`

**2. Pushdown for Dereferences in Hive:**

* The goal is to pushdown dereference expressions to Hive Connector for projections and predicates both.

* As described in #1953, creating partial column handles in `HiveMetadata#applyProjection` will give us both predicate and projection pushdown into Hive through iterative optimization. 

* `HiveMetadata#applyProjection` extracts longest simple dereference chains and variables from input expressions and provies new columnhandles for them. All the columnhandles returned by this method are unique.

**3. Projection and Predicate pushdown of subfields in Columnar Sources:**

* In case of Columnar formats (eg. ORC, Parquet), the partial columns can be read without reading entire columns, which is the primary motive here. 

* We implement p`rojectSufficientColumns` for such page sources to leverage, which lets the pagesource only read the required superset columns. Say we have a column C of type `RowType`. The query asks for a set of subcolumns S from column C. Then the superset columns here is the smallest set of columns from S such that all columns in S can be derived using identity or dereference expressions. i.e when S = {"a.b.c", "a.d" and "a.b.c.x"}, the reader will read create columns {"a.b.c", "a.d"}. The HivePageSource will adapt for ".x" for the third column.

* ORC and Parquet changes are extracted out in different PRs.
