### PR TITLE
Connector optimizer tests

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
@@ -55,11 +55,6 @@ import static org.testng.Assert.assertEquals;
 public abstract class AbstractCostBasedPlanTest
         extends BasePlanTest
 {
-    public AbstractCostBasedPlanTest(LocalQueryRunnerSupplier supplier)
-    {
-        super(supplier);
-    }
-
     protected abstract Stream<String> getQueryResourcePaths();
 
     @DataProvider

--- a/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/TestTpcdsCostBasedPlan.java
+++ b/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/TestTpcdsCostBasedPlan.java
@@ -43,26 +43,25 @@ public class TestTpcdsCostBasedPlan
      * large amount of data.
      */
 
-    public TestTpcdsCostBasedPlan()
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
     {
-        super(() -> {
-            String catalog = "local";
-            Session.SessionBuilder sessionBuilder = testSessionBuilder()
-                    .setCatalog(catalog)
-                    .setSchema("sf3000.0")
-                    .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
-                    .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name())
-                    .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name());
+        String catalog = "local";
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog(catalog)
+                .setSchema("sf3000.0")
+                .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name());
 
-            LocalQueryRunner queryRunner = LocalQueryRunner.builder(sessionBuilder.build())
-                    .withNodeCountForStats(8)
-                    .build();
-            queryRunner.createCatalog(
-                    catalog,
-                    new TpcdsConnectorFactory(1),
-                    ImmutableMap.of());
-            return queryRunner;
-        });
+        LocalQueryRunner queryRunner = LocalQueryRunner.builder(sessionBuilder.build())
+                .withNodeCountForStats(8)
+                .build();
+        queryRunner.createCatalog(
+                catalog,
+                new TpcdsConnectorFactory(1),
+                ImmutableMap.of());
+        return queryRunner;
     }
 
     @Override

--- a/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/TestTpchCostBasedPlan.java
+++ b/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/TestTpchCostBasedPlan.java
@@ -45,26 +45,25 @@ public class TestTpchCostBasedPlan
      * large amount of data.
      */
 
-    public TestTpchCostBasedPlan()
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
     {
-        super(() -> {
-            String catalog = "local";
-            SessionBuilder sessionBuilder = testSessionBuilder()
-                    .setCatalog(catalog)
-                    .setSchema("sf3000.0")
-                    .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
-                    .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name())
-                    .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name());
+        String catalog = "local";
+        SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog(catalog)
+                .setSchema("sf3000.0")
+                .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name());
 
