### PR TITLE
Support MongoDB case insensitive collection name

### DIFF
--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoInsertTableHandle.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoInsertTableHandle.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.connector.ConnectorInsertTableHandle;
-import io.prestosql.spi.connector.SchemaTableName;
 
 import java.util.List;
 
@@ -26,22 +25,22 @@ import static java.util.Objects.requireNonNull;
 public class MongoInsertTableHandle
         implements ConnectorInsertTableHandle
 {
-    private final SchemaTableName schemaTableName;
+    private final MongoTableHandle table;
     private final List<MongoColumnHandle> columns;
 
     @JsonCreator
     public MongoInsertTableHandle(
-            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+            @JsonProperty("table") MongoTableHandle table,
             @JsonProperty("columns") List<MongoColumnHandle> columns)
     {
-        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.table = requireNonNull(table, "table is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 
     @JsonProperty
-    public SchemaTableName getSchemaTableName()
+    public MongoTableHandle getTable()
     {
-        return schemaTableName;
+        return table;
     }
 
     @JsonProperty

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoOutputTableHandle.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoOutputTableHandle.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.connector.ConnectorOutputTableHandle;
-import io.prestosql.spi.connector.SchemaTableName;
 
 import java.util.List;
 
@@ -26,22 +25,22 @@ import static java.util.Objects.requireNonNull;
 public class MongoOutputTableHandle
         implements ConnectorOutputTableHandle
 {
-    private final SchemaTableName schemaTableName;
+    private final MongoTableHandle table;
     private final List<MongoColumnHandle> columns;
 
     @JsonCreator
     public MongoOutputTableHandle(
-            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+            @JsonProperty("table") MongoTableHandle table,
             @JsonProperty("columns") List<MongoColumnHandle> columns)
     {
-        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.table = requireNonNull(table, "table is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 
     @JsonProperty
-    public SchemaTableName getSchemaTableName()
+    public MongoTableHandle getTable()
     {
-        return schemaTableName;
+        return table;
     }
 
     @JsonProperty

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.StandardErrorCode;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSink;
 import io.prestosql.spi.connector.ConnectorSession;
-import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.type.BigintType;
 import io.prestosql.spi.type.BooleanType;
 import io.prestosql.spi.type.DateType;
@@ -76,7 +75,7 @@ public class MongoPageSink
 {
     private final MongoSession mongoSession;
     private final ConnectorSession session;
-    private final SchemaTableName schemaTableName;
+    private final MongoTableHandle table;
     private final List<MongoColumnHandle> columns;
     private final String implicitPrefix;
 
@@ -84,12 +83,12 @@ public class MongoPageSink
             MongoClientConfig config,
             MongoSession mongoSession,
             ConnectorSession session,
-            SchemaTableName schemaTableName,
+            MongoTableHandle table,
             List<MongoColumnHandle> columns)
     {
         this.mongoSession = mongoSession;
         this.session = session;
-        this.schemaTableName = schemaTableName;
+        this.table = table;
         this.columns = columns;
         this.implicitPrefix = requireNonNull(config.getImplicitRowFieldPrefix(), "config.getImplicitRowFieldPrefix() is null");
     }
@@ -97,7 +96,7 @@ public class MongoPageSink
     @Override
     public CompletableFuture<?> appendPage(Page page)
     {
-        MongoCollection<Document> collection = mongoSession.getCollection(schemaTableName);
+        MongoCollection<Document> collection = mongoSession.getCollection(table);
         List<Document> batch = new ArrayList<>(page.getPositionCount());
 
         for (int position = 0; position < page.getPositionCount(); position++) {

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSinkProvider.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSinkProvider.java
@@ -39,13 +39,13 @@ public class MongoPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
     {
         MongoOutputTableHandle handle = (MongoOutputTableHandle) outputTableHandle;
-        return new MongoPageSink(config, mongoSession, session, handle.getSchemaTableName(), handle.getColumns());
+        return new MongoPageSink(config, mongoSession, session, handle.getTable(), handle.getColumns());
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
     {
         MongoInsertTableHandle handle = (MongoInsertTableHandle) insertTableHandle;
-        return new MongoPageSink(config, mongoSession, session, handle.getSchemaTableName(), handle.getColumns());
+        return new MongoPageSink(config, mongoSession, session, handle.getTable(), handle.getColumns());
     }
 }

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoTableHandle.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoTableHandle.java
@@ -27,27 +27,42 @@ import static java.util.Objects.requireNonNull;
 public class MongoTableHandle
         implements ConnectorTableHandle
 {
-    private final SchemaTableName schemaTableName;
+    private final String databaseName; // case sensitive name
+    private final String collectionName; // case sensitive name
     private final TupleDomain<ColumnHandle> constraint;
 
-    public MongoTableHandle(SchemaTableName schemaTableName)
+    public MongoTableHandle(SchemaTableName table)
     {
-        this(schemaTableName, TupleDomain.all());
+        this(table.getSchemaName(), table.getTableName(), TupleDomain.all());
     }
 
     @JsonCreator
     public MongoTableHandle(
-            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+            @JsonProperty("databaseName") String databaseName,
+            @JsonProperty("collectionName") String collectionName,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
-        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.databaseName = requireNonNull(databaseName, "databaseName is null");
+        this.collectionName = requireNonNull(collectionName, "collectionName is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
     public SchemaTableName getSchemaTableName()
     {
-        return schemaTableName;
+        return new SchemaTableName(databaseName, collectionName);
+    }
+
+    @JsonProperty
+    public String getDatabaseName()
+    {
+        return databaseName;
+    }
+
+    @JsonProperty
+    public String getCollectionName()
+    {
+        return collectionName;
     }
 
     @JsonProperty
@@ -59,7 +74,7 @@ public class MongoTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName);
+        return Objects.hash(databaseName, collectionName);
     }
 
     @Override
@@ -72,12 +87,13 @@ public class MongoTableHandle
             return false;
         }
         MongoTableHandle other = (MongoTableHandle) obj;
-        return Objects.equals(this.schemaTableName, other.schemaTableName);
+        return Objects.equals(this.databaseName, other.databaseName) &&
+                Objects.equals(this.collectionName, other.collectionName);
     }
 
     @Override
     public String toString()
     {
-        return schemaTableName.toString();
+        return String.format("%s.%s", databaseName, collectionName);
     }
 }

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoQueryRunner.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoQueryRunner.java
@@ -16,12 +16,14 @@ package io.prestosql.plugin.mongodb;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.Session;
 import io.prestosql.plugin.tpch.TpchPlugin;
 import io.prestosql.testing.DistributedQueryRunner;
+import org.bson.Document;
 
 import java.util.Map;
 
@@ -60,12 +62,22 @@ public final class MongoQueryRunner
             queryRunner.createCatalog("mongodb", "mongodb", properties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            createNativeTables(server);
+
             return queryRunner;
         }
         catch (Throwable e) {
             closeAllSuppress(e, queryRunner);
             throw e;
         }
+    }
+
+    private static void createNativeTables(MongoServer server)
+    {
+        MongoClient client = new MongoClient(server.getAddress().getHost(), server.getAddress().getPort());
+        MongoCollection<Document> collection = client.getDatabase("CamelDB").getCollection("camelTable");
+
+        collection.insertOne(new Document(ImmutableMap.of("Name", "asdf", "Value", 1)));
     }
 
     public static Session createSession()

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
@@ -308,6 +308,16 @@ public class TestMongoIntegrationSmokeTest
         return false;
     }
 
+    @Test
+    public void testCaseInsensitive()
+            throws Exception
+    {
+        assertQuery("SELECT name, value FROM cameldb.cameltable", "SELECT 'asdf', 1");
+        assertUpdate("INSERT INTO cameldb.cameltable VALUES('qwer', 2)", 1);
+
+        assertQuery("SELECT value FROM cameldb.cameltable where name = 'qwer'", "SELECT 2");
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toTestTypes();

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoSession.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoSession.java
@@ -35,8 +35,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestMongoSession
 {
-    private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false);
-    private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false);
+    private static final MongoColumnHandle COL1 = new MongoColumnHandle("Col1", BIGINT, false);
+    private static final MongoColumnHandle COL2 = new MongoColumnHandle("Col2", createUnboundedVarcharType(), false);
 
     @Test
     public void testBuildQuery()

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoTableHandle.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoTableHandle.java
@@ -14,7 +14,7 @@
 package io.prestosql.plugin.mongodb;
 
 import io.airlift.json.JsonCodec;
-import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.predicate.TupleDomain;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -26,11 +26,13 @@ public class TestMongoTableHandle
     @Test
     public void testRoundTrip()
     {
-        MongoTableHandle expected = new MongoTableHandle(new SchemaTableName("schema", "table"));
+        MongoTableHandle expected = new MongoTableHandle("Schema", "Table", TupleDomain.all());
 
         String json = codec.toJson(expected);
         MongoTableHandle actual = codec.fromJson(json);
 
         assertEquals(actual.getSchemaTableName(), expected.getSchemaTableName());
+        assertEquals(actual.getDatabaseName(), expected.getDatabaseName());
+        assertEquals(actual.getCollectionName(), expected.getCollectionName());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/1102

Currently any MongoDB collection with uppercase name like "Hello" could not be queried.
This PR makes it possible by supporting case insensitivity for collection name, providing solution for case 2 mentioned here https://github.com/prestosql/presto/issues/1102#issuecomment-536331360, it doesn't help case 1 though.