### PR TITLE
Remove misleading TODO

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -226,7 +226,6 @@ public class PlanOptimizers
         Set<Rule<?>> predicatePushDownRules = ImmutableSet.of(
                 new MergeFilters(metadata));
 
-        // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule<?>> columnPruningRules = ImmutableSet.of(
                 new PruneAggregationColumns(),
                 new PruneAggregationSourceColumns(),


### PR DESCRIPTION
`PruneUnreferencedOutputs` does much more than the rules extending
`ProjectOffPushDownRule`. `ProjectOffPushDownRule` considers only
unreferenced symbols indicated by narrowing projections, whereas other
type of `PlanNode`s can effectively act as narrowing projections too.
While we want to have symbol pruning to be rule-based, the TODO per-se
was misleading.