### PR TITLE
Add MemSQL connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>presto-raptor-legacy</module>
         <module>presto-base-jdbc</module>
         <module>presto-mysql</module>
+        <module>presto-memsql</module>
         <module>presto-phoenix</module>
         <module>presto-postgresql</module>
         <module>presto-redshift</module>

--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -23,6 +23,7 @@ from different data sources.
     connector/kudu
     connector/localfile
     connector/memory
+    connector/memsql
     connector/mongodb
     connector/mysql
     connector/phoenix

--- a/presto-docs/src/main/sphinx/connector/memsql.rst
+++ b/presto-docs/src/main/sphinx/connector/memsql.rst
@@ -1,0 +1,70 @@
+================
+MemSQL Connector
+================
+
+The MemSQL connector allows querying and creating tables in an external
+MemSQL database. The MemSQL connector is very similar to the MySQL 
+connector with the only difference being the underlying driver.
+
+Configuration
+-------------
+
+To configure the MemSQL connector, create a catalog properties file
+in ``etc/catalog`` named, for example, ``memsql.properties``, to
+mount the MemSQL connector as the ``memsql`` catalog.
+Create the file with the following contents, replacing the
+connection properties as appropriate for your setup:
+
+.. code-block:: none
+
+    connector.name=memsql
+    connection-url=jdbc:mariadb://example.net:3306
+    connection-user=root
+    connection-password=secret
+
+Multiple MemSQL Servers
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can have as many catalogs as you need, so if you have additional
+MemSQL servers, simply add another properties file to ``etc/catalog``
+with a different name (making sure it ends in ``.properties``). For
+example, if you name the property file ``sales.properties``, Presto
+will create a catalog named ``sales`` using the configured connector.
+
+Querying MemSQL
+---------------
+
+The MemSQL connector provides a schema for every MemSQL *database*.
+You can see the available MemSQL databases by running ``SHOW SCHEMAS``::
+
+    SHOW SCHEMAS FROM memsql;
+
+If you have a MemSQL database named ``web``, you can view the tables
+in this database by running ``SHOW TABLES``::
+
+    SHOW TABLES FROM memsql.web;
+
+You can see a list of the columns in the ``clicks`` table in the ``web`` database
+using either of the following::
+
+    DESCRIBE memsql.web.clicks;
+    SHOW COLUMNS FROM memsql.web.clicks;
+
+Finally, you can access the ``clicks`` table in the ``web`` database::
+
+    SELECT * FROM memsql.web.clicks;
+
+If you used a different name for your catalog properties file, use
+that catalog name instead of ``memsql`` in the above examples.
+
+MemSQL Connector Limitations
+----------------------------
+
+The following SQL statements are not yet supported:
+
+* :doc:`/sql/delete`
+* :doc:`/sql/grant`
+* :doc:`/sql/revoke`
+* :doc:`/sql/show-grants`
+* :doc:`/sql/show-roles`
+* :doc:`/sql/show-role-grants`

--- a/presto-main/etc/catalog/memsql.properties
+++ b/presto-main/etc/catalog/memsql.properties
@@ -1,0 +1,4 @@
+connector.name=memsql
+connection-url=jdbc:mariadb://localhost:13306
+connection-user=test
+connection-password=test

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -40,6 +40,7 @@ plugin.bundles=\
   ../presto-tpch/pom.xml, \
   ../presto-local-file/pom.xml, \
   ../presto-mysql/pom.xml,\
+  ../presto-memsql/pom.xml,\
   ../presto-sqlserver/pom.xml, \
   ../presto-postgresql/pom.xml, \
   ../presto-thrift/pom.xml, \

