### PR TITLE
Do not allocate resources within test constructor

### DIFF
--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoins.java
@@ -55,12 +55,8 @@ public class TestSpatialJoins
             "(7.1, 7.2, 'z', 3), " +
             "(null, 1.2, 'null', 4)";
 
-    public TestSpatialJoins()
-    {
-        super(() -> createQueryRunner());
-    }
-
-    private static DistributedQueryRunner createQueryRunner()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         DistributedQueryRunner queryRunner = new DistributedQueryRunner(testSessionBuilder()

--- a/presto-google-sheets/src/test/java/io/prestosql/plugin/google/sheets/TestGoogleSheets.java
+++ b/presto-google-sheets/src/test/java/io/prestosql/plugin/google/sheets/TestGoogleSheets.java
@@ -29,11 +29,6 @@ public class TestGoogleSheets
 {
     protected static final String GOOGLE_SHEETS = "gsheets";
 
-    public TestGoogleSheets()
-    {
-        super(() -> createQueryRunner());
-    }
-
     private static Session createSession()
     {
         return testSessionBuilder()
@@ -42,7 +37,8 @@ public class TestGoogleSheets
                 .build();
     }
 
-    private static QueryRunner createQueryRunner()
+    @Override
+    protected QueryRunner createQueryRunner()
     {
         QueryRunner queryRunner;
         try {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedAggregations.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedAggregations.java
@@ -14,15 +14,17 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.testing.AbstractTestAggregations;
+import io.prestosql.testing.QueryRunner;
 
 import static io.airlift.tpch.TpchTable.getTables;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 
 public class TestHiveDistributedAggregations
         extends AbstractTestAggregations
 {
-    public TestHiveDistributedAggregations()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueries.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueries.java
@@ -14,15 +14,17 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.testing.AbstractTestJoinQueries;
+import io.prestosql.testing.QueryRunner;
 
 import static io.airlift.tpch.TpchTable.getTables;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 
 public class TestHiveDistributedJoinQueries
         extends AbstractTestJoinQueries
 {
-    public TestHiveDistributedJoinQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueriesWithDynamicFiltering.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueriesWithDynamicFiltering.java
@@ -27,21 +27,23 @@ import io.prestosql.sql.planner.plan.TableScanNode;
 import io.prestosql.testing.AbstractTestJoinQueries;
 import io.prestosql.testing.DistributedQueryRunner;
 import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
 import io.prestosql.testing.ResultWithQueryId;
 import org.testng.annotations.Test;
 
 import static io.airlift.tpch.TpchTable.getTables;
 import static io.prestosql.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveDistributedJoinQueriesWithDynamicFiltering
         extends AbstractTestJoinQueries
 {
-    public TestHiveDistributedJoinQueriesWithDynamicFiltering()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedOrderByQueries.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedOrderByQueries.java
@@ -14,15 +14,17 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.testing.AbstractTestOrderByQueries;
+import io.prestosql.testing.QueryRunner;
 
 import static io.airlift.tpch.TpchTable.getTables;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 
 public class TestHiveDistributedOrderByQueries
         extends AbstractTestOrderByQueries
 {
-    public TestHiveDistributedOrderByQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedQueries.java
@@ -15,20 +15,22 @@ package io.prestosql.plugin.hive;
 
 import io.prestosql.testing.AbstractTestDistributedQueries;
 import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.tpch.TpchTable.getTables;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 import static io.prestosql.sql.tree.ExplainType.Type.LOGICAL;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    public TestHiveDistributedQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedWindowQueries.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedWindowQueries.java
@@ -14,15 +14,17 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.testing.AbstractTestWindowQueries;
+import io.prestosql.testing.QueryRunner;
 
 import static io.airlift.tpch.TpchTable.getTables;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 
 public class TestHiveDistributedWindowQueries
         extends AbstractTestWindowQueries
 {
-    public TestHiveDistributedWindowQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(getTables()));
+        return HiveQueryRunner.createQueryRunner(getTables());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -48,6 +48,7 @@ import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.DistributedQueryRunner;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.MaterializedRow;
+import io.prestosql.testing.QueryRunner;
 import io.prestosql.type.TypeDeserializer;
 import org.apache.hadoop.fs.Path;
 import org.intellij.lang.annotations.Language;
@@ -90,7 +91,6 @@ import static io.prestosql.plugin.hive.HiveColumnHandle.PATH_COLUMN_NAME;
 import static io.prestosql.plugin.hive.HiveQueryRunner.HIVE_CATALOG;
 import static io.prestosql.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.prestosql.plugin.hive.HiveQueryRunner.createBucketedSession;
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 import static io.prestosql.plugin.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
@@ -142,18 +142,18 @@ public class TestHiveIntegrationSmokeTest
     private final Session bucketedSession;
     private final TypeTranslator typeTranslator;
 
-    @SuppressWarnings("unused")
     public TestHiveIntegrationSmokeTest()
     {
-        this(() -> createQueryRunner(ORDERS, CUSTOMER), createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))), HIVE_CATALOG, new HiveTypeTranslator());
+        this.catalog = HIVE_CATALOG;
+        this.bucketedSession = createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin"))));
+        this.typeTranslator = new HiveTypeTranslator();
     }
 
-    protected TestHiveIntegrationSmokeTest(QueryRunnerSupplier queryRunnerSupplier, Session bucketedSession, String catalog, TypeTranslator typeTranslator)
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(queryRunnerSupplier);
-        this.catalog = requireNonNull(catalog, "catalog is null");
-        this.bucketedSession = requireNonNull(bucketedSession, "bucketSession is null");
-        this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
+        return HiveQueryRunner.createQueryRunner(ORDERS, CUSTOMER);
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestShowStats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestShowStats.java
@@ -15,17 +15,18 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
 
 public class TestShowStats
         extends AbstractTestQueryFramework
 {
-    public TestShowStats()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(() -> createQueryRunner(ImmutableList.of()));
+        return HiveQueryRunner.createQueryRunner(ImmutableList.of());
     }
 
     @BeforeClass

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -45,12 +45,8 @@ public class TestIcebergMetadataListing
 {
     private static HiveMetastore metastore;
 
-    public TestIcebergMetadataListing()
-    {
-        super(TestIcebergMetadataListing::createQueryRunner);
-    }
-
-    private static DistributedQueryRunner createQueryRunner()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder()

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -44,14 +44,8 @@ import static org.testng.Assert.assertEquals;
 public class TestIcebergSystemTables
         extends AbstractTestQueryFramework
 {
-    private static HiveMetastore metastore;
-
-    public TestIcebergSystemTables()
-    {
-        super(TestIcebergSystemTables::createQueryRunner);
-    }
-
-    private static DistributedQueryRunner createQueryRunner()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -65,7 +59,7 @@ public class TestIcebergSystemTables
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
 
-        metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+        HiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
 
         queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
         queryRunner.createCatalog("iceberg", "iceberg");

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.postgresql;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -34,20 +35,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestPostgreSqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework
 {
-    private final TestingPostgreSqlServer postgreSqlServer;
+    private TestingPostgreSqlServer postgreSqlServer;
 
-    public TestPostgreSqlCaseInsensitiveMapping()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        this(new TestingPostgreSqlServer());
-    }
-
-    public TestPostgreSqlCaseInsensitiveMapping(TestingPostgreSqlServer postgreSqlServer)
-    {
-        super(() -> PostgreSqlQueryRunner.createPostgreSqlQueryRunner(
+        this.postgreSqlServer = new TestingPostgreSqlServer();
+        return PostgreSqlQueryRunner.createPostgreSqlQueryRunner(
                 postgreSqlServer,
                 ImmutableMap.of("case-insensitive-name-matching", "true"),
-                ImmutableSet.of()));
-        this.postgreSqlServer = postgreSqlServer;
+                ImmutableSet.of());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.postgresql;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.testing.AbstractTestDistributedQueries;
+import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -25,17 +26,14 @@ import static io.prestosql.plugin.postgresql.PostgreSqlQueryRunner.createPostgre
 public class TestPostgreSqlDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    private final TestingPostgreSqlServer postgreSqlServer;
+    private TestingPostgreSqlServer postgreSqlServer;
 
-    public TestPostgreSqlDistributedQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        this(new TestingPostgreSqlServer());
-    }
-
-    public TestPostgreSqlDistributedQueries(TestingPostgreSqlServer postgreSqlServer)
-    {
-        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of(), TpchTable.getTables()));
-        this.postgreSqlServer = postgreSqlServer;
+        this.postgreSqlServer = new TestingPostgreSqlServer();
+        return createPostgreSqlQueryRunner(postgreSqlServer, ImmutableMap.of(), TpchTable.getTables());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.postgresql;
 
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -35,20 +36,15 @@ import static org.testng.Assert.assertTrue;
 public class TestPostgreSqlIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final TestingPostgreSqlServer postgreSqlServer;
+    private TestingPostgreSqlServer postgreSqlServer;
 
-    public TestPostgreSqlIntegrationSmokeTest()
+    @Override
+    protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this(new TestingPostgreSqlServer());
-    }
-
-    public TestPostgreSqlIntegrationSmokeTest(TestingPostgreSqlServer postgreSqlServer)
-            throws Exception
-    {
-        super(() -> PostgreSqlQueryRunner.createPostgreSqlQueryRunner(postgreSqlServer, ORDERS));
-        this.postgreSqlServer = postgreSqlServer;
+        this.postgreSqlServer = new TestingPostgreSqlServer();
         execute("CREATE EXTENSION file_fdw");
+        return PostgreSqlQueryRunner.createPostgreSqlQueryRunner(postgreSqlServer, ORDERS);
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -20,6 +20,7 @@ import io.prestosql.Session;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.QueryRunner;
 import io.prestosql.testing.TestingSession;
 import io.prestosql.testing.datatype.CreateAndInsertDataSetup;
 import io.prestosql.testing.datatype.CreateAndPrestoInsertDataSetup;
@@ -90,7 +91,7 @@ import static java.util.stream.Collectors.toList;
 public class TestPostgreSqlTypeMapping
         extends AbstractTestQueryFramework
 {
-    private final TestingPostgreSqlServer postgreSqlServer;
+    private TestingPostgreSqlServer postgreSqlServer;
 
     private LocalDateTime beforeEpoch;
     private LocalDateTime epoch;
@@ -110,18 +111,15 @@ public class TestPostgreSqlTypeMapping
     private ZoneId kathmandu;
     private LocalDateTime timeGapInKathmandu;
 
-    public TestPostgreSqlTypeMapping()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        this(new TestingPostgreSqlServer());
-    }
-
-    private TestPostgreSqlTypeMapping(TestingPostgreSqlServer postgreSqlServer)
-    {
-        super(() -> createPostgreSqlQueryRunner(
+        this.postgreSqlServer = new TestingPostgreSqlServer();
+        return createPostgreSqlQueryRunner(
                 postgreSqlServer,
                 ImmutableMap.of("jdbc-types-mapped-to-varchar", "Tsrange, Inet" /* make sure that types are compared case insensitively */),
-                ImmutableList.of()));
-        this.postgreSqlServer = postgreSqlServer;
+                ImmutableList.of());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
@@ -25,10 +25,13 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestAggregations
         extends AbstractTestQueryFramework
 {
-    public AbstractTestAggregations(QueryRunnerSupplier supplier)
+    @Deprecated
+    protected AbstractTestAggregations(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestAggregations() {}
 
     @Test
     public void testCountBoolean()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -76,6 +76,8 @@ public abstract class AbstractTestDistributedQueries
         super(supplier);
     }
 
+    protected AbstractTestDistributedQueries() {}
+
     protected boolean supportsViews()
     {
         return true;

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIndexedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIndexedQueries.java
@@ -33,10 +33,13 @@ public abstract class AbstractTestIndexedQueries
             .addIndex("orders", TpchMetadata.TINY_SCALE_FACTOR, ImmutableSet.of("orderstatus", "shippriority"))
             .build();
 
+    @Deprecated
     protected AbstractTestIndexedQueries(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestIndexedQueries() {}
 
     @Test
     public void testExampleSystemTable()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -23,10 +23,13 @@ import static io.prestosql.testing.assertions.Assert.assertEquals;
 public abstract class AbstractTestIntegrationSmokeTest
         extends AbstractTestQueryFramework
 {
+    @Deprecated
     protected AbstractTestIntegrationSmokeTest(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestIntegrationSmokeTest() {}
 
     protected boolean isDateTypeSupported()
     {

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
@@ -36,10 +36,13 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestJoinQueries
         extends AbstractTestQueryFramework
 {
-    public AbstractTestJoinQueries(QueryRunnerSupplier supplier)
+    @Deprecated
+    protected AbstractTestJoinQueries(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestJoinQueries() {}
 
     @Test
     public void testJoinWithMultiFieldGroupBy()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestOrderByQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestOrderByQueries.java
@@ -26,10 +26,13 @@ import static io.prestosql.tests.QueryTemplate.queryTemplate;
 public abstract class AbstractTestOrderByQueries
         extends AbstractTestQueryFramework
 {
-    public AbstractTestOrderByQueries(QueryRunnerSupplier supplier)
+    @Deprecated
+    protected AbstractTestOrderByQueries(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestOrderByQueries() {}
 
     @Test
     public void testOrderBy()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -134,10 +134,13 @@ public abstract class AbstractTestQueries
 
     private static final String UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG = "line .*: Given correlated subquery is not supported";
 
+    @Deprecated
     protected AbstractTestQueries(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestQueries() {}
 
     @Test
     public void testParsingError()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -66,23 +66,41 @@ import static org.testng.Assert.fail;
 
 public abstract class AbstractTestQueryFramework
 {
-    private QueryRunnerSupplier queryRunnerSupplier;
+    @Deprecated
+    private Optional<QueryRunnerSupplier> queryRunnerSupplier;
     private QueryRunner queryRunner;
     private H2QueryRunner h2QueryRunner;
     private SqlParser sqlParser;
 
+    @Deprecated
     protected AbstractTestQueryFramework(QueryRunnerSupplier supplier)
     {
-        this.queryRunnerSupplier = requireNonNull(supplier, "queryRunnerSupplier is null");
+        this.queryRunnerSupplier = Optional.of(requireNonNull(supplier, "queryRunnerSupplier is null"));
+    }
+
+    protected AbstractTestQueryFramework()
+    {
+        this.queryRunnerSupplier = Optional.empty();
     }
 
     @BeforeClass
     public void init()
             throws Exception
     {
-        queryRunner = queryRunnerSupplier.get();
+        if (queryRunnerSupplier.isPresent()) {
+            queryRunner = queryRunnerSupplier.get().get();
+        }
+        else {
+            queryRunner = createQueryRunner();
+        }
         h2QueryRunner = new H2QueryRunner();
         sqlParser = new SqlParser();
+    }
+
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        throw new UnsupportedOperationException("Must implement createQueryRunner() when QueryRunnerSupplier is not provided");
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestWindowQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestWindowQueries.java
@@ -29,10 +29,13 @@ import static io.prestosql.testing.assertions.Assert.assertEquals;
 public abstract class AbstractTestWindowQueries
         extends AbstractTestQueryFramework
 {
-    public AbstractTestWindowQueries(QueryRunnerSupplier supplier)
+    @Deprecated
+    protected AbstractTestWindowQueries(QueryRunnerSupplier supplier)
     {
         super(supplier);
     }
+
+    protected AbstractTestWindowQueries() {}
 
     @Test
     public void testRowFieldAccessorInWindowFunction()
@@ -606,20 +609,20 @@ public abstract class AbstractTestWindowQueries
                         "lag(c, 1) RESPECT NULLS OVER (PARTITION BY b ORDER BY a), " +
                         "lag(c, 1) IGNORE NULLS OVER (PARTITION BY b ORDER BY a) " +
                         "FROM ( VALUES " +
-                            "(1, 'A', 'a'), " +
-                            "(2, 'A', NULL), " +
-                            "(3, 'A', 'c'), " +
-                            "(4, 'A', NULL), " +
-                            "(5, 'A', 'e'), " +
-                            "(6, 'A', NULL)" +
-                            ") t(a, b, c)",
+                        "(1, 'A', 'a'), " +
+                        "(2, 'A', NULL), " +
+                        "(3, 'A', 'c'), " +
+                        "(4, 'A', NULL), " +
+                        "(5, 'A', 'e'), " +
+                        "(6, 'A', NULL)" +
+                        ") t(a, b, c)",
                 "VALUES " +
-                            "(1, 'A', 'a', null, null), " +
-                            "(2, 'A', null, 'a', 'a'), " +
-                            "(3, 'A', 'c', null, 'a'), " +
-                            "(4, 'A', null, 'c', 'c'), " +
-                            "(5, 'A', 'e', null, 'c'), " +
-                            "(6, 'A', null, 'e', 'e')");
+                        "(1, 'A', 'a', null, null), " +
+                        "(2, 'A', null, 'a', 'a'), " +
+                        "(3, 'A', 'c', null, 'a'), " +
+                        "(4, 'A', null, 'c', 'c'), " +
+                        "(5, 'A', 'e', null, 'c'), " +
+                        "(6, 'A', null, 'e', 'e')");
 
         assertQueryOrdered(
                 "SELECT a, b, c, " +

--- a/presto-tests/src/test/java/io/prestosql/connector/system/TestSystemConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/connector/system/TestSystemConnector.java
@@ -61,12 +61,8 @@ public class TestSystemConnector
 
     private final ExecutorService executor = Executors.newSingleThreadScheduledExecutor(threadsNamed(TestSystemConnector.class.getSimpleName()));
 
-    protected TestSystemConnector()
-    {
-        super(TestSystemConnector::createQueryRunner);
-    }
-
-    public static QueryRunner createQueryRunner()
+    @Override
+    protected QueryRunner createQueryRunner()
             throws Exception
     {
         Session defaultSession = testSessionBuilder()

--- a/presto-tests/src/test/java/io/prestosql/execution/TestBeginQuery.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestBeginQuery.java
@@ -61,12 +61,8 @@ public class TestBeginQuery
 {
     private TestMetadata metadata;
 
-    protected TestBeginQuery()
-    {
-        super(TestBeginQuery::createQueryRunner);
-    }
-
-    private static QueryRunner createQueryRunner()
+    @Override
+    protected QueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder()

--- a/presto-tests/src/test/java/io/prestosql/tests/TestDistributedQueriesIndexed.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestDistributedQueriesIndexed.java
@@ -24,12 +24,8 @@ import static io.prestosql.testing.TestingSession.testSessionBuilder;
 public class TestDistributedQueriesIndexed
         extends AbstractTestIndexedQueries
 {
-    public TestDistributedQueriesIndexed()
-    {
-        super(TestDistributedQueriesIndexed::createQueryRunner);
-    }
-
-    private static DistributedQueryRunner createQueryRunner()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder()

--- a/presto-tests/src/test/java/io/prestosql/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestDistributedSpilledQueries.java
@@ -28,12 +28,14 @@ import static io.prestosql.testing.TestingSession.testSessionBuilder;
 public class TestDistributedSpilledQueries
         extends AbstractTestQueries
 {
-    public TestDistributedSpilledQueries()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
     {
-        super(TestDistributedSpilledQueries::createQueryRunner);
+        return createSpillingQueryRunner();
     }
 
-    public static DistributedQueryRunner createQueryRunner()
+    public static DistributedQueryRunner createSpillingQueryRunner()
             throws Exception
     {
         Session defaultSession = testSessionBuilder()

--- a/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
@@ -47,11 +47,6 @@ public class TestInformationSchemaConnector
     private static final AtomicLong LIST_TABLES_CALLS_COUNTER = new AtomicLong();
     private static final AtomicLong GET_COLUMNS_CALLS_COUNTER = new AtomicLong();
 
-    public TestInformationSchemaConnector()
-    {
-        super(TestInformationSchemaConnector::createQueryRunner);
-    }
-
     @Test
     public void testBasic()
     {
@@ -202,7 +197,8 @@ public class TestInformationSchemaConnector
                         .withGetColumnsCount(10008));
     }
 
-    private static DistributedQueryRunner createQueryRunner()
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder().build();

--- a/presto-tests/src/test/java/io/prestosql/tests/TestSpilledAggregations.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestSpilledAggregations.java
@@ -14,12 +14,15 @@
 package io.prestosql.tests;
 
 import io.prestosql.testing.AbstractTestAggregations;
+import io.prestosql.testing.QueryRunner;
 
 public class TestSpilledAggregations
         extends AbstractTestAggregations
 {
-    public TestSpilledAggregations()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(TestDistributedSpilledQueries::createQueryRunner);
+        return TestDistributedSpilledQueries.createSpillingQueryRunner();
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/tests/TestSpilledJoinQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestSpilledJoinQueries.java
@@ -14,12 +14,15 @@
 package io.prestosql.tests;
 
 import io.prestosql.testing.AbstractTestJoinQueries;
+import io.prestosql.testing.QueryRunner;
 
 public class TestSpilledJoinQueries
         extends AbstractTestJoinQueries
 {
-    public TestSpilledJoinQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(TestDistributedSpilledQueries::createQueryRunner);
+        return TestDistributedSpilledQueries.createSpillingQueryRunner();
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/tests/TestSpilledOrderByQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestSpilledOrderByQueries.java
@@ -14,12 +14,15 @@
 package io.prestosql.tests;
 
 import io.prestosql.testing.AbstractTestOrderByQueries;
+import io.prestosql.testing.QueryRunner;
 
 public class TestSpilledOrderByQueries
         extends AbstractTestOrderByQueries
 {
-    public TestSpilledOrderByQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(TestDistributedSpilledQueries::createQueryRunner);
+        return TestDistributedSpilledQueries.createSpillingQueryRunner();
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/tests/TestSpilledWindowQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestSpilledWindowQueries.java
@@ -14,12 +14,15 @@
 package io.prestosql.tests;
 
 import io.prestosql.testing.AbstractTestWindowQueries;
+import io.prestosql.testing.QueryRunner;
 
 public class TestSpilledWindowQueries
         extends AbstractTestWindowQueries
 {
-    public TestSpilledWindowQueries()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        super(TestDistributedSpilledQueries::createQueryRunner);
+        return TestDistributedSpilledQueries.createSpillingQueryRunner();
     }
 }


### PR DESCRIPTION
Maven surefire plugin does not report full exception when it happens
during test class constructor call.