### PR TITLE
Fix RemoveUnreferencedScalarSubqueries rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -63,6 +63,16 @@ public final class QueryCardinalityUtil
         return Range.closed(0L, maxCardinality).encloses(extractCardinality(node, lookup));
     }
 
+    public static boolean isAtLeastScalar(PlanNode node, Lookup lookup)
+    {
+        return isAtLeast(node, lookup, 1L);
+    }
+
+    public static boolean isAtLeast(PlanNode node, Lookup lookup, long minCardinality)
+    {
+        return Range.atLeast(minCardinality).encloses(extractCardinality(node, lookup));
+    }
+
     public static Range<Long> extractCardinality(PlanNode node)
     {
         return extractCardinality(node, noLookup());


### PR DESCRIPTION
Fixes incorrectly pruned unreferenced scalar input of correlated join.
The results were incorrect for LEFT / FULL correlated join in the case of empty subquery. By removing the input, empty result was obtained, while it should be `null`.
Also, pruning the input was incorrect in the case of correlation present. The remaining correlated subquery couldn't be decorrelated.