### PR TITLE
Split Statistics Changes

### DIFF
--- a/presto-main/src/main/java/io/prestosql/event/SplitMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/SplitMonitor.java
@@ -58,14 +58,16 @@ public class SplitMonitor
 
     private void splitCompletedEvent(TaskId taskId, DriverStats driverStats, @Nullable String failureType, @Nullable String failureMessage)
     {
-        Optional<Duration> timeToStart = Optional.empty();
+        Duration queuedTime = ofMillis(driverStats.getQueuedTime().toMillis());
+        Optional<Duration> queuedTimeIfSplitRan = Optional.empty();
         if (driverStats.getStartTime() != null) {
-            timeToStart = Optional.of(ofMillis(driverStats.getStartTime().getMillis() - driverStats.getCreateTime().getMillis()));
+            queuedTimeIfSplitRan = Optional.of(queuedTime);
         }
 
-        Optional<Duration> timeToEnd = Optional.empty();
+        Duration elapsedTime = ofMillis(driverStats.getElapsedTime().toMillis());
+        Optional<Duration> elapsedTimeIfSplitRan = Optional.empty();
         if (driverStats.getEndTime() != null) {
-            timeToEnd = Optional.of(ofMillis(driverStats.getEndTime().getMillis() - driverStats.getCreateTime().getMillis()));
+            elapsedTimeIfSplitRan = Optional.of(elapsedTime);
         }
 
         Optional<SplitFailureInfo> splitFailureMetadata = Optional.empty();
@@ -84,13 +86,13 @@ public class SplitMonitor
                             Optional.ofNullable(driverStats.getEndTime()).map(endTime -> endTime.toDate().toInstant()),
                             new SplitStatistics(
                                     ofMillis(driverStats.getTotalCpuTime().toMillis()),
-                                    ofMillis(driverStats.getElapsedTime().toMillis()),
-                                    ofMillis(driverStats.getQueuedTime().toMillis()),
+                                    elapsedTime,
+                                    queuedTime,
                                     ofMillis(driverStats.getRawInputReadTime().toMillis()),
                                     driverStats.getRawInputPositions(),
                                     driverStats.getRawInputDataSize().toBytes(),
-                                    timeToStart,
-                                    timeToEnd),
+                                    queuedTimeIfSplitRan,
+                                    elapsedTimeIfSplitRan),
                             splitFailureMetadata,
                             objectMapper.writeValueAsString(driverStats)));
         }

--- a/presto-main/src/main/java/io/prestosql/operator/DriverContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/DriverContext.java
@@ -390,7 +390,7 @@ public class DriverContext
             elapsedTime = new Duration(endNanos - createNanos, NANOSECONDS);
         }
         else {
-            elapsedTime = new Duration(0, NANOSECONDS);
+            elapsedTime = new Duration(System.nanoTime() - createNanos, NANOSECONDS);
         }
 
         ImmutableSet.Builder<BlockedReason> builder = ImmutableSet.builder();

--- a/presto-main/src/main/java/io/prestosql/operator/TaskContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TaskContext.java
@@ -463,7 +463,7 @@ public class TaskContext
             elapsedTime = new Duration(endNanos - createNanos, NANOSECONDS);
         }
         else {
-            elapsedTime = new Duration(0, NANOSECONDS);
+            elapsedTime = new Duration(System.nanoTime() - createNanos, NANOSECONDS);
         }
 
         int fullGcCount = getFullGcCount();

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/SplitStatistics.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/SplitStatistics.java
@@ -81,11 +81,13 @@ public class SplitStatistics
         return completedDataSizeBytes;
     }
 
+    @Deprecated
     public Optional<Duration> getTimeToFirstByte()
     {
         return timeToFirstByte;
     }
 
+    @Deprecated
     public Optional<Duration> getTimeToLastByte()
     {
         return timeToLastByte;


### PR DESCRIPTION
Includes two changes:

- `timeToFirstByte` and `timeToLastByte` appears to be the same as queuedTime and elapsedTime respectively, if the split actually ran. Populate them from the same fields for simplification and prepare for deprecation. @martint 

- elapsedTime being populated in DriverContext returns 0 for running splits. Changing that to reflect actual elapsed time.