### PR TITLE
Optionally specify columns for ANALYZE

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -572,6 +572,18 @@ the values of the partition keys in the order they are declared in the table sch
 This query will collect statistics for two partitions with keys
 ``p1_value1, p1_value2`` and ``p2_value1, p2_value2``.
 
+On wide tables, collecting statistics for all columns can be expensive and can have a
+detrimental effect on query planning. It is also typically unnecessary - statistics are
+only useful on specific columns, like join keys, predicates, grouping keys. One can
+specify a subset of columns to be analyzed via the optional ``columns`` property::
+
+    ANALYZE table_name WITH (
+        partitions = ARRAY[ARRAY['p2_value1', 'p2_value2']],
+        columns = ARRAY['col_1', 'col_2'])
+
+This query will collect statistics for columns ``col_1`` and ``col_2`` for the partition
+with keys ``p2_value1, p2_value2``.
+
 Schema Evolution
 ----------------
 

--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -41,3 +41,10 @@ Analyze partitions with complex partition key (``state`` and ``city`` columns) f
 
     ANALYZE hive.default.customers WITH (partitions = ARRAY[ARRAY['CA', 'San Francisco'], ARRAY['NY', 'NY']]);
 
+Analyze only columns ``department`` and ``product_id`` for partitions ``'1992-01-01', '1992-01-02'`` from a Hive partitioned
+table ``sales``::
+
+    ANALYZE hive.default.sales WITH (
+        partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']],
+        columns = ARRAY['department', 'product_id']);
+

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveAnalyzeProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveAnalyzeProperties.java
@@ -74,7 +74,7 @@ public class HiveAnalyzeProperties
     public static Optional<List<List<String>>> getPartitionList(Map<String, Object> properties)
     {
         List<List<String>> partitions = (List<List<String>>) properties.get(PARTITIONS_PROPERTY);
-        return partitions == null ? Optional.empty() : Optional.of(partitions);
+        return Optional.ofNullable(partitions);
     }
 
     private static List<List<String>> decodePartitionLists(Object object)
@@ -84,12 +84,13 @@ public class HiveAnalyzeProperties
         }
 
         // replace null partition value with hive default partition
-        return ImmutableList.copyOf(((Collection<?>) object).stream()
+        return ((Collection<?>) object).stream()
                 .peek(partition -> throwIfNull(partition, "partitions"))
                 .map(partition -> ((Collection<?>) partition).stream()
                         .map(name -> firstNonNull((String) name, HIVE_DEFAULT_DYNAMIC_PARTITION))
                         .collect(toImmutableList()))
-                .collect(toImmutableSet()));
+                .distinct()
+                .collect(toImmutableList());
     }
 
     public static Optional<Set<String>> getColumnNames(Map<String, Object> properties)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -352,11 +352,12 @@ public class HiveMetadata
         }
         Optional<List<List<String>>> partitionValuesList = getPartitionList(analyzeProperties);
         ConnectorTableMetadata tableMetadata = getTableMetadata(session, handle.getSchemaTableName());
-        handle = handle.withAnalyzePartitionValues(partitionValuesList);
 
         List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
 
-        partitionValuesList.ifPresent(list -> {
+        if (partitionValuesList.isPresent()) {
+            List<List<String>> list = partitionValuesList.get();
+
             if (partitionedBy.isEmpty()) {
                 throw new PrestoException(INVALID_ANALYZE_PROPERTY, "Partition list provided but table is not partitioned");
             }
@@ -365,13 +366,13 @@ public class HiveMetadata
                     throw new PrestoException(INVALID_ANALYZE_PROPERTY, "Partition value count does not match partition column count");
                 }
             }
-        });
 
-        HiveTableHandle table = handle;
-        return partitionValuesList
-                .map(values -> partitionManager.getPartitions(table, values))
-                .map(result -> partitionManager.applyPartitionResult(table, result))
-                .orElse(table);
+            handle = handle.withAnalyzePartitionValues(list);
+            HivePartitionResult partitions = partitionManager.getPartitions(handle, list);
+            handle = partitionManager.applyPartitionResult(handle, partitions);
+        }
+
+        return handle;
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
@@ -229,7 +229,8 @@ public class HivePartitionManager
                 partitions.getEnforcedConstraint(),
                 partitions.getBucketHandle(),
                 partitions.getBucketFilter(),
-                handle.getAnalyzePartitionValues());
+                handle.getAnalyzePartitionValues(),
+                handle.getAnalyzeColumnNames());
     }
 
     public List<HivePartition> getOrLoadPartitions(SemiTransactionalHiveMetastore metastore, HiveIdentity identity, HiveTableHandle table)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableHandle.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableHandle.java
@@ -113,7 +113,7 @@ public class HiveTableHandle
         this.analyzePartitionValues = requireNonNull(analyzePartitionValues, "analyzePartitionValues is null");
     }
 
