### PR TITLE
Simple doc content edits - section 1 -5

### DIFF
--- a/presto-docs/src/main/sphinx/admin/dist-sort.rst
+++ b/presto-docs/src/main/sphinx/admin/dist-sort.rst
@@ -1,17 +1,17 @@
 ================
-Distributed sort
+Distributed Sort
 ================
 
-Distributed sort allows to sort data which exceeds ``query.max-memory-per-node``.
-Distributed sort is enabled via ``distributed_sort`` session property or
+Distributed sort allows to sort data, which exceeds ``query.max-memory-per-node``.
+Distributed sort is enabled via the ``distributed_sort`` session property, or
 ``distributed-sort`` configuration property set in
 ``etc/config.properties`` of the coordinator. Distributed sort is enabled by
 default.
 
-When distributed sort is enabled, sort operator executes in parallel on multiple
+When distributed sort is enabled, the sort operator executes in parallel on multiple
 nodes in the cluster. Partially sorted data from each Presto worker node is then streamed
 to a single worker node for a final merge. This technique allows to utilize memory of multiple
 Presto worker nodes for sorting. The primary purpose of distributed sort is to allow for sorting
 of data sets which don't normally fit into single node memory. Performance improvement
-can be expected, but it won't scale linearly with the number of nodes since the
+can be expected, but it won't scale linearly with the number of nodes, since the
 data needs to be merged by a single node.

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -2,7 +2,7 @@
 Properties Reference
 ====================
 
-This section describes the most important config properties that
+This section describes the most important config properties, that
 may be used to tune Presto or alter its behavior when required.
 
 .. contents::
@@ -20,19 +20,19 @@ General Properties
     * **Allowed values:** ``AUTOMATIC``, ``PARTITIONED``, ``BROADCAST``
     * **Default value:** ``PARTITIONED``
 
-    The type of distributed join to use.  When set to ``PARTITIONED``, presto will
-    use hash distributed joins.  When set to ``BROADCAST``, it will broadcast the
+    The type of distributed join to use.  When set to ``PARTITIONED``, Presto
+    uses hash distributed joins.  When set to ``BROADCAST``, it broadcasts the
     right table to all nodes in the cluster that have data from the left table.
     Partitioned joins require redistributing both tables using a hash of the join key.
-    This can be slower (sometimes substantially) than broadcast joins, but allows much
-    larger joins. In particular broadcast joins will be faster if the right table is
+    This can be slower, sometimes substantially, than broadcast joins, but allows much
+    larger joins. In particular broadcast joins are faster, if the right table is
     much smaller than the left.  However, broadcast joins require that the tables on the right
     side of the join after filtering fit in memory on each node, whereas distributed joins
     only need to fit in distributed memory across all nodes. When set to ``AUTOMATIC``,
-    Presto will make a cost based decision as to which distribution type is optimal.
-    It will also consider switching the left and right inputs to the join.  In ``AUTOMATIC``
-    mode, Presto will default to hash distributed joins if no cost could be computed, such as if
-    the tables do not have statistics. This can also be specified on a per-query basis using
+    Presto makes a cost based decision as to which distribution type is optimal.
+    It considers switching the left and right inputs to the join.  In ``AUTOMATIC``
+    mode, Presto defaults to hash distributed joins if no cost could be computed, such as if
+    the tables do not have statistics. This can be specified on a per-query basis using
     the ``join_distribution_type`` session property.
 
 ``redistribute-writes``
@@ -43,9 +43,9 @@ General Properties
 
     This property enables redistribution of data before writing. This can
     eliminate the performance impact of data skew when writing by hashing it
-    across nodes in the cluster. It can be disabled when it is known that the
-    output data set is not skewed in order to avoid the overhead of hashing and
-    redistributing all the data across the network. This can also be specified
+    across nodes in the cluster. It can be disabled, when it is known that the
+    output data set is not skewed, in order to avoid the overhead of hashing and
+    redistributing all the data across the network. This can be specified
     on a per-query basis using the ``redistribute_writes`` session property.
 
 .. _tuning-memory:
@@ -61,10 +61,10 @@ Memory Management Properties
 
     This is the max amount of user memory a query can use on a worker.
     User memory is allocated during execution for things that are directly
-    attributable to or controllable by a user query. For example, memory used
+    attributable to, or controllable by, a user query. For example, memory used
     by the hash tables built during execution, memory used during sorting, etc.
-    When the user memory allocation of a query on any worker hits this limit
-    it will be killed.
+    When the user memory allocation of a query on any worker hits this limit,
+    it is killed.
 
 ``query.max-total-memory-per-node``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,9 +74,9 @@ Memory Management Properties
 
     This is the max amount of user and system memory a query can use on a worker.
     System memory is allocated during execution for things that are not directly
-    attributable to or controllable by a user query. For example, memory allocated
+    attributable to, or controllable by, a user query. For example, memory allocated
     by the readers, writers, network buffers, etc. When the sum of the user and
-    system memory allocated by a query on any worker hits this limit it will be killed.
+    system memory allocated by a query on any worker hits this limit, it is killed.
     The value of ``query.max-total-memory-per-node`` must be greater than
     ``query.max-memory-per-node``.
 
@@ -88,10 +88,10 @@ Memory Management Properties
 
     This is the max amount of user memory a query can use across the entire cluster.
     User memory is allocated during execution for things that are directly
-    attributable to or controllable by a user query. For example, memory used
+    attributable to, or controllable by, a user query. For example, memory used
     by the hash tables built during execution, memory used during sorting, etc.
     When the user memory allocation of a query across all workers hits this limit
-    it will be killed.
+    it is killed.
 
 ``query.max-total-memory``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,9 +101,9 @@ Memory Management Properties
 
     This is the max amount of user and system memory a query can use across the entire cluster.
     System memory is allocated during execution for things that are not directly
-    attributable to or controllable by a user query. For example, memory allocated
+    attributable to, or controllable by, a user query. For example, memory allocated
     by the readers, writers, network buffers, etc. When the sum of the user and
-    system memory allocated by a query across all workers hits this limit it will be
+    system memory allocated by a query across all workers hits this limit it is
     killed. The value of ``query.max-total-memory`` must be greater than
     ``query.max-memory``.
 
@@ -131,7 +131,7 @@ Spilling Properties
 
     Spilling works by offloading memory to disk. This process can allow a query with a large memory
     footprint to pass at the cost of slower execution times. Spilling is supported for
-    aggregations, joins (inner and outer), sorting, and window functions. This property will not
+    aggregations, joins (inner and outer), sorting, and window functions. This property does not
     reduce memory usage required for other join types.
 
     This config property can be overridden by the ``spill_enabled`` session property.
@@ -165,7 +165,7 @@ Spilling Properties
     * **Type:** ``string``
     * **No default value.** Must be set when spilling is enabled
 
-    Directory where spilled content will be written. It can be a comma separated
+    Directory where spilled content is written. It can be a comma separated
     list to spill simultaneously to multiple directories, which helps to utilize
     multiple drives installed in the system.
 
@@ -180,7 +180,7 @@ Spilling Properties
     * **Default value:** ``0.9``
 
     If disk space usage ratio of a given spill path is above this threshold,
-    this spill path will not be eligible for spilling.
+    this spill path is not eligible for spilling.
 
 ``spiller-threads``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ Spilling Properties
     * **Type:** ``boolean``
     * **Default value:** ``false``
 
-    Enables data compression for pages spilled to disk
+    Enables data compression for pages spilled to disk.
 
 ``spill-encryption-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +230,7 @@ Spilling Properties
     * **Default value:** ``false``
 
     Enables using a randomly generated secret key (per spill file) to encrypt and decrypt
-    data spilled to disk
+    data spilled to disk.
 
 
 Exchange Properties
@@ -262,7 +262,7 @@ communication issues or improve network utilization.
     Multiplier determining the number of concurrent requests relative to
     available buffer memory. The maximum number of requests is determined
     using a heuristic of the number of clients that can fit into available
-    buffer space based on average buffer usage per request times this
+    buffer space, based on average buffer usage per request times this
     multiplier. For example, with an ``exchange.max-buffer-size`` of ``32 MB``
     and ``20 MB`` already used and average size per request being ``2MB``,
     the maximum number of clients is
@@ -278,8 +278,8 @@ communication issues or improve network utilization.
 
     Size of buffer in the exchange client that holds data fetched from other
     nodes before it is processed. A larger buffer can increase network
-    throughput for larger clusters and thus decrease query processing time,
-    but will reduce the amount of memory available for other usages.
+    throughput for larger clusters, and thus decrease query processing time,
+    but reduces the amount of memory available for other usages.
 
 ``exchange.max-response-size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,13 +289,13 @@ communication issues or improve network utilization.
     * **Default value:** ``16MB``
 
     Maximum size of a response returned from an exchange request. The response
-    will be placed in the exchange client buffer which is shared across all
+    is placed in the exchange client buffer, which is shared across all
     concurrent requests for the exchange.
 
-    Increasing the value may improve network throughput if there is high
+    Increasing the value may improve network throughput, if there is high
     latency. Decreasing the value may improve query performance for large
-    clusters as it reduces skew due to the exchange client buffer holding
-    responses for more tasks (rather than hold more data from fewer tasks).
+    clusters as it reduces skew, due to the exchange client buffer holding
+    responses for more tasks, rather than hold more data from fewer tasks.
 
 ``sink.max-buffer-size``
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -304,10 +304,10 @@ communication issues or improve network utilization.
     * **Default value:** ``32MB``
 
     Output buffer size for task data that is waiting to be pulled by upstream
-    tasks. If the task output is hash partitioned, then the buffer will be
+    tasks. If the task output is hash partitioned, then the buffer is
     shared across all of the partitioned consumers. Increasing this value may
-    improve network throughput for data transferred between stages if the
-    network has high latency or if there are many nodes in the cluster.
+    improve network throughput for data transferred between stages, if the
+    network has high latency, or if there are many nodes in the cluster.
 
 .. _task-properties:
 
@@ -321,11 +321,11 @@ Task Properties
     * **Restrictions:** must be a power of two
     * **Default value:** ``16``
 