-            LocalQueryRunner queryRunner = LocalQueryRunner.builder(sessionBuilder.build())
-                    .withNodeCountForStats(8)
-                    .build();
-            queryRunner.createCatalog(
-                    catalog,
-                    new TpchConnectorFactory(1, false, false),
-                    ImmutableMap.of(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()));
-            return queryRunner;
-        });
+        LocalQueryRunner queryRunner = LocalQueryRunner.builder(sessionBuilder.build())
+                .withNodeCountForStats(8)
+                .build();
+        queryRunner.createCatalog(
+                catalog,
+                new TpchConnectorFactory(1, false, false),
+                ImmutableMap.of(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()));
+        return queryRunner;
     }
 
     @Override

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -59,12 +59,8 @@ public class TestSpatialJoinPlanning
 {
     private static final String KDB_TREE_JSON = KdbTreeUtils.toJson(new KdbTree(newLeaf(new Rectangle(0, 0, 10, 10), 0)));
 
-    public TestSpatialJoinPlanning()
-    {
-        super(() -> createQueryRunner());
-    }
-
-    private static LocalQueryRunner createQueryRunner()
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
     {
         LocalQueryRunner queryRunner = LocalQueryRunner.create(testSessionBuilder()
                 .setCatalog("memory")

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePlanTest.java
@@ -48,7 +48,7 @@ import static java.util.stream.Collectors.toList;
 
 public class BasePlanTest
 {
-    private final LocalQueryRunnerSupplier queryRunnerSupplier;
+    private final Map<String, String> sessionProperties;
     private LocalQueryRunner queryRunner;
 
     public BasePlanTest()
@@ -58,15 +58,11 @@ public class BasePlanTest
 
     public BasePlanTest(Map<String, String> sessionProperties)
     {
-        this.queryRunnerSupplier = () -> createQueryRunner(sessionProperties);
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
     }
 
-    public BasePlanTest(LocalQueryRunnerSupplier supplier)
-    {
-        this.queryRunnerSupplier = requireNonNull(supplier, "queryRunnerSupplier is null");
-    }
-
-    private static LocalQueryRunner createQueryRunner(Map<String, String> sessionProperties)
+    // Subclasses should implement this method to inject their own query runners
+    protected LocalQueryRunner createLocalQueryRunner()
     {
         Session.SessionBuilder sessionBuilder = testSessionBuilder()
                 .setCatalog("local")
@@ -86,7 +82,7 @@ public class BasePlanTest
     @BeforeClass
     public final void initPlanTest()
     {
-        queryRunner = queryRunnerSupplier.get();
+        this.queryRunner = createLocalQueryRunner();
     }
 
     @AfterClass(alwaysRun = true)
@@ -225,10 +221,5 @@ public class BasePlanTest
         catch (RuntimeException e) {
             throw new AssertionError("Planning failed for SQL: " + sql, e);
         }
-    }
-
-    public interface LocalQueryRunnerSupplier
-    {
-        LocalQueryRunner get();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePushdownPlanTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePushdownPlanTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import io.prestosql.Session;
+import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.spi.connector.ColumnHandle;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Extension of {@link BasePlanTest} that provides connector metadata methods
+ */
+public abstract class BasePushdownPlanTest
+        extends BasePlanTest
+{
+    protected Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName objectName)
+    {
+        return getQueryRunner().inTransaction(session, transactionSession -> { return getQueryRunner().getMetadata().getTableHandle(transactionSession, objectName); });
+    }
+
+    protected Map<String, ColumnHandle> getColumnHandles(Session session, QualifiedObjectName tableName)
+    {
+        return getQueryRunner().inTransaction(session, transactionSession -> {
+            Optional<TableHandle> table = getQueryRunner().getMetadata().getTableHandle(transactionSession, tableName);
+            return getQueryRunner().getMetadata().getColumnHandles(transactionSession, table.get());
+        });
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ColumnHandleMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ColumnHandleMatcher.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import com.google.common.base.Predicate;
+import io.prestosql.Session;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.TableScanNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnHandleMatcher
+        implements RvalueMatcher
+{
+    private final Predicate<ColumnHandle> matcher;
+
+    public ColumnHandleMatcher(Predicate<ColumnHandle> handleMatcher)
+    {
+        this.matcher = requireNonNull(handleMatcher, "handleMatcher is null");
+    }
+
+    @Override
+    public Optional<Symbol> getAssignedSymbol(PlanNode node, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (!(node instanceof TableScanNode)) {
+            return Optional.empty();
+        }
+
+        Map<Symbol, ColumnHandle> assignments = ((TableScanNode) node).getAssignments();
+
+        for (Map.Entry<Symbol, ColumnHandle> entry : assignments.entrySet()) {
+            if (matcher.test(entry.getValue())) {
+                return Optional.of(entry.getKey());
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ConnectorAwareTableScanMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ConnectorAwareTableScanMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import com.google.common.base.Predicate;
+import io.prestosql.Session;
+import io.prestosql.cost.StatsProvider;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.TableScanNode;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.node;
+import static io.prestosql.sql.planner.assertions.Util.domainsMatch;
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorAwareTableScanMatcher
+        implements Matcher
+{
+    private final Predicate<ConnectorTableHandle> expectedTable;
+    private final TupleDomain<Predicate<ColumnHandle>> expectedEnforcedConstraint;
+
+    public ConnectorAwareTableScanMatcher(Predicate<ConnectorTableHandle> expectedTable, TupleDomain<Predicate<ColumnHandle>> expectedEnforcedConstraint)
+    {
+        this.expectedTable = requireNonNull(expectedTable, "expectedTable is null");
+        this.expectedEnforcedConstraint = requireNonNull(expectedEnforcedConstraint, "expectedEnforcedConstraint is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof TableScanNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        TableScanNode tableScanNode = (TableScanNode) node;
+
+        TupleDomain<ColumnHandle> actual = tableScanNode.getEnforcedConstraint();
+        TupleDomain<Predicate<ColumnHandle>> expected = expectedEnforcedConstraint;
+
+        boolean tableMatches = expectedTable.test(tableScanNode.getTable().getConnectorHandle());
+
+        return new MatchResult(tableMatches && domainsMatch(expected, actual));
+    }
+
+    public static PlanMatchPattern create(Predicate<ConnectorTableHandle> table, TupleDomain<Predicate<ColumnHandle>> constraints)
+    {
+        return node(TableScanNode.class)
+                .with(new ConnectorAwareTableScanMatcher(table, constraints));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
@@ -45,6 +45,12 @@ public class ExpressionMatcher
         this.expression = expression(requireNonNull(expression));
     }
 
+    public ExpressionMatcher(Expression expression)
+    {
+        this.expression = requireNonNull(expression, "expression is null");
+        this.sql = requireNonNull(expression).toString();
+    }
+
     private Expression expression(String sql)
     {
         SqlParser parser = new SqlParser();

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.sql.planner.assertions;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -22,7 +23,10 @@ import io.prestosql.Session;
 import io.prestosql.cost.StatsProvider;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.spi.block.SortOrder;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.Symbol;
@@ -136,6 +140,16 @@ public final class PlanMatchPattern
     {
         PlanMatchPattern result = tableScan(expectedTableName);
         return result.addColumnReferences(expectedTableName, columnReferences);
+    }
+
+    public static PlanMatchPattern tableScan(
+            Predicate<ConnectorTableHandle> expectedTable,
+            TupleDomain<Predicate<ColumnHandle>> enforcedConstraints,
+            Map<String, Predicate<ColumnHandle>> expectedColumns)
+    {
+        PlanMatchPattern pattern = ConnectorAwareTableScanMatcher.create(expectedTable, enforcedConstraints);
+        expectedColumns.entrySet().forEach(column -> pattern.withAlias(column.getKey(), new ColumnHandleMatcher(column.getValue())));
+        return pattern;
     }
 
     public static PlanMatchPattern strictTableScan(String expectedTableName, Map<String, String> columnReferences)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -748,6 +748,11 @@ public final class PlanMatchPattern
         return new ExpressionMatcher(expression);
     }
 
+    public static ExpressionMatcher expression(Expression expression)
+    {
+        return new ExpressionMatcher(expression);
+    }
+
     public PlanMatchPattern withOutputs(String... aliases)
     {
         return withOutputs(ImmutableList.copyOf(aliases));

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/Util.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/Util.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.sql.planner.assertions;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import io.prestosql.Session;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.TableHandle;
@@ -27,9 +29,39 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 final class Util
 {
     private Util() {}
+
+    static boolean domainsMatch(TupleDomain<Predicate<ColumnHandle>> expected, TupleDomain<ColumnHandle> actual)
+    {
+        Optional<Map<Predicate<ColumnHandle>, Domain>> expectedDomains = expected.getDomains();
+        Optional<Map<ColumnHandle, Domain>> actualDomains = actual.getDomains();
+
+        if (expectedDomains.isPresent() != actualDomains.isPresent()) {
+            return false;
+        }
+
+        if (expectedDomains.isPresent()) {
+            if (expectedDomains.get().size() != actualDomains.get().size()) {
+                return false;
+            }
+
+            for (Map.Entry<Predicate<ColumnHandle>, Domain> entry : expectedDomains.get().entrySet()) {
+                // There should be exactly one column matching the expected column matcher
+                ColumnHandle actualColumn = Iterables.getOnlyElement(actualDomains.get().keySet().stream()
+                        .filter(x -> entry.getKey().test(x))
+                        .collect(toImmutableList()));
+
+                if (!actualDomains.get().get(actualColumn).contains(entry.getValue())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 
     /**
      * @param expectedDomains if empty, the actualConstraint's domains must also be empty.

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -44,6 +44,7 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static io.prestosql.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static io.prestosql.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
@@ -62,7 +63,7 @@ public class TestDetermineJoinDistributionType
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
+        tester = defaultRuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -52,6 +52,7 @@ import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static io.prestosql.sql.planner.plan.SemiJoinNode.DistributionType.PARTITIONED;
 import static io.prestosql.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
 
@@ -66,7 +67,7 @@ public class TestDetermineSemiJoinDistributionType
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
+        tester = defaultRuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.connector.CatalogName;
+import io.prestosql.connector.MockConnectorFactory;
+import io.prestosql.connector.MockConnectorFactory.MockConnector.MockConnectorTableHandle;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.plugin.tpch.TpchColumnHandle;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.ProjectionApplicationResult;
+import io.prestosql.spi.connector.ProjectionApplicationResult.Assignment;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.expression.Constant;
+import io.prestosql.spi.expression.FieldDereference;
+import io.prestosql.spi.expression.Variable;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.parser.SqlParser;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.iterative.rule.test.RuleTester;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.tree.DereferenceExpression;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.Identifier;
+import io.prestosql.sql.tree.LongLiteral;
+import io.prestosql.sql.tree.SymbolReference;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.spi.expression.ConnectorExpressionTranslator.translate;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.sql.planner.TypeProvider.viewOf;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.Arrays.asList;
+
+public class TestPushProjectionIntoTableScan
+{
+    private static final String MOCK_CATALOG = "mock_catalog";
+    private static final String TEST_SCHEMA = "test_schema";
+    private static final String TEST_TABLE = "test_table";
+    private static final SchemaTableName TEST_SCHEMA_TABLE = new SchemaTableName(TEST_SCHEMA, TEST_TABLE);
+    private static final Type ROW_TYPE = RowType.from(asList(field("a", BIGINT), field("b", BIGINT)));
+
+    private static final TableHandle TEST_TABLE_HANDLE = createTableHandle(TEST_SCHEMA, TEST_TABLE);
+
+    private static final Session MOCK_SESSION = testSessionBuilder().setCatalog(MOCK_CATALOG).setSchema(TEST_SCHEMA).build();
+
+    @Test
+    public void testDoesNotFire()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            String columnName = "input_column";
+            Type columnType = ROW_TYPE;
+            ColumnHandle inputColumnHandle = column(columnName, columnType);
+
+            MockConnectorFactory factory = createMockFactory(ImmutableMap.of(columnName, inputColumnHandle), Optional.empty());
+
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, factory, ImmutableMap.of());
+
+            PushProjectionIntoTableScan optimizer = new PushProjectionIntoTableScan(
+                    ruleTester.getMetadata(),
+                    new TypeAnalyzer(new SqlParser(), ruleTester.getMetadata()));
+
+            ruleTester.assertThat(optimizer)
+                    .on(p -> {
+                        Symbol symbol = p.symbol(columnName, columnType);
+                        return p.project(
+                                Assignments.of(p.symbol("symbol_dereference", BIGINT), new DereferenceExpression(symbol.toSymbolReference(), new Identifier("a"))),
+                                p.tableScan(TEST_TABLE_HANDLE, ImmutableList.of(symbol), ImmutableMap.of(symbol, inputColumnHandle)));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .doesNotFire();
+        }
+    }
+
+    @Test
+    public void testPushProjection()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            // Building context for input
+            String columnName = "col0";
+            Type columnType = ROW_TYPE;
+            Symbol baseColumn = new Symbol(columnName);
+            ColumnHandle columnHandle = new TpchColumnHandle(columnName, columnType);
+
+            // Create catalog with applyProjection enabled
+            MockConnectorFactory factory = createMockFactory(ImmutableMap.of(columnName, columnHandle), Optional.of(this::mockApplyProjection));
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, factory, ImmutableMap.of());
+
+            Metadata metadata = ruleTester.getMetadata();
+            TypeAnalyzer typeAnalyzer = new TypeAnalyzer(new SqlParser(), metadata);
+            PushProjectionIntoTableScan optimizer = new PushProjectionIntoTableScan(metadata, typeAnalyzer);
+
+            // Prepare project node symbols and types
+            Symbol identity = new Symbol("symbol_identity");
+            Symbol dereference = new Symbol("symbol_dereference");
+            Symbol constant = new Symbol("symbol_constant");
+            ImmutableMap<Symbol, Type> types = ImmutableMap.of(
+                    baseColumn, ROW_TYPE,
+                    identity, ROW_TYPE,
+                    dereference, BIGINT,
+                    constant, BIGINT);
+
+            // Prepare project node assignments
+            ImmutableMap<Symbol, Expression> inputProjections = ImmutableMap.of(
+                    identity, baseColumn.toSymbolReference(),
+                    dereference, new DereferenceExpression(baseColumn.toSymbolReference(), new Identifier("a")),
+                    constant, new LongLiteral("5"));
+
+            // Compute expected symbols after applyProjection
+            ImmutableMap<Symbol, String> connectorNames = inputProjections.entrySet().stream()
+                    .collect(toImmutableMap(e -> e.getKey(), e -> translate(MOCK_SESSION, e.getValue(), typeAnalyzer, viewOf(types)).get().toString()));
+            ImmutableMap<Symbol, String> newNames = ImmutableMap.of(
+                    identity, "projected_variable_" + connectorNames.get(identity),
+                    dereference, "projected_dereference_" + connectorNames.get(dereference),
+                    constant, "projected_constant_" + connectorNames.get(constant));
+
+            ruleTester.assertThat(optimizer)
+                    .on(p -> {
+                        // Register symbols
+                        Symbol columnSymbol = p.symbol(columnName, columnType);
+                        p.symbol(identity.getName(), types.get(identity));
+                        p.symbol(dereference.getName(), types.get(dereference));
+                        p.symbol(constant.getName(), types.get(constant));
+
+                        return p.project(
+                                new Assignments(inputProjections),
+                                p.tableScan(
+                                        TEST_TABLE_HANDLE,
+                                        ImmutableList.of(columnSymbol),
+                                        ImmutableMap.of(columnSymbol, columnHandle)));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .matches(project(
+                        newNames.entrySet().stream()
+                            .collect(toImmutableMap(
+                                e -> e.getKey().getName(),
+                                e -> expression(symbolReference(e.getValue())))),
+                            tableScan(
+                                equalTo(createTableHandle(TEST_SCHEMA, "projected_" + TEST_TABLE).getConnectorHandle()),
+                                TupleDomain.all(),
+                                newNames.entrySet().stream()
+                                    .collect(toImmutableMap(
+                                            e -> e.getValue(),
+                                            e -> equalTo(column(e.getValue(), types.get(e.getKey()))))))));
+        }
+    }
+
+    private MockConnectorFactory createMockFactory(Map<String, ColumnHandle> assignments, Optional<MockConnectorFactory.ApplyProjection> applyProjection)
+    {
+        List<ColumnMetadata> metadata = assignments.entrySet().stream()
+                .map(entry -> new ColumnMetadata(entry.getKey(), ((TpchColumnHandle) entry.getValue()).getType()))
+                .collect(toImmutableList());
+
+        MockConnectorFactory.Builder builder = MockConnectorFactory.builder()
+                .withListSchemaNames(connectorSession -> ImmutableList.of(TEST_SCHEMA))
+                .withListTables((connectorSession, schema) -> TEST_SCHEMA.equals(schema) ? ImmutableList.of(TEST_SCHEMA_TABLE) : ImmutableList.of())
+                .withGetColumns(schemaTableName -> metadata);
+
+        if (applyProjection.isPresent()) {
+            builder = builder.withApplyProjection(applyProjection.get());
+        }
+
+        return builder.build();
+    }
+
+    private Optional<ProjectionApplicationResult<ConnectorTableHandle>> mockApplyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        // Prepare new table handle
+        SchemaTableName inputSchemaTableName = ((MockConnectorTableHandle) tableHandle).getTableName();
+        SchemaTableName projectedTableName = new SchemaTableName(
+                inputSchemaTableName.getSchemaName(),
+                "projected_" + inputSchemaTableName.getTableName());
+        MockConnectorTableHandle newTableHandle = new MockConnectorTableHandle(projectedTableName);
+
+        // Prepare new column handles
+        ImmutableList.Builder<ConnectorExpression> outputExpressions = ImmutableList.builder();
+        ImmutableList.Builder<Assignment> outputAssignments = ImmutableList.builder();
+
+        for (ConnectorExpression projection : projections) {
+            String variablePrefix;
+            if (projection instanceof Variable) {
+                variablePrefix = "projected_variable_";
+            }
+            else if (projection instanceof FieldDereference) {
+                variablePrefix = "projected_dereference_";
+            }
+            else if (projection instanceof Constant) {
+                variablePrefix = "projected_constant_";
+            }
+            else {
+                throw new UnsupportedOperationException();
+            }
+
+            String newVariableName = variablePrefix + projection.toString();
+            Variable newVariable = new Variable(newVariableName, projection.getType());
+            ColumnHandle newColumnHandle = new TpchColumnHandle(newVariableName, projection.getType());
+            outputExpressions.add(newVariable);
+            outputAssignments.add(new Assignment(newVariableName, newColumnHandle, projection.getType()));
+        }
+
+        return Optional.of(new ProjectionApplicationResult<>(newTableHandle, outputExpressions.build(), outputAssignments.build()));
+    }
+
+    private static TableHandle createTableHandle(String schemaName, String tableName)
+    {
+        return new TableHandle(
+                new CatalogName(MOCK_CATALOG),
+                new MockConnectorTableHandle(new SchemaTableName(schemaName, tableName)),
+                new ConnectorTransactionHandle() {},
+                Optional.empty());
+    }
+
+    private static SymbolReference symbolReference(String name)
+    {
+        return new SymbolReference(name);
+    }
+
+    private static ColumnHandle column(String name, Type type)
+    {
+        return new TpchColumnHandle(name, type);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestReorderJoins.java
@@ -54,6 +54,7 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 import static io.prestosql.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static io.prestosql.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
@@ -73,7 +74,7 @@ public class TestReorderJoins
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(
+        tester = defaultRuleTester(
                 ImmutableList.of(),
                 ImmutableMap.of(
                         JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name(),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -14,13 +14,17 @@
 package io.prestosql.sql.planner.iterative.rule.test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.Plugin;
+import io.prestosql.testing.LocalQueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 
 public abstract class BaseRuleTest
 {
@@ -35,7 +39,20 @@ public abstract class BaseRuleTest
     @BeforeClass
     public final void setUp()
     {
-        tester = new RuleTester(plugins);
+        Optional<LocalQueryRunner> localQueryRunner = createLocalQueryRunner();
+
+        if (localQueryRunner.isPresent()) {
+            plugins.forEach(plugin -> localQueryRunner.get().installPlugin(plugin));
+            tester = new RuleTester(localQueryRunner.get());
+        }
+        else {
+            tester = defaultRuleTester(plugins, ImmutableMap.of(), Optional.empty());
+        }
+    }
+
+    protected Optional<LocalQueryRunner> createLocalQueryRunner()
+    {
+        return Optional.empty();
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.sql.planner.iterative.rule.test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.Session;
 import io.prestosql.connector.CatalogName;
@@ -33,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
-import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 public class RuleTester
         implements Closeable
@@ -50,22 +51,12 @@ public class RuleTester
     private final AccessControl accessControl;
     private final TypeAnalyzer typeAnalyzer;
 
-    public RuleTester()
+    public static RuleTester defaultRuleTester()
     {
-        this(emptyList());
+        return defaultRuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.empty());
     }
 
-    public RuleTester(List<Plugin> plugins)
-    {
-        this(plugins, ImmutableMap.of());
-    }
-
-    public RuleTester(List<Plugin> plugins, Map<String, String> sessionProperties)
-    {
-        this(plugins, sessionProperties, Optional.empty());
-    }
-
-    public RuleTester(List<Plugin> plugins, Map<String, String> sessionProperties, Optional<Integer> nodeCountForStats)
+    public static RuleTester defaultRuleTester(List<Plugin> plugins, Map<String, String> sessionProperties, Optional<Integer> nodeCountForStats)
     {
         Session.SessionBuilder sessionBuilder = testSessionBuilder()
                 .setCatalog(CATALOG_ID)
@@ -76,18 +67,26 @@ public class RuleTester
             sessionBuilder.setSystemProperty(entry.getKey(), entry.getValue());
         }
 
-        session = sessionBuilder.build();
+        Session session = sessionBuilder.build();
 
-        queryRunner = nodeCountForStats
+        LocalQueryRunner queryRunner = nodeCountForStats
                 .map(nodeCount -> LocalQueryRunner.builder(session)
-                        .withNodeCountForStats(nodeCount)
-                        .build())
+                    .withNodeCountForStats(nodeCount)
+                    .build())
                 .orElseGet(() -> LocalQueryRunner.create(session));
+
         queryRunner.createCatalog(session.getCatalog().get(),
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
         plugins.stream().forEach(queryRunner::installPlugin);
 
+        return new RuleTester(queryRunner);
+    }
+
+    public RuleTester(LocalQueryRunner queryRunner)
+    {
+        this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
+        this.session = queryRunner.getDefaultSession();
         this.metadata = queryRunner.getMetadata();
         this.transactionManager = queryRunner.getTransactionManager();
         this.splitManager = queryRunner.getSplitManager();
@@ -135,5 +134,10 @@ public class RuleTester
     public CatalogName getCurrentConnectorId()
     {
         return queryRunner.inTransaction(transactionSession -> metadata.getCatalogHandle(transactionSession, session.getCatalog().get())).get();
+    }
+
+    public LocalQueryRunner getQueryRunner()
+    {
+        return queryRunner;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/TestRuleTester.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/TestRuleTester.java
@@ -23,13 +23,14 @@ import org.testng.annotations.Test;
 
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 
 public class TestRuleTester
 {
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = "Plan does not match, expected .* but found .*")
     public void testReportWrongMatch()
     {
-        try (RuleTester tester = new RuleTester()) {
+        try (RuleTester tester = defaultRuleTester()) {
             tester.assertThat(new DummyReplaceNodeRule())
                     .on(p ->
                             p.project(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -59,12 +59,8 @@ import static io.prestosql.testing.TestingSession.testSessionBuilder;
 public class TestAddExchangesPlans
         extends BasePlanTest
 {
-    public TestAddExchangesPlans()
-    {
-        super(TestAddExchangesPlans::createQueryRunner);
-    }
-
-    private static LocalQueryRunner createQueryRunner()
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
     {
         Session session = testSessionBuilder()
                 .setCatalog("tpch")

--- a/presto-thrift/pom.xml
+++ b/presto-thrift/pom.xml
@@ -181,5 +181,20 @@
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-parser</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 </project>

--- a/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/TestThriftProjectionPushdown.java
+++ b/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/TestThriftProjectionPushdown.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.thrift.integration;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import io.airlift.drift.server.DriftServer;
+import io.prestosql.Session;
+import io.prestosql.connector.CatalogName;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.plugin.thrift.ThriftColumnHandle;
+import io.prestosql.plugin.thrift.ThriftPlugin;
+import io.prestosql.plugin.thrift.ThriftTableHandle;
+import io.prestosql.plugin.thrift.ThriftTransactionHandle;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.parser.SqlParser;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.iterative.rule.PushProjectionIntoTableScan;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.tree.SymbolReference;
+import io.prestosql.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.plugin.thrift.integration.ThriftQueryRunner.driftServerPort;
+import static io.prestosql.plugin.thrift.integration.ThriftQueryRunner.startThriftServers;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.stream.Collectors.joining;
+
+public class TestThriftProjectionPushdown
+        extends BaseRuleTest
+{
+    private static final String CATALOG = "test";
+    private static final String TINY_SCHEMA = "tiny";
+    private List<DriftServer> servers;
+
+    private static final ThriftTableHandle NATION_THRIFT_TABLE = new ThriftTableHandle(new SchemaTableName(TINY_SCHEMA, "nation"));
+
+    private static final TableHandle NATION_TABLE = new TableHandle(
+            new CatalogName(CATALOG),
+            NATION_THRIFT_TABLE,
+            ThriftTransactionHandle.INSTANCE,
+            Optional.empty());
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(CATALOG)
+            .setSchema(TINY_SCHEMA)
+            .build();
+
+    @Override
+    protected Optional<LocalQueryRunner> createLocalQueryRunner()
+    {
+        try {
+            servers = startThriftServers(1, false);
+        }
+        catch (Throwable t) {
+            try {
+                cleanup();
+            }
+            catch (Throwable e) {
+                t.addSuppressed(e);
+            }
+
+            throw t;
+        }
+
+        String addresses = servers.stream()
+                .map(server -> "localhost:" + driftServerPort(server))
+                .collect(joining(","));
+
+        Map<String, String> connectorProperties = ImmutableMap.<String, String>builder()
+                .put("presto.thrift.client.addresses", addresses)
+                .put("presto.thrift.client.connect-timeout", "30s")
+                .put("presto-thrift.lookup-requests-concurrency", "2")
+                .build();
+
+        LocalQueryRunner runner = LocalQueryRunner.create(SESSION);
+        runner.createCatalog(CATALOG, getOnlyElement(new ThriftPlugin().getConnectorFactories()), connectorProperties);
+
+        return Optional.of(runner);
+    }
+
+    @AfterClass
+    public void cleanup()
+    {
+        if (servers != null) {
+            try (Closer closer = Closer.create()) {
+                for (DriftServer server : servers) {
+                    closer.register(() -> server.shutdown());
+                }
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            servers = null;
+        }
+    }
+
+    @Test
+    public void testDoesNotFire()
+    {
+        PushProjectionIntoTableScan optimizer = new PushProjectionIntoTableScan(
+                tester().getMetadata(),
+                new TypeAnalyzer(new SqlParser(), tester().getMetadata()));
+
+        String columnName = "orderstatus";
+        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, "", false);
+
+        ConnectorTableHandle tableWithColumns = new ThriftTableHandle(
+                TINY_SCHEMA,
+                "nation",
+                TupleDomain.all(),
+                Optional.of(ImmutableSet.of(columnHandle)));
+
+        tester().assertThat(optimizer)
+                .on(p -> {
+                    Symbol orderStatusSymbol = p.symbol(columnName, VARCHAR);
+                    return p.project(
+                            Assignments.of(
+                                    p.symbol("expr_2", VARCHAR),
+                                    orderStatusSymbol.toSymbolReference()),
+                            p.tableScan(
+                                    new TableHandle(
+                                            new CatalogName(CATALOG),
+                                            tableWithColumns,
+                                            ThriftTransactionHandle.INSTANCE,
+                                            Optional.empty()),
+                                    ImmutableList.of(orderStatusSymbol),
+                                    ImmutableMap.of(orderStatusSymbol, columnHandle)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testProjectionPushdown()
+    {
+        PushProjectionIntoTableScan pushProjectionIntoTableScan = new PushProjectionIntoTableScan(
+                tester().getMetadata(),
+                new TypeAnalyzer(new SqlParser(), tester().getMetadata()));
+
+        TableHandle inputTableHandle = NATION_TABLE;
+        String columnName = "orderstatus";
+
+        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, "", false);
+
+        ConnectorTableHandle projectedThriftHandle = new ThriftTableHandle(
+                TINY_SCHEMA,
+                "nation",
+                TupleDomain.all(),
+                Optional.of(ImmutableSet.of(columnHandle)));
+
+        tester().assertThat(pushProjectionIntoTableScan)
+                .on(p -> {
+                    Symbol orderStatusSymbol = p.symbol(columnName, VARCHAR);
+                    return p.project(
+                            Assignments.of(
+                                    p.symbol("expr_2", VARCHAR),
+                                    orderStatusSymbol.toSymbolReference()),
+                            p.tableScan(
+                                    inputTableHandle,
+                                    ImmutableList.of(orderStatusSymbol),
+                                    ImmutableMap.of(orderStatusSymbol, columnHandle)));
+                })
+                .withSession(SESSION)
+                .matches(project(
+                        ImmutableMap.of("expr_2", expression(new SymbolReference(columnName))),
+                        tableScan(
+                                equalTo(projectedThriftHandle),
+                                TupleDomain.all(),
+                                ImmutableMap.of(columnName, equalTo(columnHandle)))));
+    }
+}

--- a/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/ThriftQueryRunner.java
@@ -93,7 +93,7 @@ public final class ThriftQueryRunner
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
     }
 
-    private static List<DriftServer> startThriftServers(int thriftServers, boolean enableIndexJoin)
+    static List<DriftServer> startThriftServers(int thriftServers, boolean enableIndexJoin)
     {
         List<DriftServer> servers = new ArrayList<>(thriftServers);
         for (int i = 0; i < thriftServers; i++) {
@@ -138,7 +138,7 @@ public final class ThriftQueryRunner
         return queryRunner;
     }
 
-    private static int driftServerPort(DriftServer server)
+    static int driftServerPort(DriftServer server)
     {
         return ((DriftNettyServerTransport) server.getServerTransport()).getPort();
     }


### PR DESCRIPTION
Adding test coverage for different optimizers dependent on input from connector metadata. Here, the eventual goal is to be able to test `PushXIntoTableScan` optimizers with different Mock Connector implementations, and also with actual implementations of different connectors. 

Will add Test for hive projection pushdown with #1720  being checked in.

This PR contains tests for projection pushdown. Working on adding other connector pushdown tests (predicate, sample, limit etc). 