### PR TITLE
Use local variables in bash function

### DIFF
--- a/presto-hive-hadoop2/bin/common.sh
+++ b/presto-hive-hadoop2/bin/common.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 function retry() {
+  local END
+  local EXIT_CODE
+
   END=$(($(date +%s) + 600))
 
   while (( $(date +%s) < $END )); do


### PR DESCRIPTION
`EXIT_CODE` conflicts with global state.