### PR TITLE
Add support for Parquet files with compatible decimal precision

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -214,9 +214,9 @@ public class ParquetPageSourceFactory
 
                 prestoTypes.add(column.getType());
 
-                internalFields.add(parquetField.map(field -> {
+                internalFields.add(parquetField.flatMap(field -> {
                     String columnName = useParquetColumnNames ? column.getName() : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
-                    return constructField(column.getType(), lookupColumnByName(messageColumnIO, columnName)).orElse(null);
+                    return constructField(column.getType(), lookupColumnByName(messageColumnIO, columnName));
                 }));
             }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -856,7 +856,7 @@ public abstract class AbstractTestParquetReader
     public void testDecimalBackedByINT64()
             throws Exception
     {
-        for (int precision = MAX_PRECISION_INT32 + 1; precision <= MAX_PRECISION_INT64; precision++) {
+        for (int precision = 1; precision <= MAX_PRECISION_INT64; precision++) {
             int scale = ThreadLocalRandom.current().nextInt(precision);
             MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT64 test (DECIMAL(%d, %d)); }", precision, scale));
             ContiguousSet<Long> longValues = longsBetween(1, 1_000);
@@ -872,7 +872,7 @@ public abstract class AbstractTestParquetReader
     public void testDecimalBackedByFixedLenByteArray()
             throws Exception
     {
-        for (int precision = MAX_PRECISION_INT64 + 1; precision < MAX_PRECISION; precision++) {
+        for (int precision = 1; precision < MAX_PRECISION; precision++) {
             int scale = ThreadLocalRandom.current().nextInt(precision);
             ContiguousSet<BigInteger> values = bigIntegersBetween(BigDecimal.valueOf(Math.pow(10, precision - 1)).toBigInteger(), BigDecimal.valueOf(Math.pow(10, precision)).toBigInteger());
             ImmutableList.Builder<SqlDecimal> expectedValues = new ImmutableList.Builder<>();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -849,6 +849,7 @@ public abstract class AbstractTestParquetReader
                 expectedValues.add(SqlDecimal.of(value, precision, scale));
             }
             tester.testRoundTrip(javaIntObjectInspector, intValues, expectedValues.build(), createDecimalType(precision, scale), Optional.of(parquetSchema));
+            tester.testRoundTrip(javaIntObjectInspector, intValues, expectedValues.build(), createDecimalType(MAX_PRECISION, scale), Optional.of(parquetSchema));
         }
     }
 
@@ -865,6 +866,7 @@ public abstract class AbstractTestParquetReader
                 expectedValues.add(SqlDecimal.of(value, precision, scale));
             }
             tester.testRoundTrip(javaLongObjectInspector, longValues, expectedValues.build(), createDecimalType(precision, scale), Optional.of(parquetSchema));
+            tester.testRoundTrip(javaLongObjectInspector, longValues, expectedValues.build(), createDecimalType(MAX_PRECISION, scale), Optional.of(parquetSchema));
         }
     }
 
@@ -885,6 +887,10 @@ public abstract class AbstractTestParquetReader
                     writeValues.build(),
                     expectedValues.build(),
                     createDecimalType(precision, scale));
+            tester.testRoundTrip(new JavaHiveDecimalObjectInspector(new DecimalTypeInfo(precision, scale)),
+                    writeValues.build(),
+                    expectedValues.build(),
+                    createDecimalType(MAX_PRECISION, scale));
         }
     }
 

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/ShortDecimalColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/ShortDecimalColumnReader.java
@@ -18,6 +18,8 @@ import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.Type;
 
 import static io.prestosql.parquet.ParquetTypeUtils.getShortDecimalValue;
+import static io.prestosql.spi.type.Decimals.isShortDecimal;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
@@ -44,7 +46,13 @@ public class ShortDecimalColumnReader
             else {
                 decimalValue = getShortDecimalValue(valuesReader.readBytes().getBytes());
             }
-            type.writeLong(blockBuilder, decimalValue);
+
+            if (isShortDecimal(type)) {
+                type.writeLong(blockBuilder, decimalValue);
+            }
+            else {
+                type.writeSlice(blockBuilder, unscaledDecimal(decimalValue));
+            }
         }
         else if (isValueNull()) {
             blockBuilder.appendNull();


### PR DESCRIPTION
Some parquet writers can use short decimal representation
while table or parition schema has decimal columns with larger precision.