-    Default local concurrency for parallel operators such as joins and aggregations.
+    Default local concurrency for parallel operators, such as joins and aggregations.
     This value should be adjusted up or down based on the query concurrency and worker
     resource utilization. Lower values are better for clusters that run many queries
-    concurrently because the cluster will already be utilized by all the running
-    queries, so adding more concurrency will result in slow downs due to context
+    concurrently, because the cluster is already utilized by all the running
+    queries, so adding more concurrency results in slow downs due to context
     switching and other overhead. Higher values are better for clusters that only run
     one or a few queries at a time. This can also be specified on a per-query basis
     using the ``task_concurrency`` session property.
@@ -339,7 +339,7 @@ Task Properties
 
     Maximum number of threads that may be created to handle HTTP responses. Threads are
     created on demand and are cleaned up when idle, thus there is no overhead to a large
-    value if the number of requests to be handled is small. More threads may be helpful
+    value, if the number of requests to be handled is small. More threads may be helpful
     on clusters with a high number of concurrent queries, or on clusters with hundreds
     or thousands of workers.
 
@@ -374,7 +374,7 @@ Task Properties
     * **Default value:** ``16MB``
 
     Maximum size of partial aggregation results for distributed aggregations. Increasing this
-    value can result in less network transfer and lower CPU utilization by allowing more
+    value can result in less network transfer and lower CPU utilization, by allowing more
     groups to be kept locally before being flushed, at the cost of additional memory usage.
 
 ``task.max-worker-threads``
@@ -384,8 +384,8 @@ Task Properties
     * **Default value:** ``Node CPUs * 2``
 
     Sets the number of threads used by workers to process splits. Increasing this number
-    can improve throughput if worker CPU utilization is low and all the threads are in use,
-    but will cause increased heap space usage. Setting the value too high may cause a drop
+    can improve throughput, if worker CPU utilization is low and all the threads are in use,
+    but it causes increased heap space usage. Setting the value too high may cause a drop
     in performance due to a context switching. The number of active threads is available
     via the ``RunningSplits`` property of the
     ``io.prestosql.execution.executor:name=TaskExecutor.RunningSplits`` JXM object.
@@ -411,8 +411,8 @@ Task Properties
 
     The number of concurrent writer threads per worker per query. Increasing this value may
     increase write speed, especially when a query is not I/O bound and can take advantage
-    of additional CPU for parallel writes (some connectors can be bottlenecked on CPU when
-    writing due to compression or other factors). Setting this too high may cause the cluster
+    of additional CPU for parallel writes. Some connectors can be bottlenecked on CPU when
+    writing due to compression or other factors. Setting this too high may cause the cluster
     to become overloaded due to excessive resource utilization. This can also be specified on
     a per-query basis using the ``task_writer_count`` session property.
 
@@ -430,13 +430,13 @@ Node Scheduler Properties
     The target value for the total number of splits that can be running for
     each worker node.
 
-    Using a higher value is recommended if queries are submitted in large batches
-    (e.g., running a large group of reports periodically) or for connectors that
+    Using a higher value is recommended, if queries are submitted in large batches
+    (e.g., running a large group of reports periodically), or for connectors that
     produce many splits that complete quickly. Increasing this value may improve
-    query latency by ensuring that the workers have enough splits to keep them
+    query latency, by ensuring that the workers have enough splits to keep them
     fully utilized.
 
-    Setting this too high will waste memory and may result in lower performance
+    Setting this too high wastes memory and may result in lower performance
     due to splits not being balanced across workers. Ideally, it should be set
     such that there is always at least one split waiting to be processed, but
     not higher.
@@ -453,7 +453,7 @@ Node Scheduler Properties
     required to prevent starvation and deadlocks.
 
     This value must be smaller than ``node-scheduler.max-splits-per-node``,
-    will usually be increased for the same reasons, and has similar drawbacks
+    is usually increased for the same reasons, and has similar drawbacks
     if set too high.
 
 ``node-scheduler.min-candidates``
@@ -463,7 +463,7 @@ Node Scheduler Properties
     * **Minimum value:** ``1``
     * **Default value:** ``10``
 
-    The minimum number of candidate nodes that will be evaluated by the
+    The minimum number of candidate nodes that are evaluated by the
     node scheduler when choosing the target node for a split. Setting
     this value too low may prevent splits from being properly balanced
     across all worker nodes. Setting it too high may increase query
@@ -476,9 +476,9 @@ Node Scheduler Properties
     * **Allowed values:** ``uniform``, ``topology``
     * **Default value:** ``uniform``
 
-    Sets the node scheduler policy to use when scheduling splits. ``uniform`` will attempt
+    Sets the node scheduler policy to use when scheduling splits. ``uniform``  attempts
     to schedule splits on the host where the data is located, while maintaining a uniform
-    distribution across all hosts. ``topology`` will try to schedule splits according to
+    distribution across all hosts. ``topology`` tries to schedule splits according to
     the topology distance between nodes and splits. It is recommended to use ``uniform``
     for clusters where distributed storage runs on the same nodes as Presto workers.
 
@@ -489,7 +489,7 @@ Node Scheduler Properties
     * **Default value:** ``machine``
 
     A comma-separated string describing the meaning of each segment of a network location.
-    For example, setting ``region,rack,machine`` means a network location will contain three segments.
+    For example, setting ``region,rack,machine`` means a network location contains three segments.
 
 ``node-scheduler.network-topology.type``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -549,11 +549,11 @@ Optimizer Properties
     Compute hash codes for distribution, joins, and aggregations early during execution,
     allowing result to be shared between operations later in the query. This can reduce
     CPU usage by avoiding computing the same hash multiple times, but at the cost of
-    additional network transfer for the hashes. In most cases it will decrease overall
+    additional network transfer for the hashes. In most cases it decreases overall
     query processing time. This can also be specified on a per-query basis using the
     ``optimize_hash_generation`` session property.
 
-    It is often helpful to disable this property when using :doc:`/sql/explain` in order
+    It is often helpful to disable this property, when using :doc:`/sql/explain` in order
     to make the query plan easier to read.
 
 ``optimizer.optimize-metadata-queries``
@@ -565,13 +565,13 @@ Optimizer Properties
     Enable optimization of some aggregations by using values that are stored as metadata.
     This allows Presto to execute some simple queries in constant time. Currently, this
     optimization applies to ``max``, ``min`` and ``approx_distinct`` of partition
-    keys and other aggregation insensitive to the cardinality of the input (including
-    ``DISTINCT`` aggregates). Using this may speed up some queries significantly.
+    keys and other aggregation insensitive to the cardinality of the input,including
+    ``DISTINCT`` aggregates. Using this may speed up some queries significantly.
 
-    The main drawback is that it can produce incorrect results if the connector returns
+    The main drawback is that it can produce incorrect results, if the connector returns
     partition keys for partitions that have no rows. In particular, the Hive connector
-    can return empty partitions if they were created by other systems (Presto cannot
-    create them).
+    can return empty partitions, if they were created by other systems. Presto cannot
+    create them.
 
 ``optimizer.push-aggregation-through-join``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -601,9 +601,9 @@ Optimizer Properties
     * **Default value:** ``true``
 
     Parallelize writes when using ``UNION ALL`` in queries that write data. This improves the
-    speed of writing output tables in ``UNION ALL`` queries because these writes do not require
+    speed of writing output tables in ``UNION ALL`` queries, because these writes do not require
     additional synchronization when collecting results. Enabling this optimization can improve
-    ``UNION ALL`` speed when write speed is not yet saturated. However, it may slow down queries
+    ``UNION ALL`` speed, when write speed is not yet saturated. However, it may slow down queries
     in an already heavily loaded system. This can also be specified on a per-query basis
     using the ``push_table_write_through_union`` session property.
 
@@ -616,12 +616,12 @@ Optimizer Properties
     * **Default value:** ``ELIMINATE_CROSS_JOINS``
 
     The join reordering strategy to use.  ``NONE`` maintains the order the tables are listed in the
-    query.  ``ELIMINATE_CROSS_JOINS`` reorders joins to eliminate cross joins where possible and
-    otherwise maintains the original query order. When reordering joins it also strives to maintain the
-    original table order as much as possible. ``AUTOMATIC`` enumerates possible orders and uses
-    statistics-based cost estimation to determine the least cost order. If stats are not available or if
+    query.  ``ELIMINATE_CROSS_JOINS`` reorders joins to eliminate cross joins, where possible, and
+    otherwise maintains the original query order. When reordering joins, it also strives to maintain the
+    original table order as much as possible. ``AUTOMATIC`` enumerates possible orders, and uses
+    statistics-based cost estimation to determine the least cost order. If stats are not available, or if
     for any reason a cost could not be computed, the ``ELIMINATE_CROSS_JOINS`` strategy is used. This can
-    also be specified on a per-query basis using the ``join_reordering_strategy`` session property.
+    be specified on a per-query basis using the ``join_reordering_strategy`` session property.
 
 ``optimizer.max-reordered-joins``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -649,7 +649,7 @@ The following properties allow tuning the :doc:`/functions/regexp`.
 
     Which library to use for regular expression functions.
     ``JONI`` is generally faster for common usage, but can require exponential
-    time for certain expression patterns. ``RE2J`` uses a different algorithm
+    time for certain expression patterns. ``RE2J`` uses a different algorithm,
     which guarantees linear time, but is often slower.
 
 ``re2j.dfa-states-limit``
@@ -659,9 +659,9 @@ The following properties allow tuning the :doc:`/functions/regexp`.
     * **Minimum value:** ``2``
     * **Default value:** ``2147483647``
 
-    The maximum number of states to use when RE2J builds the fast
-    but potentially memory intensive deterministic finite automaton (DFA)
-    for regular expression matching. If the limit is reached, RE2J will fall
+    The maximum number of states to use when RE2J builds the fast,
+    but potentially memory intensive, deterministic finite automaton (DFA)
+    for regular expression matching. If the limit is reached, RE2J falls
     back to the algorithm that uses the slower, but less memory intensive
     non-deterministic finite automaton (NFA). Decreasing this value decreases the
     maximum memory footprint of a regular expression search at the cost of speed.
