### PR TITLE
Fix NPE when reading from null partition

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -443,10 +443,10 @@ public class HiveMetadata
                     Iterable<List<Object>> records = () ->
                             stream(partitionManager.getPartitions(metastore, new HiveIdentity(session), sourceTableHandle, targetConstraint).getPartitions())
                                     .map(hivePartition ->
-                                            (List<Object>) IntStream.range(0, partitionColumns.size())
+                                            IntStream.range(0, partitionColumns.size())
                                                     .mapToObj(fieldIdToColumnHandle::get)
                                                     .map(columnHandle -> hivePartition.getKeys().get(columnHandle).getValue())
-                                                    .collect(toImmutableList()))
+                                                    .collect(toList())) // nullable
                                     .iterator();
 
                     return new InMemoryRecordSet(partitionColumnTypes, records).cursor();


### PR DESCRIPTION
This was caught by `io.prestosql.plugin.hive.TestHiveIntegrationSmokeTest#testNullPartitionValues`.