### PR TITLE
Remove redundant getTable call when fetching partitions

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -143,7 +143,7 @@ public class HiveMetadataFactory
     {
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
                 hdfsEnvironment,
-                memoizeMetastore(this.metastore, perTransactionCacheMaximumSize), // per-transaction cache
+                new HiveMetastoreClosure(memoizeMetastore(this.metastore, perTransactionCacheMaximumSize)), // per-transaction cache
                 renameExecution,
                 skipDeletionForAlter,
                 skipTargetCleanupOnRollback);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -18,7 +18,6 @@ import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
-import io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.prestosql.plugin.hive.security.AccessControlMetadataFactory;
 import io.prestosql.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
 import io.prestosql.spi.type.TypeManager;
@@ -29,6 +28,7 @@ import javax.inject.Inject;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
+import static io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static java.util.Objects.requireNonNull;
 
 public class HiveMetadataFactory
@@ -143,7 +143,7 @@ public class HiveMetadataFactory
     {
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
                 hdfsEnvironment,
-                CachingHiveMetastore.memoizeMetastore(this.metastore, perTransactionCacheMaximumSize), // per-transaction cache
+                memoizeMetastore(this.metastore, perTransactionCacheMaximumSize), // per-transaction cache
                 renameExecution,
                 skipDeletionForAlter,
                 skipTargetCleanupOnRollback);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.metastore.Database;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.HivePrincipal;