@@ -673,9 +673,9 @@ The following properties allow tuning the :doc:`/functions/regexp`.
     * **Minimum value:** ``0``
     * **Default value:** ``5``
 
-    The number of times that RE2J will retry the DFA algorithm when
+    The number of times that RE2J retries the DFA algorithm, when
     it reaches a states limit before using the slower, but less memory
-    intensive NFA algorithm for all future inputs for that search. If hitting the
+    intensive NFA algorithm, for all future inputs for that search. If hitting the
     limit for a given input row is likely to be an outlier, you want to be able
     to process subsequent rows using the faster DFA algorithm. If you are likely
     to hit the limit on matches for subsequent rows as well, you want to use the

--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -3,13 +3,13 @@ Resource Groups
 ===============
 
 Resource groups place limits on resource usage, and can enforce queueing policies on
-queries that run within them or divide their resources among sub-groups. A query
+queries that run within them, or divide their resources among sub-groups. A query
 belongs to a single resource group, and consumes resources from that group (and its ancestors).
 Except for the limit on queued queries, when a resource group runs out of a resource
 it does not cause running queries to fail; instead new queries become queued.
 A resource group may have sub-groups or may accept queries, but may not do both.
 
-The resource groups and associated selection rules are configured by a manager which is pluggable.
+The resource groups and associated selection rules are configured by a manager, which is pluggable.
 Add an ``etc/resource-groups.properties`` file with the following contents to enable
 the built-in manager that reads a JSON config file:
 
@@ -27,16 +27,16 @@ Resource Group Properties
 * ``name`` (required): name of the group. May be a template (see below).
 
 * ``maxQueued`` (required): maximum number of queued queries. Once this limit is reached
-  new queries will be rejected.
+  new queries are rejected.
 
 * ``hardConcurrencyLimit`` (required): maximum number of running queries.
 
 * ``softMemoryLimit`` (required): maximum amount of distributed memory this
-  group may use before new queries become queued. May be specified as
+  group may use, before new queries become queued. May be specified as
   an absolute value (i.e. ``1GB``) or as a percentage (i.e. ``10%``) of the cluster's memory.
 
 * ``softCpuLimit`` (optional): maximum amount of CPU time this
-  group may use in a period (see ``cpuQuotaPeriod``) before a penalty will be applied to
+  group may use in a period (see ``cpuQuotaPeriod``), before a penalty is applied to
   the maximum number of running queries. ``hardCpuLimit`` must also be specified.
 
 * ``hardCpuLimit`` (optional): maximum amount of CPU time this
@@ -46,19 +46,19 @@ Resource Group Properties
   and how sub-groups become eligible to start their queries. May be one of three values:
 
     * ``fair`` (default): queued queries are processed first-in-first-out, and sub-groups
-      must take turns starting new queries (if they have any queued).
+      must take turns starting new queries, if they have any queued.
 
     * ``weighted_fair``: sub-groups are selected based on their ``schedulingWeight`` and the number of
       queries they are already running concurrently. The expected share of running queries for a
       sub-group is computed based on the weights for all currently eligible sub-groups. The sub-group
       with the least concurrency relative to its share is selected to start the next query.
 
-    * ``weighted``: queued queries are selected stochastically in proportion to their priority
-      (specified via the ``query_priority`` :doc:`session property </sql/set-session>`). Sub groups are selected
+    * ``weighted``: queued queries are selected stochastically in proportion to their priority,
+      specified via the ``query_priority`` :doc:`session property </sql/set-session>`. Sub groups are selected
       to start new queries in proportion to their ``schedulingWeight``.
 
     * ``query_priority``: all sub-groups must also be configured with ``query_priority``.
-      Queued queries will be selected strictly according to their priority.
+      Queued queries are selected strictly according to their priority.
 
 * ``schedulingWeight`` (optional): weight of this sub-group. See above.
   Defaults to ``1``.
@@ -116,11 +116,11 @@ Example
 
 In the example configuration below, there are several resource groups, some of which are templates.
 Templates allow administrators to construct resource group trees dynamically. For example, in
-the ``pipeline_${USER}`` group, ``${USER}`` will be expanded to the name of the user that submitted
-the query. ``${SOURCE}`` is also supported, which will be expanded to the source that submitted the
+the ``pipeline_${USER}`` group, ``${USER}`` is expanded to the name of the user that submitted
+the query. ``${SOURCE}`` is also supported, which is expanded to the source that submitted the
 query. You may also use custom named variables in the ``source`` and ``user`` regular expressions.
 
-There are four selectors that define which queries run in which resource group:
+There are four selectors, that define which queries run in which resource group:
 
   * The first selector matches queries from ``bob`` and places them in the admin group.
 
@@ -134,9 +134,9 @@ There are four selectors that define which queries run in which resource group:
   * The fourth selector matches queries that come from BI tools which have a source matching the regular
     expression ``jdbc#(?<toolname>.*)``, and have client provided tags that are a superset of ``hi-pri``.
     These are placed in a dynamically-created sub-group under the ``global.pipeline.tools`` group. The dynamic
-    sub-group will be created based on the named variable ``toolname``, which is extracted from the in the
+    sub-group are created based on the named variable ``toolname``, which is extracted from the in the
     regular expression for source. Consider a query with a source ``jdbc#powerfulbi``, user ``kayla``, and
-    client tags ``hipri`` and ``fast``. This query would be routed to the ``global.pipeline.bi-powerfulbi.kayla``
+    client tags ``hipri`` and ``fast``. This query is routed to the ``global.pipeline.bi-powerfulbi.kayla``
     resource group.
 
   * The last selector is a catch-all, which places all queries that have not yet been matched into a per-user
@@ -157,7 +157,7 @@ For the remaining users:
   concurrency of 5. Queries are run in FIFO order.
 
 * For BI tools, each tool can run up to 10 concurrent queries, and each user can run up to 3. If the total demand
-  exceeds the limit of 10, the user with the fewest running queries will get the next concurrency slot. This policy
+  exceeds the limit of 10, the user with the fewest running queries gets the next concurrency slot. This policy
   results in fairness when under contention.
 
 * All remaining queries are placed into a per-user group under ``global.adhoc.other`` that behaves similarly.

--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -3,12 +3,12 @@ Session Property Managers
 =========================
 
 Administrators can add session properties to control the behavior for subsets of their workload.
-These properties are defaults and can be overridden by users (if authorized to do so). Session
+These properties are defaults, and can be overridden by users, if authorized to do so. Session
 properties can be used to control resource usage, enable or disable features, and change query
 characteristics. Session property managers are pluggable.
 
 Add an ``etc/session-property-config.properties`` file with the following contents to enable
-the built-in manager that reads a JSON config file:
+the built-in manager, that reads a JSON config file:
 
 .. code-block:: none
 

--- a/presto-docs/src/main/sphinx/admin/spill.rst
+++ b/presto-docs/src/main/sphinx/admin/spill.rst
@@ -23,10 +23,10 @@ Properties related to spilling are described in :ref:`tuning-spilling`.
 Memory Management and Spill
 ---------------------------
 
-By default, Presto kills queries if the memory requested by the query execution
+By default, Presto kills queries, if the memory requested by the query execution
 exceeds session properties ``query_max_memory`` or
 ``query_max_memory_per_node``. This mechanism ensures fairness in allocation
-of memory to queries and prevents deadlock caused by memory allocation.
+of memory to queries, and prevents deadlock caused by memory allocation.
 It is efficient when there is a lot of small queries in the cluster, but
 leads to killing large queries that don't stay within the limits.
 
@@ -39,37 +39,37 @@ process it later.
 In practice, when the cluster is idle, and all memory is available, a memory
 intensive query may use all of the memory in the cluster. On the other hand,
 when the cluster does not have much free memory, the same query may be forced to
-use disk as storage for intermediate data. A query that is forced to spill to
-disk may have a longer execution time by orders of magnitude than a query that
+use disk as storage for intermediate data. A query, that is forced to spill to
+disk, may have a longer execution time by orders of magnitude than a query that
 runs completely in memory.
 
 Please note that enabling spill-to-disk does not guarantee execution of all
-memory intensive queries. It is still possible that the query runner will fail
-to divide intermediate data into chunks small enough that every chunk fits into
+memory intensive queries. It is still possible that the query runner fails
+to divide intermediate data into chunks small enough so that every chunk fits into
 memory, leading to ``Out of memory`` errors while loading the data from disk.
 
 Revocable memory and reserved pool
 ----------------------------------
 
-Both reserved memory pool and revocable memory are designed to cope with low memory conditions.
-When user memory pool is exhausted then a single query will be promoted to a reserved pool.
-In such case only that query is allowed to progress thus reducing cluster
-concurrency. Revocable memory will try to prevent that by triggering spill.
+Both, reserved memory pool and revocable memory, are designed to cope with low memory conditions.
+When user memory pool is exhausted a single query is promoted to a reserved pool.
+In such a case, only that query is allowed to progress thus reducing cluster
+concurrency. Revocable memory tries to prevent that by triggering spill.
 Reserved pool is of ``query.max-total-memory-per-node`` size. This means that
-when ``query.max-total-memory-per-node`` is large then user memory pool might be
-much smaller than ``query_max_memory_per_node``. This will cause excessive
+when ``query.max-total-memory-per-node`` is large, then the user memory pool might be
+much smaller than ``query_max_memory_per_node``. This causes excessive
 spilling for queries that consume large amounts of memory per node.
-Such queries could finish much quicker when spill is disabled because they
-execute in reserved pool. However, this could also significantly reduce cluster concurrency.
+Such queries could finish much quicker when spill is disabled, because they
+execute in reserved pool. However, this can significantly reduce cluster concurrency.
 In such situations we recommend to disable reserved memory
 pool via ``experimental.reserved-pool-disabled`` config property.
 
 Spill Disk Space
 ----------------
 
-Spilling intermediate results to disk and retrieving them back is expensive
+Spilling intermediate results to disk, and retrieving them back, is expensive
 in terms of IO operations. Thus, queries that use spill likely become
-throttled by disk. To increase query performance it is recommended to
+throttled by disk. To increase query performance, it is recommended to
 provide multiple paths on separate local devices for spill (property
 ``spiller-spill-path`` in :ref:`tuning-spilling`).
 
