### PR TITLE
Rename toggle for disabling reserved pool

### DIFF
--- a/presto-docs/src/main/sphinx/admin/spill.rst
+++ b/presto-docs/src/main/sphinx/admin/spill.rst
@@ -62,7 +62,7 @@ spilling for queries that consume large amounts of memory per node.
 Such queries could finish much quicker when spill is disabled because they
 execute in reserved pool. However, this could also significantly reduce cluster concurrency.
 In such situations we recommend to disable reserved memory
-pool via ``experimental.reserved-pool-enabled`` config property.
+pool via ``experimental.reserved-pool-disabled`` config property.
 
 Spill Disk Space
 ----------------

--- a/presto-main/src/main/java/io/prestosql/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/io/prestosql/memory/ClusterMemoryManager.java
@@ -164,7 +164,7 @@ public class ClusterMemoryManager
         verify(maxQueryMemory.toBytes() <= maxQueryTotalMemory.toBytes(),
                 "maxQueryMemory cannot be greater than maxQueryTotalMemory");
 
-        this.pools = createClusterMemoryPools(nodeMemoryConfig.isReservedPoolEnabled());
+        this.pools = createClusterMemoryPools(!nodeMemoryConfig.isReservedPoolDisabled());
     }
 
     private Map<MemoryPoolId, ClusterMemoryPool> createClusterMemoryPools(boolean reservedPoolEnabled)

--- a/presto-main/src/main/java/io/prestosql/memory/LocalMemoryManager.java
+++ b/presto-main/src/main/java/io/prestosql/memory/LocalMemoryManager.java
@@ -69,7 +69,7 @@ public final class LocalMemoryManager
                 QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG);
         ImmutableMap.Builder<MemoryPoolId, MemoryPool> builder = ImmutableMap.builder();
         long generalPoolSize = maxMemory.toBytes();
-        if (config.isReservedPoolEnabled()) {
+        if (!config.isReservedPoolDisabled()) {
             builder.put(RESERVED_POOL, new MemoryPool(RESERVED_POOL, config.getMaxQueryTotalMemoryPerNode()));
             generalPoolSize -= config.getMaxQueryTotalMemoryPerNode().toBytes();
         }

--- a/presto-main/src/main/java/io/prestosql/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/io/prestosql/memory/NodeMemoryConfig.java
@@ -16,6 +16,7 @@ package io.prestosql.memory;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
@@ -30,7 +31,7 @@ public class NodeMemoryConfig
     public static final String QUERY_MAX_MEMORY_PER_NODE_CONFIG = "query.max-memory-per-node";
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG = "query.max-total-memory-per-node";
 
-    private boolean isReservedPoolEnabled = true;
+    private boolean isReservedPoolDisabled;
 
     private DataSize maxQueryMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
 
@@ -51,15 +52,21 @@ public class NodeMemoryConfig
         return this;
     }
 
-    public boolean isReservedPoolEnabled()
+    @LegacyConfig(value = "experimental.reserved-pool-enabled", replacedBy = "experimental.reserved-pool-disabled")
+    public void setReservedPoolEnabled(boolean reservedPoolEnabled)
     {
-        return isReservedPoolEnabled;
+        isReservedPoolDisabled = !reservedPoolEnabled;
     }
 
-    @Config("experimental.reserved-pool-enabled")
-    public NodeMemoryConfig setReservedPoolEnabled(boolean reservedPoolEnabled)
+    public boolean isReservedPoolDisabled()
     {
-        isReservedPoolEnabled = reservedPoolEnabled;
+        return isReservedPoolDisabled;
+    }
+
+    @Config("experimental.reserved-pool-disabled")
+    public NodeMemoryConfig setReservedPoolDisabled(boolean reservedPoolDisabled)
+    {
+        this.isReservedPoolDisabled = reservedPoolDisabled;
         return this;
     }
 

--- a/presto-main/src/test/java/io/prestosql/memory/TestLocalMemoryManager.java
+++ b/presto-main/src/test/java/io/prestosql/memory/TestLocalMemoryManager.java
@@ -28,7 +28,7 @@ public class TestLocalMemoryManager
     public void testReservedMemoryPoolDisabled()
     {
         NodeMemoryConfig config = new NodeMemoryConfig()
-                .setReservedPoolEnabled(false)
+                .setReservedPoolDisabled(true)
                 .setHeapHeadroom(new DataSize(10, GIGABYTE))
                 .setMaxQueryMemoryPerNode(new DataSize(20, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(20, GIGABYTE));

--- a/presto-main/src/test/java/io/prestosql/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/io/prestosql/memory/TestNodeMemoryConfig.java
@@ -35,7 +35,7 @@ public class TestNodeMemoryConfig
                 .setMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
                 .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
-                .setReservedPoolEnabled(true));
+                .setReservedPoolDisabled(false));
     }
 
     @Test
@@ -45,14 +45,14 @@ public class TestNodeMemoryConfig
                 .put("query.max-memory-per-node", "1GB")
                 .put("query.max-total-memory-per-node", "3GB")
                 .put("memory.heap-headroom-per-node", "1GB")
-                .put("experimental.reserved-pool-enabled", "false")
+                .put("experimental.reserved-pool-disabled", "true")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
                 .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
                 .setHeapHeadroom(new DataSize(1, GIGABYTE))
-                .setReservedPoolEnabled(false);
+                .setReservedPoolDisabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/test/java/io/prestosql/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/io/prestosql/memory/TestMemoryManager.java
@@ -170,7 +170,7 @@ public class TestMemoryManager
             throws Exception
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("experimental.reserved-pool-enabled", "false")
+                .put("experimental.reserved-pool-disabled", "true")
                 .put("query.low-memory-killer.delay", "5s")
                 .put("query.low-memory-killer.policy", "total-reservation")
                 .build();


### PR DESCRIPTION
When this is put in the configuration file:

    experimental.reserved-pool-enabled=true

it looks like we're enabling some experimental functionality, whereas
it's not a case. This is misleading. This commit renames the flag to
make it clear what's default behavior and what's experimental.