### PR TITLE
Verify correlation in LATERAL relation according to the Standard

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -156,6 +156,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -213,6 +214,7 @@ import static io.prestosql.sql.analyzer.ExpressionTreeUtils.extractAggregateFunc
 import static io.prestosql.sql.analyzer.ExpressionTreeUtils.extractExpressions;
 import static io.prestosql.sql.analyzer.ExpressionTreeUtils.extractWindowFunctions;
 import static io.prestosql.sql.analyzer.Scope.BasisType.TABLE;
+import static io.prestosql.sql.analyzer.ScopeReferenceExtractor.getReferencesToScope;
 import static io.prestosql.sql.analyzer.ScopeReferenceExtractor.hasReferencesToScope;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -223,6 +225,8 @@ import static io.prestosql.sql.tree.FrameBound.Type.FOLLOWING;
 import static io.prestosql.sql.tree.FrameBound.Type.PRECEDING;
 import static io.prestosql.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static io.prestosql.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+import static io.prestosql.sql.tree.Join.Type.FULL;
+import static io.prestosql.sql.tree.Join.Type.RIGHT;
 import static io.prestosql.sql.tree.WindowFrame.Type.RANGE;
 import static io.prestosql.type.UnknownType.UNKNOWN;
 import static io.prestosql.util.MoreLists.mappedCopy;
@@ -1273,6 +1277,13 @@ class StatementAnalyzer
 
             Scope left = process(node.getLeft(), scope);
             Scope right = process(node.getRight(), isLateralRelation(node.getRight()) ? Optional.of(left) : scope);
+
+            if (isLateralRelation(node.getRight()) && (node.getType().equals(RIGHT) || node.getType().equals(FULL))) {
+                Stream<Expression> leftScopeReferences = getReferencesToScope(node.getRight(), analysis, left);
+                leftScopeReferences.findFirst().ifPresent(reference -> {
+                    throw semanticException(INVALID_COLUMN_REFERENCE, reference, "LATERAL reference not allowed in %s JOIN", node.getType().name());
+                });
+            }
 
             if (criteria instanceof JoinUsing) {
                 return analyzeJoinUsing(node, ((JoinUsing) criteria).getColumns(), scope, left, right);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedJoinToJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedJoinToJoin.java
@@ -15,34 +15,24 @@ package io.prestosql.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import io.prestosql.matching.Captures;
 import io.prestosql.matching.Pattern;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.optimizations.PlanNodeDecorrelator;
 import io.prestosql.sql.planner.optimizations.PlanNodeDecorrelator.DecorrelatedNode;
-import io.prestosql.sql.planner.plan.Assignments;
 import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.JoinNode.Type;
 import io.prestosql.sql.planner.plan.PlanNode;
-import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.tree.Expression;
-import io.prestosql.sql.tree.IfExpression;
-import io.prestosql.sql.tree.NullLiteral;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.matching.Pattern.nonEmpty;
 import static io.prestosql.sql.ExpressionUtils.combineConjuncts;
-import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.FULL;
 import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.INNER;
 import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.LEFT;
-import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.RIGHT;
 import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.correlation;
 import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -73,6 +63,7 @@ public class TransformCorrelatedJoinToJoin
     @Override
     public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
+        checkArgument(correlatedJoinNode.getType().equals(INNER) || correlatedJoinNode.getType().equals(LEFT), "correlation in %s JOIN", correlatedJoinNode.getType().name());
         PlanNode subquery = correlatedJoinNode.getSubquery();
 
         PlanNodeDecorrelator planNodeDecorrelator = new PlanNodeDecorrelator(metadata, context.getSymbolAllocator(), context.getLookup());
@@ -82,78 +73,23 @@ public class TransformCorrelatedJoinToJoin
         }
         DecorrelatedNode decorrelatedSubquery = decorrelatedNodeOptional.get();
 
