### PR TITLE
handle empty object field

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
@@ -456,8 +456,11 @@ public class ElasticsearchClient
                     }
                     result.add(new IndexMetadata.Field(name, new IndexMetadata.DateTimeType(formats)));
                 }
-                else {
+                else if (!type.equals("object")) {
                     result.add(new IndexMetadata.Field(name, new IndexMetadata.PrimitiveType(type)));
+                }
+                else {
+                    LOG.debug("Empty object field %s ignored, row type must have at least one field", name);
                 }
             }
             else if (value.has("properties")) {


### PR DESCRIPTION
In some indexes mapping, I've some field with this structure:

"myEmptyObjectField": {
              "type": "object"
            }

Since mapping is dynamic on these indexes, and object is empty elasticsearch cannot guess a type for sub fields, so it has "object" type. (ie empty object).

Because  presto row type need at least one field, I just add a condition to drop the field, so that index is queryable.