--- a/presto-memsql/pom.xml
+++ b/presto-memsql/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prestosql</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>326-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-memsql</artifactId>
+    <description>Presto - MemSQL Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.memsql;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.plugin.jdbc.BaseJdbcClient;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ConnectionFactory;
+import io.prestosql.plugin.jdbc.TheConnectionFactory;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class MemSqlClient
+        extends BaseJdbcClient
+{
+    @Inject
+    public MemSqlClient(BaseJdbcConfig config, @TheConnectionFactory ConnectionFactory connectionFactory)
+    {
+        super(config, "`", connectionFactory);
+    }
+
+    @Override
+    protected Collection<String> listSchemas(Connection connection)
+    {
+        // for MemSQL, we need to list catalogs instead of schemas
+        try (ResultSet resultSet = connection.getMetaData().getCatalogs()) {
+            ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
+            while (resultSet.next()) {
+                String schemaName = resultSet.getString("TABLE_CAT");
+                // skip internal schemas
+                if (!schemaName.equalsIgnoreCase("information_schema") && !schemaName.equalsIgnoreCase("memsql")) {
+                    schemaNames.add(schemaName);
+                }
+            }
+            return schemaNames.build();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        // MemSQL maps their "database" to SQL catalogs and does not have schemas
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getTables(
+                schemaName.orElse(null),
+                null,
+                escapeNamePattern(tableName, metadata.getSearchStringEscape()).orElse(null),
+                new String[] {"TABLE", "VIEW"});
+    }
+
+    @Override
+    protected String getTableSchemaName(ResultSet resultSet)
+            throws SQLException
+    {
+        // MemSQL uses catalogs instead of schemas
+        return resultSet.getString("TABLE_CAT");
+    }
+
+    @Override
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
+    {
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
+    }
+
+    @Override
+    public boolean isLimitGuaranteed()
+    {
+        return true;
+    }
+}

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClientModule.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClientModule.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.memsql;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ConnectionFactory;
+import io.prestosql.plugin.jdbc.DriverConnectionFactory;
+import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
+import org.mariadb.jdbc.Driver;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class MemSqlClientModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(JdbcClient.class).to(MemSqlClient.class).in(Scopes.SINGLETON);
+        ensureCatalogIsEmpty(buildConfigObject(BaseJdbcConfig.class).getConnectionUrl());
+        configBinder(binder).bindConfig(MemSqlConfig.class);
+    }
+
+    private static void ensureCatalogIsEmpty(String connectionUrl)
+    {
+        try {
+            Driver driver = new Driver();
+            DriverPropertyInfo[] urlProperties = driver.getPropertyInfo(connectionUrl, null);
+            checkArgument(urlProperties != null, "Invalid JDBC URL for MemSQL connector: '%s'", connectionUrl);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Provides
+    @Singleton
+    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, MemSqlConfig memsqlConfig)
+    {
+        Properties connectionProperties = new Properties();
+        // we don't want to interpret tinyInt type (with cardinality as 2) as boolean/bit
+        connectionProperties.setProperty("tinyInt1isBit", "false");
+        connectionProperties.setProperty("autoReconnect", String.valueOf(memsqlConfig.isAutoReconnect()));
+        connectionProperties.setProperty("connectTimeout", String.valueOf(memsqlConfig.getConnectionTimeout().toMillis()));
+
+        return new DriverConnectionFactory(
+                new Driver(),
+                config.getConnectionUrl(),
+                connectionProperties,
+                credentialProvider);
+    }
+}

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlConfig.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.memsql;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class MemSqlConfig
+{
+    private boolean autoReconnect = true;
+    private Duration connectionTimeout = new Duration(10, TimeUnit.SECONDS);
+
+    public boolean isAutoReconnect()
+    {
+        return autoReconnect;
+    }
+
+    @Config("memsql.auto-reconnect")
+    public MemSqlConfig setAutoReconnect(boolean autoReconnect)
+    {
+        this.autoReconnect = autoReconnect;
+        return this;
+    }
+
+    public Duration getConnectionTimeout()
+    {
+        return connectionTimeout;
+    }
+
+    @NotNull
+    @Config("memsql.connection-timeout")
+    public MemSqlConfig setConnectionTimeout(Duration connectionTimeout)
+    {
+        this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+}

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlPlugin.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlPlugin.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.memsql;
+
+import io.prestosql.plugin.jdbc.JdbcPlugin;
+
+public class MemSqlPlugin
+        extends JdbcPlugin
+{
+    public MemSqlPlugin()
+    {
+        super("memsql", new MemSqlClientModule());
+    }
+}

--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlConfig.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.memsql;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestMemSqlConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(MemSqlConfig.class)
+                .setAutoReconnect(true)
+                .setConnectionTimeout(new Duration(10, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("memsql.auto-reconnect", "false")
+                .put("memsql.connection-timeout", "4s")
+                .build();
+
+        MemSqlConfig expected = new MemSqlConfig()
+                .setAutoReconnect(false)
+                .setConnectionTimeout(new Duration(4, TimeUnit.SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlPlugin.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.memsql;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.connector.ConnectorFactory;
+import io.prestosql.testing.TestingConnectorContext;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestMemSqlPlugin
+{
+    @Test
+    public void testCreateConnector()
+    {
+        Plugin plugin = new MemSqlPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:mariadb://test"), new TestingConnectorContext());
+    }
+}


### PR DESCRIPTION
Fixes #1739 

This is a fork of MySQL connector with few modifications in the config. Removed incompatible configurations like `nullCatalogMeansCurrent`, `useInformationSchema`, `useUnicode`, `characterEncoding`etc.
