### PR TITLE
Supporting basic authentication for Elasticsearch connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -213,6 +213,19 @@ as part of the table name, separated by a colon. For example:
 .. _full text query: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax
 
 
+X-Pack Authentication
+---------------------
+
+To enable X-Pack authentication, the ``elasticsearch.security`` option needs to be set to ``X_PACK``.
+Additionally, the following options need to be configured appropriately:
+
+================================================ ==================================================================
+Property Name                                    Description
+================================================ ==================================================================
+``elasticsearch.username``                       X-Pack username for connecting to the Elasticsearch. This option is required.
+``elasticsearch.password``                       X-Pack password for connecting to the Elasticsearch. This option is required
+================================================ ==================================================================
+
 AWS Authorization
 -----------------
 
@@ -227,4 +240,3 @@ Property Name                                    Description
 ``elasticsearch.aws.secret-key``                 AWS secret key to use to connect to the Elasticsearch domain.
 ``elasticsearch.aws.use-instance-credentials``   Use the EC2 metadata service to retrieve API credentials.
 ================================================ ==================================================================
-

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConfig.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConfig.java
@@ -48,11 +48,14 @@ public class ElasticsearchConfig
 {
     public enum Security
     {
-        AWS
+        AWS,
+        X_PACK
     }
 
     private String host;
     private int port = 9200;
+    private String username;
+    private String password;
     private String defaultSchema = "default";
     private int scrollSize = 1_000;
     private Duration scrollTimeout = new Duration(1, MINUTES);
@@ -92,6 +95,33 @@ public class ElasticsearchConfig
     public ElasticsearchConfig setPort(int port)
     {
         this.port = port;
+        return this;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("elasticsearch.username")
+    @ConfigDescription("Username for connecting to X-Pack secured Elasticsearch")
+    public ElasticsearchConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("elasticsearch.password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password for connecting to X-Pack secured Elasticsearch")
+    public ElasticsearchConfig setPassword(String password)
+    {
+        this.password = password;
         return this;
     }
 

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchConfig.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchConfig.java
@@ -35,6 +35,8 @@ public class TestElasticsearchConfig
         assertRecordedDefaults(recordDefaults(ElasticsearchConfig.class)
                 .setHost(null)
                 .setPort(9200)
+                .setUsername(null)
+                .setPassword(null)
                 .setDefaultSchema("default")
                 .setScrollSize(1000)
                 .setScrollTimeout(new Duration(1, MINUTES))
@@ -71,6 +73,8 @@ public class TestElasticsearchConfig
                 .put("elasticsearch.tls.truststore-password", "truststore-password")
                 .put("elasticsearch.tls.verify-hostnames", "false")
                 .put("elasticsearch.security", "AWS")
+                .put("elasticsearch.username", "username")
+                .put("elasticsearch.password", "password")
                 .build();
 
         ElasticsearchConfig expected = new ElasticsearchConfig()
@@ -89,7 +93,9 @@ public class TestElasticsearchConfig
                 .setTrustStorePath(new File("/tmp/truststore"))
                 .setTruststorePassword("truststore-password")
                 .setVerifyHostnames(false)
-                .setSecurity(AWS);
+                .setSecurity(AWS)
+                .setUsername("username")
+                .setPassword("password");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Starting from elasticsearch 7.x.x, basic authentication using username and password is supported through its x-pack.

In this pull request, if the user set `elasticsearch.security` to `X_PACK` (instead of `AWS`), he's able to connect to a secured elastic search by setting `elasticsearch.username` and `elasticsearch.password`  variables in catalog file.

You can bring up a secured elasticsearch like this and test it if needed.
``` 
version: '3.4'
services:
  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
    environment:
      cluster.name: elasticsearch
      discovery.type: single-node
      xpack.security.enabled: 'true'
      ELASTIC_USERNAME: elastic
      ELASTIC_PASSWORD: magic-word
    ports:
      - '9200:9200'
      - '9300:9300'
    volumes:
      - ./esdata01:/path/to/elasticsearch/data
```
