### PR TITLE
Support for creating skewed StorageDescriptor

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -726,9 +726,6 @@ public final class ThriftMetastoreUtil
 
     private static StorageDescriptor makeStorageDescriptor(String tableName, List<Column> columns, Storage storage)
     {
-        if (storage.isSkewed()) {
-            throw new IllegalArgumentException("Writing to skewed table/partition is not supported");
-        }
         SerDeInfo serdeInfo = new SerDeInfo();
         serdeInfo.setName(tableName);
         serdeInfo.setSerializationLib(storage.getStorageFormat().getSerDeNullable());
@@ -742,6 +739,7 @@ public final class ThriftMetastoreUtil
         sd.setSerdeInfo(serdeInfo);
         sd.setInputFormat(storage.getStorageFormat().getInputFormatNullable());
         sd.setOutputFormat(storage.getStorageFormat().getOutputFormatNullable());
+        sd.setSkewedInfoIsSet(storage.isSkewed());
         sd.setParameters(ImmutableMap.of());
 
         Optional<HiveBucketProperty> bucketProperty = storage.getBucketProperty();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreUtil.java
@@ -153,18 +153,4 @@ public class TestMetastoreUtil
         Properties actual = MetastoreUtil.getHiveSchema(ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS), ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE_WITH_UNSUPPORTED_FIELDS, TEST_SCHEMA));
         assertEquals(actual, expected);
     }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Writing to skewed table/partition is not supported")
-    public void testTableRoundTripUnsupported()
-    {
-        Table table = ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE_WITH_UNSUPPORTED_FIELDS, TEST_SCHEMA);
-        ThriftMetastoreUtil.toMetastoreApiTable(table, null);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Writing to skewed table/partition is not supported")
-    public void testPartitionRoundTripUnsupported()
-    {
-        Partition partition = ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS);
-        ThriftMetastoreUtil.toMetastoreApiPartition(partition);
-    }
 }


### PR DESCRIPTION
Checking for skewed table already happens
in HiveWriteUtils#checkTableIsWritable