### PR TITLE
Prevent column shift during insert

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -524,7 +524,10 @@ public class BaseJdbcClient
     {
         String temporaryTable = quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTemporaryTableName());
         String targetTable = quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName());
-        String insertSql = format("INSERT INTO %s SELECT * FROM %s", targetTable, temporaryTable);
+        String columnNames = handle.getColumnNames().stream()
+                .map(this::quoted)
+                .collect(joining(", "));
+        String insertSql = format("INSERT INTO %s (%s) SELECT * FROM %s", targetTable, columnNames, temporaryTable);
         String cleanupSql = "DROP TABLE " + temporaryTable;
 
         try (Connection connection = getConnection(identity, handle)) {

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -111,6 +111,18 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Test
+    public void testInsertInPresenceOfNotSupportedColumn()
+            throws Exception
+    {
+        execute("CREATE TABLE tpch.test_insert_not_supported_column_present(x bigint, y decimal(50,0), z varchar(10))");
+        // Check that column y is not supported.
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_insert_not_supported_column_present'", "VALUES 'x', 'z'");
+        assertUpdate("INSERT INTO test_insert_not_supported_column_present (x, z) VALUES (123, 'test')", 1);
+        assertQuery("SELECT x, z FROM test_insert_not_supported_column_present", "SELECT 123, 'test'");
+        assertUpdate("DROP TABLE test_insert_not_supported_column_present");
+    }
+
+    @Test
     public void testNameEscaping()
     {
         Session session = testSessionBuilder()

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -78,6 +78,18 @@ public class TestPostgreSqlIntegrationSmokeTest
     }
 
     @Test
+    public void testInsertInPresenceOfNotSupportedColumn()
+            throws Exception
+    {
+        execute("CREATE TABLE tpch.test_insert_not_supported_column_present(x bigint, y decimal(50,0), z varchar(10))");
+        // Check that column y is not supported.
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_insert_not_supported_column_present'", "VALUES 'x', 'z'");
+        assertUpdate("INSERT INTO test_insert_not_supported_column_present (x, z) VALUES (123, 'test')", 1);
+        assertQuery("SELECT x, z FROM test_insert_not_supported_column_present", "SELECT 123, 'test'");
+        assertUpdate("DROP TABLE test_insert_not_supported_column_present");
+    }
+
+    @Test
     public void testViews()
             throws Exception
     {

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
@@ -55,6 +55,17 @@ public class TestSqlServerIntegrationSmokeTest
     }
 
     @Test
+    public void testInsertInPresenceOfNotSupportedColumn()
+    {
+        sqlServer.execute("CREATE TABLE test_insert_not_supported_column_present(x bigint, y sql_variant, z varchar(10))");
+        // Check that column y is not supported.
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_insert_not_supported_column_present'", "VALUES 'x', 'z'");
+        assertUpdate("INSERT INTO test_insert_not_supported_column_present (x, z) VALUES (123, 'test')", 1);
+        assertQuery("SELECT x, z FROM test_insert_not_supported_column_present", "SELECT 123, 'test'");
+        assertUpdate("DROP TABLE test_insert_not_supported_column_present");
+    }
+
+    @Test
     public void testView()
     {
         sqlServer.execute("CREATE VIEW test_view AS SELECT * FROM orders");


### PR DESCRIPTION
This change in `BaseJdbcClient` adds explicit enumeration of target columns in the final phase of insert. Before, the columns of the temporary table were copied into the leftmost columns of the target table. It caused a failure or incorrect results when a column of unsupported type was encountered.