### PR TITLE
Fix TransformUncorrelatedSubqueryToJoin rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -1345,6 +1345,14 @@ class StatementAnalyzer
                         }
                     }
                 }
+                else if (node.getType() == FULL) {
+                    if (!(criteria instanceof JoinOn) || !((JoinOn) criteria).getExpression().equals(TRUE_LITERAL)) {
+                        throw semanticException(
+                                NOT_SUPPORTED,
+                                criteria instanceof JoinOn ? ((JoinOn) criteria).getExpression() : node,
+                                "FULL JOIN involving LATERAL relation is only supported with condition ON TRUE");
+                    }
+                }
             }
 
             if (criteria instanceof JoinUsing) {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -60,7 +60,6 @@ import io.prestosql.sql.tree.InPredicate;
 import io.prestosql.sql.tree.Intersect;
 import io.prestosql.sql.tree.Join;
 import io.prestosql.sql.tree.JoinCriteria;
-import io.prestosql.sql.tree.JoinOn;
 import io.prestosql.sql.tree.JoinUsing;
 import io.prestosql.sql.tree.LambdaArgumentDeclaration;
 import io.prestosql.sql.tree.Lateral;
@@ -224,14 +223,7 @@ class RelationPlanner
 
         Optional<Unnest> unnest = getUnnest(node.getRight());
         if (unnest.isPresent()) {
-            if (node.getType() == CROSS || node.getType() == IMPLICIT) {
-                return planJoinUnnest(leftPlan, node, unnest.get());
-            }
-            checkState(node.getCriteria().isPresent(), "missing Join criteria");
-            if (node.getCriteria().get() instanceof JoinOn && ((JoinOn) node.getCriteria().get()).getExpression().equals(TRUE_LITERAL)) {
-                return planJoinUnnest(leftPlan, node, unnest.get());
-            }
-            throw semanticException(NOT_SUPPORTED, unnest.get(), "UNNEST in conditional JOIN is not supported");
+            return planJoinUnnest(leftPlan, node, unnest.get());
         }
 
         Optional<Lateral> lateral = getLateral(node.getRight());

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -2002,6 +2002,14 @@ public class TestAnalyzer
                 .hasErrorCode(INVALID_COLUMN_REFERENCE);
         assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true")
                 .hasErrorCode(INVALID_COLUMN_REFERENCE);
+        // FULL join involving LATERAL relation only supported with condition ON TRUE
+        analyze("SELECT * FROM (VALUES 1) FULL OUTER JOIN LATERAL(VALUES 2) ON true");
+        assertFails("SELECT * FROM (VALUES 1) a(x) FULL OUTER JOIN LATERAL(VALUES 2) b(x) USING (x)")
+                .hasErrorCode(NOT_SUPPORTED);
+        assertFails("SELECT * FROM (VALUES 1) FULL OUTER JOIN LATERAL(VALUES 2) ON 1 = 1")
+                .hasErrorCode(NOT_SUPPORTED);
+        assertFails("SELECT * FROM (VALUES 1) FULL OUTER JOIN LATERAL(VALUES 2) ON false")
+                .hasErrorCode(NOT_SUPPORTED);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -1982,6 +1982,14 @@ public class TestAnalyzer
                 .hasErrorCode(INVALID_COLUMN_REFERENCE);
         assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN UNNEST(x) ON true")
                 .hasErrorCode(INVALID_COLUMN_REFERENCE);
+        // Join involving UNNEST only supported without condition (cross join) or with condition ON TRUE
+        analyze("SELECT * FROM (VALUES 1), UNNEST(array[2])");
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) LEFT JOIN UNNEST(x) b(x) USING (x)")
+                .hasErrorCode(NOT_SUPPORTED);
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) LEFT JOIN UNNEST(x) ON 1 = 1")
+                .hasErrorCode(NOT_SUPPORTED);
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) LEFT JOIN UNNEST(x) ON false")
+                .hasErrorCode(NOT_SUPPORTED);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
@@ -116,7 +116,7 @@ public class TestUnnest
                 "VALUES (ARRAY[], null, CAST(NULL AS bigint))");
         assertions.assertFails(
                 "SELECT * FROM (VALUES ARRAY[1, null]) a(x) LEFT OUTER JOIN UNNEST(x) b(y) ON b.y = 1",
-                "line .*: UNNEST in conditional JOIN is not supported");
+                "line .*: LEFT JOIN involving UNNEST is only supported with condition ON TRUE");
         assertions.assertQuery(
                 "SELECT * FROM (VALUES 'a', 'b') LEFT JOIN UNNEST(ARRAY[]) ON TRUE",
                 "VALUES ('a', null), ('b', null)");
@@ -147,7 +147,7 @@ public class TestUnnest
                 "VALUES (ARRAY[1, null], 2, BIGINT '1'), (ARRAY[1, null], null, BIGINT '2')");
         assertions.assertFails(
                 "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(ARRAY[2, null]) b(y) ON b.y = 1",
-                "line .*: UNNEST in conditional JOIN is not supported");
+                "line .*: RIGHT JOIN involving UNNEST is only supported with condition ON TRUE");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class TestUnnest
                 "VALUES (ARRAY[], 2, BIGINT '1'), (ARRAY[], null, BIGINT '2')");
         assertions.assertFails(
                 "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) b(y) ON b.y = 1",
-                "line .*: UNNEST in conditional JOIN is not supported");
+                "line .*: FULL JOIN involving UNNEST is only supported with condition ON TRUE");
     }
 
     @Test
@@ -186,6 +186,6 @@ public class TestUnnest
                 "SELECT * FROM (VALUES ARRAY[]) a(x) INNER JOIN UNNEST(x) WITH ORDINALITY ON true");
         assertions.assertFails(
                 "SELECT * FROM (VALUES ARRAY[1, null]) a(x) INNER JOIN UNNEST(x) b(y) ON b.y = 1",
-                "line .*: UNNEST in conditional JOIN is not supported");
+                "line .*: INNER JOIN involving UNNEST is only supported with condition ON TRUE");
     }
 }


### PR DESCRIPTION
Before this change, the TransformUncorrelatedSubqueryToJoin rule
caused incorrect results for CorrelatedJoinNode of type RIGHT or FULL
in the case of empty input.
These nodes used to be rewritten to JoinNode of type RIGHT or FULL,
respectively. As a consequence, in the case of empty input and non-empty
subquery, non-empty result was returned, while accordingly to the
semantics of LATERAL derived relation, it should be empty.

It was fixed by rewriting RIGHT or FULL CorrelatedJoinNode
to INNER or LEFT JoinNode, respectively, with filter TRUE.
If the CorrelatedJoinNode's condition is other than ON TRUE, it is:
- applied as a Projection in the case of RIGHT CorrelatedJoinNode,
- unsupported in the case of FULL CorrelatedJoinNode.