### PR TITLE
Resolve issue with IS DISTINCT FROM and Decimal values with precision > 18

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalInequalityOperators.java
@@ -205,8 +205,8 @@ public final class DecimalInequalityOperators
 
         long leftLow = left.getLong(leftPosition, 0);
         long leftHigh = left.getLong(leftPosition, SIZE_OF_LONG);
-        long rightLow = left.getLong(rightPosition, 0);
-        long rightHigh = left.getLong(rightPosition, SIZE_OF_LONG);
+        long rightLow = right.getLong(rightPosition, 0);
+        long rightHigh = right.getLong(rightPosition, SIZE_OF_LONG);
         return UnscaledDecimal128Arithmetic.compare(leftLow, leftHigh, rightLow, rightHigh) != 0;
     }
 

--- a/presto-main/src/test/java/io/prestosql/block/TestInt128ArrayBlock.java
+++ b/presto-main/src/test/java/io/prestosql/block/TestInt128ArrayBlock.java
@@ -88,11 +88,8 @@ public class TestInt128ArrayBlock
     @Test
     public void testIsDistinctFrom()
     {
-        long[] arr1 = {112L, 0L}; // DECIMAL '1.12'
-        long[] arr2 = {185L, 0L}; // DECIMAL '1.85'
-
-        Block left = new Int128ArrayBlock(1, Optional.empty(), arr1);
-        Block right = new Int128ArrayBlock(1, Optional.empty(), arr2);
+        Block left = new Int128ArrayBlock(1, Optional.empty(), new long[]{112L, 0L});
+        Block right = new Int128ArrayBlock(1, Optional.empty(), new long[]{185L, 0L});
 
         assertFalse(DecimalInequalityOperators.distinctBlockPositionLongLong(left, 0, left, 0));
         assertTrue(DecimalInequalityOperators.distinctBlockPositionLongLong(left, 0, right, 0));

--- a/presto-main/src/test/java/io/prestosql/block/TestInt128ArrayBlock.java
+++ b/presto-main/src/test/java/io/prestosql/block/TestInt128ArrayBlock.java
@@ -14,16 +14,19 @@
 package io.prestosql.block;
 
 import io.airlift.slice.Slice;
+import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.block.Int128ArrayBlock;
 import io.prestosql.spi.block.Int128ArrayBlockBuilder;
 import io.prestosql.spi.block.VariableWidthBlockBuilder;
+import io.prestosql.type.DecimalInequalityOperators;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static io.prestosql.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestInt128ArrayBlock
@@ -80,6 +83,19 @@ public class TestInt128ArrayBlock
         testCompactBlock(new Int128ArrayBlock(0, Optional.empty(), new long[0]));
         testCompactBlock(new Int128ArrayBlock(valueIsNull.length, Optional.of(valueIsNull), longArray));
         testIncompactBlock(new Int128ArrayBlock(valueIsNull.length - 2, Optional.of(valueIsNull), longArray));
+    }
+
+    @Test
+    public void testIsDistinctFrom()
+    {
+        long[] arr1 = {112L, 0L}; // DECIMAL '1.12'
+        long[] arr2 = {185L, 0L}; // DECIMAL '1.85'
+
+        Block left = new Int128ArrayBlock(1, Optional.empty(), arr1);
+        Block right = new Int128ArrayBlock(1, Optional.empty(), arr2);
+
+        assertFalse(DecimalInequalityOperators.distinctBlockPositionLongLong(left, 0, left, 0));
+        assertTrue(DecimalInequalityOperators.distinctBlockPositionLongLong(left, 0, right, 0));
     }
 
     private void assertFixedWithValues(Slice[] expectedValues)


### PR DESCRIPTION
Correct the logic in method `distinctBlockPositionLongLong` to get the proper values for `rightLow` and `rightHigh`.

This PR resolve issue https://github.com/prestosql/presto/issues/1984.