-    public HiveTableHandle withAnalyzePartitionValues(Optional<List<List<String>>> analyzePartitionValues)
+    public HiveTableHandle withAnalyzePartitionValues(List<List<String>> analyzePartitionValues)
     {
         return new HiveTableHandle(
                 schemaName,
@@ -125,7 +125,7 @@ public class HiveTableHandle
                 enforcedConstraint,
                 bucketHandle,
                 bucketFilter,
-                analyzePartitionValues);
+                Optional.of(analyzePartitionValues));
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -52,6 +53,11 @@ public class HiveTableProperties
     public static final String BUCKETING_VERSION = "bucketing_version";
     public static final String BUCKET_COUNT_PROPERTY = "bucket_count";
     public static final String SORTED_BY_PROPERTY = "sorted_by";
+    // TODO: This property represents the subset of columns to be analyzed. This exists mainly because there is no way
+    //       to pass the column names to ConnectorMetadata#getStatisticsCollectionMetadata; we should consider passing
+    //       ConnectorTableHandle instead of ConnectorTableMetadata as an argument since it makes more information
+    //       available (including the names of the columns to be analyzed)
+    public static final String ANALYZE_COLUMNS_PROPERTY = "presto.analyze_columns";
     public static final String ORC_BLOOM_FILTER_COLUMNS = "orc_bloom_filter_columns";
     public static final String ORC_BLOOM_FILTER_FPP = "orc_bloom_filter_fpp";
     public static final String AVRO_SCHEMA_URL = "avro_schema_url";
@@ -183,6 +189,12 @@ public class HiveTableProperties
     {
         List<String> partitionedBy = (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
         return partitionedBy == null ? ImmutableList.of() : ImmutableList.copyOf(partitionedBy);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Optional<Set<String>> getAnalyzeColumns(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Set<String>) tableProperties.get(ANALYZE_COLUMNS_PROPERTY));
     }
 
     public static Optional<HiveBucketProperty> getBucketProperty(Map<String, Object> tableProperties)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3978,7 +3978,9 @@ public class TestHiveIntegrationSmokeTest
     {
         assertQuery(
                 "SELECT * FROM system.metadata.analyze_properties WHERE catalog_name = 'hive'",
-                "SELECT 'hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'");
+                "SELECT * FROM VALUES " +
+                        "('hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'), " +
+                        "('hive', 'columns', '', 'array(varchar)', 'Columns to be analyzed')");
     }
 
     @Test
@@ -4040,7 +4042,7 @@ public class TestHiveIntegrationSmokeTest
         String tableName = "test_analyze_partitioned_table";
         createPartitionedTableForAnalyzeTest(tableName);
 
-        // No column stats before running analyze
+        // No column stats before ANALYZE
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
                         "('c_boolean', null, null, null, null, null, null), " +
