### PR TITLE
Support polylines in geometry apis

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -466,3 +466,17 @@ These functions convert between geometries and
 
     Returns the minimum set of Bing tiles that fully covers a given geometry at
     a given zoom level. Zoom levels from 1 to 23 are supported.
+
+Encoded Polylines
+-----------------
+
+These functions convert between geometries and
+`encoded polylines <https://developers.google.com/maps/documentation/utilities/polylinealgorithm>`_.
+
+.. function:: to_encoded_polyline(Geometry) -> varchar
+
+    Encodes a linestring or multipoint to a polyline.
+
+.. function:: from_encoded_polyline(varchar) -> Geometry
+
+    Decodes a polyline to a linestring.

--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/EncodedPolylineFunctions.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/EncodedPolylineFunctions.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.geospatial;
+
+import com.esri.core.geometry.MultiPath;
+import com.esri.core.geometry.MultiVertexGeometry;
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.Polyline;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.esri.core.geometry.ogc.OGCLineString;
+import com.google.common.base.Joiner;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.prestosql.geospatial.GeometryType;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.StandardTypes;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static io.prestosql.geospatial.GeometryType.LINE_STRING;
+import static io.prestosql.geospatial.GeometryType.MULTI_POINT;
+import static io.prestosql.geospatial.serde.GeometrySerde.deserialize;
+import static io.prestosql.geospatial.serde.GeometrySerde.serialize;
+import static io.prestosql.plugin.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
+import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.String.format;
+
+/**
+ * A set of functions to convert between geometries and encoded polylines.
+ *
+ * @see <a href="https://developers.google.com/maps/documentation/utilities/polylinealgorithm">
+ *     https://developers.google.com/maps/documentation/utilities/polylinealgorithm</a> for a description of encoded polylines.
+ */
+public final class EncodedPolylineFunctions
+{
+    private EncodedPolylineFunctions() {}
+
+    @Description("Decodes a polyline to a linestring")
+    @ScalarFunction("from_encoded_polyline")
+    @SqlType(GEOMETRY_TYPE_NAME)
+    public static Slice fromEncodedPolyline(@SqlType(StandardTypes.VARCHAR) Slice input)
+    {
+        return serialize(decodePolyline(input.toStringUtf8()));
+    }
+
+    private static OGCLineString decodePolyline(String polyline)
+    {
+        MultiPath multipath = new Polyline();
+        boolean isFirstPoint = true;
+
+        int index = 0;
+        int latitude = 0;
+        int longitude = 0;
+
+        while (index < polyline.length()) {
+            int result = 1;
+            int shift = 0;
+            int bytes;
+            do {
+                bytes = polyline.charAt(index++) - 63 - 1;
+                result += bytes << shift;
+                shift += 5;
+            } while (bytes >= 0x1f);
+            latitude += (result & 1) != 0 ? ~(result >> 1) : (result >> 1);
+
+            result = 1;
+            shift = 0;
+            do {
+                bytes = polyline.charAt(index++) - 63 - 1;
+                result += bytes << shift;
+                shift += 5;
+            } while (bytes >= 0x1f);
+            longitude += (result & 1) != 0 ? ~(result >> 1) : (result >> 1);
+
+            if (isFirstPoint) {
+                multipath.startPath(longitude * 1e-5, latitude * 1e-5);
+                isFirstPoint = false;
+            }
+            else {
+                multipath.lineTo(longitude * 1e-5, latitude * 1e-5);
+            }
+        }
+
+        return new OGCLineString(multipath, 0, null);
+    }
+
+    @Description("Encodes a linestring or multipoint geometry to a polyline")
+    @ScalarFunction("to_encoded_polyline")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice toEncodedPolyline(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    {
+        OGCGeometry geometry = deserialize(input);
+        validateType("encode_polyline", geometry, EnumSet.of(LINE_STRING, MULTI_POINT));
+        GeometryType geometryType = GeometryType.getForEsriGeometryType(geometry.geometryType());
+        switch (geometryType) {
+            case LINE_STRING:
+            case MULTI_POINT:
+                return encodePolyline((MultiVertexGeometry) geometry.getEsriGeometry());
+            default:
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Unexpected geometry type: " + geometryType);
+        }
+    }
+
+    private static Slice encodePolyline(MultiVertexGeometry multiVertexGeometry)
+    {
+        long lastLatitude = 0;
+        long lastLongitude = 0;
+
+        DynamicSliceOutput output = new DynamicSliceOutput(0);
+
+        for (int i = 0; i < multiVertexGeometry.getPointCount(); i++) {
+            Point point = multiVertexGeometry.getPoint(i);
+
+            long latitude = Math.round(point.getY() * 1e5);
+            long longitude = Math.round(point.getX() * 1e5);
+
+            long latitudeDelta = latitude - lastLatitude;
+            long longitudeDelta = longitude - lastLongitude;
+
+            encode(latitudeDelta, output);
+            encode(longitudeDelta, output);
+
+            lastLatitude = latitude;
+            lastLongitude = longitude;
+        }
+        return output.slice();
+    }
+
+    private static void encode(long value, DynamicSliceOutput output)
+    {
+        value = value < 0 ? ~(value << 1) : value << 1;
+        while (value >= 0x20) {
+            output.appendByte((byte) ((0x20 | (value & 0x1f)) + 63));
+            value >>= 5;
+        }
+        output.appendByte((byte) (value + 63));
+    }
+
+    private static void validateType(String function, OGCGeometry geometry, Set<GeometryType> validTypes)
+    {
+        GeometryType type = GeometryType.getForEsriGeometryType(geometry.geometryType());
+        if (!validTypes.contains(type)) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("%s only applies to %s. Input type is: %s", function, Joiner.on(" or ").join(validTypes), type));
+        }
+    }
+}