@@ -85,19 +85,19 @@ Spill Compression
 -----------------
 
 When spill compression is enabled (``spill-compression-enabled`` property in
-:ref:`tuning-spilling`), spilled pages will be compressed before being
-written to dis. Enabling this feature can reduce disk IO at the cost
+:ref:`tuning-spilling`), spilled pages are compressed, before being
+written to disk. Enabling this feature can reduce disk IO at the cost
 of extra CPU load to compress and decompress spilled pages.
 
 Spill Encryption
 ----------------
 
 When spill encryption is enabled (``spill-encryption-enabled`` property in
-:ref:`tuning-spilling`), spill contents will be encrypted with a randomly generated
-(per spill file) secret key. Enabling this will increase CPU load and reduce throughput
+:ref:`tuning-spilling`), spill contents are encrypted with a randomly generated
+(per spill file) secret key. Enabling this increases CPU load and reduces throughput
 of spilling to disk, but can protect spilled data from being recovered from spill files.
 Consider reducing the value of ``memory-revoking-threshold`` when spill
-encryption is enabled to account for the increase in latency of spilling.
+encryption is enabled, to account for the increase in latency of spilling.
 
 Supported Operations
 --------------------
@@ -111,7 +111,7 @@ Joins
 
 During the join operation, one of the tables being joined is stored in memory.
 This table is called the build table. The rows from the other table stream
-through and are passed onto the next operation if they match rows in the build
+through and are passed onto the next operation, if they match rows in the build
 table. The most memory-intensive part of the join is this build table.
 
 When the task concurrency is greater than one, the build table is partitioned.
@@ -122,14 +122,14 @@ When the build table is partitioned, the spill-to-disk mechanism can decrease
 the peak memory usage needed by the join operation. When a query approaches the
 memory limit, a subset of the partitions of the build table gets spilled to disk,
 along with rows from the other table that fall into those same partitions. The
-number of partitions that get spilled influences the amount of disk space needed.
+number of partitions, that get spilled, influences the amount of disk space needed.
 
 Afterward, the spilled partitions are read back one-by-one to finish the join
 operation.
 
 With this mechanism, the peak memory used by the join operator can be decreased
-to the size of the largest build table partition. Assuming no data skew, this will
-be ``1 / task.concurrency`` times the size of the whole build table.
+to the size of the largest build table partition. Assuming no data skew, this
+is ``1 / task.concurrency`` times the size of the whole build table.
 
 Aggregations
 ^^^^^^^^^^^^
@@ -144,16 +144,16 @@ Order By
 ^^^^^^^^
 
 If your trying to sort a larger amount of data, a significant amount of memory 
-may be needed. When spill to disk for order by is enabled, if there is not enough
-memory, intemediate sorted results are written to disk. They are loaded back and
+may be needed. When spill to disk for ``order by`` is enabled, if there is not enough
+memory, intermediate sorted results are written to disk. They are loaded back and
 merged with a lower memory footprint.
 
-Window functions
+Window Functions
 ^^^^^^^^^^^^^^^^
 
-Window Functions perform an operators over a window of rows and return one value
+Window functions perform an operator over a window of rows, and return one value
 for each row. If this window of rows is large, a significant amount of memory may
 be needed. When spill to disk for window functions is enabled, if there is not enough
-memory, intemediate sorted results are written to disk. They are loaded back and
-merged when memory is available. There is a current limitation that spill will not work
-in all cases such as when a single window is very large.
+memory, intermediate sorted results are written to disk. They are loaded back and
+merged when memory is available. There is a current limitation that spill does not work
+in all cases, such as when a single window is very large.

--- a/presto-docs/src/main/sphinx/admin/tuning.rst
+++ b/presto-docs/src/main/sphinx/admin/tuning.rst
@@ -3,7 +3,7 @@ Tuning Presto
 =============
 
 The default Presto settings should work well for most workloads. The following
-information may help you if your cluster is facing a specific performance problem.
+information may help you, if your cluster is facing a specific performance problem.
 
 Config Properties
 -----------------
@@ -13,7 +13,7 @@ See :doc:`/admin/properties`.
 JVM Settings
 ------------
 
-The following can be helpful for diagnosing GC issues:
+The following can be helpful for diagnosing garbage collection (GC) issues:
 
 .. code-block:: none
 

--- a/presto-docs/src/main/sphinx/installation/benchmark-driver.rst
+++ b/presto-docs/src/main/sphinx/installation/benchmark-driver.rst
@@ -3,7 +3,7 @@ Benchmark Driver
 ================
 
 The benchmark driver can be used to measure the performance of queries in a
-Presto cluster. We use it to continuously measure the performance of trunk.
+Presto cluster. We use it to continuously measure the performance of the master branch.
 
 Download :maven_download:`benchmark-driver`, rename it to ``presto-benchmark-driver``,
 then make it executable with ``chmod +x``.
@@ -31,7 +31,7 @@ Create a ``suite.json`` file:
     }
 
 This example contains two suites ``file_formats`` and ``legacy_orc``. The
-``file_formats`` suite will run queries with names matching the regular expression
+``file_formats`` suite runs queries with names matching the regular expression
 ``single_.*`` or ``tpch_.*`` in all schemas matching the regular expression
 ``tpch_sf.*_.*_.*?``. The ``legacy_orc`` suite adds a session property to
 disable the optimized ORC reader and only runs in the ``tpch_sf.*_orc_.*?``
@@ -47,7 +47,7 @@ without the extension.
 Output
 ------
 
-The benchmark driver will measure the wall time, total CPU time used by
+The benchmark driver measures the wall time, total CPU time used by
 all Presto processes and the CPU time used by the query. For each timing, the
 driver reports median, mean and standard deviation of the query runs. The
 difference between process and query CPU times is the query overhead, which
@@ -87,7 +87,7 @@ SQL files. For example, the following SQL file declares two tags,
     SELECT SUM(LENGTH(comment))
     FROM lineitem
 
-This will cause the driver to output these values for each run of this query.
+This causes the driver to output these values for each run of this query.
 
 CLI Arguments
 -------------

--- a/presto-docs/src/main/sphinx/installation/cli.rst
+++ b/presto-docs/src/main/sphinx/installation/cli.rst
@@ -2,7 +2,7 @@
 Command Line Interface
 ======================
 
-The Presto CLI provides a terminal-based interactive shell for running
+The Presto CLI provides a terminal-based, interactive shell for running
 queries. The CLI is a
 `self-executing <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>`_
 JAR file, which means it acts like a normal UNIX executable.

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -6,8 +6,8 @@ Installing Presto
 -----------------
 
 Download the Presto server tarball, :maven_download:`server`, and unpack it.
-The tarball will contain a single top-level directory,
-|presto_server_release|, which we will call the *installation* directory.
+The tarball contains a single top-level directory,
+|presto_server_release|, which we call the *installation* directory.
 
 Presto needs a *data* directory for storing logs, etc.
 We recommend creating a data directory outside of the installation directory,
@@ -17,7 +17,7 @@ Configuring Presto
 ------------------
 
 Create an ``etc`` directory inside the installation directory.
-This will hold the following configuration:
+This holds the following configuration:
 
 * Node Properties: environmental configuration specific to each node
 * JVM Config: command line options for the Java Virtual Machine
@@ -54,7 +54,7 @@ The above properties are described below:
   each installation must have a unique identifier.
 
 * ``node.data-dir``:
-  The location (filesystem path) of the data directory. Presto will store
+  The location (filesystem path) of the data directory. Presto stores
   logs and other data here.
 
 .. _presto_jvm_config:
@@ -85,8 +85,8 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
 
-Because an ``OutOfMemoryError`` will typically leave the JVM in an
-inconsistent state, we write a heap dump (for debugging) and forcibly
+Because an ``OutOfMemoryError`` typically leaves the JVM in an
+inconsistent state, we write a heap dump, for debugging, and forcibly
 terminate the process when this occurs.
 
 
@@ -125,8 +125,8 @@ And this is a minimal configuration for the workers:
     query.max-total-memory-per-node=2GB
     discovery.uri=http://example.net:8080
 
-Alternatively, if you are setting up a single machine for testing that
-will function as both a coordinator and worker, use this configuration:
+Alternatively, if you are setting up a single machine for testing, that
+functions as both a coordinator and worker, use this configuration:
 
 .. code-block:: none
 
@@ -142,8 +142,8 @@ will function as both a coordinator and worker, use this configuration:
 These properties require some explanation:
 
 * ``coordinator``:
-  Allow this Presto instance to function as a coordinator
-  (accept queries from clients and manage query execution).
+  Allow this Presto instance to function as a coordinator, so to
+  accept queries from clients and manage query execution.
 
 * ``node-scheduler.include-coordinator``:
   Allow scheduling work on the coordinator.
@@ -157,18 +157,18 @@ These properties require some explanation:
   communication, internal and external.
 
 * ``query.max-memory``:
-  The maximum amount of distributed memory that a query may use.
+  The maximum amount of distributed memory, that a query may use.
 
 * ``query.max-memory-per-node``:
-  The maximum amount of user memory that a query may use on any one machine.
+  The maximum amount of user memory, that a query may use on any one machine.
 
 * ``query.max-total-memory-per-node``:
-  The maximum amount of user and system memory that a query may use on any one machine,
+  The maximum amount of user and system memory, that a query may use on any one machine,
   where system memory is the memory used during execution by readers, writers, and network buffers, etc.
 
 * ``discovery-server.enabled``:
   Presto uses the Discovery service to find all the nodes in the cluster.
-  Every Presto instance will register itself with the Discovery service
+  Every Presto instance registers itself with the Discovery service
   on startup. In order to simplify deployment and avoid running an additional
   service, the Presto coordinator can run an embedded version of the
   Discovery service. It shares the HTTP server with Presto and thus uses
@@ -187,7 +187,7 @@ You may also wish to set the following properties:
   Specifies the port for the JMX RMI registry. JMX clients should connect to this port.
 
 * ``jmx.rmiserver.port``:
