### PR TITLE
Support narrowing type coercions during INSERT

### DIFF
--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/TestAccumuloDistributedQueries.java
@@ -133,16 +133,21 @@ public class TestAccumuloDistributedQueries
         assertUpdate("DROP TABLE test_insert");
     }
 
+    @Override
+    public void testInsertWithCoercion()
+    {
+        // Override because of non-canonical varchar mapping
+    }
+
     @Override // Overridden because we currently do not support arrays with null elements
     public void testInsertArray()
     {
         assertUpdate("CREATE TABLE test_insert_array (a ARRAY<DOUBLE>, b ARRAY<BIGINT>)");
 
         // assertUpdate("INSERT INTO test_insert_array (a) VALUES (ARRAY[null])", 1); TODO support ARRAY with null elements
-        assertUpdate("INSERT INTO test_insert_array (a) VALUES (ARRAY[1234])", 1);
-        assertQuery("SELECT a[1] FROM test_insert_array", "VALUES (1234)");
 
-        assertQueryFails("INSERT INTO test_insert_array (b) VALUES (ARRAY[1.23E1])", "Insert query has mismatched column types: .*");
+        assertUpdate("INSERT INTO test_insert_array (a, b) VALUES (ARRAY[1.23E1], ARRAY[1.23E1])", 1);
+        assertQuery("SELECT a[1], b[1] FROM test_insert_array", "VALUES (12.3, 12)");
 
         assertUpdate("DROP TABLE test_insert_array");
     }

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -70,6 +70,13 @@ public class TestCassandraDistributedQueries
     }
 
     @Override