@@ -4215,12 +4217,194 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testAnalyzePartitionedTableWithColumnSubset()
+    {
+        String tableName = "test_analyze_columns_partitioned_table";
+        createPartitionedTableForAnalyzeTest(tableName);
+
+        // No column stats before ANALYZE
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 24.0, 3.0, 0.25, null, null, null), " +
+                        "('p_bigint', null, 2.0, 0.25, null, '7', '8'), " +
+                        "(null, null, null, null, 16.0, null, null)");
+
+        // Run analyze on 3 partitions including a null partition and a duplicate partition,
+        // restricting to just 2 columns (one duplicate)
+        assertUpdate(
+                format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['p1', '7'], ARRAY['p2', '7'], ARRAY['p2', '7'], ARRAY[NULL, NULL]], " +
+                        "columns = ARRAY['c_timestamp', 'c_varchar', 'c_timestamp'])", tableName), 12);
+
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1' AND p_bigint = 7)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2' AND p_bigint = 7)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar IS NULL AND p_bigint IS NULL)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, 4.0, 0.0, null, null, null), " +
+                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 1.0, null, null, null), " +
+                        "(null, null, null, null, 4.0, null, null)");
+
+        // Partition [p3, 8], [e1, 9], [e2, 9] have no column stats
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3' AND p_bigint = 8)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '8', '8'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e1' AND p_bigint = 9)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e2' AND p_bigint = 9)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null)");
+
+        // Run analyze again, this time on 2 new columns (for all partitions); the previously computed stats
+        // should be preserved
+        assertUpdate(
+                format("ANALYZE %s WITH (columns = ARRAY['c_bigint', 'c_double'])", tableName), 16);
+
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1' AND p_bigint = 7)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '0', '1'), " +
+                        "('c_double', null, 2.0, 0.5, null, '1.2', '2.2'), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2' AND p_bigint = 7)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '1', '2'), " +
+                        "('c_double', null, 2.0, 0.5, null, '2.3', '3.3'), " +
+                        "('c_timestamp', null, 2.0, 0.5, null, null, null), " +
+                        "('c_varchar', 8.0, 2.0, 0.5, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '7', '7'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar IS NULL AND p_bigint IS NULL)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, 4.0, 0.0, null, '4', '7'), " +
+                        "('c_double', null, 4.0, 0.0, null, '4.7', '7.7'), " +
+                        "('c_timestamp', null, 4.0, 0.0, null, null, null), " +
+                        "('c_varchar', 16.0, 4.0, 0.0, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 1.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 1.0, null, null, null), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p3' AND p_bigint = 8)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, 2.0, 0.5, null, '2', '3'), " +
+                        "('c_double', null, 2.0, 0.5, null, '3.4', '4.4'), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', 8.0, 1.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 1.0, 0.0, null, '8', '8'), " +
+                        "(null, null, null, null, 4.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e1' AND p_bigint = 9)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 0.0, 0.0, null, null, null), " +
+                        "('c_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "('c_double', null, 0.0, 0.0, null, null, null), " +
+                        "('c_timestamp', null, 0.0, 0.0, null, null, null), " +
+                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('c_varbinary', 0.0, null, 0.0, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null)");
+        assertQuery(
+                format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'e2' AND p_bigint = 9)", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 0.0, 0.0, null, null, null), " +
+                        "('c_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "('c_double', null, 0.0, 0.0, null, null, null), " +
+                        "('c_timestamp', null, 0.0, 0.0, null, null, null), " +
+                        "('c_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('c_varbinary', 0.0, null, 0.0, null, null, null), " +
+                        "('p_varchar', 0.0, 0.0, 0.0, null, null, null), " +
+                        "('p_bigint', null, 0.0, 0.0, null, null, null), " +
+                        "(null, null, null, null, 0.0, null, null)");
+
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
     public void testAnalyzeUnpartitionedTable()
     {
         String tableName = "test_analyze_unpartitioned_table";
         createUnpartitionedTableForAnalyzeTest(tableName);
 
-        // No column stats before running analyze
+        // No column stats before ANALYZE
         assertQuery("SHOW STATS FOR " + tableName,
                 "SELECT * FROM VALUES " +
                         "('c_boolean', null, null, null, null, null, null), " +
@@ -4249,6 +4433,74 @@ public class TestHiveIntegrationSmokeTest
                         "(null, null, null, null, 16.0, null, null)");
 
         // Drop the unpartitioned test table
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testInvalidColumnsAnalyzeTable()
+    {
+        String tableName = "test_invalid_analyze_table";
+        createUnpartitionedTableForAnalyzeTest(tableName);
+
+        // It doesn't make sense to analyze an empty subset of columns
+        assertQueryFails(
+                "ANALYZE " + tableName + " WITH (columns = ARRAY[])",
+                ".*Cannot analyze with empty column list.*");
+
+        // Specifying a null column name is not cool
+        assertQueryFails(
+                "ANALYZE " + tableName + " WITH (columns = ARRAY[null])",
+                ".*Invalid null value in analyze columns property.*");
+
+        // You must specify valid column names
+        assertQueryFails(
+                "ANALYZE " + tableName + " WITH (columns = ARRAY['invalid_name'])",
+                ".*Invalid columns specified for analysis.*");
+
+        // Column names must be strings
+        assertQueryFails(
+                "ANALYZE " + tableName + " WITH (columns = ARRAY[42])",
+                "\\QInvalid value for analyze property 'columns': Cannot convert [ARRAY[42]] to array(varchar)\\E");
+
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testAnalyzeUnpartitionedTableWithColumnSubset()
+    {
+        String tableName = "test_analyze_columns_unpartitioned_table";
+        createUnpartitionedTableForAnalyzeTest(tableName);
+
+        // No column stats before ANALYZE
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, null, null, null, null, null), " +
+                        "('c_double', null, null, null, null, null, null), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', null, null, null, null, null, null), " +
+                        "('p_bigint', null, null, null, null, null, null), " +
+                        "(null, null, null, null, 16.0, null, null)");
+
+        // Run analyze on the whole table
+        assertUpdate("ANALYZE " + tableName + " WITH (columns = ARRAY['c_bigint', 'c_double'])", 16);
+
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, null, null, null, null, null), " +
+                        "('c_bigint', null, 8.0, 0.375, null, '0', '7'), " +
+                        "('c_double', null, 10.0, 0.375, null, '1.2', '7.7'), " +
+                        "('c_timestamp', null, null, null, null, null, null), " +
+                        "('c_varchar', null, null, null, null, null, null), " +
+                        "('c_varbinary', null, null, null, null, null, null), " +
+                        "('p_varchar', null, null, null, null, null, null), " +
+                        "('p_bigint', null, null, null, null, null, null), " +
+                        "(null, null, null, null, 16.0, null, null)");
+
         assertUpdate(format("DROP TABLE %s", tableName));
     }
 


### PR DESCRIPTION
Specify the columns for which analysis should be performed, similar to how partitions are specified.  Restricting the columns to be analyzed reduces the execution time for `ANALYZE` and can also cut down on query planning (e.g. for tables with thousands of columns, reading the stats can be expensive).

To analyze only columns `department` and `product_id`:
```
ANALYZE hive.default.sales WITH (columns = ARRAY['department', 'product_id']);
```

To restrict by partition, as well:
```
ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']], columns = ARRAY['department', 'product_id']);
```

Fixes https://github.com/prestosql/presto/issues/1884