+import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
+import io.prestosql.plugin.hive.metastore.Partition;
+import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
+import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
+import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.spi.security.RoleGrant;
+import io.prestosql.spi.statistics.ColumnStatisticType;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class HiveMetastoreClosure
+{
+    private final HiveMetastore delegate;
+
+    public HiveMetastoreClosure(HiveMetastore delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    public Optional<Database> getDatabase(String databaseName)
+    {
+        return delegate.getDatabase(databaseName);
+    }
+
+    public List<String> getAllDatabases()
+    {
+        return delegate.getAllDatabases();
+    }
+
+    public Optional<Table> getTable(HiveIdentity identity, String databaseName, String tableName)
+    {
+        return delegate.getTable(identity, databaseName, tableName);
+    }
+
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        return delegate.getSupportedColumnStatistics(type);
+    }
+
+    public PartitionStatistics getTableStatistics(HiveIdentity identity, String databaseName, String tableName)
+    {
+        return delegate.getTableStatistics(identity, databaseName, tableName);
+    }
+
+    public Map<String, PartitionStatistics> getPartitionStatistics(HiveIdentity identity, String databaseName, String tableName, Set<String> partitionNames)
+    {
+        return delegate.getPartitionStatistics(identity, databaseName, tableName, partitionNames);
+    }
+
+    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        delegate.updateTableStatistics(identity, databaseName, tableName, update);
+    }
+
+    public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        delegate.updatePartitionStatistics(identity, databaseName, tableName, partitionName, update);
+    }
+
+    public List<String> getAllTables(String databaseName)
+    {
+        return delegate.getAllTables(databaseName);
+    }
+
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
+    }
+
+    public List<String> getAllViews(String databaseName)
+    {
+        return delegate.getAllViews(databaseName);
+    }
+
+    public void createDatabase(HiveIdentity identity, Database database)
+    {
+        delegate.createDatabase(identity, database);
+    }
+
+    public void dropDatabase(HiveIdentity identity, String databaseName)
+    {
+        delegate.dropDatabase(identity, databaseName);
+    }
+
+    public void renameDatabase(HiveIdentity identity, String databaseName, String newDatabaseName)
+    {
+        delegate.renameDatabase(identity, databaseName, newDatabaseName);
+    }
+
+    public void createTable(HiveIdentity identity, Table table, PrincipalPrivileges principalPrivileges)
+    {
+        delegate.createTable(identity, table, principalPrivileges);
+    }
+
+    public void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData)
+    {
+        delegate.dropTable(identity, databaseName, tableName, deleteData);
+    }
+
+    public void replaceTable(HiveIdentity identity, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        delegate.replaceTable(identity, databaseName, tableName, newTable, principalPrivileges);
+    }
+
+    public void renameTable(HiveIdentity identity, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        delegate.renameTable(identity, databaseName, tableName, newDatabaseName, newTableName);
+    }
+
+    public void commentTable(HiveIdentity identity, String databaseName, String tableName, Optional<String> comment)
+    {
+        delegate.commentTable(identity, databaseName, tableName, comment);
+    }
+
+    public void addColumn(HiveIdentity identity, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        delegate.addColumn(identity, databaseName, tableName, columnName, columnType, columnComment);
+    }
+
+    public void renameColumn(HiveIdentity identity, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        delegate.renameColumn(identity, databaseName, tableName, oldColumnName, newColumnName);
+    }
+
+    public void dropColumn(HiveIdentity identity, String databaseName, String tableName, String columnName)
+    {
+        delegate.dropColumn(identity, databaseName, tableName, columnName);
+    }
+
+    public Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues)
+    {
+        return delegate.getTable(identity, databaseName, tableName)
+                .flatMap(table -> delegate.getPartition(identity, table, partitionValues));
+    }
+
+    public Optional<List<String>> getPartitionNames(HiveIdentity identity, String databaseName, String tableName)
+    {
+        return delegate.getPartitionNames(identity, databaseName, tableName);
+    }
+
+    public Optional<List<String>> getPartitionNamesByParts(HiveIdentity identity, String databaseName, String tableName, List<String> parts)
+    {
+        return delegate.getPartitionNamesByParts(identity, databaseName, tableName, parts);
+    }
+
+    public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, String databaseName, String tableName, List<String> partitionNames)
+    {
+        return delegate.getTable(identity, databaseName, tableName)
+                .map(table -> delegate.getPartitionsByNames(identity, table, partitionNames))
+                .orElseGet(() -> partitionNames.stream()
+                        .collect(toImmutableMap(name -> name, name -> Optional.empty())));
+    }
+
+    public void addPartitions(HiveIdentity identity, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    {
+        delegate.addPartitions(identity, databaseName, tableName, partitions);
+    }
+
+    public void dropPartition(HiveIdentity identity, String databaseName, String tableName, List<String> parts, boolean deleteData)
+    {
+        delegate.dropPartition(identity, databaseName, tableName, parts, deleteData);
+    }
+
+    public void alterPartition(HiveIdentity identity, String databaseName, String tableName, PartitionWithStatistics partition)
+    {
+        delegate.alterPartition(identity, databaseName, tableName, partition);
+    }
+
+    public void createRole(String role, String grantor)
+    {
+        delegate.createRole(role, grantor);
+    }
+
+    public void dropRole(String role)
+    {
+        delegate.dropRole(role);
+    }
+
+    public Set<String> listRoles()
+    {
+        return delegate.listRoles();
+    }
+
+    public void grantRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean withAdminOption, HivePrincipal grantor)
+    {
+        delegate.grantRoles(roles, grantees, withAdminOption, grantor);
+    }
+
+    public void revokeRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean adminOptionFor, HivePrincipal grantor)
+    {
+        delegate.revokeRoles(roles, grantees, adminOptionFor, grantor);
+    }
+
+    public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
+    {
+        return delegate.listRoleGrants(principal);
+    }
+
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        delegate.grantTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
+    }
+
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        delegate.revokeTablePrivileges(databaseName, tableName, tableOwner, grantee, privileges);
+    }
+
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, Optional<HivePrincipal> principal)
+    {
+        return delegate.listTablePrivileges(databaseName, tableName, tableOwner, principal);
+    }
+
+    public boolean isImpersonationEnabled()
+    {
+        return delegate.isImpersonationEnabled();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
@@ -144,7 +144,10 @@ public class HivePageSinkProvider
                 handle.getLocationHandle(),
                 locationService,
                 session.getQueryId(),
-                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), memoizeMetastore(metastore, perTransactionMetastoreCacheMaximumSize), new HiveIdentity(session)),
+                new HivePageSinkMetadataProvider(
+                        handle.getPageSinkMetadata(),
+                        new HiveMetastoreClosure(memoizeMetastore(metastore, perTransactionMetastoreCacheMaximumSize)),
+                        new HiveIdentity(session)),
                 typeManager,
                 hdfsEnvironment,
                 pageSorter,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -77,13 +77,13 @@ public interface HiveMetastore
 
     void dropColumn(HiveIdentity identity, String databaseName, String tableName, String columnName);
 
