### PR TITLE
Run single test in TestOrcReader with full tester

### DIFF
--- a/presto-orc/src/test/java/io/prestosql/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/AbstractTestOrcReader.java
@@ -450,7 +450,7 @@ public abstract class AbstractTestOrcReader
         };
     }
 
-    private static List<Double> doubleSequence(double start, double step, int items)
+    protected static List<Double> doubleSequence(double start, double step, int items)
     {
         List<Double> values = new ArrayList<>();
         double nextValue = start;

--- a/presto-orc/src/test/java/io/prestosql/orc/TestOrcReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestOrcReader.java
@@ -15,6 +15,9 @@ package io.prestosql.orc;
 
 import org.testng.annotations.Test;
 
+import static io.prestosql.orc.OrcTester.fullOrcTester;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+
 @Test
 public class TestOrcReader
         extends AbstractTestOrcReader
@@ -22,5 +25,13 @@ public class TestOrcReader
     public TestOrcReader()
     {
         super(OrcTester.quickOrcTester());
+    }
+
+    @Test
+    public void testDoubleSequenceFull()
+            throws Exception
+    {
+        // run a single test using the full tester
+        fullOrcTester().testRoundTrip(DOUBLE, doubleSequence(0, 0.1, 30_000));
     }
 }


### PR DESCRIPTION
This increases default test coverage with minimal overhead.