### PR TITLE
Use terse template for Travis Buddy

### DIFF
--- a/travis-buddy-failure-template.md
+++ b/travis-buddy-failure-template.md
@@ -1,0 +1,1 @@
+Hi @{{pullRequestAuthor}}, please check the Travis results.


### PR DESCRIPTION
Travis Buddy currently cannot provide actionable information for
travis-ci.com builds, so use terse template just to inform the PR author
that Travis build failed.

Relates to https://github.com/prestosql/presto/issues/1900