### PR TITLE
Fix column aliases handling in RelationType

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/RelationType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/RelationType.java
@@ -169,9 +169,9 @@ public class RelationType
                     visibleFields.size());
         }
 
+        int aliasIndex = 0;
         ImmutableList.Builder<Field> fieldsBuilder = ImmutableList.builder();
-        for (int i = 0; i < allFields.size(); i++) {
-            Field field = allFields.get(i);
+        for (Field field : allFields) {
             Optional<String> columnAlias = field.getName();
             if (columnAliases == null) {
                 fieldsBuilder.add(Field.newQualified(
@@ -185,7 +185,8 @@ public class RelationType
             }
             else if (!field.isHidden()) {
                 // hidden fields are not exposed when there are column aliases
-                columnAlias = Optional.of(columnAliases.get(i));
+                columnAlias = Optional.of(columnAliases.get(aliasIndex));
+                aliasIndex++;
                 fieldsBuilder.add(Field.newQualified(
                         QualifiedName.of(relationAlias),
                         columnAlias,

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -1474,6 +1474,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT x, T.y, z + 1 FROM (SELECT custkey, orderstatus, totalprice FROM orders) T (x, y, z)",
                 "SELECT custkey, orderstatus, totalprice + 1 FROM orders");
+
+        // wildcard from aliased table with column aliases
+        assertQuery("SELECT a, b, c FROM (SELECT T.* FROM region T (a, b, c))");
     }
 
     @Test


### PR DESCRIPTION
Add support for the case when there are any hidden columns before
some of the visible columns in the RelationType.
Kafka, Redis and Cassandra relations are structured this way and
before this change failed on the following query:
`SELECT a, b, c FROM (SELECT T.* FROM region T (a, b, c))`