+    public void testInsertWithCoercion()
+    {
+        // Cassandra connector currently does not support create table
+        // TODO test inserts
+    }
+
+    @Override
     public void testInsertUnicode()
     {
         // Cassandra connector currently does not support create table

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
@@ -62,4 +62,10 @@ public class TestIcebergDistributed
     {
         assertQueryFails("ALTER TABLE orders RENAME TO rename_orders", "Rename not supported for Iceberg tables");
     }
+
+    @Override
+    public void testInsertWithCoercion()
+    {
+        // Iceberg does not support parameterized varchar
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -47,6 +47,7 @@ import static io.airlift.slice.SliceUtf8.toUpperCase;
 import static io.airlift.slice.SliceUtf8.tryGetCodePointAt;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.prestosql.spi.type.Chars.byteCountWithoutTrailingSpace;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.Chars.trimTrailingSpaces;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -103,6 +104,14 @@ public final class StringFunctions
     public static long charLength(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
     {
         return x;
+    }
+
+    @Description("returns length of a character string without trailing spaces")
+    @ScalarFunction(value = "$space_trimmed_length", hidden = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long spaceTrimmedLength(@SqlType("varchar") Slice slice)
+    {
+        return countCodePoints(slice, 0, byteCountWithoutTrailingSpace(slice, 0, slice.length()));
     }
 
     @Description("greedily removes occurrences of a pattern in a string")

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -47,10 +47,12 @@ import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.Identity;
 import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeNotFoundException;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.analyzer.Analysis.SelectExpression;
 import io.prestosql.sql.analyzer.Scope.AsteriskedIdentifierChainBasis;
 import io.prestosql.sql.parser.ParsingException;
@@ -394,13 +396,52 @@ class StatementAnalyzer
                 return false;
             }
 
+            /*
+            TODO enable coercions based on type compatibility for INSERT of structural types containing nested bounded character types.
+            It might require defining a new range of cast operators and changes in FunctionRegistry to ensure proper handling
+            of nested types.
+            Currently, INSERT for such structural types is only allowed in the case of strict type coercibility.
+            INSERT for other types is allowed in all cases described by the Standard. It is obtained
+            by emulating a "guarded cast" in LogicalPlanner, and without any changes to the actual operators.
+            */
             for (int i = 0; i < tableTypes.size(); i++) {
-                if (!typeCoercion.canCoerce(queryTypes.get(i), tableTypes.get(i))) {
+                if (hasNestedBoundedCharacterType(tableTypes.get(i))) {
+                    if (!typeCoercion.canCoerce(queryTypes.get(i), tableTypes.get(i))) {
+                        return false;
+                    }
+                }
+                else if (!typeCoercion.isCompatible(queryTypes.get(i), tableTypes.get(i))) {
                     return false;
                 }
             }
 
             return true;
+        }
+
+        private boolean hasNestedBoundedCharacterType(Type type)
+        {
+            if (type instanceof ArrayType) {
+                return hasBoundedCharacterType(((ArrayType) type).getElementType());
+            }
+
+            if (type instanceof MapType) {
+                return hasBoundedCharacterType(((MapType) type).getKeyType()) || hasBoundedCharacterType(((MapType) type).getValueType());
+            }
+
+            if (type instanceof RowType) {
+                for (Type fieldType : type.getTypeParameters()) {
+                    if (hasBoundedCharacterType(fieldType)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private boolean hasBoundedCharacterType(Type type)
+        {
+            return type instanceof CharType || (type instanceof VarcharType && !((VarcharType) type).isUnbounded()) || hasNestedBoundedCharacterType(type);
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
@@ -27,6 +27,7 @@ import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.NewTableLayout;
 import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.ResolvedFunction;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.metadata.TableMetadata;
 import io.prestosql.spi.PrestoException;
@@ -34,7 +35,9 @@ import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.statistics.TableStatisticsMetadata;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.analyzer.Analysis;
 import io.prestosql.sql.analyzer.Field;
 import io.prestosql.sql.analyzer.RelationId;
@@ -59,18 +62,25 @@ import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.planner.sanity.PlanSanityChecker;
 import io.prestosql.sql.tree.Analyze;
 import io.prestosql.sql.tree.Cast;
+import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.CreateTableAsSelect;
 import io.prestosql.sql.tree.Delete;
 import io.prestosql.sql.tree.Explain;
 import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.FunctionCall;
+import io.prestosql.sql.tree.GenericLiteral;
+import io.prestosql.sql.tree.IfExpression;
 import io.prestosql.sql.tree.Insert;
 import io.prestosql.sql.tree.LambdaArgumentDeclaration;
 import io.prestosql.sql.tree.LongLiteral;
 import io.prestosql.sql.tree.NodeRef;
 import io.prestosql.sql.tree.NullLiteral;
+import io.prestosql.sql.tree.QualifiedName;
 import io.prestosql.sql.tree.Query;
 import io.prestosql.sql.tree.Statement;
+import io.prestosql.sql.tree.StringLiteral;
 import io.prestosql.type.TypeCoercion;
+import io.prestosql.type.UnknownType;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -90,6 +100,8 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.statistics.TableStatisticType.ROW_COUNT;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.prestosql.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
 import static io.prestosql.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
@@ -98,6 +110,7 @@ import static io.prestosql.sql.planner.plan.TableWriterNode.CreateReference;
 import static io.prestosql.sql.planner.plan.TableWriterNode.InsertReference;
 import static io.prestosql.sql.planner.plan.TableWriterNode.WriterTarget;
 import static io.prestosql.sql.planner.sanity.PlanSanityChecker.DISTRIBUTED_PLAN_SANITY_CHECKER;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -356,7 +369,7 @@ public class LogicalPlanner
                     assignments.put(output, input.toSymbolReference());
                 }
                 else {
-                    Expression cast = new Cast(input.toSymbolReference(), toSqlType(tableType));
+                    Expression cast = noTruncationCast(input.toSymbolReference(), queryType, tableType);
                     assignments.put(output, cast);
                 }
             }
@@ -464,6 +477,52 @@ public class LogicalPlanner
                 Optional.empty());
 
         return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputSymbols());
+    }
+
+    /*
+    According to the standard, for the purpose of store assignment (INSERT),
+    no non-space characters of a character string, and no non-zero octets
+    of a binary string must be lost when the inserted value is truncated to
+    fit in the target column type.
+    The following method returns a cast from source type to target type
+    with a guarantee of no illegal truncation.
+    TODO Once BINARY and parametric VARBINARY types are supported, they should be handled here.
+    TODO This workaround is insufficient to handle structural types
+     */
+    private Expression noTruncationCast(Expression expression, Type fromType, Type toType)
+    {
+        if (fromType instanceof UnknownType || (!(toType instanceof VarcharType) && !(toType instanceof CharType))) {
+            return new Cast(expression, toSqlType(toType));
+        }
+        int targetLength;
+        if (toType instanceof VarcharType) {
+            if (((VarcharType) toType).isUnbounded()) {
+                return new Cast(expression, toSqlType(toType));
+            }
+            targetLength = ((VarcharType) toType).getBoundedLength();
+        }
+        else {
+            targetLength = ((CharType) toType).getLength();
+        }
+
+        checkState(fromType instanceof VarcharType || fromType instanceof CharType, "inserting non-character value to column of character type");
+        ResolvedFunction spaceTrimmedLength = metadata.resolveFunction(QualifiedName.of("$space_trimmed_length"), fromTypes(VARCHAR));
+        ResolvedFunction fail = metadata.resolveFunction(QualifiedName.of("fail"), fromTypes(VARCHAR));
+
+        return new IfExpression(
+                // check if the trimmed value fits in the target type
+                new ComparisonExpression(
+                        GREATER_THAN_OR_EQUAL,
+                        new GenericLiteral("BIGINT", Integer.toString(targetLength)),
+                        new FunctionCall(
+                                spaceTrimmedLength.toQualifiedName(),
+                                ImmutableList.of(new Cast(expression, toSqlType(VARCHAR))))),
+                new Cast(expression, toSqlType(toType)),
+                new Cast(
+                        new FunctionCall(
+                                fail.toQualifiedName(),
+                                ImmutableList.of(new Cast(new StringLiteral("Cannot truncate non-space characters on INSERT"), toSqlType(VARCHAR)))),
+                        toSqlType(toType)));
     }
 
     private RelationPlan createDeletePlan(Analysis analysis, Delete node)

--- a/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
+++ b/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
@@ -111,6 +111,12 @@ public final class TypeCoercion
         return Optional.of(compatibility.getCommonSuperType());
     }
 
+    public boolean isCompatible(Type fromType, Type toType)
+    {
+        TypeCompatibility typeCompatibility = compatibility(fromType, toType);
+        return typeCompatibility.isCompatible();
+    }
+
     public boolean canCoerce(Type fromType, Type toType)
     {
         TypeCompatibility typeCompatibility = compatibility(fromType, toType);

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -106,8 +106,17 @@ import static io.prestosql.spi.connector.ConnectorViewDefinition.ViewColumn;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.CharType.createCharType;
+import static io.prestosql.spi.type.DateType.DATE;
+import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.RowType.anonymousRow;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static io.prestosql.testing.assertions.PrestoExceptionAssert.assertPrestoExceptionThrownBy;
 import static io.prestosql.transaction.InMemoryTransactionManager.createTestTransactionManager;
@@ -1047,20 +1056,41 @@ public class TestAnalyzer
         assertFails("INSERT INTO t6 (a, A) SELECT * FROM t6")
                 .hasErrorCode(DUPLICATE_COLUMN_NAME);
 
-        // b is bigint, while a is double, coercion from b to a is possible
+        // b is bigint, while a is double, coercion is possible either way
         analyze("INSERT INTO t7 (b) SELECT (a) FROM t7 ");
-        assertFails("INSERT INTO t7 (a) SELECT (b) FROM t7")
-                .hasErrorCode(TYPE_MISMATCH);
+        analyze("INSERT INTO t7 (a) SELECT (b) FROM t7");
 
-        // d is array of bigints, while c is array of doubles, coercion from d to c is possible
+        // d is array of bigints, while c is array of doubles, coercion is possible either way
         analyze("INSERT INTO t7 (d) SELECT (c) FROM t7 ");
-        assertFails("INSERT INTO t7 (c) SELECT (d) FROM t7 ")
-                .hasErrorCode(TYPE_MISMATCH);
+        analyze("INSERT INTO t7 (c) SELECT (d) FROM t7 ");
 
         analyze("INSERT INTO t7 (d) VALUES (ARRAY[null])");
 
         analyze("INSERT INTO t6 (d) VALUES (1), (2), (3)");
         analyze("INSERT INTO t6 (a,b,c,d) VALUES (1, 'a', 1, 1), (2, 'b', 2, 2), (3, 'c', 3, 3), (4, 'd', 4, 4)");
+
+        // coercion is allowed between compatible types
+        analyze("INSERT INTO t8 (tinyint_column, integer_column, decimal_column, real_column) VALUES (1e0, 1e0, 1e0, 1e0)");
+        analyze("INSERT INTO t8 (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST('aa     ' AS varchar), CAST('aa     ' AS varchar), CAST('aa     ' AS varchar))");
+        analyze("INSERT INTO t8 (tinyint_array_column) SELECT (bigint_array_column) FROM t8");
+        analyze("INSERT INTO t8 (row_column) VALUES (ROW(ROW(1e0, CAST('aa     ' AS varchar))))");
+        analyze("INSERT INTO t8 (date_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')");
+
+        // coercion is not allowed between incompatible types
+        assertFails("INSERT INTO t8 (integer_column) VALUES ('text')")
+                .hasErrorCode(TYPE_MISMATCH);
+        assertFails("INSERT INTO t8 (integer_column) VALUES (true)")
+                .hasErrorCode(TYPE_MISMATCH);
+        assertFails("INSERT INTO t8 (integer_column) VALUES (ROW(ROW(1e0)))")
+                .hasErrorCode(TYPE_MISMATCH);
+        assertFails("INSERT INTO t8 (integer_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')")
+                .hasErrorCode(TYPE_MISMATCH);
+        assertFails("INSERT INTO t8 (unbounded_varchar_column) VALUES (1)")
+                .hasErrorCode(TYPE_MISMATCH);
+
+        // coercion with potential loss is not allowed for nested bounded character string types
+        assertFails("INSERT INTO t8 (nested_bounded_varchar_column) VALUES (ROW(ROW(CAST('aa' AS varchar(10)))))")
+                .hasErrorCode(TYPE_MISMATCH);
     }
 
     @Test
@@ -2097,6 +2127,24 @@ public class TestAnalyzer
                 Optional.of("user"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, false));
+
+        // type analysis for INSERT
+        SchemaTableName table8 = new SchemaTableName("s1", "t8");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table8, ImmutableList.of(
+                        new ColumnMetadata("tinyint_column", TINYINT),
+                        new ColumnMetadata("integer_column", INTEGER),
+                        new ColumnMetadata("decimal_column", createDecimalType(5, 3)),
+                        new ColumnMetadata("real_column", REAL),
+                        new ColumnMetadata("char_column", createCharType(3)),
+                        new ColumnMetadata("bounded_varchar_column", createVarcharType(3)),
+                        new ColumnMetadata("unbounded_varchar_column", VARCHAR),
+                        new ColumnMetadata("tinyint_array_column", new ArrayType(TINYINT)),
+                        new ColumnMetadata("bigint_array_column", new ArrayType(BIGINT)),
+                        new ColumnMetadata("nested_bounded_varchar_column", anonymousRow(createVarcharType(3))),
+                        new ColumnMetadata("row_column", anonymousRow(TINYINT, createUnboundedVarcharType())),
+                        new ColumnMetadata("date_column", DATE))),
+                false));
 
         // for identifier chain resolving tests
         catalogManager.registerCatalog(createTestingCatalog(CATALOG_FOR_IDENTIFIER_CHAIN_TESTS, CATALOG_FOR_IDENTIFIER_CHAIN_TESTS_NAME));

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
@@ -83,6 +83,12 @@ public class TestMySqlDistributedQueries
     }
 
     @Override
+    public void testInsertWithCoercion()
+    {
+        // this connector uses a non-canonical type for varchar columns in tpch
+    }
+
+    @Override
     public void testDescribeOutput()
     {
         // this connector uses a non-canonical type for varchar columns in tpch

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorDistributedQueries.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorDistributedQueries.java
@@ -38,4 +38,10 @@ public class TestRaptorDistributedQueries
         // Raptor connector currently does not support comment on table
         assertQueryFails("COMMENT ON TABLE orders IS 'hello'", "This connector does not support setting table comments");
     }
+
+    @Override
+    public void testInsertWithCoercion()
+    {
+        // No support for char type
+    }
 }


### PR DESCRIPTION
This change enables all types of coercions during INSERT, as described
by the SQL standard.
Example: a value of type TINYINT can be inserted into a column of type BIGINT,
but also a value of type BIGINT can be inserted into a column of type TINYINT.
Insert will succeed as long as the source value can be converted into the
target type without loss.
Due to the need of special handling, this change does not apply to structural
types containing a bounded character type. For such types, insert is allowed
only when the source type guarantees lossless coercion.