### PR TITLE
Fix generated code when ScalarFunction name has special characters

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
@@ -335,7 +335,8 @@ public final class BytecodeUtils
 
     public static BytecodeExpression invoke(Binding binding, String name)
     {
-        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), name, binding.getType());
+        // ensure that name doesn't have a special characters
+        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), name.replaceAll("[^(A-Za-z0-9_$)]", "_"), binding.getType());
     }
 
     public static BytecodeExpression invoke(Binding binding, Signature signature)

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/CustomFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/CustomFunctions.java
@@ -45,4 +45,11 @@ public final class CustomFunctions
     {
         return value == null;
     }
+
+    @ScalarFunction(value = "identity.function", alias = "identity&function")
+    @SqlType(StandardTypes.BIGINT)
+    public static long customIdentityFunction(@SqlType(StandardTypes.BIGINT) long x)
+    {
+        return x;
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestCustomFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestCustomFunctions.java
@@ -47,4 +47,11 @@ public class TestCustomFunctions
         assertFunction("custom_is_null(CAST(NULL AS BIGINT))", BOOLEAN, true);
         assertFunction("custom_is_null(0)", BOOLEAN, false);
     }
+
+    @Test
+    public void testIdentityFunction()
+    {
+        assertFunction("\"identity&function\"(\"identity.function\"(123))", BIGINT, 123L);
+        assertFunction("\"identity.function\"(\"identity&function\"(123))", BIGINT, 123L);
+    }
 }


### PR DESCRIPTION
Fixes #1998 