### PR TITLE
select view require select privilege instead of create view privilege

### DIFF
--- a/presto-main/src/main/java/io/prestosql/security/ViewAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/ViewAccessControl.java
@@ -32,7 +32,7 @@ public class ViewAccessControl
     @Override
     public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
     {
-        delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+        delegate.checkCanSelectFromColumns(context, tableName, columnNames);
     }
 
     @Override


### PR DESCRIPTION
In ViewAccessControl when check select privilege, using delegate.checkCanSelectFromColumns method instead of checkCanCreateViewWithSelectFromColumns method.