### PR TITLE
Use specific @Path on class level

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
@@ -83,7 +83,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
-@Path("/")
+@Path("/v1/statement")
 public class QueuedStatementResource
 {
     private static final Logger log = Logger.get(QueuedStatementResource.class);
@@ -145,7 +145,6 @@ public class QueuedStatementResource
     }
 
     @POST
-    @Path("/v1/statement")
     @Produces(APPLICATION_JSON)
     public Response postStatement(
             String statement,
@@ -165,7 +164,7 @@ public class QueuedStatementResource
     }
 
     @GET
-    @Path("/v1/statement/queued/{queryId}/{slug}/{token}")
+    @Path("queued/{queryId}/{slug}/{token}")
     @Produces(APPLICATION_JSON)
     public void getStatus(
             @PathParam("queryId") QueryId queryId,
@@ -200,7 +199,7 @@ public class QueuedStatementResource
     }
 
     @DELETE
-    @Path("/v1/statement/queued/{queryId}/{slug}/{token}")
+    @Path("queued/{queryId}/{slug}/{token}")
     @Produces(APPLICATION_JSON)
     public Response cancelQuery(
             @PathParam("queryId") QueryId queryId,

--- a/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
@@ -31,11 +31,10 @@ import java.util.List;
 
 import static io.prestosql.server.ThreadResource.Info.byName;
 
-@Path("/")
+@Path("/v1/thread")
 public class ThreadResource
 {
     @GET
-    @Path("/v1/thread")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Info> getThreadInfo()
     {

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
@@ -82,7 +82,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
-@Path("/")
+@Path("/v1/statement/executing")
 public class ExecutingStatementResource
 {
     private static final Logger log = Logger.get(ExecutingStatementResource.class);
@@ -145,7 +145,7 @@ public class ExecutingStatementResource
     }
 
     @GET
-    @Path("/v1/statement/executing/{queryId}/{slug}/{token}")
+    @Path("{queryId}/{slug}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
     public void getQueryResults(
             @PathParam("queryId") QueryId queryId,
@@ -271,7 +271,7 @@ public class ExecutingStatementResource
     }
 
     @DELETE
-    @Path("/v1/statement/executing/{queryId}/{slug}/{token}")
+    @Path("{queryId}/{slug}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response cancelQuery(
             @PathParam("queryId") QueryId queryId,
@@ -301,7 +301,7 @@ public class ExecutingStatementResource
     }
 
     @DELETE
-    @Path("/v1/statement/executing/partialCancel/{queryId}/{stage}/{slug}/{token}")
+    @Path("partialCancel/{queryId}/{stage}/{slug}/{token}")
     public void partialCancel(
             @PathParam("queryId") QueryId queryId,
             @PathParam("stage") int stage,

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
@@ -301,7 +301,7 @@ public class ExecutingStatementResource
     }
 
     @DELETE
-    @Path("/v1/statement/partialCancel/{queryId}/{stage}/{slug}/{token}")
+    @Path("/v1/statement/executing/partialCancel/{queryId}/{stage}/{slug}/{token}")
     public void partialCancel(
             @PathParam("queryId") QueryId queryId,
             @PathParam("stage") int stage,

--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -564,7 +564,7 @@ class Query
     {
         return uriInfo.getBaseUriBuilder()
                 .scheme(scheme)
-                .replacePath("/v1/statement/partialCancel")
+                .replacePath("/v1/statement/executing/partialCancel")
                 .path(queryId.toString())
                 .path(String.valueOf(stage))
                 .path(slug.makeSlug(EXECUTING_QUERY, nextToken))


### PR DESCRIPTION
Most resource classes use specific `@Path` on class level. Update
remaining ones.