### PR TITLE
Convert Type to DataType via TypeSignature

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -318,6 +318,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestTypeSignatureTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestTypeSignatureTranslator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.analyzer;
+
+import io.prestosql.sql.parser.SqlParser;
+import io.prestosql.sql.tree.Identifier;
+import org.testng.annotations.Test;
+
+import java.util.Comparator;
+import java.util.Locale;
+
+import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toDataType;
+import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
+import static io.prestosql.sql.parser.ParserAssert.type;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTypeSignatureTranslator
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+
+    private void assertRoundTrip(String expression)
+    {
+        assertThat(type(expression))
+                .ignoringLocation()
+                .withComparatorForType(Comparator.comparing(identifier -> identifier.getValue().toLowerCase(Locale.ENGLISH)), Identifier.class)
+                .isEqualTo(toDataType(toTypeSignature(SQL_PARSER.createType(expression))));
+    }
+
+    @Test
+    public void testSimpleTypes()
+    {
+        assertRoundTrip("varchar");
+        assertRoundTrip("BIGINT");
+        assertRoundTrip("DOUBLE");
+        assertRoundTrip("BOOLEAN");
+    }
+
+    @Test
+    public void testDayTimeTypes()
+    {
+        assertRoundTrip("TIMESTAMP");
+        assertRoundTrip("TIMESTAMP WITHOUT TIME ZONE");
+        assertRoundTrip("TIMESTAMP WITH TIME ZONE");
+        assertRoundTrip("TIME");
+        assertRoundTrip("TIME WITHOUT TIME ZONE");
+        assertRoundTrip("TIME WITH TIME ZONE");
+    }
+
+    @Test
+    public void testIntervalTypes()
+    {
+        assertRoundTrip("INTERVAL DAY TO SECOND");
+        assertRoundTrip("INTERVAL YEAR TO MONTH");
+    }
+
+    @Test
+    public void testParametricTypes()
+    {
+        assertRoundTrip("ARRAY(TINYINT)");
+        assertRoundTrip("MAP(BIGINT, SMALLINT)");
+        assertRoundTrip("VARCHAR(123)");
+        assertRoundTrip("DECIMAL(1)");
+        assertRoundTrip("DECIMAL(1, 38)");
+    }
+
+    @Test
+    public void testArray()
+    {
+        assertRoundTrip("foo(42, 55) ARRAY");
+        assertRoundTrip("VARCHAR(7) ARRAY");
+        assertRoundTrip("VARCHAR(7) ARRAY array");
+    }
+
+    @Test
+    public void testRowType()
+    {
+        assertRoundTrip("ROW(a BIGINT, b VARCHAR)");
+        assertRoundTrip("ROW(a BIGINT,b VARCHAR)");
+        assertRoundTrip("ROW(\"a\" BIGINT, \"from\" VARCHAR)");
+    }
+
+    @Test
+    public void testComplexTypes()
+    {
+        assertRoundTrip("ROW(x BIGINT, y DOUBLE PRECISION, z ROW(m array<bigint>,n map<double,varchar>))");
+    }
+}

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/DateTimeDataType.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/DateTimeDataType.java
@@ -35,7 +35,12 @@ public class DateTimeDataType
 
     public DateTimeDataType(NodeLocation location, Type type, boolean withTimeZone, Optional<String> precision)
     {
-        super(Optional.of(location));
+        this(Optional.of(location), type, withTimeZone, precision);
+    }
+
+    public DateTimeDataType(Optional<NodeLocation> location, Type type, boolean withTimeZone, Optional<String> precision)
+    {
+        super(location);
         this.type = requireNonNull(type, "type is null");
         this.withTimeZone = withTimeZone;
         this.precision = requireNonNull(precision, "precision is null");

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/GenericDataType.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/GenericDataType.java
@@ -34,6 +34,13 @@ public class GenericDataType
         this.arguments = requireNonNull(arguments, "arguments is null");
     }
 
+    public GenericDataType(Optional<NodeLocation> location, Identifier name, List<DataTypeParameter> arguments)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+        this.arguments = requireNonNull(arguments, "arguments is null");
+    }
+
     public Identifier getName()
     {
         return name;

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/IntervalDayTimeDataType.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/IntervalDayTimeDataType.java
@@ -39,7 +39,12 @@ public class IntervalDayTimeDataType
 
     public IntervalDayTimeDataType(NodeLocation location, Field from, Field to)
     {
-        super(Optional.of(location));
+        this(Optional.of(location), from, to);
+    }
+
+    public IntervalDayTimeDataType(Optional<NodeLocation> location, Field from, Field to)
+    {
+        super(location);
         this.from = requireNonNull(from, "from is null");
         this.to = requireNonNull(to, "to is null");
     }

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/NumericParameter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/NumericParameter.java
@@ -28,7 +28,12 @@ public class NumericParameter
 
     public NumericParameter(NodeLocation location, String value)
     {
-        super(Optional.of(location));
+        this(Optional.of(location), value);
+    }
+
+    public NumericParameter(Optional<NodeLocation> location, String value)
+    {
+        super(location);
         this.value = requireNonNull(value, "value is null");
     }
 

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/RowDataType.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/RowDataType.java
@@ -32,6 +32,12 @@ public class RowDataType
         this.fields = ImmutableList.copyOf(fields);
     }
 
+    public RowDataType(Optional<NodeLocation> location, List<Field> fields)
+    {
+        super(location);
+        this.fields = ImmutableList.copyOf(fields);
+    }
+
     public List<Field> getFields()
     {
         return fields;
@@ -77,6 +83,14 @@ public class RowDataType
         public Field(NodeLocation location, Optional<Identifier> name, DataType type)
         {
             super(Optional.of(location));
+
+            this.name = requireNonNull(name, "name is null");
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        public Field(Optional<NodeLocation> location, Optional<Identifier> name, DataType type)
+        {
+            super(location);
 
             this.name = requireNonNull(name, "name is null");
             this.type = requireNonNull(type, "type is null");


### PR DESCRIPTION
Previously we were using SqlParser to convert a Type to DataType which fails for SHOW CREATE TABLE for table with columns of row type having reserved keyword as its field name

Fixes #2130 