### PR TITLE
Use provisio for RPM instead of maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1317,7 +1317,7 @@
             <plugin>
                 <groupId>ca.vanzyl.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.4</version>
                 <extensions>true</extensions>
             </plugin>
 

--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -23,39 +23,20 @@
         <server.tar.package>presto-server-${project.version}</server.tar.package>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.prestosql</groupId>
-            <artifactId>presto-server</artifactId>
-            <version>${project.version}</version>
-            <type>tar.gz</type>
-            <scope>runtime</scope>
-        </dependency>
-    </dependencies>
-
     <build>
-        <!-- Untar presto-server tgz to target build folder -->
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>ca.vanzyl.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>unpack</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>provision</goal>
                         </goals>
                         <configuration>
-                            <skip>false</skip>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.prestosql</groupId>
-                                    <artifactId>presto-server</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>tar.gz</type>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/presto-server-rpm/src/main/provisio/presto.xml
+++ b/presto-server-rpm/src/main/provisio/presto.xml
@@ -1,0 +1,10 @@
+<runtime>
+
+    <!-- Bring server tar.gz over for the RPM -->
+    <artifactSet to="/">
+        <artifact id="${project.groupId}:presto-server:tar.gz:${project.version}">
+            <unpack useRoot="true" />
+        </artifact>
+    </artifactSet>
+
+</runtime>


### PR DESCRIPTION
Fixes #1767

- The m-d-p doesn't have support for unpacking archives with hardlinks
  so using the takari-archiver to unpack the presto-server via
  provisio to preserve the hardlinks