### PR TITLE
Add preconditions in NodeLocation constructor

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/tree/NodeLocation.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/NodeLocation.java
@@ -15,6 +15,8 @@ package io.prestosql.sql.tree;
 
 import java.util.Objects;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public final class NodeLocation
 {
     private final int line;
@@ -22,6 +24,9 @@ public final class NodeLocation
 
     public NodeLocation(int line, int charPositionInLine)
     {
+        checkArgument(line >= 1, "line must be at least one, got: %s", line);
+        checkArgument(charPositionInLine >= 0, "charPositionInLine must be at least zero, got: %s", charPositionInLine);
+
         this.line = line;
         this.charPositionInLine = charPositionInLine;
     }


### PR DESCRIPTION
This ensures `NodeLocation` can be used to construct `Location` or
`ErrorLocation`.