-        // handle INNER and LEFT correlated join
-        if (correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT) {
-            Expression filter = combineConjuncts(
-                    metadata,
-                    decorrelatedSubquery.getCorrelatedPredicates().orElse(TRUE_LITERAL),
-                    correlatedJoinNode.getFilter());
-            return Result.ofPlanNode(rewriteToJoin(
-                    correlatedJoinNode,
-                    correlatedJoinNode.getType().toJoinNodeType(),
-                    filter,
-                    decorrelatedSubquery.getNode()));
-        }
-
-        checkState(
-                correlatedJoinNode.getType() == RIGHT || correlatedJoinNode.getType() == FULL,
-                "unexpected CorrelatedJoin type: " + correlatedJoinNode.getType());
-
-        // handle RIGHT and FULL correlated join ON TRUE
-        Type type;
-        if (correlatedJoinNode.getType() == RIGHT) {
-            type = Type.INNER;
-        }
-        else {
-            type = Type.LEFT;
-        }
-        JoinNode joinNode = rewriteToJoin(
-                correlatedJoinNode,
-                type,
+        Expression filter = combineConjuncts(
+                metadata,
                 decorrelatedSubquery.getCorrelatedPredicates().orElse(TRUE_LITERAL),
-                decorrelatedSubquery.getNode());
+                correlatedJoinNode.getFilter());
 
-        if (correlatedJoinNode.getFilter().equals(TRUE_LITERAL)) {
-            return Result.ofPlanNode(joinNode);
-        }
-
-        // handle RIGHT correlated join on condition other than TRUE
-        if (correlatedJoinNode.getType() == RIGHT) {
-            Assignments.Builder assignments = Assignments.builder();
-            assignments.putIdentities(Sets.intersection(
-                    ImmutableSet.copyOf(decorrelatedSubquery.getNode().getOutputSymbols()),
-                    ImmutableSet.copyOf(correlatedJoinNode.getOutputSymbols())));
-            for (Symbol inputSymbol : Sets.intersection(
-                    ImmutableSet.copyOf(correlatedJoinNode.getInput().getOutputSymbols()),
-                    ImmutableSet.copyOf(correlatedJoinNode.getOutputSymbols()))) {
-                assignments.put(inputSymbol, new IfExpression(correlatedJoinNode.getFilter(), inputSymbol.toSymbolReference(), new NullLiteral()));
-            }
-            ProjectNode projectNode = new ProjectNode(
-                    context.getIdAllocator().getNextId(),
-                    joinNode,
-                    assignments.build());
-
-            return Result.ofPlanNode(projectNode);
-        }
-
-        // no support for FULL correlated join on condition other than TRUE
-        return Result.empty();
-    }
-
-    private JoinNode rewriteToJoin(CorrelatedJoinNode parent, Type type, Expression filter, PlanNode decorrelatedSubqueryNode)
-    {
-        return new JoinNode(
-                parent.getId(),
-                type,
-                parent.getInput(),
-                decorrelatedSubqueryNode,
+        return Result.ofPlanNode(new JoinNode(
+                correlatedJoinNode.getId(),
+                correlatedJoinNode.getType().toJoinNodeType(),
+                correlatedJoinNode.getInput(),
+                decorrelatedSubquery.getNode(),
                 ImmutableList.of(),
-                parent.getOutputSymbols(),
+                correlatedJoinNode.getOutputSymbols(),
                 filter.equals(TRUE_LITERAL) ? Optional.empty() : Optional.of(filter),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableMap.of());
+                ImmutableMap.of()));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -1943,19 +1943,25 @@ public class TestAnalyzer
     @Test
     public void testJoinUnnest()
     {
+        // Lateral references are only allowed in INNER and LEFT join.
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) CROSS JOIN UNNEST(x)");
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) LEFT OUTER JOIN UNNEST(x) ON true");
-        analyze("SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN UNNEST(x) ON true");
-        analyze("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN UNNEST(x) ON true");
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN UNNEST(x) ON true")
+                .hasErrorCode(INVALID_COLUMN_REFERENCE);
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN UNNEST(x) ON true")
+                .hasErrorCode(INVALID_COLUMN_REFERENCE);
     }
 
     @Test
     public void testJoinLateral()
     {
+        // Lateral references are only allowed in INNER and LEFT join.
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) CROSS JOIN LATERAL(VALUES x)");
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) LEFT OUTER JOIN LATERAL(VALUES x) ON true");
-        analyze("SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN LATERAL(VALUES x) ON true");
-        analyze("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true");
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN LATERAL(VALUES x) ON true")
+                .hasErrorCode(INVALID_COLUMN_REFERENCE);
+        assertFails("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true")
+                .hasErrorCode(INVALID_COLUMN_REFERENCE);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -421,26 +421,6 @@ public class TestSubqueries
                 "VALUES (1, 2), (2, null), (3, null), (null, null)");
 
         assertions.assertQueryReturnsEmptyResult("SELECT * FROM (SELECT 1 where 0 = 1) t(a) LEFT JOIN LATERAL (SELECT 2 WHERE a = 1 ) t2(b) ON TRUE");
