### PR TITLE
Do not return partial analysis time when query is interrupted

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
@@ -110,7 +110,7 @@ public class QuerySystemTable
                     queryInfo.getResourceGroupId().map(QuerySystemTable::resourceGroupIdToBlock).orElse(null),
 
                     toMillis(queryStats.getQueuedTime()),
-                    toMillis(queryStats.getAnalysisTime()),
+                    queryStats.getAnalysisTime().map(QuerySystemTable::toMillis).orElse(null),
                     toMillis(queryStats.getPlanningTime()),
 
                     toTimeStamp(queryStats.getCreateTime()),

--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -20,6 +20,7 @@ import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
 import io.airlift.stats.Distribution;
 import io.airlift.stats.Distribution.DistributionSnapshot;
+import io.airlift.units.Duration;
 import io.prestosql.SessionRepresentation;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.connector.CatalogName;
@@ -227,7 +228,7 @@ public class QueryMonitor
                 ofMillis(queryStats.getElapsedTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
                 Optional.of(ofMillis(queryStats.getResourceWaitingTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getAnalysisTime().toMillis())),
+                queryStats.getAnalysisTime().map(Duration::toMillis).map(java.time.Duration::ofMillis),
                 queryStats.getPeakUserMemoryReservation().toBytes(),
                 queryStats.getPeakTotalMemoryReservation().toBytes(),
                 queryStats.getPeakTaskUserMemory().toBytes(),

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateTimer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateTimer.java
@@ -224,9 +224,9 @@ class QueryStateTimer
         return toDateTime(endNanos);
     }
 
-    public Duration getAnalysisTime()
+    public Optional<Duration> getAnalysisTime()
     {
-        return getDuration(analysisTime, beginAnalysisNanos);
+        return Optional.ofNullable(analysisTime.get());
     }
 
     public DateTime getLastHeartbeat()

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -28,6 +28,7 @@ import org.joda.time.DateTime;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class QueryStats
     private final Duration resourceWaitingTime;
     private final Duration dispatchingTime;
     private final Duration executionTime;
-    private final Duration analysisTime;
+    private final Optional<Duration> analysisTime;
     private final Duration planningTime;
     private final Duration finishingTime;
 
@@ -114,7 +115,7 @@ public class QueryStats
             @JsonProperty("resourceWaitingTime") Duration resourceWaitingTime,
             @JsonProperty("dispatchingTime") Duration dispatchingTime,
             @JsonProperty("executionTime") Duration executionTime,
-            @JsonProperty("analysisTime") Duration analysisTime,
+            @JsonProperty("analysisTime") Optional<Duration> analysisTime,
             @JsonProperty("planningTime") Duration planningTime,
             @JsonProperty("finishingTime") Duration finishingTime,
 
@@ -299,7 +300,7 @@ public class QueryStats
     }
 
     @JsonProperty
-    public Duration getAnalysisTime()
+    public Optional<Duration> getAnalysisTime()
     {
         return analysisTime;
     }

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
@@ -163,7 +163,7 @@ public class TestQueryStats
             new Duration(31, NANOSECONDS),
             new Duration(32, NANOSECONDS),
             new Duration(41, NANOSECONDS),
-            new Duration(33, NANOSECONDS),
+            Optional.of(new Duration(33, NANOSECONDS)),
 
             new Duration(100, NANOSECONDS),
             new Duration(200, NANOSECONDS),
@@ -247,7 +247,7 @@ public class TestQueryStats
         assertEquals(actual.getResourceWaitingTime(), new Duration(31, NANOSECONDS));
         assertEquals(actual.getDispatchingTime(), new Duration(32, NANOSECONDS));
         assertEquals(actual.getExecutionTime(), new Duration(41, NANOSECONDS));
-        assertEquals(actual.getAnalysisTime(), new Duration(33, NANOSECONDS));
+        assertEquals(actual.getAnalysisTime().get(), new Duration(33, NANOSECONDS));
 
         assertEquals(actual.getPlanningTime(), new Duration(100, NANOSECONDS));
         assertEquals(actual.getFinishingTime(), new Duration(200, NANOSECONDS));


### PR DESCRIPTION
Do not return partial analysis time when query is interrupted