--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoPlugin.java
@@ -48,6 +48,7 @@ public class GeoPlugin
                 .add(ConvexHullAggregation.class)
                 .add(GeometryUnionAgg.class)
                 .add(KdbTreeCasts.class)
+                .add(EncodedPolylineFunctions.class)
                 .add(SpatialPartitioningAggregateFunction.class)
                 .add(SpatialPartitioningInternalAggregateFunction.class)
                 .build();

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestEncodedPolylineFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestEncodedPolylineFunctions.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.geospatial;
+
+import io.prestosql.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+
+public class TestEncodedPolylineFunctions
+        extends AbstractTestFunctions
+{
+    @BeforeClass
+    protected void registerFunctions()
+    {
+        functionAssertions.installPlugin(new GeoPlugin());
+    }
+
+    @Test
+    public void testFromEncodedPolyline()
+    {
+        assertFromEncodedPolyline("", "LINESTRING EMPTY");
+        assertFromEncodedPolyline("iiqeFjs_jV", "LINESTRING EMPTY");
+        assertFromEncodedPolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", "LINESTRING (-120.2 38.5, -120.95 40.7, -126.45300000000002 43.252)");
+    }
+
+    private void assertFromEncodedPolyline(String polyline, String wkt)
+    {
+        assertFunction(format("ST_AsText(from_encoded_polyline('%s'))", polyline), VARCHAR, wkt);
+    }
+
+    @Test
+    public void testToEncodedPolyline()
+    {
+        assertToEncodedPolyline("LINESTRING EMPTY", "");
+        assertToEncodedPolyline("LINESTRING (-120.2 38.5, -120.95 40.7, -126.453 43.252)", "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+        assertToEncodedPolyline("LINESTRING (-120.2 38.5, -120.95 40.7, -126.453 43.252, -128.318 46.102)", "_p~iF~ps|U_ulLnnqC_mqNvxq`@oskPfgkJ");
+
+        assertToEncodedPolyline("MULTIPOINT EMPTY", "");
+        assertToEncodedPolyline("MULTIPOINT (-120.2 38.5)", "_p~iF~ps|U");
+        assertToEncodedPolyline("MULTIPOINT (-120.2 38.5, -120.95 40.7, -126.453 43.252)", "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+        assertToEncodedPolyline("MULTIPOINT (-120.2 38.5, -120.95 40.7, -126.453 43.252, -128.318 46.102)", "_p~iF~ps|U_ulLnnqC_mqNvxq`@oskPfgkJ");
+
+        assertInvalidFunction("to_encoded_polyline(ST_GeometryFromText('POINT (-120.2 38.5)'))", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("to_encoded_polyline(ST_GeometryFromText('MULTILINESTRING ((-122.39174 37.77701))'))", INVALID_FUNCTION_ARGUMENT);
+    }
+
+    private void assertToEncodedPolyline(String wkt, String polyline)
+    {
+        assertFunction(format("to_encoded_polyline(ST_GeometryFromText('%s'))", wkt), VARCHAR, polyline);
+    }
+}


### PR DESCRIPTION
Adds postgis [ST_LineFromEncodedPolyline](https://postgis.net/docs/ST_LineFromEncodedPolyline.html) and [ST_AsEncodedPolyline](https://postgis.net/docs/ST_AsEncodedPolyline.html) functions.

Encoded polyline algorithm is described [here](https://developers.google.com/maps/documentation/utilities/polylinealgorithm) and implemented [here](https://github.com/googlemaps/google-maps-services-java/blob/032d6c830561ad64e4148276a1078584b57d07da/src/main/java/com/google/maps/internal/PolylineEncoding.java).