### PR TITLE
Bind to localhost in development

### DIFF
--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -8,6 +8,7 @@
 # sample nodeId to provide consistency across test runs
 node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
 node.environment=test
+node.internal-address=localhost
 http-server.http.port=8080
 
 discovery-server.enabled=true

--- a/presto-proxy/etc/config.properties
+++ b/presto-proxy/etc/config.properties
@@ -1,4 +1,5 @@
 node.environment=test
+node.internal-address=localhost
 http-server.http.port=8088
 proxy.uri=http://localhost:8080/
 proxy.shared-secret-file=etc/secret.txt


### PR DESCRIPTION
`node.internal-address` may default to machine's external address. This
is not a good default in development.