### PR TITLE
Remove redundant configuration

### DIFF
--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos-kms.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos-kms.yaml
@@ -7,7 +7,6 @@ hdfs:
 
 databases:
   hive:
-    host: hadoop-master
     jdbc_url: jdbc:hive2://${databases.hive.host}:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM;auth=kerberos;kerberosAuthType=fromSubject;
     jdbc_user: alice # Note: databases.hive.jdbc_user is not being used in kerberized environment as of now
     jdbc_password: na

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
@@ -7,7 +7,6 @@ hdfs:
 
 databases:
   hive:
-    host: hadoop-master
     jdbc_url: jdbc:hive2://${databases.hive.host}:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM;auth=kerberos;kerberosAuthType=fromSubject;
     jdbc_user: hdfs # Note: databases.hive.jdbc_user is not being used in kerberized environment as of now
     jdbc_password: na

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-ldap.yaml
@@ -1,9 +1,5 @@
 databases:
-  hive:
-    host: hadoop-master
   presto:
-    host: presto-master
-    configured_hdfs_user: hive
     cli_ldap_truststore_path: /etc/openldap/certs/cacerts.jks
     cli_ldap_truststore_password: testldap
     cli_ldap_user_name: DefaultGroupUser

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-simba.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-simba.yaml
@@ -1,9 +1,5 @@
 databases:
-  hive:
-    host: hadoop-master
   presto:
-    host: presto-master
-    configured_hdfs_user: hive
     jdbc_driver_class: com.teradata.presto.jdbc42.Driver
     jdbc_url: jdbc:presto://${databases.presto.server_address}/hive/${databases.hive.schema};TimeZoneID=Africa/Abidjan;
     cli_ldap_truststore_path: /etc/openldap/certs/cacerts.jks

--- a/presto-product-tests/conf/tempto/tempto-configuration-for-docker-tls.yaml
+++ b/presto-product-tests/conf/tempto/tempto-configuration-for-docker-tls.yaml
@@ -1,6 +1,4 @@
 databases:
-  hive:
-    host: hadoop-master
   presto:
     host: presto-master.docker.cluster
     port: 7778


### PR DESCRIPTION
Defaults are set in `tempto-configuration-for-docker-default.yaml`.