### PR TITLE
Handle common disk failures in the spill code path

### DIFF
--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -86,23 +86,20 @@ public class TestFileSingleStreamSpillerFactory
     }
 
     @Test
-    public void testDistributesSpillOverPaths()
-            throws Exception
+    public void testDistributesSpillOverPaths() throws Exception
     {
         verifySpills(ImmutableMap.of(spillPath1.toPath(), 5, spillPath2.toPath(), 5));
     }
 
     @Test
-    public void testDistributesSpillOverPathsBadDisk()
-        throws Exception
+    public void testDistributesSpillOverPathsBadDisk() throws Exception
     {
         // reset path permission to 400, this will prohibit creation of spills
         java.nio.file.Files.setPosixFilePermissions(spillPath1.toPath(), ImmutableSet.of(PosixFilePermission.OWNER_READ));
         verifySpills(ImmutableMap.of(spillPath1.toPath(), 0, spillPath2.toPath(), 10));
     }
 
-    private void verifySpills(Map<Path, Integer> expectedSpills)
-        throws Exception
+    private void verifySpills(Map<Path, Integer> expectedSpills) throws Exception
     {
         for (Path path : expectedSpills.keySet()) {
             assertEquals(listFiles(path).size(), 0);


### PR DESCRIPTION
In a JBOD setup disk failures are quite common. In the absence of basic failure
handling, a presto worker will not recover untill a config is changed and process
is restarted -- which is unarguably bad ops experience.

Spill path discovery routine already handles the case when one or more paths
are out of free space, this change adds couple of additional checks to cover
out of band disk failures.

Fixes: https://github.com/prestosql/presto/issues/2173