-
-        assertions.assertQuery(
-                "SELECT * FROM (VALUES 1, 2, 3, null) t1(a) RIGHT JOIN LATERAL (SELECT b FROM (VALUES 2, 3, null) t2(b) WHERE b > a) ON TRUE",
-                "VALUES (1, 2), (1, 3), (2, 3)");
-
-        assertions.assertQuery(
-                "SELECT * FROM (VALUES 1, 2, 3, null) t1(a) RIGHT JOIN LATERAL (SELECT b FROM (VALUES 2, 3, null) t2(b) WHERE b > a) ON b < 3",
-                "VALUES (1, 2), (null, 3), (null, 3)");
-
-        assertions.assertQueryReturnsEmptyResult("SELECT * FROM (SELECT 1 where 0 = 1) t(a) RIGHT JOIN LATERAL (SELECT 2 WHERE a = 1 ) t2(b) ON TRUE");
-
-        assertions.assertQuery(
-                "SELECT * FROM (VALUES 1, 2, 3, null) t1(a) FULL JOIN LATERAL (SELECT b FROM (VALUES 2, 3, null) t2(b) WHERE b > a) ON TRUE",
-                "VALUES (1, 2), (1, 3), (2, 3), (3, null), (null, null)");
-
-        assertions.assertFails(
-                "SELECT * FROM (VALUES 1, 2, 3, null) t1(a) FULL JOIN LATERAL (SELECT b FROM (VALUES 2, 3, null) t2(b) WHERE b > a) ON b < 3",
-                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
-
-        assertions.assertQueryReturnsEmptyResult("SELECT * FROM (SELECT 1 where 0 = 1) t(a) FULL JOIN LATERAL (SELECT 2 WHERE a = 1 ) t2(b) ON TRUE");
     }
 
     private void assertExistsRewrittenToAggregationBelowJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