-    Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues);
+    Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues);
 
     Optional<List<String>> getPartitionNames(HiveIdentity identity, String databaseName, String tableName);
 
     Optional<List<String>> getPartitionNamesByParts(HiveIdentity identity, String databaseName, String tableName, List<String> parts);
 
-    Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, String databaseName, String tableName, List<String> partitionNames);
+    Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, Table table, List<String> partitionNames);
 
     void addPartitions(HiveIdentity identity, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
@@ -54,7 +54,8 @@ public class HivePageSinkMetadataProvider
         }
         Optional<Partition> modifiedPartition = modifiedPartitions.get(partitionValues);
         if (modifiedPartition == null) {
-            return delegate.getPartition(identity, schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues);
+            return delegate.getTable(identity, table.get().getDatabaseName(), table.get().getTableName())
+                    .flatMap(existingTable -> delegate.getPartition(identity, existingTable, partitionValues));
         }
         else {
             return modifiedPartition;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePageSinkMetadataProvider.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore;
 
+import io.prestosql.plugin.hive.HiveMetastoreClosure;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.spi.connector.SchemaTableName;
 
@@ -26,12 +27,12 @@ import static java.util.Objects.requireNonNull;
 public class HivePageSinkMetadataProvider
 {
     private final HiveIdentity identity;
-    private final HiveMetastore delegate;
+    private final HiveMetastoreClosure delegate;
     private final SchemaTableName schemaTableName;
     private final Optional<Table> table;
     private final Map<List<String>, Optional<Partition>> modifiedPartitions;
 
-    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, HiveMetastore delegate, HiveIdentity identity)
+    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, HiveMetastoreClosure delegate, HiveIdentity identity)
     {
         requireNonNull(pageSinkMetadata, "pageSinkMetadata is null");
         this.delegate = delegate;
@@ -54,8 +55,7 @@ public class HivePageSinkMetadataProvider
         }
         Optional<Partition> modifiedPartition = modifiedPartitions.get(partitionValues);
         if (modifiedPartition == null) {
-            return delegate.getTable(identity, table.get().getDatabaseName(), table.get().getTableName())
-                    .flatMap(existingTable -> delegate.getPartition(identity, existingTable, partitionValues));
+            return delegate.getPartition(identity, schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues);
         }
         else {
             return modifiedPartition;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePartitionName.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePartitionName.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.prestosql.plugin.hive.metastore.HiveTableName.hiveTableName;
 import static io.prestosql.plugin.hive.util.HiveUtil.toPartitionValues;
 import static java.util.Objects.requireNonNull;
 
@@ -51,14 +50,9 @@ public class HivePartitionName
         return new HivePartitionName(hiveTableName, toPartitionValues(partitionName), Optional.of(partitionName));
     }
 
