### PR TITLE
Update S3 tests

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -245,7 +245,7 @@ public abstract class AbstractTestHiveFileSystem
             ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, table, UNGROUPED_SCHEDULING);
 
             List<ConnectorSplit> splits = getAllSplits(splitSource);
-            assertEquals(splits.size(), 1);
+            assertEquals(splits.size(), 4);
 
             long sum = 0;
             for (ConnectorSplit split : splits) {


### PR DESCRIPTION
The 4 splits are `test1.csv`, `test1.csv.gz`, `test1.csv.lz4`,
`test1.csv.bz2`. The number of files was changed in
43bd519052ba4c56ff1f4fc807075637ab5f4f10.