### PR TITLE
Add support for accessing MongoDB view

### DIFF
--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
@@ -221,6 +221,9 @@ public class MongoSession
 
     public List<MongoIndex> getIndexes(SchemaTableName tableName)
     {
+        if (isView(tableName)) {
+            return ImmutableList.of();
+        }
         return MongoIndex.parse(getCollection(tableName).listIndexes());
     }
 
@@ -557,5 +560,12 @@ public class MongoSession
         }
 
         return Optional.ofNullable(typeSignature);
+    }
+
+    private boolean isView(SchemaTableName tableName)
+    {
+        MongoCollection views = client.getDatabase(tableName.getSchemaName()).getCollection("system.views");
+        Object view = views.find(new Document("_id", tableName.toString())).first();
+        return view != null;
     }
 }

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
@@ -285,6 +285,16 @@ public class TestMongoIntegrationSmokeTest
         assertUpdate("DROP TABLE tmp_objectid");
     }
 
+    @Test
+    public void testSelectView()
+    {
+        assertUpdate("CREATE TABLE test.view_base AS SELECT 'foo' _varchar", 1);
+        mongoQueryRunner.getMongoClient().getDatabase("test").createView("test_view", "view_base", ImmutableList.of());
+        assertQuery("SELECT * FROM test.view_base", "SELECT 'foo'");
+        assertUpdate("DROP TABLE test.test_view");
+        assertUpdate("DROP TABLE test.view_base");
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toTestTypes();


### PR DESCRIPTION
Fixes #2137

I tried to add test for this PR, but even the latest `bwaldvogel/mongo-java-server` doesn't support creating a view. Perhaps, it would be better to consider other testing libraries. (I confirmed Testcontainers doesn't have mongodb module)