### PR TITLE
Be verbose when exiting from test suite

### DIFF
--- a/presto-product-tests/bin/product-tests-suite-1.sh
+++ b/presto-product-tests/bin/product-tests-suite-1.sh
@@ -9,4 +9,5 @@ presto-product-tests/bin/run_on_docker.sh \
     -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql,postgresql,kafka,simba_jdbc,hive_compression,"${DISTRO_SKIP_GROUP}" \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-2.sh
+++ b/presto-product-tests/bin/product-tests-suite-2.sh
@@ -25,4 +25,5 @@ presto-product-tests/bin/run_on_docker.sh \
     -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-3.sh
+++ b/presto-product-tests/bin/product-tests-suite-3.sh
@@ -19,4 +19,5 @@ presto-product-tests/bin/run_on_docker.sh \
     -g storage_formats,cli,hdfs_impersonation,authorization \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-5.sh
+++ b/presto-product-tests/bin/product-tests-suite-5.sh
@@ -14,4 +14,5 @@ presto-product-tests/bin/run_on_docker.sh \
     -g storage_formats,hdfs_impersonation,authorization \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
@@ -43,4 +43,5 @@ presto-product-tests/bin/run_on_docker.sh \
     -g kafka \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
@@ -52,4 +52,5 @@ env HADOOP_BASE_IMAGE="not-used" TESTS_HIVE_VERSION_MAJOR="3" TESTS_HIVE_VERSION
     -g hdp3_only,storage_formats,hive_transactional \
     || exit_code=1
 
+echo "$0: exiting with ${exit_code}"
 exit "${exit_code}"


### PR DESCRIPTION
Previously output from CI job could end with

    + exit 0
    + exit 1

which looked weird and didn't suggest there was a previous test run that
failed.