### PR TITLE
Add client_buffers reorder strategy for ArbitraryOutputBuffer.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlTask.java
@@ -58,6 +58,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.succinctBytes;
+import static io.prestosql.SystemSessionProperties.getClientBuffersReorderStrategy;
 import static io.prestosql.execution.TaskState.ABORTED;
 import static io.prestosql.execution.TaskState.FAILED;
 import static io.prestosql.util.Failures.toFailures;
@@ -367,7 +368,7 @@ public class SqlTask
             // The LazyOutput buffer does not support write methods, so the actual
             // output buffer must be established before drivers are created (e.g.
             // a VALUES query).
-            outputBuffer.setOutputBuffers(outputBuffers);
+            outputBuffer.setOutputBuffers(outputBuffers, getClientBuffersReorderStrategy(session));
 
             // assure the task execution is only created once
             SqlTaskExecution taskExecution;

--- a/presto-main/src/main/java/io/prestosql/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/LazyOutputBuffer.java
@@ -147,6 +147,12 @@ public class LazyOutputBuffer
     @Override
     public void setOutputBuffers(OutputBuffers newOutputBuffers)
     {
+        setOutputBuffers(newOutputBuffers, ArbitraryOutputBuffer.ClientBuffersReorderStrategy.DEFAULT);
+    }
+
+    @Override
+    public void setOutputBuffers(OutputBuffers newOutputBuffers, ArbitraryOutputBuffer.ClientBuffersReorderStrategy reorderStrategy)
+    {
         Set<OutputBufferId> abortedBuffers = ImmutableSet.of();
         List<PendingRead> pendingReads = ImmutableList.of();
         OutputBuffer outputBuffer;
@@ -164,7 +170,7 @@ public class LazyOutputBuffer
                         delegate = new BroadcastOutputBuffer(taskInstanceId, state, maxBufferSize, systemMemoryContextSupplier, executor);
                         break;
                     case ARBITRARY:
-                        delegate = new ArbitraryOutputBuffer(taskInstanceId, state, maxBufferSize, systemMemoryContextSupplier, executor);
+                        delegate = new ArbitraryOutputBuffer(taskInstanceId, state, maxBufferSize, systemMemoryContextSupplier, executor, reorderStrategy);
                         break;
                 }
 

--- a/presto-main/src/main/java/io/prestosql/execution/buffer/OutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/OutputBuffer.java
@@ -57,6 +57,11 @@ public interface OutputBuffer
      */
     void setOutputBuffers(OutputBuffers newOutputBuffers);
 
+    default void setOutputBuffers(OutputBuffers newOutputBuffers, ArbitraryOutputBuffer.ClientBuffersReorderStrategy reorderStrategy)
+    {
+        setOutputBuffers(newOutputBuffers);
+    }
+
     /**
      * Gets pages from the output buffer, and acknowledges all pages received from the last
      * request.  The initial token is zero. Subsequent tokens are acquired from the


### PR DESCRIPTION
Hi, prestosql community. Recently, we found that Client Buffers in ArbitraryOutputBuffer are selected by requests or a fixed order to load page from Master Buffer, so it may cause input_data skewness in next stage.
And here are some details:
In our case, we do an `order by` after all `aggregations`. And we find that after `RoundRobin` distribution of last `aggregation`, the input_data rows/bytes on sort nodes have obvious skewness. And it may cause the query fail since one of the nodes exceeds `max-(total)-memory-per-node`. The data distribution skewness and the memory usage(max/avg/min) in reserved pool shows as following:
![image](https://user-images.githubusercontent.com/52450359/70372133-fe51c200-1915-11ea-9e81-81c9a33d3c86.png)
![image](https://user-images.githubusercontent.com/52450359/70372134-014cb280-1916-11ea-88a0-9e511cf8da02.png)
After investigating, we find `RoundRobin` distribution uses `ArbitraryOutputBuffer` as its task_output_buffer and `ArbitraryOutputBuffer` uses a `for loop` to assign pages from master_buffer to all client_buffers, so if there are only very few pages in master_buffer when assignment starts, only the first several client_buffers can get such pages, then skewness comes.
I think data skewness is not good for any distribution system, so we try to change the order of client_buffers when assignment starts. We provide 4 reorder strategies: DEFAULT(same as now), SHUFFLE, ROW_COUNT and PAGE_COUNT in SessionProperties as `client_buffers_reorder_strategy`. 
The data distribution and the memory usage when set to ROW_COUNT shows as following:
![image](https://user-images.githubusercontent.com/52450359/70372136-0f9ace80-1916-11ea-8ea9-ed44a609c58f.png)
![image](https://user-images.githubusercontent.com/52450359/70372137-1295bf00-1916-11ea-8e39-03cd67aaed39.png)
I'm not sure if this PR is a good solution, but I think the data skewness after ArbitraryOutputBuffer is not expected.