### PR TITLE
Lazily build hashtable for map

### DIFF
--- a/presto-array/src/main/java/io/prestosql/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/io/prestosql/array/ReferenceCountMap.java
@@ -15,6 +15,7 @@ package io.prestosql.array;
 
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
+import io.prestosql.spi.block.AbstractMapBlock;
 import io.prestosql.spi.block.Block;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import org.openjdk.jol.info.ClassLayout;
@@ -89,6 +90,9 @@ public final class ReferenceCountMap
         }
         else if (key.getClass().isArray()) {
             extraIdentity = getLength(key);
+        }
+        else if (key instanceof AbstractMapBlock.HashTables) {
+            extraIdentity = (int) ((AbstractMapBlock.HashTables) key).getRetainedSizeInBytes();
         }
         else {
             throw new IllegalArgumentException(format("Unsupported type for %s", key));

--- a/presto-main/src/test/java/io/prestosql/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/io/prestosql/block/AbstractTestBlock.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.block.AbstractMapBlock.HashTables;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.block.BlockBuilderStatus;
@@ -61,6 +62,9 @@ public abstract class AbstractTestBlock
 
     protected <T> void assertBlock(Block block, Supplier<BlockBuilder> newBlockBuilder, T[] expectedValues)
     {
+        assertBlockSize(block);
+        assertRetainedSize(block);
+
         assertBlockPositions(block, newBlockBuilder, expectedValues);
         assertBlockPositions(copyBlockViaBlockSerde(block), newBlockBuilder, expectedValues);
         assertBlockPositions(copyBlockViaWritePositionTo(block, newBlockBuilder), newBlockBuilder, expectedValues);
@@ -144,6 +148,9 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == DictionaryId.class) {
                     retainedSize += ClassLayout.parseClass(DictionaryId.class).instanceSize();
+                }
+                else if (type == HashTables.class) {
+                    retainedSize += ((HashTables) field.get(block)).getRetainedSizeInBytes();
                 }
                 else if (type == MethodHandle.class) {
                     // MethodHandles are only used in MapBlock/MapBlockBuilder,

--- a/presto-spi/src/main/java/io/prestosql/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/AbstractMapBlock.java
@@ -15,6 +15,7 @@
 package io.prestosql.spi.block;
 
 import io.prestosql.spi.type.MapType;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -22,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.prestosql.spi.block.BlockUtil.checkArrayRange;
 import static io.prestosql.spi.block.BlockUtil.checkValidPositions;
 import static io.prestosql.spi.block.BlockUtil.checkValidRegion;
@@ -55,7 +57,7 @@ public abstract class AbstractMapBlock
 
     protected abstract Block getRawValueBlock();
 
-    protected abstract int[] getHashTables();
+    protected abstract HashTables getHashTables();
 
     /**
      * offset is entry-based, not position-based. In other words,
@@ -71,6 +73,8 @@ public abstract class AbstractMapBlock
 
     @Nullable
     protected abstract boolean[] getMapIsNull();
+
+    protected abstract void ensureHashTableLoaded();
 
     int getOffset(int position)
     {
@@ -113,22 +117,34 @@ public abstract class AbstractMapBlock
             newPosition++;
         }
 
-        int[] hashTable = getHashTables();
-        int[] newHashTable = new int[newOffsets[newOffsets.length - 1] * HASH_MULTIPLIER];
-        int newHashIndex = 0;
-        for (int i = offset; i < offset + length; ++i) {
-            int position = positions[i];
-            int entriesStartOffset = getOffset(position);
-            int entriesEndOffset = getOffset(position + 1);
-            for (int hashIndex = entriesStartOffset * HASH_MULTIPLIER; hashIndex < entriesEndOffset * HASH_MULTIPLIER; hashIndex++) {
-                newHashTable[newHashIndex] = hashTable[hashIndex];
-                newHashIndex++;
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int newHashTableEntries = newOffsets[newOffsets.length - 1] * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = new int[newHashTableEntries];
+            int newHashIndex = 0;
+            for (int i = offset; i < offset + length; ++i) {
+                int position = positions[i];
+                int entriesStartOffset = getOffset(position);
+                int entriesEndOffset = getOffset(position + 1);
+                for (int hashIndex = entriesStartOffset * HASH_MULTIPLIER; hashIndex < entriesEndOffset * HASH_MULTIPLIER; hashIndex++) {
+                    newRawHashTables[newHashIndex] = rawHashTables[hashIndex];
+                    newHashIndex++;
+                }
             }
         }
 
         Block newKeys = getRawKeyBlock().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
         Block newValues = getRawValueBlock().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
-        return createMapBlockInternal(mapType, 0, length, Optional.of(newMapIsNull), newOffsets, newKeys, newValues, newHashTable);
+        return createMapBlockInternal(
+                mapType,
+                0,
+                length,
+                Optional.of(newMapIsNull),
+                newOffsets,
+                newKeys,
+                newValues,
+                new HashTables(Optional.ofNullable(newRawHashTables), length, newHashTableEntries));
     }
 
     @Override
@@ -161,7 +177,8 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 getRawValueBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 (Integer.BYTES + Byte.BYTES) * (long) length +
-                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;
+                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount +
+                getHashTables().getInstanceSizeInBytes();
     }
 
     @Override
@@ -191,7 +208,8 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getPositionsSizeInBytes(entryPositions) +
                 getRawValueBlock().getPositionsSizeInBytes(entryPositions) +
                 (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount;
+                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount +
+                getHashTables().getInstanceSizeInBytes();
     }
 
     @Override
@@ -208,9 +226,14 @@ public abstract class AbstractMapBlock
         int[] newOffsets = compactOffsets(getOffsets(), position + getOffsetBase(), length);
         boolean[] mapIsNull = getMapIsNull();
         boolean[] newMapIsNull = mapIsNull == null ? null : compactArray(mapIsNull, position + getOffsetBase(), length);
-        int[] newHashTable = compactArray(getHashTables(), startValueOffset * HASH_MULTIPLIER, (endValueOffset - startValueOffset) * HASH_MULTIPLIER);
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = compactArray(rawHashTables, startValueOffset * HASH_MULTIPLIER, expectedNewHashTableEntries);
+        }
 
-        if (newKeys == getRawKeyBlock() && newValues == getRawValueBlock() && newOffsets == getOffsets() && newMapIsNull == mapIsNull && newHashTable == getHashTables()) {
+        if (newKeys == getRawKeyBlock() && newValues == getRawValueBlock() && newOffsets == getOffsets() && newMapIsNull == mapIsNull && newRawHashTables == rawHashTables) {
             return this;
         }
         return createMapBlockInternal(
@@ -221,7 +244,7 @@ public abstract class AbstractMapBlock
                 newOffsets,
                 newKeys,
                 newValues,
-                newHashTable);
+                new HashTables(Optional.ofNullable(newRawHashTables), length, expectedNewHashTableEntries));
     }
 
     @Override
@@ -235,12 +258,9 @@ public abstract class AbstractMapBlock
         int startEntryOffset = getOffset(position);
         int endEntryOffset = getOffset(position + 1);
         return clazz.cast(new SingleMapBlock(
-                mapType,
                 startEntryOffset * 2,
                 (endEntryOffset - startEntryOffset) * 2,
-                getRawKeyBlock(),
-                getRawValueBlock(),
-                getHashTables()));
+                this));
     }
 
     @Override
@@ -260,7 +280,12 @@ public abstract class AbstractMapBlock
         int valueLength = endValueOffset - startValueOffset;
         Block newKeys = getRawKeyBlock().copyRegion(startValueOffset, valueLength);
         Block newValues = getRawValueBlock().copyRegion(startValueOffset, valueLength);
-        int[] newHashTable = Arrays.copyOfRange(getHashTables(), startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = Arrays.copyOfRange(rawHashTables, startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
+        }
 
         return createMapBlockInternal(
                 mapType,
@@ -270,7 +295,7 @@ public abstract class AbstractMapBlock
                 new int[] {0, valueLength},
                 newKeys,
                 newValues,
-                newHashTable);
+                new HashTables(Optional.ofNullable(newRawHashTables), 1, expectedNewHashTableEntries));
     }
 
     @Override
@@ -303,10 +328,72 @@ public abstract class AbstractMapBlock
         return mapIsNull != null && mapIsNull[position + getOffsetBase()];
     }
 
+    public boolean isHashTablesPresent()
+    {
+        return getHashTables().get().isPresent();
+    }
+
     private void checkReadablePosition(int position)
     {
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    public static class HashTables
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(HashTables.class).instanceSize();
+
+        // Hash to location in map. Writes to the field by MapBlock is protected by "HashTables" monitor in MapBlock.
+        // MapBlockBuilder instances have their dedicated hashTables instances, so the write accesses to the hashTables
+        // fields do not need to be synchronized in that class.
+        @Nullable
+        private volatile int[] hashTables;
+
+        // The number of hash tables. Each map row corresponds to one hash table if it's built.
+        private int expectedHashTableCount;
+
+        // The total number of entries of all hashTables as if they are always built. It's used to calculate the retained size.
+        private int expectedEntryCount;
+
+        HashTables(Optional<int[]> hashTables, int expectedHashTableCount, int expectedEntryCount)
+        {
+            if (hashTables.isPresent() && hashTables.get().length != expectedEntryCount) {
+                throw new IllegalArgumentException("hashTables size does not match expectedEntryCount");
+            }
+
+            this.hashTables = hashTables.orElse(null);
+            this.expectedEntryCount = expectedEntryCount;
+            this.expectedHashTableCount = expectedHashTableCount;
+        }
+
+        Optional<int[]> get()
+        {
+            return Optional.ofNullable(hashTables);
+        }
+
+        void set(int[] hashTables)
+        {
+            requireNonNull(hashTables, "hashTables is null");
+            this.hashTables = hashTables;
+
+            // The passed in hashTables are always sized as if they are fully built.
+            this.expectedEntryCount = hashTables.length;
+        }
+
+        int getExpectedHashTableCount()
+        {
+            return expectedHashTableCount;
+        }
+
+        public long getInstanceSizeInBytes()
+        {
+            return INSTANCE_SIZE;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE + sizeOfIntArray(expectedEntryCount);
         }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/MapBlockEncoding.java
@@ -16,6 +16,7 @@ package io.prestosql.spi.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.prestosql.spi.block.AbstractMapBlock.HashTables;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSerde;
@@ -54,7 +55,7 @@ public class MapBlockEncoding
 
         int offsetBase = mapBlock.getOffsetBase();
         int[] offsets = mapBlock.getOffsets();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().get().orElse(null);
 
         int entriesStartOffset = offsets[offsetBase];
         int entriesEndOffset = offsets[offsetBase + positionCount];
@@ -64,8 +65,15 @@ public class MapBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawKeyBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawValueBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
 
-        sliceOutput.appendInt((entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER));
+        if (hashTable != null) {
+            int hashTableLength = (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength); // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);  // hashtable length
+        }
 
         sliceOutput.appendInt(positionCount);
         for (int position = 0; position < positionCount + 1; position++) {
@@ -82,18 +90,27 @@ public class MapBlockEncoding
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
+        }
 
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
             throw new IllegalArgumentException(
-                    format("Deserialized MapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+                    format("Deserialized MapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized MapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
         }
 
         int positionCount = sliceInput.readInt();
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return createMapBlockInternal(mapType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable);
+        return createMapBlockInternal(mapType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, new HashTables(Optional.ofNullable(hashTable), positionCount, hashTableLength));
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlock.java
@@ -16,12 +16,13 @@ package io.prestosql.spi.block;
 
 import io.airlift.slice.Slice;
 import io.prestosql.spi.PrestoException;
-import io.prestosql.spi.type.MapType;
+import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
 
 import java.util.function.BiConsumer;
 
-import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -34,21 +35,15 @@ public class SingleMapBlock
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMapBlock.class).instanceSize();
 
-    protected final MapType mapType;
     private final int offset;
-    private final int positionCount;
-    private final Block keyBlock;
-    private final Block valueBlock;
-    private final int[] hashTable;
+    private final int positionCount;    // The number of keys in this single map * 2
+    private final AbstractMapBlock mapBlock;
 
-    SingleMapBlock(MapType mapType, int offset, int positionCount, Block keyBlock, Block valueBlock, int[] hashTable)
+    SingleMapBlock(int offset, int positionCount, AbstractMapBlock mapBlock)
     {
-        this.mapType = mapType;
         this.offset = offset;
         this.positionCount = positionCount;
-        this.keyBlock = keyBlock;
-        this.valueBlock = valueBlock;
-        this.hashTable = hashTable;
+        this.mapBlock = mapBlock;
     }
 
     @Override
@@ -60,23 +55,26 @@ public class SingleMapBlock
     @Override
     public long getSizeInBytes()
     {
-        return keyBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
-                valueBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
+        return mapBlock.getRawKeyBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
+                mapBlock.getRawValueBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER);
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable);
+        return INSTANCE_SIZE +
+                mapBlock.getRawKeyBlock().getRetainedSizeInBytes() +
+                mapBlock.getRawValueBlock().getRetainedSizeInBytes() +
+                mapBlock.getHashTables().getRetainedSizeInBytes();
     }
 
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
-        consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
-        consumer.accept(hashTable, sizeOf(hashTable));
+        consumer.accept(mapBlock.getRawKeyBlock(), mapBlock.getRawKeyBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getRawValueBlock(), mapBlock.getRawValueBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getHashTables(), mapBlock.getHashTables().getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -95,13 +93,13 @@ public class SingleMapBlock
     @Override
     Block getRawKeyBlock()
     {
-        return keyBlock;
+        return mapBlock.getRawKeyBlock();
     }
 
     @Override
     Block getRawValueBlock()
     {
-        return valueBlock;
+        return mapBlock.getRawValueBlock();
     }
 
     @Override
@@ -113,33 +111,36 @@ public class SingleMapBlock
     @Override
     public boolean isLoaded()
     {
-        return keyBlock.isLoaded() && valueBlock.isLoaded();
+        return mapBlock.getRawKeyBlock().isLoaded() && mapBlock.getRawValueBlock().isLoaded();
     }
 
     @Override
     public Block getLoadedBlock()
     {
-        if (keyBlock != keyBlock.getLoadedBlock()) {
+        if (mapBlock.getRawKeyBlock() != mapBlock.getRawKeyBlock().getLoadedBlock()) {
             // keyBlock has to be loaded since MapBlock constructs hash table eagerly.
             throw new IllegalStateException();
         }
 
-        Block loadedValueBlock = valueBlock.getLoadedBlock();
-        if (loadedValueBlock == valueBlock) {
+        Block loadedValueBlock = mapBlock.getRawValueBlock().getLoadedBlock();
+        if (loadedValueBlock == mapBlock.getRawValueBlock()) {
             return this;
         }
         return new SingleMapBlock(
-                mapType,
                 offset,
                 positionCount,
-                keyBlock,
-                loadedValueBlock,
-                hashTable);
+                mapBlock);
     }
 
+    @Nullable
     int[] getHashTable()
     {
-        return hashTable;
+        return mapBlock.getHashTables().get().orElse(null);
+    }
+
+    Type getMapType()
+    {
+        return mapBlock.mapType;
     }
 
     /**
@@ -151,9 +152,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invoke(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invoke(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -170,7 +174,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invoke(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invoke(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -195,9 +199,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invokeExact(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -214,7 +221,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -236,9 +243,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invokeExact(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -255,7 +265,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -277,9 +287,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invokeExact(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -296,7 +309,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -318,9 +331,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invokeExact(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -337,7 +353,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -359,9 +375,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) mapType.getKeyNativeHashCode().invokeExact(nativeValue);
+            hashCode = (long) mapBlock.mapType.getKeyNativeHashCode().invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -378,7 +397,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) mapType.getKeyBlockNativeEquals().invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.mapType.getKeyBlockNativeEquals().invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);

--- a/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/SingleMapBlockEncoding.java
@@ -20,6 +20,8 @@ import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSerde;
 
+import java.util.Optional;
+
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.prestosql.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static java.lang.String.format;
@@ -47,15 +49,23 @@ public class SingleMapBlockEncoding
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         SingleMapBlock singleMapBlock = (SingleMapBlock) block;
-        TypeSerde.writeType(sliceOutput, singleMapBlock.mapType);
+        TypeSerde.writeType(sliceOutput, singleMapBlock.getMapType());
 
         int offset = singleMapBlock.getOffset();
         int positionCount = singleMapBlock.getPositionCount();
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawKeyBlock().getRegion(offset / 2, positionCount / 2));
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawValueBlock().getRegion(offset / 2, positionCount / 2));
         int[] hashTable = singleMapBlock.getHashTable();
-        sliceOutput.appendInt(positionCount / 2 * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, positionCount / 2 * HASH_MULTIPLIER));
+
+        if (hashTable != null) {
+            int hashTableLength = positionCount / 2 * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength);  // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);
+        }
     }
 
     @Override
@@ -66,14 +76,33 @@ public class SingleMapBlockEncoding
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
-
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
-            throw new IllegalArgumentException(
-                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
         }
 
-        return new SingleMapBlock(mapType, 0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable);
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
+        }
+
+        MapBlock mapBlock = MapBlock.createMapBlockInternal(
+                mapType,
+                0,
+                1,
+                Optional.empty(),
+                new int[] {0, keyBlock.getPositionCount()},
+                keyBlock,
+                valueBlock,
+                new AbstractMapBlock.HashTables(Optional.ofNullable(hashTable), 1, hashTableLength));
+
+        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, mapBlock);
     }
 }


### PR DESCRIPTION
I try to port the new implementation of Lazily build hashtable to prestosql.

This PR contains

prestodb/presto#12198 New implementation of lazily build hashtable
prestodb/presto#13371 Fix MapBlock.ensureHashTableLoaded

We confirmed 6% performance improvement in the test with query including map type that need to be built.