-  Specifies the port for the JMX RMI server. Presto exports many metrics
+  Specifies the port for the JMX RMI server. Presto exports many metrics,
   that are useful for monitoring via JMX.
 
 The above configuration properties are a minimal set to help you get started.
@@ -200,7 +200,7 @@ Log Levels
 The optional log levels file, ``etc/log.properties``, allows setting the
 minimum log level for named logger hierarchies. Every logger has a name,
 which is typically the fully qualified name of the class that uses the logger.
-Loggers have a hierarchy based on the dots in the name (like Java packages).
+Loggers have a hierarchy based on the dots in the name, like Java packages.
 For example, consider the following log levels file:
 
 .. code-block:: none
@@ -209,8 +209,8 @@ For example, consider the following log levels file:
 
 This would set the minimum level to ``INFO`` for both
 ``io.prestosql.server`` and ``io.prestosql.plugin.hive``.
-The default minimum level is ``INFO``
-(thus the above example does not actually change anything).
+The default minimum level is ``INFO``, 
+thus the above example does not actually change anything.
 There are four levels: ``DEBUG``, ``INFO``, ``WARN`` and ``ERROR``.
 
 Catalog Properties
@@ -218,9 +218,9 @@ Catalog Properties
 
 Presto accesses data via *connectors*, which are mounted in catalogs.
 The connector provides all of the schemas and tables inside of the catalog.
-For example, the Hive connector maps each Hive database to a schema,
-so if the Hive connector is mounted as the ``hive`` catalog, and Hive
-contains a table ``clicks`` in database ``web``, that table would be accessed
+For example, the Hive connector maps each Hive database to a schema. 
+If the Hive connector is mounted as the ``hive`` catalog, and Hive
+contains a table ``clicks`` in database ``web``, that table can be accessed
 in Presto as ``hive.web.clicks``.
 
 Catalogs are registered by creating a catalog properties file
@@ -247,8 +247,8 @@ Presto can be started as a daemon by running the following:
     bin/launcher start
 
 Alternatively, it can be run in the foreground, with the logs and other
-output being written to stdout/stderr (both streams should be captured
-if using a supervision system like daemontools):
+output written to stdout/stderr. Bboth streams should be captured
+if using a supervision system like daemontools:
 
 .. code-block:: none
 
@@ -262,12 +262,12 @@ After launching, you can find the log files in ``var/log``:
 
 * ``launcher.log``:
   This log is created by the launcher and is connected to the stdout
-  and stderr streams of the server. It will contain a few log messages
-  that occur while the server logging is being initialized and any
+  and stderr streams of the server. It contains a few log messages
+  that occur while the server logging is being initialized, and any
   errors or diagnostics produced by the JVM.
 
 * ``server.log``:
-  This is the main log file used by Presto. It will typically contain
+  This is the main log file used by Presto. It typically contains
   the relevant information if the server fails during initialization.
   It is automatically rotated and compressed.
 

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -19,7 +19,7 @@ Driver Name
 -----------
 
 The driver class name is ``io.prestosql.jdbc.PrestoDriver``.
-Most users will not need this information as drivers are loaded automatically.
+Most users do not need this information as drivers are loaded automatically.
 
 Connecting
 ----------
@@ -50,7 +50,7 @@ The above URL can be used as follows to create a connection:
 Connection Parameters
 ---------------------
 
-The driver supports various parameters that may be set as URL parameters
+The driver supports various parameters that may be set as URL parameters,
 or as properties passed to ``DriverManager``. Both of the following
 examples are equivalent:
 
@@ -68,7 +68,7 @@ examples are equivalent:
     String url = "jdbc:presto://example.net:8080/hive/sales?user=test&password=secret&SSL=true";
     Connection connection = DriverManager.getConnection(url);
 
-These methods may be mixed; some parameters may be specified in the URL
+These methods may be mixed; some parameters may be specified in the URL,
 while others are specified using properties. However, the same parameter
 may not be specified using both methods.
 
@@ -85,13 +85,13 @@ Name                                   Description
 ``applicationNamePrefix``              Prefix to append to any specified ``ApplicationName`` client info
                                        property, which is used to set the source name for the Presto query.
                                        If neither this property nor ``ApplicationName`` are set, the source
-                                       for the query will be ``presto-jdbc``.
+                                       for the query is ``presto-jdbc``.
 ``accessToken``                        Access token for token based authentication.
 ``SSL``                                Use HTTPS for connections
 ``SSLKeyStorePath``                    The location of the Java KeyStore file that contains the certificate
                                        and private key to use for authentication.
 ``SSLKeyStorePassword``                The password for the KeyStore.
-``SSLTrustStorePath``                  The location of the Java TrustStore file that will be used
+``SSLTrustStorePath``                  The location of the Java TrustStore file to use.
                                        to validate HTTPS server certificates.
 ``SSLTrustStorePassword``              The password for the TrustStore.
 ``KerberosRemoteServiceName``          Presto coordinator Kerberos service name. This parameter is

--- a/presto-docs/src/main/sphinx/installation/tableau.rst
+++ b/presto-docs/src/main/sphinx/installation/tableau.rst
@@ -7,21 +7,20 @@ Tableau against Presto. It implements the functions in the
 `Tableau web connector API
 <https://community.tableau.com/community/developers/web-data-connectors>`_.
 
-When creating a new web data source, Tableau will ask for the URL of the web
+When creating a new web data source, Tableau asks for the URL of the web
 connector. Use the following URL, replacing ``example.net:8080`` with the
-hostname and port number of the Presto coordinator
-(the default port is ``8080``):
+hostname and port number of the Presto coordinator, the default port is ``8080``:
 
 .. code-block:: none
 
      http://example.net:8080/tableau/presto-connector.html
 
-When Tableau first loads the Presto web connector, it will render an HTML
-form. In this form you need to fill in details such as your user name,
+When Tableau first loads the Presto web connector, it renders an HTML
+form. In this form you need to fill in details, such as your user name,
 the catalog and the schema you want to query, the data source name,
-session parameters you want to set and finally the SQL query to run.
-After you click ``Submit``, the query will be submitted to the Presto
-coordinator and Tableau will then create an extract out of the results
+session parameters you want to set, and finally the SQL query to run.
+After you click ``Submit``, the query is submitted to the Presto
+coordinator and Tableau then creates an extract out of the results
 retrieved from the coordinator, page by page. After Tableau is done
 extracting the results of your query, you can then use this extract
 for further analysis with Tableau.
@@ -34,8 +33,8 @@ for further analysis with Tableau.
      in Presto. In particular, the Tableau web connector API currently supports
      the following Tableau data types:
      ``bool``, ``date``, ``datetime``, ``float``, ``int`` and ``string``.
-     Presto ``boolean`` and ``date`` types will be converted to the Tableau
+     Presto ``boolean`` and ``date`` types are converted to the Tableau
      data types ``bool`` and ``date``, respectively, on the Tableau client side.
      Any other Presto types such as ``array``, ``map``, ``row``, ``double``,
-     ``bigint``, etc., will be converted to a Tableau ``string`` as they do
+     ``bigint``, etc., are converted to a Tableau ``string`` as they do
      not map to any Tableau type.

--- a/presto-docs/src/main/sphinx/installation/verifier.rst
+++ b/presto-docs/src/main/sphinx/installation/verifier.rst
@@ -2,11 +2,11 @@
 Presto Verifier
 ===============
 
-The Presto Verifier can be used to test Presto against another database (such as MySQL),
-or to test two Presto clusters against each other. We use it to continuously test trunk
-against the previous release while developing Presto.
+The Presto Verifier can be used to test Presto against a database, such as MySQL,
+or to test two Presto clusters against each other. We use it to continuously test the master branch
+against the previous release, while developing Presto.
 
-Create a MySQL database with the following table and load it with the queries you would like to run:
+To use the Verifier, create a MySQL database with the following table and load it with the queries you would like to run:
 
 .. code-block:: sql
 

--- a/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
@@ -10,14 +10,14 @@ Join Enumeration
 The order in which joins are executed in a query can have a significant impact
 on the query's performance. The aspect of join ordering that has the largest
 impact on performance is the size of the data being processed and transferred
-over the network. If a join that produces a lot of data is performed early in
-the execution, then subsequent stages will need to process large amounts of
+over the network. If a join, that produces a lot of data, is performed early in
+the execution, then subsequent stages need to process large amounts of
 data for longer than necessary, increasing the time and resources needed for
 the query.
 
 With cost based join enumeration, Presto uses
 :doc:`/optimizer/statistics` provided by connectors to estimate
-the costs for different join orders and automatically pick the
+the costs for different join orders and automatically picks the
 join order with the lowest computed costs.
 
 The join enumeration strategy is governed by the ``join_reordering_strategy``
@@ -37,8 +37,8 @@ Join Distribution Selection
 ---------------------------
 
 Presto uses a hash based join algorithm. That implies that for each join
-operator a hash table must be created from one join input (called build side).
-The other input (probe side) is then iterated and for each row the hash table is
+operator a hash table must be created from one join input, called build side.
+The other input, called probe side, is then iterated, and for each row the hash table is
 queried to find matching rows.
 
 There are two types of join distributions:
@@ -48,9 +48,9 @@ There are two types of join distributions:
    from all of the data (data is replicated to each node)
 
 Each type have their trade offs. Partitioned joins require redistributing both
-tables using a hash of the join key. This can be slower (sometimes
-substantially) than broadcast joins, but allows much larger joins. In
-particular, broadcast joins will be faster if the build side is much smaller
+tables using a hash of the join key. This can be slower, sometimes
+substantially slower, than broadcast joins, but allows much larger joins. In
+particular, broadcast joins are faster if the build side is much smaller
 than the probe side. However, broadcast joins require that the tables on the
 build side of the join after filtering fit in memory on each node, whereas
 distributed joins only need to fit in distributed memory across all nodes.

--- a/presto-docs/src/main/sphinx/optimizer/cost-in-explain.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-in-explain.rst
@@ -34,9 +34,9 @@ For example:
 
 Generally, there is only one cost printed for each plan node.  However, when a
 ``Scan`` operator is combined with a ``Filter`` and/or ``Project`` operator,
