### PR TITLE
Unique product tests reports

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -53,7 +53,6 @@ function check_presto() {
 
 function run_product_tests() {
   local REPORT_DIR="${PRODUCT_TESTS_ROOT}/target/test-reports"
-  rm -rf "${REPORT_DIR}"
   mkdir -p "${REPORT_DIR}"
   run_in_application_runner_container /docker/presto-product-tests/conf/docker/files/run-tempto.sh "$@" &
   PRODUCT_TESTS_PROCESS_ID=$!

--- a/presto-product-tests/conf/docker/files/run-tempto.sh
+++ b/presto-product-tests/conf/docker/files/run-tempto.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 DOCKER_TEMPTO_CONF_DIR="/docker/presto-product-tests/conf/tempto"
 TEMPTO_CONFIG_FILES="tempto-configuration.yaml" # this comes from classpath
 TEMPTO_CONFIG_FILES="${TEMPTO_CONFIG_FILES},${DOCKER_TEMPTO_CONF_DIR}/tempto-configuration-for-docker-default.yaml"
+START_TIME=$(date "+%Y-%m-%dT%H:%M:%S")
 
 if ! test -z ${TEMPTO_ENVIRONMENT_CONFIG_FILE:-}; then
   TEMPTO_CONFIG_FILES="${TEMPTO_CONFIG_FILES},${TEMPTO_ENVIRONMENT_CONFIG_FILE}"
@@ -24,6 +25,6 @@ java \
   -Duser.timezone=Asia/Kathmandu \
   -cp "/docker/presto-jdbc.jar:/docker/presto-product-tests-executable.jar" \
   io.prestosql.tests.TemptoProductTestRunner \
-  --report-dir "/docker/test-reports" \
+  --report-dir "/docker/test-reports/${START_TIME}" \
   --config "${TEMPTO_CONFIG_FILES}" \
   "$@"


### PR DESCRIPTION
When executing different product-tests suites, if anyone of them has
more than one execution of product tests, only the last one's test reports
are visible (they override each other). Thanks to this change, each of the
product-test (environment + tempto tests args) will be reporting to its own unique folder,
allowing either manual or automatic tests reports gathering.