### PR TITLE
Downgrade Maven wrapper to 3.6.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip


### PR DESCRIPTION
After upgrade to 3.6.2 some build instability was observed around
getting project dependencies from Maven Central. This was attributed to
Maven version change.