-then multiple cost structures will be printed, each corresponding to an
+then multiple cost structures are printed, each corresponding to an
 individual logical part of the combined operator. For example, three cost
-structures will be printed for a ``ScanFilterProject`` operator, corresponding
+structures are printed for a ``ScanFilterProject`` operator, corresponding
 to the ``Scan``, ``Filter``, and ``Project`` parts of the operator, in that order.
 
 Estimated cost is also printed in :doc:`/sql/explain-analyze` in addition to actual

--- a/presto-docs/src/main/sphinx/optimizer/statistics.rst
+++ b/presto-docs/src/main/sphinx/optimizer/statistics.rst
@@ -13,16 +13,16 @@ Table Layouts
 -------------
 
 Statistics are exposed to the query planner by a table layout. A table layout
-represents a subset of a table's data and contains information about the
-organizational properties of that data (like sort order and bucketing).
+represents a subset of a table's data, and contains information about the
+organizational properties of that data, like sort order and bucketing.
 
-The number of table layouts available for a table and the details of those table
-layouts are specific to each connector.  Using the Hive connector as an example:
+The number of table layouts available for a table, and the details of those table
+layouts, are specific to each connector.  Using the Hive connector as an example:
 
 * Non-partitioned tables have just one table layout representing all data in the table
 * Partitioned tables have a family of table layouts. Each set of partitions to
-  be scanned represents one table layout.  Presto will try to pick a table
-  layout consisting of the smallest number of partitions based on filtering
+  be scanned represents one table layout.  Presto tries to pick a table
+  layout consisting of the smallest number of partitions, based on filtering
   predicates from the query.
 
 Available Statistics

--- a/presto-docs/src/main/sphinx/overview/concepts.rst
+++ b/presto-docs/src/main/sphinx/overview/concepts.rst
@@ -10,7 +10,7 @@ Presto Concepts
 Overview
 --------
 
-To understand Presto you must first understand the terms and concepts
+To understand Presto, you must first understand the terms and concepts
 used throughout the Presto documentation.
 
 While it's easy to understand statements and queries, as an end-user
@@ -43,7 +43,7 @@ instance of Presto can be configured to perform both roles.
 
 The coordinator keeps track of the activity on each worker and
 coordinates the execution of a query. The coordinator creates
-a logical model of a query involving a series of stages which is then
+a logical model of a query involving a series of stages, which is then
 translated into a series of connected tasks running on a cluster of
 Presto workers.
 
@@ -52,7 +52,7 @@ Coordinators communicate with workers and clients using a REST API.
 Worker
 ^^^^^^
 
-A Presto worker is a server in a Presto installation which is responsible
+A Presto worker is a server in a Presto installation, which is responsible
 for executing tasks and processing data. Worker nodes fetch data from
 connectors and exchange intermediate data with each other. The coordinator
 is responsible for fetching results from the workers and returning the
@@ -79,7 +79,7 @@ Connector
 A connector adapts Presto to a data source such as Hive or a
 relational database. You can think of a connector the same way you
 think of a driver for a database. It is an implementation of Presto's
-:doc:`SPI </develop/spi-overview>` which allows Presto to interact
+:doc:`SPI </develop/spi-overview>`, which allows Presto to interact
 with a resource using a standard API.
 
 Presto contains several built-in connectors: a connector for
@@ -91,14 +91,14 @@ data. Many third-party developers have contributed connectors so that
 Presto can access data in a variety of data sources.
 
 Every catalog is associated with a specific connector. If you examine
-a catalog configuration file, you will see that each contains a
-mandatory property ``connector.name`` which is used by the catalog
+a catalog configuration file, you see that each contains a
+mandatory property ``connector.name``, which is used by the catalog
 manager to create a connector for a given catalog. It is possible
 to have more than one catalog use the same connector to access two
 different instances of a similar database. For example, if you have
 two Hive clusters, you can configure two catalogs in a single Presto
 cluster that both use the Hive connector, allowing you to query data
-from both Hive clusters (even within the same SQL query).
+from both Hive clusters, even within the same SQL query.
 
 Catalog
 ^^^^^^^
@@ -112,7 +112,7 @@ Hive data source.
 
 When addressing a table in Presto, the fully-qualified table name is
 always rooted in a catalog. For example, a fully-qualified table name
-of ``hive.test_data.test`` would refer to the ``test`` table in the
+of ``hive.test_data.test`` refers to the ``test`` table in the
 ``test_data`` schema in the ``hive`` catalog.
 
 Catalogs are defined in properties files stored in the Presto
@@ -131,14 +131,14 @@ the underlying data source.
 Table
 ^^^^^
 
-A table is a set of unordered rows which are organized into named columns
+A table is a set of unordered rows, which are organized into named columns
 with types. This is the same as in any relational database. The mapping
 from source data to tables is defined by the connector.
 
 Query Execution Model
 ---------------------
 
-Presto executes SQL statements and turns these statements into queries
+Presto executes SQL statements and turns these statements into queries,
 that are executed across a distributed cluster of coordinator and workers.
 
 Statement
@@ -146,7 +146,7 @@ Statement
 
 Presto executes ANSI-compatible SQL statements.  When the Presto
 documentation refers to a statement, it is referring to statements as
-defined in the ANSI SQL standard which consists of clauses,
+defined in the ANSI SQL standard, which consists of clauses,
 expressions, and predicates.
 
 Some readers might be curious why this section lists separate concepts
@@ -160,7 +160,7 @@ Query
 ^^^^^
 
 When Presto parses a statement, it converts it into a query and creates
-a distributed query plan which is then realized as a series of
+a distributed query plan, which is then realized as a series of
 interconnected stages running on Presto workers. When you retrieve
 information about a query in Presto, you receive a snapshot of every
 component that is involved in producing a result set in response to a
@@ -179,12 +179,12 @@ Stage
 When Presto executes a query, it does so by breaking up the execution
 into a hierarchy of stages. For example, if Presto needs to aggregate
 data from one billion rows stored in Hive, it does so by creating a
-root stage to aggregate the output of several other stages all of
+root stage to aggregate the output of several other stages, all of
 which are designed to implement different sections of a distributed
 query plan.
 
 The hierarchy of stages that comprises a query resembles a tree.
-Every query has a root stage which is responsible for aggregating
+Every query has a root stage, which is responsible for aggregating
 the output from other stages. Stages are what the coordinator uses to
 model a distributed query plan, but stages themselves don't run on
 Presto workers.
@@ -195,12 +195,12 @@ Task
 As mentioned in the previous section, stages model a particular
 section of a distributed query plan, but stages themselves don't
 execute on Presto workers. To understand how a stage is executed,
-you'll need to understand that a stage is implemented as a series of
+you need to understand that a stage is implemented as a series of
 tasks distributed over a network of Presto workers.
 
 Tasks are the "work horse" in the Presto architecture as a distributed
-query plan is deconstructed into a series of stages which are then
-translated to tasks which then act upon or process splits. A Presto
+query plan is deconstructed into a series of stages, which are then
+translated to tasks, which then act upon or process splits. A Presto
 task has inputs and outputs, and just as a stage can be executed in
 parallel by a series of tasks, a task is executing in parallel with a
 series of drivers.
@@ -208,14 +208,14 @@ series of drivers.
 Split
 ^^^^^
 
-Tasks operate on splits which are sections of a larger data
+Tasks operate on splits, which are sections of a larger data
 set. Stages at the lowest level of a distributed query plan retrieve
 data via splits from connectors, and intermediate stages at a higher
 level of a distributed query plan retrieve data from other stages.
 
-When Presto is scheduling a query, the coordinator will query a
+When Presto is scheduling a query, the coordinator queries a
 connector for a list of all splits that are available for a table.
-The coordinator keeps track of which machines are running which tasks
+The coordinator keeps track of which machines are running which tasks,
 and what splits are being processed by which tasks.
 
 Driver

--- a/presto-docs/src/main/sphinx/overview/use-cases.rst
+++ b/presto-docs/src/main/sphinx/overview/use-cases.rst
@@ -2,7 +2,7 @@
 Use Cases
 =========
 
-This section puts Presto into perspective so that prospective
+This section puts Presto into perspective, so that prospective
 administrators and end users know what to expect from Presto.
 
 ------------------
@@ -27,9 +27,9 @@ Presto is a tool designed to efficiently query vast amounts of data
 using distributed queries. If you work with terabytes or petabytes of
 data, you are likely using tools that interact with Hadoop and HDFS.
 Presto was designed as an alternative to tools that query HDFS
-using pipelines of MapReduce jobs such as Hive or Pig, but Presto
+using pipelines of MapReduce jobs, such as Hive or Pig, but Presto
 is not limited to accessing HDFS. Presto can be and has been extended
-to operate over different kinds of data sources including traditional
+to operate over different kinds of data sources, including traditional
 relational databases and other data sources such as Cassandra.
 
 Presto was designed to handle data warehousing and analytics: data analysis,

--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -4,7 +4,7 @@ Built-in System Access Control
 
 A system access control plugin enforces authorization at a global level,
 before any connector level authorization. You can either use one of the built-in
-plugins in Presto or provide your own by following the guidelines in
+plugins in Presto, or provide your own by following the guidelines in
 :doc:`/develop/system-access-control`. Presto offers three built-in plugins:
 
 ================================================== ============================================================
@@ -87,7 +87,7 @@ Catalog Rules
 -------------
 
 These rules govern the catalogs particular users can access. The user is
-granted access to a catalog based on the first matching rule read from top to
+granted access to a catalog, based on the first matching rule read from top to
 bottom. If no rule matches, access is denied. Each rule is composed of the
 following fields:
 
@@ -140,9 +140,9 @@ Principal Rules
 ---------------
 
 These rules serve to enforce a specific matching between a principal and a
-specified user name. The principal is granted authorization as a user based
+specified user name. The principal is granted authorization as a user, based
 on the first matching rule read from top to bottom. If no rules are specified,
-no checks will be performed. If no rule matches, user authorization is denied.
+no checks are performed. If no rule matches, user authorization is denied.
 Each rule is composed of the following fields:
 
 * ``principal`` (required): regex to match and group against principal.
