### PR TITLE
Document default max rows in Google Sheets Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/googlesheets.rst
+++ b/presto-docs/src/main/sphinx/connector/googlesheets.rst
@@ -82,7 +82,8 @@ address of the service account.
 The sheet needs to be mapped to a Presto table name. Specify a table name
 (column A) and the sheet ID (column B) in the metadata sheet. To refer
 to a specific tab in the sheet, add the tab name after the sheet ID, separated
-with ``#``.
+with ``#``. If tab name is not provided, connector loads only 10,000 rows by default from
+the first tab in the sheet.
 
 API Usage Limits
 ----------------

--- a/presto-google-sheets/src/main/java/io/prestosql/plugin/google/sheets/SheetsClient.java
+++ b/presto-google-sheets/src/main/java/io/prestosql/plugin/google/sheets/SheetsClient.java
@@ -202,7 +202,7 @@ public class SheetsClient
     private List<List<Object>> readAllValuesFromSheetExpression(String sheetExpression)
     {
         try {
-            // by default loading up to max 10k columns
+            // by default loading up to 10k rows from the first tab of the sheet
             String defaultRange = "$1:$10000";
             String[] tableOptions = sheetExpression.split("#");
             String sheetId = tableOptions[0];


### PR DESCRIPTION
- Documenting default max rows in Google Sheets Connector