@@ -132,36 +132,39 @@ public class TestUnnest
     @Test
     public void testRightJoinUnnest()
     {
+        // The SQL standard doesn't allow lateral references in UNNEST subquery of RIGHT join.
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(x) ON true",
-                "VALUES (ARRAY[1, null], 1), (ARRAY[1, null], null)");
-        assertions.assertQueryReturnsEmptyResult(
-                "SELECT * FROM (VALUES ARRAY[]) a(x) RIGHT OUTER JOIN UNNEST(x) ON true");
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(ARRAY[2, null]) ON true",
+                "VALUES (ARRAY[1, null], 2), (ARRAY[1, null], null)");
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(x) WITH ORDINALITY ON true",
-                "VALUES (ARRAY[1, null], 1, BIGINT '1'), (ARRAY[1, null], null, BIGINT '2')");
+                "SELECT * FROM (VALUES ARRAY[]) a(x) RIGHT OUTER JOIN UNNEST(ARRAY[2, null]) ON true",
+                "VALUES (ARRAY[], 2), (ARRAY[], null)");
+        assertions.assertQuery(
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(ARRAY[2, null]) WITH ORDINALITY ON true",
+                "VALUES (ARRAY[1, null], 2, BIGINT '1'), (ARRAY[1, null], null, BIGINT '2')");
         assertions.assertFails(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(x) b(y) ON b.y = 1",
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) RIGHT OUTER JOIN UNNEST(ARRAY[2, null]) b(y) ON b.y = 1",
                 "line .*: UNNEST in conditional JOIN is not supported");
     }
 
     @Test
     public void testFullJoinUnnest()
     {
+        // The SQL standard doesn't allow lateral references in UNNEST subquery of FULL join.
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(x) ON true",
-                "VALUES (ARRAY[1, null], 1), (ARRAY[1, null], null)");
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) ON true",
+                "VALUES (ARRAY[1, null], 2), (ARRAY[1, null], null)");
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(x) WITH ORDINALITY ON true",
-                "VALUES (ARRAY[1, null], 1, BIGINT '1'), (ARRAY[1, null], null, BIGINT '2')");
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) WITH ORDINALITY ON true",
+                "VALUES (ARRAY[1, null], 2, BIGINT '1'), (ARRAY[1, null], null, BIGINT '2')");
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[]) a(x) FULL OUTER JOIN UNNEST(x) ON true",
-                "VALUES (ARRAY[], null)");
+                "SELECT * FROM (VALUES ARRAY[]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) ON true",
+                "VALUES (ARRAY[], 2), (ARRAY[], null)");
         assertions.assertQuery(
-                "SELECT * FROM (VALUES ARRAY[]) a(x) FULL OUTER JOIN UNNEST(x) WITH ORDINALITY ON true",
-                "VALUES (ARRAY[], null, CAST(NULL AS bigint))");
+                "SELECT * FROM (VALUES ARRAY[]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) WITH ORDINALITY ON true",
+                "VALUES (ARRAY[], 2, BIGINT '1'), (ARRAY[], null, BIGINT '2')");
         assertions.assertFails(
-                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(x) b(y) ON b.y = 1",
+                "SELECT * FROM (VALUES ARRAY[1, null]) a(x) FULL OUTER JOIN UNNEST(ARRAY[2, null]) b(y) ON b.y = 1",
                 "line .*: UNNEST in conditional JOIN is not supported");
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -5292,16 +5292,6 @@ public abstract class AbstractTestQueries
                 "SELECT r.name, a FROM region r LEFT JOIN LATERAL (SELECT name FROM nation WHERE r.regionkey = nation.regionkey) n(a) ON r.name > a ORDER BY r.name LIMIT 1",
                 "SELECT 'AFRICA', NULL");
         assertQuery(
-                "SELECT r.name, a FROM region r RIGHT JOIN LATERAL (SELECT name FROM nation WHERE r.regionkey = nation.regionkey) n(a) ON r.name > a ORDER BY a LIMIT 1",
-                "SELECT NULL, 'ALGERIA'");
-        // FULL correlated join with non-trivial correlation filter and non-trivial join condition currently not supported
-        assertQueryFails(
-                "SELECT * FROM (VALUES 1) a(x) FULL JOIN LATERAL(SELECT y FROM (VALUES 2) b(y) WHERE y > x) ON x=y",
-                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG /*"VALUES (1, NULL), (NULL, 2)"*/);
-        assertQueryFails(
-                "SELECT * FROM (VALUES 1, 2, 3) a(x) FULL JOIN LATERAL(SELECT z FROM (VALUES 1, 2, 3, 5) b(z) WHERE z != x) ON x != 1 AND z != 5",
-                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG /*"VALUES (1, NULL), (2, 3), (2, 1), (3, 2), (3, 1), (NULL, 5)"*/);
-        assertQuery(
                 "SELECT * FROM (VALUES 1, 2) a(x) JOIN LATERAL(SELECT y FROM (VALUES 2, 3) b(y) WHERE y > x) c(z) ON z > 2*x",
                 "VALUES (1, 3)");
 


### PR DESCRIPTION
According to SQL Standard, for JOIN involving LATERAL relation,
lateral references to symbols of left join source are only allowed
in the case of LEFT or INNER join type. It applies to both explicitly
defined LATERAL relation, and UNNEST relation.
This change adds verification at the stage of semantic analysis
that no correlated symbols are present in the right source of
RIGHT or FULL correlated join.