@@ -157,7 +157,7 @@ Each rule is composed of the following fields:
 .. note::
 
     You would at least specify one criterion in a principal rule. If you specify
-    both criteria in a principal rule, it will return the desired conclusion when
+    both criteria in a principal rule, it returns the desired conclusion when
     either of criteria is satisfied.
 
 The following implements an exact matching of the full principal name for LDAP
@@ -185,7 +185,7 @@ and Kerberos authentication:
       ]
     }
 
-If you want to allow users to use the extractly same name as their Kerberos principal
+If you want to allow users to use the exact same name as their Kerberos principal
 name, and allow ``alice`` and ``bob`` to use a group principal named as
 ``group@example.net``, you can use the following rules.
 

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -3,7 +3,7 @@ CLI Kerberos Authentication
 ===========================
 
 The Presto :doc:`/installation/cli` can connect to a :doc:`Presto coordinator
-</security/server>` that has Kerberos authentication enabled.
+</security/server>`, that has Kerberos authentication enabled.
 
 Environment Configuration
 -------------------------
@@ -16,8 +16,8 @@ Environment Configuration
 Kerberos Principals and Keytab Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each user who connects to the Presto coordinator needs a Kerberos principal.
-You will need to create these users in Kerberos using `kadmin
+Each user, who connects to the Presto coordinator, needs a Kerberos principal.
+You need to create these users in Kerberos using `kadmin
 <http://web.mit.edu/kerberos/krb5-latest/doc/admin/admin_commands/kadmin_local.html>`_.
 
 Additionally, each user needs a `keytab file
@@ -38,7 +38,7 @@ principal.
 Java Keystore File for TLS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Access to the Presto coordinator must be through https when using Kerberos
+Access to the Presto coordinator must be through HTTPS when using Kerberos
 authentication. The Presto coordinator uses a :ref:`Java Keystore
 <server_java_keystore>` file for its TLS configuration. This file can be
 copied to the client machine and used for its configuration.
@@ -47,7 +47,7 @@ Presto CLI execution
 --------------------
 
 In addition to the options that are required when connecting to a Presto
-coordinator that does not require Kerberos authentication, invoking the CLI
+coordinator, that does not require Kerberos authentication, invoking the CLI
 with Kerberos support enabled requires a number of additional command line
 options. The simplest way to invoke the CLI is with a wrapper script.
 
@@ -77,7 +77,7 @@ Option                          Description
 ``--krb5-keytab-path``          The location of the the keytab that can be used to
                                 authenticate the principal specified by ``--krb5-principal``
 ``--krb5-remote-service-name``  Presto coordinator Kerberos service name.
-``--keystore-path``             The location of the Java Keystore file that will be used
+``--keystore-path``             The location of the Java Keystore file that is used
                                 to secure TLS.
 ``--keystore-password``         The password for the keystore. This must match the
                                 password you specified when creating the keystore.
@@ -86,14 +86,14 @@ Option                          Description
 Troubleshooting
 ---------------
 
-Many of the same steps that can be used when troubleshooting the :ref:`Presto
-coordinator <coordinator-troubleshooting>` apply to troubleshooting the CLI.
+Many of the same steps, that can be used when troubleshooting the :ref:`Presto
+coordinator <coordinator-troubleshooting>`, apply to troubleshooting the CLI.
 
 Additional Kerberos Debugging Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can enable additional Kerberos debugging information for the Presto CLI
-process by passing ``-Dsun.security.krb5.debug=true`` as a JVM argument when
+process by passing ``-Dsun.security.krb5.debug=true`` as a JVM argument, when
 starting the CLI process. Doing so requires invoking the CLI JAR via ``java``
 instead of running the self-executable JAR directly. The self-executable jar
 file cannot pass the option to the JVM.

--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -11,7 +11,7 @@ Internal SSL/TLS configuration
 SSL/TLS is configured in the ``config.properties`` file.  The SSL/TLS on the
 worker and coordinator nodes are configured using the same set of properties.
 Every node in the cluster must be configured. Nodes that have not been
-configured, or are configured incorrectly, will not be able to communicate with
+configured, or are configured incorrectly, are not able to communicate with
 other nodes in the cluster.
 
 To enable SSL/TLS for Presto internal communication, do the following:
@@ -24,7 +24,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
 
     .. warning::
 
-        You can enable HTTPS while leaving HTTP enabled. In most cases this is a
+        You can enable HTTPS, while leaving HTTP enabled. In most cases this is a
         security hole. If you are certain you want to use this configuration, you
         should consider using an firewall to limit access to the HTTP endpoint to
         only those hosts that should be allowed to use it.
@@ -32,7 +32,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
 2. Configure the cluster to communicate using the fully qualified domain name (fqdn)
    of the cluster nodes. This can be done in either of the following ways:
 
-   - If the DNS service is configured properly, we can just let the nodes to
+   - If the DNS service is configured properly, we can just let the nodes
      introduce themselves to the coordinator using the hostname taken from
      the system configuration (``hostname --fqdn``)
 
@@ -41,7 +41,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
          node.internal-address-source=FQDN
 
    - It is also possible to specify each node's fully-qualified hostname manually.
-     This will be different for every host. Hosts should be in the same domain to
+     This is different for every host. Hosts should be in the same domain to
      make it easy to create the correct SSL/TLS certificates.
      e.g.: ``coordinator.example.com``, ``worker1.example.com``, ``worker2.example.com``.
 
@@ -54,7 +54,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
    any other node within the same cluster. It is possible to create unique
    certificates for every node using the fully-qualified hostname of each host,
    create a keystore that contains all the public keys for all of the hosts,
-   and specify it for the client (see step #8 below). In most cases it will be
+   and specify it for the client (see step #8 below). In most cases it is
    simpler to use a wildcard in the certificate as shown below.
 
     .. code-block:: none
@@ -140,18 +140,18 @@ Enabling encryption impacts performance. The performance degradation can vary
 based on the environment, queries, and concurrency.
 
 For queries that do not require transferring too much data between the Presto
-nodes (e.g. ``SELECT count(*) FROM table``), the performance impact is negligible.
+nodes e.g. ``SELECT count(*) FROM table``, the performance impact is negligible.
 
 However, for CPU intensive queries which require a considerable amount of data
 to be transferred between the nodes (for example, distributed joins, aggregations and
-window functions, which require repartitioning), the performance impact might be
+window functions, which require repartitioning), the performance impact can be
 considerable. The slowdown may vary from 10% to even 100%+, depending on the network
 traffic and the CPU utilization.
 
 Advanced Performance Tuning
 ---------------------------
 
-In some cases, changing the source of random numbers will improve performance
+In some cases, changing the source of random numbers improves performance
 significantly.
 
 By default, TLS encryption uses the ``/dev/urandom`` system device as a source of entropy.

--- a/presto-docs/src/main/sphinx/security/jce-policy.fragment
+++ b/presto-docs/src/main/sphinx/security/jce-policy.fragment
@@ -14,8 +14,8 @@ policy files can be downloaded from Oracle. Note that the JCE policy files vary
 based on the major version of Java you are running. Java 6 policy files will
 not work with Java 8, for example.
 
-The Java 8 policy files are available `here
+The Java 8 policy files are available `from Oracle
 <http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html>`_.
 Instructions for installing the policy files are included in a ``README`` file in
-the ZIP archive. You will need administrative access to install the policy
-files if you are installing them in a system JRE.
+the ZIP archive. You need administrative access to install the policy
+files, if you are installing them in a system JRE.

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -204,7 +204,7 @@ Example:
 For OpenLDAP, for this query to work, make sure you enable the
 ``memberOf`` `overlay <http://www.openldap.org/doc/admin24/overlays.html>`_.
 
-You can  use this property for scenarios where you want to authorize a user
+You can use this property for scenarios where you want to authorize a user
 based on complex group authorization search queries. For example, if you want to
 authorize a user belonging to any one of multiple groups (in OpenLDAP), this
 property may be set as follows:

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -4,9 +4,9 @@ LDAP Authentication
 
 Presto can be configured to enable frontend LDAP authentication over
 HTTPS for clients, such as the :ref:`cli_ldap`, or the JDBC and ODBC
-drivers. At present only simple LDAP authentication mechanism involving
+drivers. At present, only simple LDAP authentication mechanism involving
 username and password is supported. The Presto client sends a username
-and password to the coordinator and coordinator validates these
+and password to the coordinator, and the coordinator validates these
 credentials using an external LDAP service.
 
 To enable LDAP authentication for Presto, configuration changes are made on
@@ -42,7 +42,7 @@ the following example ``keytool`` command to import the certificate
     $ keytool -import -keystore <JAVA_HOME>/jre/lib/security/cacerts -trustcacerts -alias ldap_server -file ldap_server.crt
 
 In addition to this, access to the Presto coordinator should be
-through HTTPS. You can do it by creating a :ref:`server_java_keystore` on
+through HTTPS. You can do that by creating a :ref:`server_java_keystore` on
 the coordinator.
 
 Presto Coordinator Node Configuration
@@ -114,7 +114,7 @@ Property                                                Description
                                                         ``ldaps://`` since Presto allows only Secure LDAP.
 ``ldap.user-bind-pattern``                              This property can be used to specify the LDAP user
                                                         bind string for password authentication. This property
-                                                        must contain the pattern ``${USER}`` which will be
+                                                        must contain the pattern ``${USER}``, which is
                                                         replaced by the actual username during the password
                                                         authentication. Example: ``${USER}@corp.example.com``.
 ======================================================= ======================================================
@@ -152,8 +152,8 @@ Authorization based on LDAP Group Membership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can further restrict the set of users allowed to connect to the Presto
-coordinator based on their group membership by setting the optional
-``ldap.group-auth-pattern`` and ``ldap.user-base-dn`` properties in addition
+coordinator, based on their group membership, by setting the optional
+``ldap.group-auth-pattern`` and ``ldap.user-base-dn`` properties, in addition
 to the basic LDAP authentication properties.
 
 ======================================================= ======================================================
@@ -164,10 +164,10 @@ Property                                                Description
                                                         Example: ``OU=America,DC=corp,DC=example,DC=com``
 ``ldap.group-auth-pattern``                             This property is used to specify the LDAP query for
                                                         the LDAP group membership authorization. This query
