### PR TITLE
Iceberg Connector ORC support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
             <dependency>
                 <groupId>io.prestosql.orc</groupId>
                 <artifactId>orc-protobuf</artifactId>
-                <version>9</version>
+                <version>10</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/FileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/FileWriter.java
@@ -17,7 +17,7 @@ import io.prestosql.spi.Page;
 
 import java.util.Optional;
 
-public interface HiveFileWriter
+public interface FileWriter
 {
     long getWrittenBytes();
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveFileWriterFactory.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 
 public interface HiveFileWriterFactory
 {
-    Optional<HiveFileWriter> createFileWriter(
+    Optional<FileWriter> createFileWriter(
             Path path,
             List<String> inputColumnNames,
             StorageFormat storageFormat,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriter.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public class HiveWriter
 {
-    private final HiveFileWriter fileWriter;
+    private final FileWriter fileWriter;
     private final Optional<String> partitionName;
     private final UpdateMode updateMode;
     private final String fileName;
@@ -38,7 +38,7 @@ public class HiveWriter
     private long inputSizeInBytes;
 
     public HiveWriter(
-            HiveFileWriter fileWriter,
+            FileWriter fileWriter,
             Optional<String> partitionName,
             UpdateMode updateMode,
             String fileName,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -437,9 +437,9 @@ public class HiveWriterFactory
 
         Path path = new Path(writeInfo.getWritePath(), fileNameWithExtension);
 
-        HiveFileWriter hiveFileWriter = null;
+        FileWriter hiveFileWriter = null;
         for (HiveFileWriterFactory fileWriterFactory : fileWriterFactories) {
-            Optional<HiveFileWriter> fileWriter = fileWriterFactory.createFileWriter(
+            Optional<FileWriter> fileWriter = fileWriterFactory.createFileWriter(
                     path,
                     dataColumns.stream()
                             .map(DataColumn::getName)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriter.java
@@ -47,7 +47,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILE
 import static java.util.Objects.requireNonNull;
 
 public class RcFileFileWriter
-        implements HiveFileWriter
+        implements FileWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RcFileFileWriter.class).instanceSize();
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
@@ -85,7 +85,7 @@ public class RcFileFileWriterFactory
     }
 
     @Override
-    public Optional<HiveFileWriter> createFileWriter(
+    public Optional<FileWriter> createFileWriter(
             Path path,
             List<String> inputColumnNames,
             StorageFormat storageFormat,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
@@ -53,7 +53,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 
 public class RecordFileWriter
-        implements HiveFileWriter
+        implements FileWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RecordFileWriter.class).instanceSize();
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/SortingFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/SortingFileWriter.java
@@ -58,7 +58,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
 public class SortingFileWriter
-        implements HiveFileWriter
+        implements FileWriter
 {
     private static final Logger log = Logger.get(SortingFileWriter.class);
 
@@ -70,7 +70,7 @@ public class SortingFileWriter
     private final List<Type> types;
     private final List<Integer> sortFields;
     private final List<SortOrder> sortOrders;
-    private final HiveFileWriter outputWriter;
+    private final FileWriter outputWriter;
     private final SortBuffer sortBuffer;
     private final TempFileSinkFactory tempFileSinkFactory;
     private final Queue<TempFile> tempFiles = new PriorityQueue<>(comparing(TempFile::getSize));
@@ -79,7 +79,7 @@ public class SortingFileWriter
     public SortingFileWriter(
             FileSystem fileSystem,
             Path tempFilePrefix,
-            HiveFileWriter outputWriter,
+            FileWriter outputWriter,
             DataSize maxMemory,
             int maxOpenTempFiles,
             List<Type> types,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
@@ -21,7 +21,7 @@ import io.prestosql.orc.OrcWriter;
 import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
 import io.prestosql.orc.metadata.CompressionKind;
-import io.prestosql.plugin.hive.HiveFileWriter;
+import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
@@ -48,7 +48,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILE
 import static java.util.Objects.requireNonNull;
 
 public class OrcFileWriter
-        implements HiveFileWriter
+        implements FileWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OrcFileWriter.class).instanceSize();
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
@@ -20,7 +20,9 @@ import io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode;
 import io.prestosql.orc.OrcWriter;
 import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
+import io.prestosql.orc.metadata.ColumnMetadata;
 import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
@@ -66,6 +68,7 @@ public class OrcFileWriter
             Callable<Void> rollbackAction,
             List<String> columnNames,
             List<Type> fileColumnTypes,
+            ColumnMetadata<OrcType> fileColumnOrcTypes,
             CompressionKind compression,
             OrcWriterOptions options,
             boolean writeLegacyVersion,
@@ -82,6 +85,7 @@ public class OrcFileWriter
                 orcDataSink,
                 columnNames,
                 fileColumnTypes,
+                fileColumnOrcTypes,
                 compression,
                 options,
                 writeLegacyVersion,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
@@ -23,9 +23,9 @@ import io.prestosql.orc.OrcWriterStats;
 import io.prestosql.orc.OutputStreamOrcDataSink;
 import io.prestosql.orc.metadata.CompressionKind;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
+import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveConfig;
-import io.prestosql.plugin.hive.HiveFileWriter;
 import io.prestosql.plugin.hive.HiveFileWriterFactory;
 import io.prestosql.plugin.hive.HiveMetadata;
 import io.prestosql.plugin.hive.HiveSessionProperties;
@@ -126,7 +126,7 @@ public class OrcFileWriterFactory
     }
 
     @Override
-    public Optional<HiveFileWriter> createFileWriter(
+    public Optional<FileWriter> createFileWriter(
             Path path,
             List<String> inputColumnNames,
             StorageFormat storageFormat,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
@@ -22,6 +22,7 @@ import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
 import io.prestosql.orc.OutputStreamOrcDataSink;
 import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.plugin.hive.HdfsEnvironment;
@@ -182,6 +183,7 @@ public class OrcFileWriterFactory
                     rollbackAction,
                     fileColumnNames,
                     fileColumnTypes,
+                    OrcType.createRootOrcType(fileColumnNames, fileColumnTypes),
                     compression,
                     orcWriterOptions
                             .withStripeMinSize(getOrcOptimizedWriterMinStripeSize(session))

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/TempFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/TempFileWriter.java
@@ -20,6 +20,7 @@ import io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode;
 import io.prestosql.orc.OrcWriter;
 import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
 
@@ -77,6 +78,7 @@ public class TempFileWriter
                 sink,
                 columnNames,
                 types,
+                OrcType.createRootOrcType(columnNames, types),
                 LZ4,
                 new OrcWriterOptions()
                         .withMaxStringStatisticsLimit(new DataSize(0, BYTE))

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -535,7 +535,7 @@ public abstract class AbstractTestHiveFileFormats
                         .map(TestColumn::getType)
                         .collect(Collectors.joining(",")));
 
-        Optional<HiveFileWriter> fileWriter = fileWriterFactory.createFileWriter(
+        Optional<FileWriter> fileWriter = fileWriterFactory.createFileWriter(
                 new Path(filePath),
                 testColumns.stream()
                         .map(TestColumn::getName)
@@ -545,7 +545,7 @@ public abstract class AbstractTestHiveFileFormats
                 jobConf,
                 session);
 
-        HiveFileWriter hiveFileWriter = fileWriter.orElseThrow(() -> new IllegalArgumentException("fileWriterFactory"));
+        FileWriter hiveFileWriter = fileWriter.orElseThrow(() -> new IllegalArgumentException("fileWriterFactory"));
         hiveFileWriter.appendRows(page);
         hiveFileWriter.commit();
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -20,6 +20,7 @@ import io.prestosql.orc.OrcWriter;
 import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
 import io.prestosql.orc.OutputStreamOrcDataSink;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
@@ -450,6 +451,7 @@ public enum FileFormat
                     new OutputStreamOrcDataSink(new FileOutputStream(targetFile)),
                     columnNames,
                     types,
+                    OrcType.createRootOrcType(columnNames, types),
                     compressionCodec.getOrcCompressionKind(),
                     new OrcWriterOptions(),
                     false,

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -43,6 +43,11 @@
 
         <dependency>
             <groupId>io.prestosql</groupId>
+            <artifactId>presto-orc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
             <artifactId>presto-parquet</artifactId>
         </dependency>
 
@@ -162,6 +167,18 @@
             <groupId>${dep.iceberg.groupId}</groupId>
             <artifactId>iceberg-hive</artifactId>
             <version>${dep.iceberg.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${dep.iceberg.groupId}</groupId>
+            <artifactId>iceberg-orc</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -14,12 +14,19 @@
 package io.prestosql.plugin.iceberg;
 
 import io.airlift.configuration.Config;
+import io.prestosql.plugin.hive.HiveCompressionCodec;
+import org.apache.iceberg.FileFormat;
 
 import javax.validation.constraints.Min;
+
+import static io.prestosql.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.prestosql.plugin.iceberg.IcebergFileFormat.ORC;
 
 public class IcebergConfig
 {
     private long metastoreTransactionCacheSize = 1000;
+    private IcebergFileFormat fileFormat = ORC;
+    private HiveCompressionCodec compressionCodec = GZIP;
 
     @Min(1)
     public long getMetastoreTransactionCacheSize()
@@ -31,6 +38,30 @@ public class IcebergConfig
     public IcebergConfig setMetastoreTransactionCacheSize(long metastoreTransactionCacheSize)
     {
         this.metastoreTransactionCacheSize = metastoreTransactionCacheSize;
+        return this;
+    }
+
+    public FileFormat getFileFormat()
+    {
+        return FileFormat.valueOf(fileFormat.name());
+    }
+
+    @Config("iceberg.file-format")
+    public IcebergConfig setFileFormat(IcebergFileFormat fileFormat)
+    {
+        this.fileFormat = fileFormat;
+        return this;
+    }
+
+    public HiveCompressionCodec getCompressionCodec()
+    {
+        return compressionCodec;
+    }
+
+    @Config("iceberg.compression-codec")
+    public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
+    {
+        this.compressionCodec = compressionCodec;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergErrorCode.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergErrorCode.java
@@ -18,6 +18,7 @@ import io.prestosql.spi.ErrorCodeSupplier;
 import io.prestosql.spi.ErrorType;
 
 import static io.prestosql.spi.ErrorType.EXTERNAL;
+import static io.prestosql.spi.ErrorType.INTERNAL_ERROR;
 import static io.prestosql.spi.ErrorType.USER_ERROR;
 
 public enum IcebergErrorCode
@@ -30,6 +31,10 @@ public enum IcebergErrorCode
     ICEBERG_BAD_DATA(4, EXTERNAL),
     ICEBERG_MISSING_DATA(5, EXTERNAL),
     ICEBERG_CANNOT_OPEN_SPLIT(6, EXTERNAL),
+    ICEBERG_WRITER_OPEN_ERROR(7, EXTERNAL),
+    ICEBERG_FILESYSTEM_ERROR(8, EXTERNAL),
+    ICEBERG_CURSOR_ERROR(9, EXTERNAL),
+    ICEBERG_WRITE_VALIDATION_FAILED(10, INTERNAL_ERROR),
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileFormat.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileFormat.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+public enum IcebergFileFormat
+{
+    ORC,
+    PARQUET,
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import io.prestosql.plugin.hive.FileWriter;
+import io.prestosql.plugin.hive.HiveStorageFormat;
+import io.prestosql.plugin.hive.RecordFileWriter;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.IOConstants;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Properties;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.prestosql.plugin.hive.util.ParquetRecordWriterUtil.setParquetSchema;
+import static io.prestosql.plugin.iceberg.TypeConverter.toHiveType;
+import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
+
+public class IcebergFileWriterFactory
+{
+    private final TypeManager typeManager;
+
+    @Inject
+    public IcebergFileWriterFactory(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @SuppressWarnings("SwitchStatementWithTooFewBranches")
+    public FileWriter createFileWriter(
+            Path outputPath,
+            Schema icebergSchema,
+            List<IcebergColumnHandle> columns,
+            JobConf jobConf,
+            ConnectorSession session,
+            FileFormat fileFormat)
+    {
+        switch (fileFormat) {
+            case PARQUET:
+                return createParquetWriter(outputPath, icebergSchema, columns, jobConf, session);
+        }
+        throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
+    }
+
+    private FileWriter createParquetWriter(
+            Path outputPath,
+            Schema icebergSchema,
+            List<IcebergColumnHandle> columns,
+            JobConf jobConf,
+            ConnectorSession session)
+    {
+        Properties properties = new Properties();
+        properties.setProperty(IOConstants.COLUMNS, columns.stream()
+                .map(IcebergColumnHandle::getName)
+                .collect(joining(",")));
+        properties.setProperty(IOConstants.COLUMNS_TYPES, columns.stream()
+                .map(column -> toHiveType(column.getType()).getHiveTypeName().toString())
+                .collect(joining(":")));
+
+        setParquetSchema(jobConf, convert(icebergSchema, "table"));
+
+        return new RecordFileWriter(
+                outputPath,
+                columns.stream()
+                        .map(IcebergColumnHandle::getName)
+                        .collect(toImmutableList()),
+                fromHiveStorageFormat(HiveStorageFormat.PARQUET),
+                properties,
+                HiveStorageFormat.PARQUET.getEstimatedWriterSystemMemoryUsage(),
+                jobConf,
+                typeManager,
+                session);
+    }
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
@@ -13,43 +13,105 @@
  */
 package io.prestosql.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.orc.OrcDataSink;
+import io.prestosql.orc.OrcDataSource;
+import io.prestosql.orc.OrcDataSourceId;
+import io.prestosql.orc.OrcReaderOptions;
+import io.prestosql.orc.OrcWriterOptions;
+import io.prestosql.orc.OrcWriterStats;
+import io.prestosql.orc.OutputStreamOrcDataSink;
+import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.FileWriter;
+import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveStorageFormat;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.RecordFileWriter;
+import io.prestosql.plugin.hive.orc.HdfsOrcDataSource;
+import io.prestosql.plugin.hive.orc.OrcFileWriter;
+import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
+import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_VERSION_NAME;
 import static io.prestosql.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static io.prestosql.plugin.hive.util.ParquetRecordWriterUtil.setParquetSchema;
+import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
+import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITE_VALIDATION_FAILED;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getCompressionCodec;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcStringStatisticsLimit;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxDictionaryMemory;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxStripeRows;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxStripeSize;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcWriterMinStripeSize;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcWriterValidateMode;
+import static io.prestosql.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.prestosql.plugin.iceberg.TypeConverter.toHiveType;
+import static io.prestosql.plugin.iceberg.TypeConverter.toOrcType;
+import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
+import static org.joda.time.DateTimeZone.UTC;
 
 public class IcebergFileWriterFactory
 {
+    private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
+    private final NodeVersion nodeVersion;
+    private final FileFormatDataSourceStats readStats;
+    private final OrcWriterStats orcWriterStats = new OrcWriterStats();
+    private final OrcWriterOptions orcWriterOptions;
 
     @Inject
-    public IcebergFileWriterFactory(TypeManager typeManager)
+    public IcebergFileWriterFactory(
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            NodeVersion nodeVersion,
+            FileFormatDataSourceStats readStats,
+            OrcWriterConfig orcWriterConfig)
     {
+        checkArgument(!requireNonNull(orcWriterConfig, "orcWriterConfig is null").isUseLegacyVersion(), "the ORC writer shouldn't be configured to use a legacy version");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
+        this.readStats = requireNonNull(readStats, "readStats is null");
+        this.orcWriterOptions = orcWriterConfig.toOrcWriterOptions();
     }
 
-    @SuppressWarnings("SwitchStatementWithTooFewBranches")
+    @Managed
+    @Flatten
+    public OrcWriterStats getOrcWriterStats()
+    {
+        return orcWriterStats;
+    }
+
     public FileWriter createFileWriter(
             Path outputPath,
             Schema icebergSchema,
@@ -61,6 +123,8 @@ public class IcebergFileWriterFactory
         switch (fileFormat) {
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, columns, jobConf, session);
+            case ORC:
+                return createOrcWriter(outputPath, icebergSchema, jobConf, session);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }
@@ -81,6 +145,7 @@ public class IcebergFileWriterFactory
                 .collect(joining(":")));
 
         setParquetSchema(jobConf, convert(icebergSchema, "table"));
+        jobConf.set(ParquetOutputFormat.COMPRESSION, getCompressionCodec(session).getParquetCompressionCodec().name());
 
         return new RecordFileWriter(
                 outputPath,
@@ -93,5 +158,74 @@ public class IcebergFileWriterFactory
                 jobConf,
                 typeManager,
                 session);
+    }
+
+    private FileWriter createOrcWriter(
+            Path outputPath,
+            Schema icebergSchema,
+            JobConf jobConf,
+            ConnectorSession session)
+    {
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getUser(), outputPath, jobConf);
+            OrcDataSink orcDataSink = new OutputStreamOrcDataSink(fileSystem.create(outputPath));
+            Callable<Void> rollbackAction = () -> {
+                fileSystem.delete(outputPath, false);
+                return null;
+            };
+
+            List<Types.NestedField> columnFields = icebergSchema.columns();
+            List<String> fileColumnNames = columnFields.stream()
+                    .map(Types.NestedField::name)
+                    .collect(toImmutableList());
+            List<Type> fileColumnTypes = columnFields.stream()
+                    .map(Types.NestedField::type)
+                    .map(type -> toPrestoType(type, typeManager))
+                    .collect(toImmutableList());
+
+            Optional<Supplier<OrcDataSource>> validationInputFactory = Optional.empty();
+            if (isOrcWriterValidate(session)) {
+                validationInputFactory = Optional.of(() -> {
+                    try {
+                        return new HdfsOrcDataSource(
+                                new OrcDataSourceId(outputPath.toString()),
+                                fileSystem.getFileStatus(outputPath).getLen(),
+                                new OrcReaderOptions(),
+                                fileSystem.open(outputPath),
+                                readStats);
+                    }
+                    catch (IOException e) {
+                        throw new PrestoException(ICEBERG_WRITE_VALIDATION_FAILED, e);
+                    }
+                });
+            }
+
+            return new OrcFileWriter(
+                    orcDataSink,
+                    rollbackAction,
+                    fileColumnNames,
+                    fileColumnTypes,
+                    toOrcType(icebergSchema),
+                    getCompressionCodec(session).getOrcCompressionKind(),
+                    orcWriterOptions
+                            .withStripeMinSize(getOrcWriterMinStripeSize(session))
+                            .withStripeMaxSize(getOrcWriterMaxStripeSize(session))
+                            .withStripeMaxRowCount(getOrcWriterMaxStripeRows(session))
+                            .withDictionaryMaxMemory(getOrcWriterMaxDictionaryMemory(session))
+                            .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session)),
+                    false,
+                    IntStream.range(0, fileColumnNames.size()).toArray(),
+                    ImmutableMap.<String, String>builder()
+                            .put(PRESTO_VERSION_NAME, nodeVersion.toString())
+                            .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
+                            .build(),
+                    UTC,
+                    validationInputFactory,
+                    getOrcWriterValidateMode(session),
+                    orcWriterStats);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_WRITER_OPEN_ERROR, "Error creating ORC file", e);
+        }
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -108,6 +109,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.Transactions.createTableTransaction;
 
 public class IcebergMetadata
@@ -314,7 +316,8 @@ public class IcebergMetadata
             throw new TableAlreadyExistsException(schemaTableName);
         }
 
-        TableMetadata metadata = newTableMetadata(operations, schema, partitionSpec, targetPath);
+        FileFormat fileFormat = (FileFormat) tableMetadata.getProperties().get(FILE_FORMAT_PROPERTY);
+        TableMetadata metadata = newTableMetadata(operations, schema, partitionSpec, targetPath, ImmutableMap.of(DEFAULT_FILE_FORMAT, fileFormat.toString()));
 
         transaction = createTableTransaction(operations, metadata);
 
@@ -325,7 +328,7 @@ public class IcebergMetadata
                 PartitionSpecParser.toJson(metadata.spec()),
                 getColumns(metadata.schema(), typeManager),
                 targetPath,
-                getFileFormat(tableMetadata.getProperties()));
+                fileFormat);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
@@ -28,6 +28,8 @@ import io.prestosql.plugin.hive.HiveNodePartitioningProvider;
 import io.prestosql.plugin.hive.HiveTransactionManager;
 import io.prestosql.plugin.hive.LocationService;
 import io.prestosql.plugin.hive.NamenodeStats;
+import io.prestosql.plugin.hive.orc.OrcReaderConfig;
+import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
 import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
 import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
@@ -67,6 +69,9 @@ public class IcebergModule
         binder.bind(HdfsConfigurationInitializer.class).in(Scopes.SINGLETON);
         newSetBinder(binder, DynamicConfigurationProvider.class);
 
+        configBinder(binder).bindConfig(OrcReaderConfig.class);
+        configBinder(binder).bindConfig(OrcWriterConfig.class);
+
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
 
@@ -80,5 +85,6 @@ public class IcebergModule
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
         binder.bind(IcebergFileWriterFactory.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(IcebergFileWriterFactory.class).withGeneratedName();
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
@@ -78,5 +78,7 @@ public class IcebergModule
 
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
+
+        binder.bind(IcebergFileWriterFactory.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.hadoop.HadoopInputFile;
+import org.apache.iceberg.orc.OrcMetrics;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.transforms.Transform;
 
@@ -328,6 +329,9 @@ public class IcebergPageSink
         switch (fileFormat) {
             case PARQUET:
                 return ParquetUtil.fileMetrics(HadoopInputFile.fromPath(path, jobConf), MetricsConfig.getDefault());
+            case ORC:
+                // TODO: update Iceberg version after OrcMetrics is completed
+                return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, jobConf), jobConf);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
@@ -16,9 +16,9 @@ package io.prestosql.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
+import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.prestosql.plugin.hive.HiveFileWriter;
 import io.prestosql.plugin.hive.HiveStorageFormat;
 import io.prestosql.plugin.hive.RecordFileWriter;
 import io.prestosql.plugin.iceberg.PartitionTransforms.ColumnTransform;
@@ -267,7 +267,7 @@ public class IcebergPageSink
                 pageForWriter = pageForWriter.getPositions(positions, 0, positions.length);
             }
 
-            HiveFileWriter writer = writers.get(index).getWriter();
+            FileWriter writer = writers.get(index).getWriter();
 
             long currentWritten = writer.getWrittenBytes();
             long currentMemory = writer.getSystemMemoryUsage();
@@ -321,13 +321,13 @@ public class IcebergPageSink
         outputPath = new Path(outputPath, randomUUID().toString());
         outputPath = new Path(fileFormat.addExtension(outputPath.toString()));
 
-        HiveFileWriter writer = createWriter(outputPath);
+        FileWriter writer = createWriter(outputPath);
 
         return new WriteContext(writer, outputPath, partitionData);
     }
 
     @SuppressWarnings("SwitchStatementWithTooFewBranches")
-    private HiveFileWriter createWriter(Path outputPath)
+    private FileWriter createWriter(Path outputPath)
     {
         switch (fileFormat) {
             case PARQUET:
@@ -336,7 +336,7 @@ public class IcebergPageSink
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }
 
-    private HiveFileWriter createParquetWriter(Path outputPath)
+    private FileWriter createParquetWriter(Path outputPath)
     {
         Properties properties = new Properties();
         properties.setProperty(IOConstants.COLUMNS, inputColumns.stream()
@@ -452,18 +452,18 @@ public class IcebergPageSink
 
     private static class WriteContext
     {
-        private final HiveFileWriter writer;
+        private final FileWriter writer;
         private final Path path;
         private final Optional<PartitionData> partitionData;
 
-        public WriteContext(HiveFileWriter writer, Path path, Optional<PartitionData> partitionData)
+        public WriteContext(FileWriter writer, Path path, Optional<PartitionData> partitionData)
         {
             this.writer = requireNonNull(writer, "writer is null");
             this.path = requireNonNull(path, "path is null");
             this.partitionData = requireNonNull(partitionData, "partitionData is null");
         }
 
-        public HiveFileWriter getWriter()
+        public FileWriter getWriter()
         {
             return writer;
         }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSinkProvider.java
@@ -23,7 +23,6 @@ import io.prestosql.spi.connector.ConnectorPageSink;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
-import io.prestosql.spi.type.TypeManager;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -38,19 +37,19 @@ public class IcebergPageSinkProvider
 {
     private final HdfsEnvironment hdfsEnvironment;
     private final JsonCodec<CommitTaskData> jsonCodec;
-    private final TypeManager typeManager;
+    private final IcebergFileWriterFactory fileWriterFactory;
     private final PageIndexerFactory pageIndexerFactory;
 
     @Inject
     public IcebergPageSinkProvider(
             HdfsEnvironment hdfsEnvironment,
             JsonCodec<CommitTaskData> jsonCodec,
-            TypeManager typeManager,
+            IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
     }
 
@@ -75,11 +74,11 @@ public class IcebergPageSinkProvider
                 schema,
                 partitionSpec,
                 tableHandle.getOutputPath(),
+                fileWriterFactory,
                 pageIndexerFactory,
                 hdfsEnvironment,
                 hdfsContext,
                 tableHandle.getInputColumns(),
-                typeManager,
                 jsonCodec,
                 session,
                 tableHandle.getFileFormat());

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -15,33 +15,158 @@ package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode;
+import io.prestosql.plugin.hive.HiveCompressionCodec;
+import io.prestosql.plugin.hive.orc.OrcReaderConfig;
+import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
 import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
+import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.session.PropertyMetadata;
 
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
+import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
+    private static final String COMPRESSION_CODEC = "compression_codec";
+    private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
+    private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
+    private static final String ORC_MAX_BUFFER_SIZE = "orc_max_buffer_size";
+    private static final String ORC_STREAM_BUFFER_SIZE = "orc_stream_buffer_size";
+    private static final String ORC_TINY_STRIPE_THRESHOLD = "orc_tiny_stripe_threshold";
+    private static final String ORC_MAX_READ_BLOCK_SIZE = "orc_max_read_block_size";
+    private static final String ORC_LAZY_READ_SMALL_RANGES = "orc_lazy_read_small_ranges";
+    private static final String ORC_NESTED_LAZY_ENABLED = "orc_nested_lazy_enabled";
+    private static final String ORC_STRING_STATISTICS_LIMIT = "orc_string_statistics_limit";
+    private static final String ORC_WRITER_VALIDATE_PERCENTAGE = "orc_writer_validate_percentage";
+    private static final String ORC_WRITER_VALIDATE_MODE = "orc_writer_validate_mode";
+    private static final String ORC_WRITER_MIN_STRIPE_SIZE = "orc_writer_min_stripe_size";
+    private static final String ORC_WRITER_MAX_STRIPE_SIZE = "orc_writer_max_stripe_size";
+    private static final String ORC_WRITER_MAX_STRIPE_ROWS = "orc_writer_max_stripe_rows";
+    private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
     private static final String PARQUET_FAIL_WITH_CORRUPTED_STATISTICS = "parquet_fail_with_corrupted_statistics";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
-
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public IcebergSessionProperties(
+            IcebergConfig icebergConfig,
+            OrcReaderConfig orcReaderConfig,
+            OrcWriterConfig orcWriterConfig,
             ParquetReaderConfig parquetReaderConfig,
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(enumProperty(
+                        COMPRESSION_CODEC,
+                        "Compression codec to use when writing files",
+                        HiveCompressionCodec.class,
+                        icebergConfig.getCompressionCodec(),
+                        false))
+                .add(booleanProperty(
+                        ORC_BLOOM_FILTERS_ENABLED,
+                        "ORC: Enable bloom filters for predicate pushdown",
+                        orcReaderConfig.isBloomFiltersEnabled(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_MAX_MERGE_DISTANCE,
+                        "ORC: Maximum size of gap between two reads to merge into a single read",
+                        orcReaderConfig.getMaxMergeDistance(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_MAX_BUFFER_SIZE,
+                        "ORC: Maximum size of a single read",
+                        orcReaderConfig.getMaxBufferSize(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_STREAM_BUFFER_SIZE,
+                        "ORC: Size of buffer for streaming reads",
+                        orcReaderConfig.getStreamBufferSize(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_TINY_STRIPE_THRESHOLD,
+                        "ORC: Threshold below which an ORC stripe or file will read in its entirety",
+                        orcReaderConfig.getTinyStripeThreshold(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_MAX_READ_BLOCK_SIZE,
+                        "ORC: Soft max size of Presto blocks produced by ORC reader",
+                        orcReaderConfig.getMaxBlockSize(),
+                        false))
+                .add(booleanProperty(
+                        ORC_LAZY_READ_SMALL_RANGES,
+                        "Experimental: ORC: Read small file segments lazily",
+                        orcReaderConfig.isLazyReadSmallRanges(),
+                        false))
+                .add(booleanProperty(
+                        ORC_NESTED_LAZY_ENABLED,
+                        "Experimental: ORC: Lazily read nested data",
+                        orcReaderConfig.isNestedLazy(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_STRING_STATISTICS_LIMIT,
+                        "ORC: Maximum size of string statistics; drop if exceeding",
+                        orcWriterConfig.getStringStatisticsLimit(),
+                        false))
+                .add(new PropertyMetadata<>(
+                        ORC_WRITER_VALIDATE_PERCENTAGE,
+                        "ORC: Percentage of written files to validate by re-reading them",
+                        DOUBLE,
+                        Double.class,
+                        orcWriterConfig.getValidationPercentage(),
+                        false,
+                        value -> {
+                            double doubleValue = ((Number) value).doubleValue();
+                            if (doubleValue < 0.0 || doubleValue > 100.0) {
+                                throw new PrestoException(INVALID_SESSION_PROPERTY, format(
+                                        "%s must be between 0.0 and 100.0 inclusive: %s",
+                                        ORC_WRITER_VALIDATE_PERCENTAGE,
+                                        doubleValue));
+                            }
+                            return doubleValue;
+                        },
+                        value -> value))
+                .add(enumProperty(
+                        ORC_WRITER_VALIDATE_MODE,
+                        "ORC: Level of detail in ORC validation",
+                        OrcWriteValidationMode.class,
+                        orcWriterConfig.getValidationMode(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_WRITER_MIN_STRIPE_SIZE,
+                        "ORC: Min stripe size",
+                        orcWriterConfig.getStripeMinSize(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_WRITER_MAX_STRIPE_SIZE,
+                        "ORC: Max stripe size",
+                        orcWriterConfig.getStripeMaxSize(),
+                        false))
+                .add(integerProperty(
+                        ORC_WRITER_MAX_STRIPE_ROWS,
+                        "ORC: Max stripe row count",
+                        orcWriterConfig.getStripeMaxRowCount(),
+                        false))
+                .add(dataSizeProperty(
+                        ORC_WRITER_MAX_DICTIONARY_MEMORY,
+                        "ORC: Max dictionary memory",
+                        orcWriterConfig.getDictionaryMaxMemory(),
+                        false))
                 .add(booleanProperty(
                         PARQUET_FAIL_WITH_CORRUPTED_STATISTICS,
                         "Parquet: Fail when scanning Parquet files with corrupted statistics",
@@ -68,6 +193,93 @@ public final class IcebergSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static boolean isOrcBloomFiltersEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_BLOOM_FILTERS_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getOrcMaxMergeDistance(ConnectorSession session)
+    {
+        return session.getProperty(ORC_MAX_MERGE_DISTANCE, DataSize.class);
+    }
+
+    public static DataSize getOrcMaxBufferSize(ConnectorSession session)
+    {
+        return session.getProperty(ORC_MAX_BUFFER_SIZE, DataSize.class);
+    }
+
+    public static DataSize getOrcStreamBufferSize(ConnectorSession session)
+    {
+        return session.getProperty(ORC_STREAM_BUFFER_SIZE, DataSize.class);
+    }
+
+    public static DataSize getOrcTinyStripeThreshold(ConnectorSession session)
+    {
+        return session.getProperty(ORC_TINY_STRIPE_THRESHOLD, DataSize.class);
+    }
+
+    public static DataSize getOrcMaxReadBlockSize(ConnectorSession session)
+    {
+        return session.getProperty(ORC_MAX_READ_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static boolean getOrcLazyReadSmallRanges(ConnectorSession session)
+    {
+        return session.getProperty(ORC_LAZY_READ_SMALL_RANGES, Boolean.class);
+    }
+
+    public static boolean isOrcNestedLazy(ConnectorSession session)
+    {
+        return session.getProperty(ORC_NESTED_LAZY_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getOrcStringStatisticsLimit(ConnectorSession session)
+    {
+        return session.getProperty(ORC_STRING_STATISTICS_LIMIT, DataSize.class);
+    }
+
+    public static boolean isOrcWriterValidate(ConnectorSession session)
+    {
+        double percentage = session.getProperty(ORC_WRITER_VALIDATE_PERCENTAGE, Double.class);
+        if (percentage == 0.0) {
+            return false;
+        }
+
+        checkArgument(percentage > 0.0 && percentage <= 100.0);
+
+        return ThreadLocalRandom.current().nextDouble(100) < percentage;
+    }
+
+    public static OrcWriteValidationMode getOrcWriterValidateMode(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_VALIDATE_MODE, OrcWriteValidationMode.class);
+    }
+
+    public static DataSize getOrcWriterMinStripeSize(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_MIN_STRIPE_SIZE, DataSize.class);
+    }
+
+    public static DataSize getOrcWriterMaxStripeSize(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_MAX_STRIPE_SIZE, DataSize.class);
+    }
+
+    public static int getOrcWriterMaxStripeRows(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_MAX_STRIPE_ROWS, Integer.class);
+    }
+
+    public static DataSize getOrcWriterMaxDictionaryMemory(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_MAX_DICTIONARY_MEMORY, DataSize.class);
+    }
+
+    public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)
+    {
+        return session.getProperty(COMPRESSION_CODEC, HiveCompressionCodec.class);
     }
 
     public static boolean isFailOnCorruptedParquetStatistics(ConnectorSession session)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplit.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.HostAddress;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.predicate.TupleDomain;
+import org.apache.iceberg.FileFormat;
 
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ public class IcebergSplit
     private final String path;
     private final long start;
     private final long length;
+    private final FileFormat fileFormat;
     private final List<HostAddress> addresses;
     private final TupleDomain<IcebergColumnHandle> predicate;
     private final Map<Integer, String> partitionKeys;
@@ -42,6 +44,7 @@ public class IcebergSplit
             @JsonProperty("path") String path,
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
+            @JsonProperty("fileFormat") FileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate,
             @JsonProperty("partitionKeys") Map<Integer, String> partitionKeys)
@@ -49,6 +52,7 @@ public class IcebergSplit
         this.path = requireNonNull(path, "path is null");
         this.start = start;
         this.length = length;
+        this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.predicate = requireNonNull(predicate, "predicate is null");
         this.partitionKeys = ImmutableMap.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
@@ -83,6 +87,12 @@ public class IcebergSplit
     public long getLength()
     {
         return length;
+    }
+
+    @JsonProperty
+    public FileFormat getFileFormat()
+    {
+        return fileFormat;
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitSource.java
@@ -112,6 +112,7 @@ public class IcebergSplitSource
                 task.file().path().toString(),
                 task.start(),
                 task.length(),
+                task.file().format(),
                 ImmutableList.of(),
                 predicate,
                 getPartitionKeys(task));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableProperties.java
@@ -37,14 +37,14 @@ public class IcebergTableProperties
     private final List<PropertyMetadata<?>> tableProperties;
 
     @Inject
-    public IcebergTableProperties()
+    public IcebergTableProperties(IcebergConfig icebergConfig)
     {
         tableProperties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(enumProperty(
                         FILE_FORMAT_PROPERTY,
                         "File format for the table",
                         FileFormat.class,
-                        FileFormat.PARQUET,
+                        icebergConfig.getFileFormat(),
                         false))
                 .add(new PropertyMetadata<>(
                         PARTITIONING_PROPERTY,

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import io.prestosql.plugin.hive.HiveCompressionCodec;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -21,6 +22,9 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.prestosql.plugin.iceberg.IcebergFileFormat.ORC;
+import static io.prestosql.plugin.iceberg.IcebergFileFormat.PARQUET;
 
 public class TestIcebergConfig
 {
@@ -28,7 +32,9 @@ public class TestIcebergConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(IcebergConfig.class)
-                .setMetastoreTransactionCacheSize(1000));
+                .setMetastoreTransactionCacheSize(1000)
+                .setFileFormat(ORC)
+                .setCompressionCodec(GZIP));
     }
 
     @Test
@@ -36,10 +42,14 @@ public class TestIcebergConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("iceberg.metastore.transaction-cache.size", "999")
+                .put("iceberg.file-format", "Parquet")
+                .put("iceberg.compression-codec", "NONE")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
-                .setMetastoreTransactionCacheSize(999);
+                .setMetastoreTransactionCacheSize(999)
+                .setFileFormat(PARQUET)
+                .setCompressionCodec(HiveCompressionCodec.NONE);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -212,6 +212,36 @@ public class TestIcebergSmoke
         dropTable(session, "test_column_comments");
     }
 
+    @Test
+    public void testSchemaEvolution()
+    {
+        // Schema evolution should be id based
+        testWithAllFileFormats(this::testSchemaEvolution);
+    }
+
+    private void testSchemaEvolution(Session session, FileFormat fileFormat)
+    {
+        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "INSERT INTO test_schema_evolution_drop_end VALUES (0, 1, 2)", 1);
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_end", "VALUES(0, 1, 2)");
+        assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_end DROP COLUMN col2");
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_end", "VALUES(0, 1)");
+        assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_end ADD COLUMN col2 INTEGER");
+        assertUpdate(session, "INSERT INTO test_schema_evolution_drop_end VALUES (3, 4, 5)", 1);
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_end", "VALUES(0, 1, NULL), (3, 4, 5)");
+        dropTable(session, "test_schema_evolution_drop_end");
+
+        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_middle (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "INSERT INTO test_schema_evolution_drop_middle VALUES (0, 1, 2)", 1);
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_middle", "VALUES(0, 1, 2)");
+        assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_middle DROP COLUMN col1");
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_middle", "VALUES(0, 2)");
+        assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_middle ADD COLUMN col1 INTEGER");
+        assertUpdate(session, "INSERT INTO test_schema_evolution_drop_middle VALUES (3, 4, 5)", 1);
+        assertQuery(session, "SELECT * FROM test_schema_evolution_drop_middle", "VALUES(0, 2, NULL), (3, 4, 5)");
+        dropTable(session, "test_schema_evolution_drop_middle");
+    }
+
     private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
     {
         test.accept(getSession(), FileFormat.PARQUET);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -183,7 +183,7 @@ public class TestIcebergSmoke
                         "   order_status varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'PARQUET',\n" +
+                        "   format = '" + fileFormat + "',\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)']\n" +
                         ")",
                 getSession().getCatalog().get(),
@@ -245,6 +245,7 @@ public class TestIcebergSmoke
     private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
     {
         test.accept(getSession(), FileFormat.PARQUET);
+        test.accept(getSession(), FileFormat.ORC);
     }
 
     private void dropTable(Session session, String table)

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -71,7 +71,8 @@ public class TestIcebergSystemTables
     public void setUp()
     {
         assertUpdate("CREATE SCHEMA test_schema");
-        assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'])");
+        // "$partitions" tables with ORC file format are not fully supported yet. So we use Parquet here for testing
+        assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'], format = 'Parquet')");
         assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
         assertUpdate("INSERT INTO test_schema.test_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
         assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcColumn.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcColumn.java
@@ -14,10 +14,12 @@
 package io.prestosql.orc;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.orc.metadata.OrcColumnId;
 import io.prestosql.orc.metadata.OrcType.OrcTypeKind;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -30,6 +32,7 @@ public final class OrcColumn
     private final String columnName;
     private final OrcDataSourceId orcDataSourceId;
     private final List<OrcColumn> nestedColumns;
+    private final Map<String, String> attributes;
 
     public OrcColumn(
             String path,
@@ -37,7 +40,8 @@ public final class OrcColumn
             String columnName,
             OrcTypeKind columnType,
             OrcDataSourceId orcDataSourceId,
-            List<OrcColumn> nestedColumns)
+            List<OrcColumn> nestedColumns,
+            Map<String, String> attributes)
     {
         this.path = requireNonNull(path, "path is null");
         this.columnId = requireNonNull(columnId, "columnId is null");
@@ -45,6 +49,7 @@ public final class OrcColumn
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.orcDataSourceId = requireNonNull(orcDataSourceId, "orcDataSourceId is null");
         this.nestedColumns = ImmutableList.copyOf(requireNonNull(nestedColumns, "nestedColumns is null"));
+        this.attributes = ImmutableMap.copyOf(requireNonNull(attributes, "attributes is null"));
     }
 
     public String getPath()
@@ -75,6 +80,11 @@ public final class OrcColumn
     public List<OrcColumn> getNestedColumns()
     {
         return nestedColumns;
+    }
+
+    public Map<String, String> getAttributes()
+    {
+        return attributes;
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
@@ -320,7 +320,7 @@ public class OrcReader
                     createOrcColumn(path, "key", orcType.getFieldTypeIndex(0), types, orcDataSourceId),
                     createOrcColumn(path, "value", orcType.getFieldTypeIndex(1), types, orcDataSourceId));
         }
-        return new OrcColumn(path, columnId, fieldName, orcType.getOrcTypeKind(), orcDataSourceId, nestedColumns);
+        return new OrcColumn(path, columnId, fieldName, orcType.getOrcTypeKind(), orcDataSourceId, nestedColumns, orcType.getAttributes());
     }
 
     /**

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriter.java
@@ -126,6 +126,7 @@ public final class OrcWriter
             OrcDataSink orcDataSink,
             List<String> columnNames,
             List<Type> types,
+            ColumnMetadata<OrcType> orcTypes,
             CompressionKind compression,
             OrcWriterOptions options,
             boolean writeLegacyVersion,
@@ -163,7 +164,7 @@ public final class OrcWriter
         this.stats = requireNonNull(stats, "stats is null");
 
         requireNonNull(columnNames, "columnNames is null");
-        this.orcTypes = OrcType.createRootOrcType(columnNames, types);
+        this.orcTypes = requireNonNull(orcTypes, "orcTypes is null");
         recordValidation(validation -> validation.setColumnNames(columnNames));
 
         // create column writers

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
@@ -492,7 +492,7 @@ public class OrcMetadataReader
             precision = Optional.of(type.getPrecision());
             scale = Optional.of(type.getScale());
         }
-        return new OrcType(toTypeKind(type.getKind()), toOrcColumnId(type.getSubtypesList()), type.getFieldNamesList(), length, precision, scale);
+        return new OrcType(toTypeKind(type.getKind()), toOrcColumnId(type.getSubtypesList()), type.getFieldNamesList(), length, precision, scale, toMap(type.getAttributesList()));
     }
 
     private static List<OrcColumnId> toOrcColumnId(List<Integer> columnIds)
@@ -551,6 +551,20 @@ public class OrcMetadataReader
             default:
                 throw new IllegalStateException(typeKind + " stream type not implemented yet");
         }
+    }
+
+    // This method assumes type attributes have no duplicate key
+    private static Map<String, String> toMap(List<OrcProto.StringPair> attributes)
+    {
+        ImmutableMap.Builder<String, String> results = new ImmutableMap.Builder<>();
+        if (attributes != null) {
+            for (OrcProto.StringPair attribute : attributes) {
+                if (attribute.hasKey() && attribute.hasValue()) {
+                    results.put(attribute.getKey(), attribute.getValue());
+                }
+            }
+        }
+        return results.build();
     }
 
     private static StreamKind toStreamKind(OrcProto.Stream.Kind streamKind)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataWriter.java
@@ -34,10 +34,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TimeZone;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.orc.metadata.PostScript.MAGIC;
 import static java.lang.Math.toIntExact;
 import static java.util.stream.Collectors.toList;
@@ -151,7 +153,8 @@ public class OrcMetadataWriter
                 .addAllSubtypes(type.getFieldTypeIndexes().stream()
                         .map(OrcColumnId::getId)
                         .collect(toList()))
-                .addAllFieldNames(type.getFieldNames());
+                .addAllFieldNames(type.getFieldNames())
+                .addAllAttributes(toStringPairList(type.getAttributes()));
 
         if (type.getLength().isPresent()) {
             builder.setMaximumLength(type.getLength().get());
@@ -206,6 +209,16 @@ public class OrcMetadataWriter
                 return OrcProto.Type.Kind.UNION;
         }
         throw new IllegalArgumentException("Unsupported type: " + orcTypeKind);
+    }
+
+    private static List<OrcProto.StringPair> toStringPairList(Map<String, String> attributes)
+    {
+        return attributes.entrySet().stream()
+            .map(entry -> OrcProto.StringPair.newBuilder()
+                .setKey(entry.getKey())
+                .setValue(entry.getValue())
+                .build())
+            .collect(toImmutableList());
     }
 
     private static OrcProto.ColumnStatistics toColumnStatistics(ColumnStatistics columnStatistics)

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcType.java
@@ -14,6 +14,7 @@
 package io.prestosql.orc.metadata;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.CharType;
@@ -26,6 +27,7 @@ import io.prestosql.spi.type.VarcharType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -80,28 +82,29 @@ public class OrcType
     private final Optional<Integer> length;
     private final Optional<Integer> precision;
     private final Optional<Integer> scale;
+    private final Map<String, String> attributes;
 
     private OrcType(OrcTypeKind orcTypeKind)
     {
-        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
+        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableMap.of());
     }
 
     private OrcType(OrcTypeKind orcTypeKind, int length)
     {
-        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.of(length), Optional.empty(), Optional.empty());
+        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.of(length), Optional.empty(), Optional.empty(), ImmutableMap.of());
     }
 
     private OrcType(OrcTypeKind orcTypeKind, int precision, int scale)
     {
-        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.of(precision), Optional.of(scale));
+        this(orcTypeKind, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.of(precision), Optional.of(scale), ImmutableMap.of());
     }
 
     private OrcType(OrcTypeKind orcTypeKind, List<OrcColumnId> fieldTypeIndexes, List<String> fieldNames)
     {
-        this(orcTypeKind, fieldTypeIndexes, fieldNames, Optional.empty(), Optional.empty(), Optional.empty());
+        this(orcTypeKind, fieldTypeIndexes, fieldNames, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableMap.of());
     }
 
-    public OrcType(OrcTypeKind orcTypeKind, List<OrcColumnId> fieldTypeIndexes, List<String> fieldNames, Optional<Integer> length, Optional<Integer> precision, Optional<Integer> scale)
+    public OrcType(OrcTypeKind orcTypeKind, List<OrcColumnId> fieldTypeIndexes, List<String> fieldNames, Optional<Integer> length, Optional<Integer> precision, Optional<Integer> scale, Map<String, String> attributes)
     {
         this.orcTypeKind = requireNonNull(orcTypeKind, "typeKind is null");
         this.fieldTypeIndexes = ImmutableList.copyOf(requireNonNull(fieldTypeIndexes, "fieldTypeIndexes is null"));
@@ -115,6 +118,7 @@ public class OrcType
         this.length = requireNonNull(length, "length is null");
         this.precision = requireNonNull(precision, "precision is null");
         this.scale = requireNonNull(scale, "scale cannot be null");
+        this.attributes = ImmutableMap.copyOf(requireNonNull(attributes, "attributes is null"));
     }
 
     public OrcTypeKind getOrcTypeKind()
@@ -160,6 +164,11 @@ public class OrcType
     public Optional<Integer> getScale()
     {
         return scale;
+    }
+
+    public Map<String, String> getAttributes()
+    {
+        return attributes;
     }
 
     @Override

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -24,6 +24,7 @@ import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
@@ -591,10 +592,14 @@ public class OrcTester
         metadata.put("columns", "test");
         metadata.put("columns.types", createSettableStructObjectInspector("test", type).getTypeName());
 
+        List<String> columnNames = ImmutableList.of("test");
+        List<Type> types = ImmutableList.of(type);
+
         OrcWriter writer = new OrcWriter(
                 new OutputStreamOrcDataSink(new FileOutputStream(outputFile)),
                 ImmutableList.of("test"),
-                ImmutableList.of(type),
+                types,
+                OrcType.createRootOrcType(columnNames, types),
                 compression,
                 new OrcWriterOptions(),
                 false,

--- a/presto-orc/src/test/java/io/prestosql/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestOrcWriter.java
@@ -21,6 +21,7 @@ import io.airlift.units.DataSize;
 import io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode;
 import io.prestosql.orc.metadata.Footer;
 import io.prestosql.orc.metadata.OrcMetadataReader;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.orc.metadata.Stream;
 import io.prestosql.orc.metadata.StripeFooter;
 import io.prestosql.orc.metadata.StripeInformation;
@@ -29,11 +30,13 @@ import io.prestosql.orc.stream.OrcInputStream;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
@@ -58,10 +61,15 @@ public class TestOrcWriter
     {
         for (OrcWriteValidationMode validationMode : OrcWriteValidationMode.values()) {
             TempFile tempFile = new TempFile();
+
+            List<String> columnNames = ImmutableList.of("test1", "test2", "test3", "test4", "test5");
+            List<Type> types = ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR);
+
             OrcWriter writer = new OrcWriter(
                     new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
                     ImmutableList.of("test1", "test2", "test3", "test4", "test5"),
-                    ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR),
+                    types,
+                    OrcType.createRootOrcType(columnNames, types),
                     NONE,
                     new OrcWriterOptions()
                             .withStripeMinSize(new DataSize(0, MEGABYTE))

--- a/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.prestosql.metadata.Metadata;
+import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
@@ -217,10 +218,13 @@ public class TestStructColumnReader
     private void write(TempFile tempFile, Type writerType, List<String> data)
             throws IOException
     {
+        List<String> columnNames = ImmutableList.of(STRUCT_COL_NAME);
+        List<Type> types = ImmutableList.of(writerType);
         OrcWriter writer = new OrcWriter(
                 new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
-                ImmutableList.of(STRUCT_COL_NAME),
-                ImmutableList.of(writerType),
+                columnNames,
+                types,
+                OrcType.createRootOrcType(columnNames, types),
                 NONE,
                 new OrcWriterOptions()
                         .withStripeMinSize(new DataSize(0, MEGABYTE))


### PR DESCRIPTION
This is ready for review.

Some notes:
1. The implementation conforms to [this spec](https://github.com/apache/incubator-iceberg/pull/227/files#diff-116b0afb33e66021cf000896fde94817R509)
2. `TestIcebergSmoke` passes with the ORC format.
3. `TIME` and `TIME WITH TIME ZONE` are not supported. The current syntax is that an Iceberg table is also a Hive table (see [HiveTableOperations](https://github.com/prestosql/presto/blob/b5a6a8ff962a304fcdde48b27ebf7eb890b3daac/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/HiveTableOperations.java#L159-L232)). So types unsupported by Hive are not supported by Iceberg Connector neither.
4. The commit `Handle data files with no column metrics` is related because ORC files' column metrics collection is not supported yet. This commit ensures that partition tables don't break.

Supersedes #1290 
Umbrella issue: #1324 

cc: @electrum @wagnermarkd @phd3 