### PR TITLE
Add convenience constructor for JdbcColumnHandle

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcColumnHandle.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcColumnHandle.java
@@ -33,6 +33,15 @@ public final class JdbcColumnHandle
     private final Type columnType;
     private final boolean nullable;
 
+    // All and only required fields
+    public JdbcColumnHandle(
+            String columnName,
+            JdbcTypeHandle jdbcTypeHandle,
+            Type columnType)
+    {
+        this(columnName, jdbcTypeHandle, columnType, true);
+    }
+
     @JsonCreator
     public JdbcColumnHandle(
             @JsonProperty("columnName") String columnName,

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcClient.java
@@ -83,9 +83,9 @@ public class TestJdbcClient
         assertEquals(table.get().getTableName(), "NUMBERS");
         assertEquals(table.get().getSchemaTableName(), schemaTableName);
         assertEquals(jdbcClient.getColumns(session, table.orElse(null)), ImmutableList.of(
-                new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR, true),
-                new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32), true),
-                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT, true)));
+                new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
     }
 
     @Test
@@ -95,8 +95,8 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
         assertTrue(table.isPresent(), "table is missing");
         assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
-                new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR, true),
-                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT, true)));
+                new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT)));
     }
 
     @Test
@@ -106,9 +106,9 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
         assertTrue(table.isPresent(), "table is missing");
         assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
-                new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT, true),
-                new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE, true),
-                new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE, true),
-                new JdbcColumnHandle("COL4", JDBC_REAL, REAL, true)));
+                new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("COL4", JDBC_REAL, REAL)));
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcColumnHandle.java
@@ -28,7 +28,7 @@ public class TestJdbcColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR, true));
+        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR));
     }
 
     @Test
@@ -36,15 +36,15 @@ public class TestJdbcColumnHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR, true),
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR, true),
-                        new JdbcColumnHandle("columnName", JDBC_BIGINT, BIGINT, true),
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR, true))
+                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("columnName", JDBC_BIGINT, BIGINT),
+                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR, true),
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR, true),
-                        new JdbcColumnHandle("columnNameX", JDBC_BIGINT, BIGINT, true),
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR, true))
+                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("columnNameX", JDBC_BIGINT, BIGINT),
+                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR))
                 .check();
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadata.java
@@ -85,9 +85,9 @@ public class TestJdbcMetadata
     {
         // known table
         assertEquals(metadata.getColumnHandles(SESSION, tableHandle), ImmutableMap.of(
-                "text", new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR, true),
-                "text_short", new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32), true),
-                "value", new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT, true)));
+                "text", new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
+                "text_short", new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                "value", new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown"));
@@ -172,7 +172,7 @@ public class TestJdbcMetadata
     public void getColumnMetadata()
     {
         assertEquals(
-                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR, true)),
+                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)),
                 new ColumnMetadata("text", VARCHAR));
     }
 
@@ -195,7 +195,7 @@ public class TestJdbcMetadata
         assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
         assertEquals(layout.getColumns().get(1), new ColumnMetadata("x", VARCHAR));
 
-        JdbcColumnHandle columnHandle = new JdbcColumnHandle("x", JDBC_VARCHAR, VARCHAR, true);
+        JdbcColumnHandle columnHandle = new JdbcColumnHandle("x", JDBC_VARCHAR, VARCHAR);
         metadata.dropColumn(SESSION, handle, columnHandle);
         layout = metadata.getTableMetadata(SESSION, handle);
         assertEquals(layout.getColumns().size(), 1);

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -93,18 +93,18 @@ public class TestJdbcQueryBuilder
         CharType charType = CharType.createCharType(0);
 
         columns = ImmutableList.of(
-                new JdbcColumnHandle("col_0", JDBC_BIGINT, BIGINT, true),
-                new JdbcColumnHandle("col_1", JDBC_DOUBLE, DOUBLE, true),
-                new JdbcColumnHandle("col_2", JDBC_BOOLEAN, BOOLEAN, true),
-                new JdbcColumnHandle("col_3", JDBC_VARCHAR, VARCHAR, true),
-                new JdbcColumnHandle("col_4", JDBC_DATE, DATE, true),
-                new JdbcColumnHandle("col_5", JDBC_TIME, TIME, true),
-                new JdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP, true),
-                new JdbcColumnHandle("col_7", JDBC_TINYINT, TINYINT, true),
-                new JdbcColumnHandle("col_8", JDBC_SMALLINT, SMALLINT, true),
-                new JdbcColumnHandle("col_9", JDBC_INTEGER, INTEGER, true),
-                new JdbcColumnHandle("col_10", JDBC_REAL, REAL, true),
-                new JdbcColumnHandle("col_11", JDBC_CHAR, charType, true));
+                new JdbcColumnHandle("col_0", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("col_1", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("col_2", JDBC_BOOLEAN, BOOLEAN),
+                new JdbcColumnHandle("col_3", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("col_4", JDBC_DATE, DATE),
+                new JdbcColumnHandle("col_5", JDBC_TIME, TIME),
+                new JdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP),
+                new JdbcColumnHandle("col_7", JDBC_TINYINT, TINYINT),
+                new JdbcColumnHandle("col_8", JDBC_SMALLINT, SMALLINT),
+                new JdbcColumnHandle("col_9", JDBC_INTEGER, INTEGER),
+                new JdbcColumnHandle("col_10", JDBC_REAL, REAL),
+                new JdbcColumnHandle("col_11", JDBC_CHAR, charType));
 
         Connection connection = database.getConnection();
         try (PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSet.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSet.java
@@ -65,20 +65,20 @@ public class TestJdbcRecordSet
     public void testGetColumnTypes()
     {
         RecordSet recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR, true),
-                new JdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32), true),
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT, true)));
+                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32)),
+                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(VARCHAR, createVarcharType(32), BIGINT));
 
         recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT, true),
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR, true)));
+                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT, true),
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT, true),
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR, true)));
+                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of());


### PR DESCRIPTION
Add `JdbcColumnHandle` constructor that takes all the required fields.