### PR TITLE
Add rule for Pruning columns in Correlated Joins

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -60,6 +60,7 @@ import io.prestosql.sql.planner.iterative.rule.MergeLimits;
 import io.prestosql.sql.planner.iterative.rule.MultipleDistinctAggregationToMarkDistinct;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationSourceColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import io.prestosql.sql.planner.iterative.rule.PruneCrossJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneFilterColumns;
@@ -240,6 +241,7 @@ public class PlanOptimizers
                 new PruneProjectColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
+                new PruneCorrelatedJoinColumns(),
                 new PruneTopNColumns(),
                 new PruneValuesColumns(),
                 new PruneWindowColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCorrelatedJoinColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCorrelatedJoinColumns.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import io.prestosql.sql.planner.PlanNodeIdAllocator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
+import io.prestosql.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.sql.planner.iterative.rule.Util.restrictOutputs;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
+
+public class PruneCorrelatedJoinColumns
+        extends ProjectOffPushDownRule<CorrelatedJoinNode>
+{
+    public PruneCorrelatedJoinColumns()
+    {
+        super(correlatedJoin());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, CorrelatedJoinNode correlatedJoinNode, Set<Symbol> referencedOutputs)
+    {
+        Set<Symbol> requiredSourceInputs = Streams.concat(
+                referencedOutputs.stream(),
+                correlatedJoinNode.getCorrelation().stream())
+                .collect(toImmutableSet());
+
+        return restrictOutputs(idAllocator, correlatedJoinNode.getInput(), requiredSourceInputs)
+                .map(newSource ->
+                        correlatedJoinNode.replaceChildren(ImmutableList.of(
+                                newSource, correlatedJoinNode.getSubquery())));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneCorrelatedJoinColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneCorrelatedJoinColumns.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.iterative.rule.test.PlanBuilder;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.ProjectNode;
+import org.testng.annotations.Test;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.correlatedJoin;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneCorrelatedJoinColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllInputsReferenced()
+    {
+        tester().assertThat(new PruneCorrelatedJoinColumns())
+                .on(p -> buildProjectedCorrelated(p, symbol -> symbol.getName().equals("b")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("b", expression("b"), "c", expression("c")),
+                                correlatedJoin(
+                                        ImmutableList.of(),
+                                        strictProject(
+                                                ImmutableMap.of("b", expression("b")),
+                                                values("a", "b")),
+                                        values("c"))));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+    {
+        tester().assertThat(new PruneCorrelatedJoinColumns())
+                .on(p -> buildProjectedCorrelated(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    private ProjectNode buildProjectedCorrelated(PlanBuilder planBuilder, Predicate<Symbol> projectionFilter)
+    {
+        Symbol a = planBuilder.symbol("a");
+        Symbol b = planBuilder.symbol("b");
+        Symbol c = planBuilder.symbol("c");
+        return planBuilder.project(
+                Assignments.identity(Streams.concat(Stream.of(a, b).filter(projectionFilter), Stream.of(c)).collect(toImmutableSet())),
+                planBuilder.correlatedJoin(
+                        ImmutableList.of(),
+                        planBuilder.values(a, b),
+                        planBuilder.values(c)));
+    }
+}


### PR DESCRIPTION
This rule ensures that Projection push down for TableScan happens for queries with lateral joins