### PR TITLE
change listPrefix in s3 file system to listobjectv2

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -530,14 +530,9 @@ public class PrestoS3FileSystem
                     return null;
                 }
 
-                final ListObjectsV2Request nextRequest = new ListObjectsV2Request()
-                        .withBucketName(previous.getBucketName())
-                        .withPrefix(previous.getPrefix())
-                        .withDelimiter(previous.getDelimiter())
-                        .withRequesterPays(requesterPaysEnabled)
-                        .withContinuationToken(previous.getNextContinuationToken());
+                request.setContinuationToken(previous.getNextContinuationToken());
 
-                return s3.listObjectsV2(nextRequest);
+                return s3.listObjectsV2(request);
             }
         };
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -47,8 +47,8 @@ import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
@@ -514,29 +514,37 @@ public class PrestoS3FileSystem
             key += PATH_SEPARATOR;
         }
 
-        ListObjectsRequest request = new ListObjectsRequest()
+        ListObjectsV2Request request = new ListObjectsV2Request()
                 .withBucketName(getBucketName(uri))
                 .withPrefix(key)
                 .withDelimiter(PATH_SEPARATOR)
                 .withRequesterPays(requesterPaysEnabled);
 
         STATS.newListObjectsCall();
-        Iterator<ObjectListing> listings = new AbstractSequentialIterator<ObjectListing>(s3.listObjects(request))
+        Iterator<ListObjectsV2Result> listings = new AbstractSequentialIterator<ListObjectsV2Result>(s3.listObjectsV2(request))
         {
             @Override
-            protected ObjectListing computeNext(ObjectListing previous)
+            protected ListObjectsV2Result computeNext(ListObjectsV2Result previous)
             {
                 if (!previous.isTruncated()) {
                     return null;
                 }
-                return s3.listNextBatchOfObjects(previous);
+
+                final ListObjectsV2Request nextRequest = new ListObjectsV2Request()
+                        .withBucketName(previous.getBucketName())
+                        .withPrefix(previous.getPrefix())
+                        .withDelimiter(previous.getDelimiter())
+                        .withRequesterPays(requesterPaysEnabled)
+                        .withContinuationToken(previous.getNextContinuationToken());
+
+                return s3.listObjectsV2(nextRequest);
             }
         };
 
         return Iterators.concat(Iterators.transform(listings, this::statusFromListing));
     }
 
-    private Iterator<LocatedFileStatus> statusFromListing(ObjectListing listing)
+    private Iterator<LocatedFileStatus> statusFromListing(ListObjectsV2Result listing)
     {
         return Iterators.concat(
                 statusFromPrefixes(listing.getCommonPrefixes()),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
@@ -19,6 +19,8 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -115,6 +117,28 @@ public class MockAmazonS3
         }
 
         return listing;
+    }
+
+    @Override
+    public ListObjectsV2Result listObjectsV2(ListObjectsV2Request listObjectsV2Request)
+    {
+        ListObjectsV2Result listingV2 = new ListObjectsV2Result();
+
+        S3ObjectSummary standard = new S3ObjectSummary();
+        standard.setStorageClass(StorageClass.Standard.toString());
+        standard.setKey("test/standard");
+        standard.setLastModified(new Date());
+        listingV2.getObjectSummaries().add(standard);
+
+        if (hasGlacierObjects) {
+            S3ObjectSummary glacier = new S3ObjectSummary();
+            glacier.setStorageClass(StorageClass.Glacier.toString());
+            glacier.setKey("test/glacier");
+            glacier.setLastModified(new Date());
+            listingV2.getObjectSummaries().add(glacier);
+        }
+
+        return listingV2;
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
@@ -98,20 +98,33 @@ public class MockAmazonS3
     @Override
     public ListObjectsV2Result listObjectsV2(ListObjectsV2Request listObjectsV2Request)
     {
+        final String continuationToken = "continue";
+
         ListObjectsV2Result listingV2 = new ListObjectsV2Result();
 
-        S3ObjectSummary standard = new S3ObjectSummary();
-        standard.setStorageClass(StorageClass.Standard.toString());
-        standard.setKey("test/standard");
-        standard.setLastModified(new Date());
-        listingV2.getObjectSummaries().add(standard);
+        if (continuationToken.equals(listObjectsV2Request.getContinuationToken())) {
+            S3ObjectSummary standardTwo = new S3ObjectSummary();
+            standardTwo.setStorageClass(StorageClass.Standard.toString());
+            standardTwo.setKey("test/standardTwo");
+            standardTwo.setLastModified(new Date());
+            listingV2.getObjectSummaries().add(standardTwo);
 
-        if (hasGlacierObjects) {
-            S3ObjectSummary glacier = new S3ObjectSummary();
-            glacier.setStorageClass(StorageClass.Glacier.toString());
-            glacier.setKey("test/glacier");
-            glacier.setLastModified(new Date());
-            listingV2.getObjectSummaries().add(glacier);
+            if (hasGlacierObjects) {
+                S3ObjectSummary glacier = new S3ObjectSummary();
+                glacier.setStorageClass(StorageClass.Glacier.toString());
+                glacier.setKey("test/glacier");
+                glacier.setLastModified(new Date());
+                listingV2.getObjectSummaries().add(glacier);
+            }
+        }
+        else {
+            S3ObjectSummary standardOne = new S3ObjectSummary();
+            standardOne.setStorageClass(StorageClass.Standard.toString());
+            standardOne.setKey("test/standardOne");
+            standardOne.setLastModified(new Date());
+            listingV2.getObjectSummaries().add(standardOne);
+            listingV2.setTruncated(true);
+            listingV2.setNextContinuationToken(continuationToken);
         }
 
         return listingV2;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
@@ -18,10 +18,8 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
-import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
@@ -95,28 +93,6 @@ public class MockAmazonS3
     {
         this.acl = putObjectRequest.getCannedAcl();
         return new PutObjectResult();
-    }
-
-    @Override
-    public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
-    {
-        ObjectListing listing = new ObjectListing();
-
-        S3ObjectSummary standard = new S3ObjectSummary();
-        standard.setStorageClass(StorageClass.Standard.toString());
-        standard.setKey("test/standard");
-        standard.setLastModified(new Date());
-        listing.getObjectSummaries().add(standard);
-
-        if (hasGlacierObjects) {
-            S3ObjectSummary glacier = new S3ObjectSummary();
-            glacier.setStorageClass(StorageClass.Glacier.toString());
-            glacier.setKey("test/glacier");
-            glacier.setLastModified(new Date());
-            listing.getObjectSummaries().add(glacier);
-        }
-
-        return listing;
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
@@ -511,7 +511,7 @@ public class TestPrestoS3FileSystem
             fs.initialize(new URI("s3n://test-bucket/"), config);
             fs.setS3Client(s3);
             FileStatus[] statuses = fs.listStatus(new Path("s3n://test-bucket/test"));
-            assertEquals(statuses.length, skipGlacierObjects ? 1 : 2);
+            assertEquals(statuses.length, skipGlacierObjects ? 2 : 3);
         }
     }
 


### PR DESCRIPTION
According to [AWS S3 document](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html),
```
Important
    This section describes the latest revision of the API. 
    We recommend that you use this revised API for application development.
    For backward compatibility, Amazon S3 continues to support the prior version of this API, ListObjects.
```
And after some tests, V2 is indeed better. So we change ListObjects to ListObjectsV2 in PrestoS3FileSystem.