### PR TITLE
Generate javadoc and sources artifact for presto-tests

### DIFF
--- a/presto-tests/src/main/java/io/prestosql/tests/Dummy.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/Dummy.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+class Dummy
+{
+    // This class is here so that maven produces a source and javadoc artifact, which are
+    // needed by Sonatype in order to publish a release
+}


### PR DESCRIPTION
They are needed to be able to publish a release to Sonatype