-    public static HivePartitionName hivePartitionName(String databaseName, String tableName, String partitionName)
+    public static HivePartitionName hivePartitionName(HiveTableName hiveTableName, List<String> partitionValues)
     {
-        return hivePartitionName(hiveTableName(databaseName, tableName), partitionName);
-    }
-
-    public static HivePartitionName hivePartitionName(String databaseName, String tableName, List<String> partitionValues)
-    {
-        return new HivePartitionName(hiveTableName(databaseName, tableName), partitionValues, Optional.empty());
+        return new HivePartitionName(hiveTableName, partitionValues, Optional.empty());
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
@@ -32,7 +32,9 @@ import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.prestosql.plugin.hive.HiveMetadata.AVRO_SCHEMA_URL_KEY;
 import static io.prestosql.plugin.hive.HiveSplitManager.PRESTO_OFFLINE;
+import static io.prestosql.plugin.hive.HiveStorageFormat.AVRO;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.security.PrincipalType.USER;
 import static java.util.stream.Collectors.toList;
@@ -176,6 +178,13 @@ public final class MetastoreUtil
     public static ProtectMode getProtectMode(Table table)
     {
         return getProtectMode(table.getParameters());
+    }
+
+    public static boolean isAvroTableWithSchemaSet(Table table)
+    {
+        return AVRO.getSerDe().equals(table.getStorage().getStorageFormat().getSerDeNullable()) &&
+                (table.getParameters().get(AVRO_SCHEMA_URL_KEY) != null ||
+                        (table.getStorage().getSerdeParameters().get(AVRO_SCHEMA_URL_KEY) != null));
     }
 
     public static String makePartName(List<Column> partitionColumns, List<String> values)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -353,7 +353,7 @@ public class RecordingHiveMetastore
     {
         return loadValue(
                 partitionCache,
-                hivePartitionName(databaseName, tableName, partitionValues),
+                hivePartitionName(hiveTableName(databaseName, tableName), partitionValues),
                 () -> delegate.getPartition(identity, databaseName, tableName, partitionValues));
     }
 
@@ -431,7 +431,7 @@ public class RecordingHiveMetastore
     private Set<HivePartitionName> getHivePartitionNames(String databaseName, String tableName, Set<String> partitionNames)
     {
         return partitionNames.stream()
-                .map(partitionName -> HivePartitionName.hivePartitionName(databaseName, tableName, partitionName))
+                .map(partitionName -> hivePartitionName(hiveTableName(databaseName, tableName), partitionName))
                 .collect(ImmutableSet.toImmutableSet());
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -370,7 +370,7 @@ public class CachingHiveMetastore
             delegate.updatePartitionStatistics(identity, databaseName, tableName, partitionName, update);
         }
         finally {
-            partitionStatisticsCache.invalidate(new WithIdentity<>(identity, hivePartitionName(databaseName, tableName, partitionName)));
+            partitionStatisticsCache.invalidate(new WithIdentity<>(identity, hivePartitionName(hiveTableName(databaseName, tableName), partitionName)));
         }
     }
 
@@ -578,7 +578,7 @@ public class CachingHiveMetastore
     @Override
     public Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues)
     {
-        return get(partitionCache, new WithIdentity<>(updateIdentity(identity), hivePartitionName(databaseName, tableName, partitionValues)));
+        return get(partitionCache, new WithIdentity<>(updateIdentity(identity), hivePartitionName(hiveTableName(databaseName, tableName), partitionValues)));
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -926,21 +926,14 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues)
+    public synchronized Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues)
     {
-        requireNonNull(databaseName, "databaseName is null");
-        requireNonNull(tableName, "tableName is null");
+        requireNonNull(table, "table is null");
         requireNonNull(partitionValues, "partitionValues is null");
-
-        Optional<Table> tableReference = getTable(identity, databaseName, tableName);
-        if (!tableReference.isPresent()) {
-            return Optional.empty();
-        }
-        Table table = tableReference.get();
 
         Path partitionDirectory = getPartitionMetadataDirectory(table, partitionValues);
         return readSchemaFile("partition", partitionDirectory, partitionCodec)
-                .map(partitionMetadata -> partitionMetadata.toPartition(databaseName, tableName, partitionValues, partitionDirectory.toString()));
+                .map(partitionMetadata -> partitionMetadata.toPartition(table.getDatabaseName(), table.getTableName(), partitionValues, partitionDirectory.toString()));
     }
 
     @Override
