### PR TITLE
Display PreparedQuery in Web UI

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -968,6 +968,29 @@ export class QueryDetail extends React.Component {
         );
     }
 
+    renderPreparedQuery() {
+        const query = this.state.query;
+        if (query.preparedQuery === null) {
+            return;
+        }
+
+        return (
+            <div className="col-xs-12">
+                <h3>
+                    Prepared Query
+                        <a className="btn copy-button" data-clipboard-target="#prepared-query-text" data-toggle="tooltip" data-placement="right" title="Copy to clipboard">
+                            <span className="glyphicon glyphicon-copy" aria-hidden="true" alt="Copy to clipboard"/>
+                        </a>
+                </h3>
+                <pre id="prepared-query">
+                    <code className="lang-sql" id="prepared-query-text">
+                        {query.preparedQuery}
+                    </code>
+                </pre>
+            </div>
+        );
+    }
+
     renderSessionProperties() {
         const query = this.state.query;
 
@@ -1549,6 +1572,7 @@ export class QueryDetail extends React.Component {
                             </code>
                         </pre>
                     </div>
+                    {this.renderPreparedQuery()}
                 </div>
                 {this.renderStages()}
                 {this.renderTasks()}


### PR DESCRIPTION
This patch displays the Prepared Query along with the Execute statement in the WebUI. 

Before applying this patch : 
<img width="1322" alt="Screenshot 2019-11-07 at 7 20 14 PM" src="https://user-images.githubusercontent.com/8536261/68394564-13f78e80-0194-11ea-884a-5c58c2189dbc.png">


After applying this patch : 
<img width="1322" alt="Screenshot 2019-11-07 at 7 15 19 PM" src="https://user-images.githubusercontent.com/8536261/68394601-2b367c00-0194-11ea-8b21-1fcdbe9ed0e8.png">
