### PR TITLE
Add support for Iceberg snapshots tables

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -171,6 +171,8 @@ public class IcebergMetadata
                 return Optional.of(new PartitionTable(table, typeManager, icebergTable));
             case HISTORY:
                 return Optional.of(new HistoryTable(table.getSchemaTableNameWithType(), icebergTable));
+            case SNAPSHOTS:
+                return Optional.of(new SnapshotsTable(table.getSchemaTableNameWithType(), typeManager, icebergTable));
         }
         return Optional.empty();
     }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/SnapshotsTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/SnapshotsTable.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.iceberg.util.PageListBuilder;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.FixedPageSource;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.TimeZoneKey;
+import io.prestosql.spi.type.TypeManager;
+import io.prestosql.spi.type.TypeSignature;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class SnapshotsTable
+        implements SystemTable
+{
+    private final ConnectorTableMetadata tableMetadata;
+    private final Table icebergTable;
+
+    public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
+    {
+        requireNonNull(typeManager, "typeManager is null");
+
+        this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+        tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
+                ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("committed_at", TIMESTAMP_WITH_TIME_ZONE))
+                        .add(new ColumnMetadata("snapshot_id", BIGINT))
+                        .add(new ColumnMetadata("parent_id", BIGINT))
+                        .add(new ColumnMetadata("operation", VARCHAR))
+                        .add(new ColumnMetadata("manifest_list", VARCHAR))
+                        .add(new ColumnMetadata("summary", typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                        .build());
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        return new FixedPageSource(buildPages(tableMetadata, session, icebergTable));
+    }
+
+    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, ConnectorSession session, Table icebergTable)
+    {
+        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
+
+        TimeZoneKey timeZoneKey = session.getTimeZoneKey();
+        icebergTable.snapshots().forEach(snapshot -> {
+            pagesBuilder.beginRow();
+            pagesBuilder.appendTimestamp(packDateTimeWithZone(snapshot.timestampMillis(), timeZoneKey));
+            pagesBuilder.appendBigint(snapshot.snapshotId());
+            if (checkNonNull(snapshot.parentId(), pagesBuilder)) {
+                pagesBuilder.appendBigint(snapshot.parentId());
+            }
+            if (checkNonNull(snapshot.operation(), pagesBuilder)) {
+                pagesBuilder.appendVarchar(snapshot.operation());
+            }
+            if (checkNonNull(snapshot.manifestListLocation(), pagesBuilder)) {
+                pagesBuilder.appendVarchar(snapshot.manifestListLocation());
+            }
+            if (checkNonNull(snapshot.summary(), pagesBuilder)) {
+                pagesBuilder.appendVarcharVarcharMap(snapshot.summary());
+            }
+            pagesBuilder.endRow();
+        });
+
+        return pagesBuilder.build();
+    }
+
+    private static boolean checkNonNull(Object object, PageListBuilder pagesBuilder)
+    {
+        if (object == null) {
+            pagesBuilder.appendNull();
+            return false;
+        }
+        return true;
+    }
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TableType.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TableType.java
@@ -17,7 +17,7 @@ public enum TableType
 {
     DATA,
     HISTORY,
-    SNAPSHOTS, // TODO: to be implemented
+    SNAPSHOTS,
     MANIFESTS, // TODO: to be implemented
     PARTITIONS,
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/util/PageListBuilder.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/util/PageListBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg.util;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.type.BigintType;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+
+public final class PageListBuilder
+{
+    private final int channels;
+    private final PageBuilder pageBuilder;
+
+    private ImmutableList.Builder<Page> pages;
+    private int channel;
+
+    public PageListBuilder(List<Type> types)
+    {
+        this.channels = types.size();
+        this.pageBuilder = new PageBuilder(types);
+        reset();
+    }
+
+    public void reset()
+    {
+        pages = ImmutableList.builder();
+        pageBuilder.reset();
+        channel = -1;
+    }
+
+    public List<Page> build()
+    {
+        checkArgument(channel == -1, "cannot be in row");
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+        return pages.build();
+    }
+
+    public void beginRow()
+    {
+        checkArgument(channel == -1, "already in row");
+        if (pageBuilder.isFull()) {
+            pages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+        pageBuilder.declarePosition();
+        channel = 0;
+    }
+
+    public void endRow()
+    {
+        checkArgument(channel == channels, "not at end of row");
+        channel = -1;
+    }
+
+    public void appendNull()
+    {
+        nextColumn().appendNull();
+    }
+
+    public void appendBigint(long value)
+    {
+        BigintType.BIGINT.writeLong(nextColumn(), value);
+    }
+
+    public void appendTimestamp(long value)
+    {
+        TIMESTAMP.writeLong(nextColumn(), value);
+    }
+
+    public void appendVarchar(String value)
+    {
+        VARCHAR.writeString(nextColumn(), value);
+    }
+
+    public void appendVarcharArray(Iterable<String> values)
+    {
+        BlockBuilder column = nextColumn();
+        BlockBuilder array = column.beginBlockEntry();
+        for (String value : values) {
+            VARCHAR.writeString(array, value);
+        }
+        column.closeEntry();
+    }
+
+    public void appendVarcharVarcharMap(Map<String, String> values)
+    {
+        BlockBuilder column = nextColumn();
+        BlockBuilder map = column.beginBlockEntry();
+        values.forEach((key, value) -> {
+            VARCHAR.writeString(map, key);
+            VARCHAR.writeString(map, value);
+        });
+        column.closeEntry();
+    }
+
+    private BlockBuilder nextColumn()
+    {
+        int currentChannel = channel;
+        channel++;
+        return pageBuilder.getBlockBuilder(currentChannel);
+    }
+
+    public static PageListBuilder forTable(ConnectorTableMetadata table)
+    {
+        return new PageListBuilder(table.getColumns().stream()
+                .map(ColumnMetadata::getType)
+                .collect(toImmutableList()));
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.MaterializedRow;
+import io.prestosql.tests.AbstractTestQueryFramework;
+import io.prestosql.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.testing.MaterializedResult.DEFAULT_PRECISION;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestIcebergSystemTables
+        extends AbstractTestQueryFramework
+{
+    private static HiveMetastore metastore;
+
+    public TestIcebergSystemTables()
+    {
+        super(TestIcebergSystemTables::createQueryRunner);
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+
+        metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.createCatalog("iceberg", "iceberg");
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        assertUpdate("CREATE SCHEMA test_schema");
+        assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'])");
+        assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
+        assertUpdate("INSERT INTO test_schema.test_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
+        assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");
+    }
+
+    @Test
+    public void testPartitionTable()
+    {
+        assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");
+        assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$partitions\"",
+                "VALUES ('_date', 'date', '', '')," +
+                        "('row_count', 'bigint', '', '')," +
+                        "('file_count', 'bigint', '', '')," +
+                        "('total_size', 'bigint', '', '')," +
+                        "('_bigint', 'row(min bigint, max bigint, null_count bigint)', '', '')");
+
+        MaterializedResult result = computeActual("SELECT * from test_schema.\"test_table$partitions\"");
+        assertEquals(result.getRowCount(), 3);
+
+        Map<LocalDate, MaterializedRow> rowsByPartition = result.getMaterializedRows().stream()
+                .collect(toImmutableMap(row -> (LocalDate) row.getField(0), Function.identity()));
+
+        // Test if row counts are computed correctly
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(1), 1L);
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(1), 3L);
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1), 2L);
+
+        // Test if min/max values and null value count are computed correctly.
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 0L, 0L, 0L));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 1L, 3L, 0L));
+        assertEquals(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(4), new MaterializedRow(DEFAULT_PRECISION, 4L, 5L, 0L));
+    }
+
+    @Test
+    public void testHistoryTable()
+    {
+        assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$history\"",
+                "VALUES ('made_current_at', 'timestamp with time zone', '', '')," +
+                        "('snapshot_id', 'bigint', '', '')," +
+                        "('parent_id', 'bigint', '', '')," +
+                        "('is_current_ancestor', 'boolean', '', '')");
+
+        // Test the number of history entries
+        assertQuery("SELECT count(*) FROM test_schema.\"test_table$history\"", "VALUES 3");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        assertUpdate("DROP TABLE IF EXISTS test_schema.test_table");
+        assertUpdate("DROP SCHEMA IF EXISTS test_schema");
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -124,6 +124,21 @@ public class TestIcebergSystemTables
         assertQuery("SELECT count(*) FROM test_schema.\"test_table$history\"", "VALUES 3");
     }
 
+    @Test
+    public void testSnapshotsTable()
+    {
+        assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$snapshots\"",
+                "VALUES ('committed_at', 'timestamp with time zone', '', '')," +
+                        "('snapshot_id', 'bigint', '', '')," +
+                        "('parent_id', 'bigint', '', '')," +
+                        "('operation', 'varchar', '', '')," +
+                        "('manifest_list', 'varchar', '', '')," +
+                        "('summary', 'map(varchar, varchar)', '', '')");
+
+        assertQuery("SELECT operation FROM test_schema.\"test_table$snapshots\"", "VALUES 'append', 'append', 'append'");
+        assertQuery("SELECT summary['total-records'] FROM test_schema.\"test_table$snapshots\"", "VALUES '0', '3', '6'");
+    }
+
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {


### PR DESCRIPTION
Spec: https://iceberg.apache.org/spark/
Umbrella issue: #1324 

The `snapshots` table has a column with the map type. So I added a `SingleMapBlockBuilder` class so that we can construct map elements and add them to `InMemoryRecordSet`. Please see commit messages for detailed explanations.

cc: @electrum @wagnermarkd 