-                                                        will be executed against the LDAP server and if
-                                                        successful, the user will be authorized.
-                                                        This property must contain a pattern ``${USER}``
-                                                        which will be replaced by the actual username in
+                                                        is executed against the LDAP server and if
+                                                        successful, the user is authorized.
+                                                        This property must contain a pattern ``${USER}``,
+                                                        which is replaced by the actual username in
                                                         the group authorization search query.
                                                         See samples below.
 ======================================================= ======================================================
@@ -204,7 +204,7 @@ Example:
 For OpenLDAP, for this query to work, make sure you enable the
 ``memberOf`` `overlay <http://www.openldap.org/doc/admin24/overlays.html>`_.
 
-You can also use this property for scenarios where you want to authorize a user
+You can  use this property for scenarios where you want to authorize a user
 based on complex group authorization search queries. For example, if you want to
 authorize a user belonging to any one of multiple groups (in OpenLDAP), this
 property may be set as follows:
@@ -229,9 +229,9 @@ authentication. The Presto CLI can use either a :ref:`Java Keystore
 <server_java_keystore>` file or :ref:`Java Truststore <cli_java_truststore>`
 for its TLS configuration.
 
-If you are using keystore file, it can be copied to the client machine and used
+If you are using a keystore file, it can be copied to the client machine and used
 for its TLS configuration. If you are using truststore, you can either use
-default java truststores or create a custom truststore on the CLI. We do not
+default Java truststores or create a custom truststore on the CLI. We do not
 recommend using self-signed certificates in production.
 
 Presto CLI Execution
@@ -276,7 +276,7 @@ Option                          Description
                                 password you specified when creating the truststore.
 ``--user``                      The LDAP username. For Active Directory this should be your
                                 ``sAMAccountName`` and for OpenLDAP this should be the ``uid`` of
-                                the user. This is the username which will be
+                                the user. This is the username which is
                                 used to replace the ``${USER}`` placeholder pattern in the properties
                                 specified in ``config.properties``.
 ``--password``                  Prompts for a password for the ``user``.
@@ -295,7 +295,7 @@ SSL Debugging for Presto CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you encounter any SSL related errors when running Presto CLI, you can run CLI using ``-Djavax.net.debug=ssl``
-parameter for debugging. You should use the Presto CLI executable jar to enable this. Eg:
+parameter for debugging. You should use the Presto CLI executable jar to enable this. E.g.:
 
 .. code-block:: none
 
@@ -311,11 +311,11 @@ Common SSL errors
 java.security.cert.CertificateException: No subject alternative names present
 *****************************************************************************
 
-This error is seen when the Presto coordinator’s certificate is invalid and does not have the IP you provide
-in the ``--server`` argument of the CLI. You will have to regenerate the coordinator's SSL certificate
+This error is seen when the Presto coordinator’s certificate is invalid, and does not have the IP you provide
+in the ``--server`` argument of the CLI. You have to regenerate the coordinator's SSL certificate
 with the appropriate :abbr:`SAN (Subject Alternative Name)` added.
 
-Adding a SAN to this certificate is required in cases where ``https://`` uses IP address in the URL rather
+Adding a SAN to this certificate is required in cases where ``https://`` uses IP address in the URL, rather
 than the domain contained in the coordinator's certificate, and the certificate does not contain the
 :abbr:`SAN (Subject Alternative Name)` parameter with the matching IP address as an alternative attribute.
 
@@ -325,17 +325,17 @@ Authentication or SSL errors with JDK Upgrade
 Starting with the JDK 8u181 release, to improve the robustness of LDAPS
 (secure LDAP over TLS) connections, endpoint identification algorithms have
 been enabled by default. See release notes
-`here <https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html#JDK-8200666.>`_.
-The same LDAP server certificate on the Presto coordinator (running on JDK
-version >= 8u181) that was previously able to successfully connect to an
-LDAPS server may now fail with the below error:
+`from Oracle <https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html#JDK-8200666.>`_.
+The same LDAP server certificate on the Presto coordinator, running on JDK
+version >= 8u181, that was previously able to successfully connect to an
+LDAPS server, may now fail with the below error:
 
 .. code-block:: none
 
     javax.naming.CommunicationException: simple bind failed: ldapserver:636
     [Root exception is javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching ldapserver found.]
 
-If you want to temporarily disable endpoint identification you can add the
+If you want to temporarily disable endpoint identification, you can add the
 property ``-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true``
 to Presto's ``jvm.config`` file. However, in a production environment, we
 suggest fixing the issue by regenerating the LDAP server certificate so that

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -7,8 +7,8 @@ HTTPS for clients, such as the :doc:`Presto CLI </security/cli>`, or the
 JDBC and ODBC drivers.
 
 To enable Kerberos authentication for Presto, configuration changes are made on
-the Presto coordinator. No changes are required to the worker configuration;
-the worker nodes will continue to connect to the coordinator over
+the Presto coordinator. No changes are required to the worker configuration.
+The worker nodes continue to connect to the coordinator over
 unauthenticated HTTP. However, if you want to secure the communication between
 Presto nodes with SSL/TLS, configure :doc:`/security/internal-communication`.
 
@@ -30,7 +30,7 @@ Kerberos Principals and Keytab Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Presto coordinator needs a Kerberos principal, as do users who are going to
-connect to the Presto coordinator. You will need to create these users in
+connect to the Presto coordinator. You need to create these users in
 Kerberos using `kadmin
 <http://web.mit.edu/kerberos/krb5-latest/doc/admin/admin_commands/kadmin_local.html>`_.
 
@@ -58,7 +58,7 @@ coordinator.
 System Access Control Plugin
 ----------------------------
 
-A Presto coordinator with Kerberos enabled will probably need a
+A Presto coordinator with Kerberos enabled probably needs a
 :doc:`/develop/system-access-control` plugin to achieve
 the desired level of security.
 
@@ -106,7 +106,7 @@ Property                                                Description
                                                         Must match the Kerberos principal.
 ``http-server.authentication.krb5.principal-hostname``  The Kerberos hostname for the Presto coordinator.
                                                         Must match the Kerberos principal. This parameter is
-                                                        optional. If included, Presto will use this value
+                                                        optional. If included, Presto uses this value
                                                         in the host part of the Kerberos principal instead
                                                         of the machine's hostname.
 ``http-server.authentication.krb5.keytab``              The location of the keytab that can be used to
@@ -115,7 +115,7 @@ Property                                                Description
 ``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
                                                         Should be set to ``true``.
 ``http-server.https.port``                              HTTPS server port.
-``http-server.https.keystore.path``                     The location of the Java Keystore file that will be
+``http-server.https.keystore.path``                     The location of the Java Keystore file that is
                                                         used to secure TLS.
 ``http-server.https.keystore.key``                      The password for the keystore. This must match the
                                                         password you specified when creating the keystore.
@@ -123,8 +123,8 @@ Property                                                Description
 
 .. note::
 
-    Monitor CPU usage on the Presto coordinator after enabling HTTPS. Java
-    prefers the more CPU-intensive cipher suites if you allow it to choose from
+    Monitor the CPU usage on the Presto coordinator after enabling HTTPS. Java
+    prefers the more CPU-intensive cipher suites, if you allow it to choose from
     a big list. If the CPU usage is unacceptably high after enabling HTTPS,
     you can configure Java to use specific cipher suites by setting
     the ``http-server.https.included-cipher`` property to only allow
@@ -155,7 +155,7 @@ Troubleshooting
 ---------------
 
 Getting Kerberos authentication working can be challenging. You can
-independently verify some of the configuration outside of Presto to help narrow
+independently verify some of the configuration outside of Presto, to help narrow
 your focus when trying to solve a problem.
 
 Kerberos Verification
@@ -204,7 +204,7 @@ to ``stdout`` to appear in the logs.
 
 The amount and usefulness of the information the Kerberos debugging output
 sends to the logs varies depending on where the authentication is failing.
-Exception messages and stack traces can also provide useful clues about the
+Exception messages and stack traces can provide useful clues about the
 nature of the problem.
 
 .. _server_additional_resources:

--- a/presto-docs/src/main/sphinx/security/tls.rst
+++ b/presto-docs/src/main/sphinx/security/tls.rst
@@ -14,7 +14,7 @@ generated using :command:`keytool` and stored in a Java Keystore file for the
 Presto coordinator.
 
 The alias in the :command:`keytool` command line should match the principal that the
-Presto coordinator will use.
+Presto coordinator uses.
 
 You'll be prompted for the first and last name. Use the Common Name that will
 be used in the certificate. In this case, it should be the unqualified hostname
@@ -51,17 +51,17 @@ Java Truststore File for TLS
 
 Truststore files contain certificates of trusted TLS/SSL servers, or of
 Certificate Authorities trusted to identify servers. For securing access
-to the Presto coordinator through HTTPS the clients can configure truststores.
+to the Presto coordinator through HTTPS, the clients can configure truststores.
 For the Presto CLI to trust the Presto coordinator, the coordinator's certificate
 must be imported to the CLI's truststore.
 
 You can either import the certificate to the default Java truststore, or to a
-custom truststore. You should be careful if you choose to use the default
+custom truststore. You should be careful, if you choose to use the default
 one, since you may need to remove the certificates of CAs you do not deem trustworthy.
 
 You can use :command:`keytool` to import the certificate to the truststore.
 In the example, we are going to import ``presto_certificate.cer`` to a custom
-truststore ``presto_trust.jks``, and you will get a prompt asking if the certificate
+truststore ``presto_trust.jks``, and you get a prompt asking if the certificate
 can be trusted or not.
 
 .. code-block:: none


### PR DESCRIPTION
A whole bunch minor/trivial changes done while reading through the whole docs to learn.

- comma usage
- removal of future and would/could as possible
- grammar and spelling

Sections 1 to 5

- overview 
- installation
- security
- admin
- optimizer

Signed-off-by: Manfred Moser <mmoser@apache.org>
Signed-off-by: Manfred Moser <manfred@simpligility.com>

Follow up for connectors section and others is separate to reduce PR size. See https://github.com/prestosql/presto/pull/1964