@@ -968,12 +961,12 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, String databaseName, String tableName, List<String> partitionNames)
+    public synchronized Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, Table table, List<String> partitionNames)
     {
         ImmutableMap.Builder<String, Optional<Partition>> builder = ImmutableMap.builder();
         for (String partitionName : partitionNames) {
             List<String> partitionValues = toPartitionValues(partitionName);
-            builder.put(partitionName, getPartition(identity, databaseName, tableName, partitionValues));
+            builder.put(partitionName, getPartition(identity, table, partitionValues));
         }
         return builder.build();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -674,7 +674,7 @@ public final class ThriftMetastoreUtil
         }
     }
 
-    private static FieldSchema toMetastoreApiFieldSchema(Column column)
+    public static FieldSchema toMetastoreApiFieldSchema(Column column)
     {
         return new FieldSchema(column.getName(), column.getType().getHiveTypeName().toString(), column.getComment().orElse(null));
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -42,7 +42,6 @@ import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.SortingColumn;
 import io.prestosql.plugin.hive.metastore.StorageFormat;
 import io.prestosql.plugin.hive.metastore.Table;
-import io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
@@ -220,6 +219,7 @@ import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createDoub
 import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createStringColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.cachingHiveMetastore;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.prestosql.plugin.hive.util.HiveUtil.columnExtraInfo;
 import static io.prestosql.plugin.hive.util.HiveUtil.toPartitionValues;
@@ -701,7 +701,7 @@ public abstract class AbstractTestHive
 
         MetastoreLocator metastoreLocator = new TestingMetastoreLocator(proxy, HostAndPort.fromParts(host, port));
 
-        HiveMetastore metastore = new CachingHiveMetastore(
+        HiveMetastore metastore = cachingHiveMetastore(
                 new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new ThriftMetastoreConfig(), new HiveAuthenticationConfig())),
                 executor,
                 Duration.valueOf("1m"),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -33,7 +33,6 @@ import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
 import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore;
-import io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
@@ -73,6 +72,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -457,7 +457,7 @@ public abstract class AbstractTestHiveFileSystem
 
         public TestingHiveMetastore(HiveMetastore delegate, Executor executor, Path basePath, HdfsEnvironment hdfsEnvironment)
         {
-            super(delegate, executor, new CachingHiveMetastoreConfig());
+            super(delegate, executor, OptionalLong.empty(), OptionalLong.empty(), 0);
             this.basePath = basePath;
             this.hdfsEnvironment = hdfsEnvironment;
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -543,7 +543,7 @@ public abstract class AbstractTestHiveFileSystem
 
             Optional<List<String>> partitionNames = getPartitionNames(identity, schemaName, tableName);
             if (partitionNames.isPresent()) {
-                getPartitionsByNames(identity, schemaName, tableName, partitionNames.get()).values().stream()
+                getPartitionsByNames(identity, table, partitionNames.get()).values().stream()
                         .map(Optional::get)
                         .map(partition -> partition.getStorage().getLocation())
                         .filter(location -> !location.startsWith(table.getStorage().getLocation()))

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -136,10 +136,10 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.getAllTables("database"), ImmutableList.of("table"));
         assertEquals(hiveMetastore.getTablesWithParameter("database", "param", "value3"), ImmutableList.of("table"));
         assertEquals(hiveMetastore.getAllViews("database"), ImmutableList.of());
-        assertEquals(hiveMetastore.getPartition(HIVE_CONTEXT, "database", "table", ImmutableList.of("value")), Optional.of(PARTITION));
+        assertEquals(hiveMetastore.getPartition(HIVE_CONTEXT, TABLE, ImmutableList.of("value")), Optional.of(PARTITION));
         assertEquals(hiveMetastore.getPartitionNames(HIVE_CONTEXT, "database", "table"), Optional.of(ImmutableList.of("value")));
         assertEquals(hiveMetastore.getPartitionNamesByParts(HIVE_CONTEXT, "database", "table", ImmutableList.of("value")), Optional.of(ImmutableList.of("value")));
-        assertEquals(hiveMetastore.getPartitionsByNames(HIVE_CONTEXT, "database", "table", ImmutableList.of("value")), ImmutableMap.of("value", Optional.of(PARTITION)));
+        assertEquals(hiveMetastore.getPartitionsByNames(HIVE_CONTEXT, TABLE, ImmutableList.of("value")), ImmutableMap.of("value", Optional.of(PARTITION)));
         assertEquals(hiveMetastore.listTablePrivileges("database", "table", "owner", Optional.of(new HivePrincipal(USER, "user"))), ImmutableSet.of(PRIVILEGE_INFO));
         assertEquals(hiveMetastore.listRoles(), ImmutableSet.of("role"));
         assertEquals(hiveMetastore.listRoleGrants(new HivePrincipal(USER, "user")), ImmutableSet.of(ROLE_GRANT));
@@ -236,9 +236,9 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues)
+        public Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues)
         {
-            if (databaseName.equals("database") && tableName.equals("table") && partitionValues.equals(ImmutableList.of("value"))) {
+            if (table.getDatabaseName().equals("database") && table.getTableName().equals("table") && partitionValues.equals(ImmutableList.of("value"))) {
                 return Optional.of(PARTITION);
             }
 
@@ -266,9 +266,9 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, String databaseName, String tableName, List<String> partitionNames)
+        public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, Table table, List<String> partitionNames)
         {
-            if (databaseName.equals("database") && tableName.equals("table") && partitionNames.contains("value")) {
+            if (table.getDatabaseName().equals("database") && table.getTableName().equals("table") && partitionNames.contains("value")) {
                 return ImmutableMap.of("value", Optional.of(PARTITION));
             }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -162,7 +162,7 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public Optional<Partition> getPartition(HiveIdentity identity, String databaseName, String tableName, List<String> partitionValues)
+    public Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues)
     {
         throw new UnsupportedOperationException();
     }
@@ -180,7 +180,7 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, String databaseName, String tableName, List<String> partitionNames)
+    public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, Table table, List<String> partitionNames)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore.cachingHiveMetastore;
 import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.BAD_DATABASE;
 import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_DATABASE;
 import static io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1;
