### PR TITLE
Remove default Maven settings for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ git:
   quiet: true
 
 install:
+  - rm -f ~/.m2/settings.xml
   - travis_retry ./mvnw -v
   - |
     if [[ -v TEST_SPECIFIC_MODULES ]]; then


### PR DESCRIPTION
The default settings use the GCS Maven Central mirror, which lately
has had long delays on updating after new artifacts are published.