### PR TITLE
Do not return correlated node as decorrelated

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -98,6 +98,9 @@ public class PlanNodeDecorrelator
         @Override
         protected Optional<DecorrelationResult> visitPlan(PlanNode node, Void context)
         {
+            if (containsCorrelation(node, correlation)) {
+                return Optional.empty();
+            }
             return Optional.of(new DecorrelationResult(
                     node,
                     ImmutableSet.of(),

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -365,6 +365,23 @@ public class TestSubqueries
                 "VALUES 1");
     }
 
+    @Test
+    public void testCorrelatedSubqueryWithoutFilter()
+    {
+        assertions.assertQuery(
+                "SELECT (SELECT outer_relation.b FROM (VALUES 1) inner_relation) FROM (values 2) outer_relation(b)",
+                "VALUES 2");
+        assertions.assertFails(
+                "SELECT (VALUES b) FROM (VALUES 2) outer_relation(b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertions.assertFails(
+                "SELECT (SELECT a + b FROM (VALUES 1) inner_relation(a)) FROM (VALUES 2) outer_relation(b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertions.assertFails(
+                "SELECT (SELECT rank() OVER(partition by b) FROM (VALUES 1) inner_relation(a)) FROM (VALUES 2) outer_relation(b)",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+    }
+
     private void assertExistsRewrittenToAggregationBelowJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)
     {
         PlanMatchPattern source = node(ValuesNode.class);


### PR DESCRIPTION
This change in the `visitPlan()` method allows the decorrelator
to fail early  when unable to decorrelate a node.
Before this change, `visitPlan()` always returned a decorrelation
result, which in case when it was correlated, concealed unresolved
correlation until the final check performed after decorrelating the
whole plan.