@@ -66,7 +67,7 @@ public class TestCachingHiveMetastore
         mockClient = new MockThriftMetastoreClient();
         ThriftHiveMetastore thriftHiveMetastore = createThriftHiveMetastore();
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
-        metastore = new CachingHiveMetastore(
+        metastore = (CachingHiveMetastore) cachingHiveMetastore(
                 new BridgingHiveMetastore(thriftHiveMetastore),
                 executor,
                 new Duration(5, TimeUnit.MINUTES),
@@ -288,7 +289,7 @@ public class TestCachingHiveMetastore
 
     private CachingHiveMetastore createMetastoreWithDirectExecutor(CachingHiveMetastoreConfig config)
     {
-        return new CachingHiveMetastore(
+        return (CachingHiveMetastore) cachingHiveMetastore(
                 new BridgingHiveMetastore(createThriftHiveMetastore()),
                 directExecutor(),
                 config);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -51,6 +51,7 @@ public class MockThriftMetastoreClient
     public static final String TEST_TABLE = "testtbl";
     public static final String TEST_PARTITION1 = "key=testpartition1";
     public static final String TEST_PARTITION2 = "key=testpartition2";
+    public static final String BAD_PARTITION = "key=badpartition1";
     public static final List<String> TEST_PARTITION_VALUES1 = ImmutableList.of("testpartition1");
     public static final List<String> TEST_PARTITION_VALUES2 = ImmutableList.of("testpartition2");
     public static final List<String> TEST_ROLES = ImmutableList.of("testrole");


### PR DESCRIPTION
Back to the original idea of passing down Table