### PR TITLE
Create presto cli history file if it doesn't exist

### DIFF
--- a/presto-product-tests/bin/run_presto_cli_on_docker.sh
+++ b/presto-product-tests/bin/run_presto_cli_on_docker.sh
@@ -16,4 +16,8 @@ if [[ ! -f "$DOCKER_CONF_LOCATION/$ENVIRONMENT/compose.sh" ]]; then
   usage
 fi
 
+# create CLI history file (otherwise Docker creates it as a directory)
+export PRESTO_CLI_HISTORY_FILE="/tmp/presto_history_docker"
+touch "${PRESTO_CLI_HISTORY_FILE}"
+
 environment_compose run -p 5008:5008 application-runner /docker/presto-product-tests/conf/docker/files/presto-cli.sh "$@"

--- a/presto-product-tests/bin/run_tempto_on_docker.sh
+++ b/presto-product-tests/bin/run_tempto_on_docker.sh
@@ -16,4 +16,8 @@ if [[ ! -f "$DOCKER_CONF_LOCATION/$ENVIRONMENT/compose.sh" ]]; then
   usage
 fi
 
+# create CLI history file (otherwise Docker creates it as a directory)
+export PRESTO_CLI_HISTORY_FILE="/tmp/presto_history_docker"
+touch "${PRESTO_CLI_HISTORY_FILE}"
+
 environment_compose run -p 5007:5007 application-runner /docker/presto-product-tests/conf/docker/files/run-tempto.sh "$@"

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -27,7 +27,8 @@ source "${BASH_SOURCE%/*}/../../../conf/product-tests-defaults.sh"
 source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
 
 # create CLI history file (otherwise Docker creates it as a directory)
-touch /tmp/presto_history_docker
+export PRESTO_CLI_HISTORY_FILE="/tmp/presto_history_docker"
+touch "${PRESTO_CLI_HISTORY_FILE}"
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars
 # and without building the project. The `presto.env` file should only be sourced if any of the variables

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -54,7 +54,7 @@ services:
       - ${PRESTO_JDBC_DRIVER_JAR_DIR}:/docker/volumes/jdbc/
       - ${PRESTO_JDBC_DRIVER_JAR}:/docker/presto-jdbc.jar
       - ../../../target/test-reports:/docker/test-reports
-      - /tmp/presto_history_docker:/root/.presto_history
+      - ${PRESTO_CLI_HISTORY_FILE}:/root/.presto_history
     environment:
       - PRESTO_JDBC_DRIVER_CLASS
       - TESTS_HIVE_VERSION_MAJOR


### PR DESCRIPTION
Docker creates an empty directory when an non-existing path is being
mounted. This behaviour can cause an error from presto cli because it
requires .presto_history to be a regular file.