### PR TITLE
Using JAVA_HOME bugfix in rpm

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
+++ b/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
@@ -38,7 +38,7 @@ start () {
         echo "Warning: No value found for \$JAVA_HOME. Default Java will be used." >&2
         sudo -u $SERVICE_USER /usr/lib/presto/bin/launcher start "${CONFIGURATION[@]}"
     else
-        sudo -u $SERVICE_USER PATH=${PRESTO_JAVA_HOME}/bin:$PATH /usr/lib/presto/bin/launcher start "${CONFIGURATION[@]}"
+        sudo -u $SERVICE_USER PATH=${JAVA_HOME}/bin:$PATH /usr/lib/presto/bin/launcher start "${CONFIGURATION[@]}"
     fi
     return $?
 }


### PR DESCRIPTION
Using JAVA_HOME bugfix in rpm

PRESTO_JAVA_HOME was supposed to be removed with:
4a0c5f01ce587fbb28c23d7f217945a030073a8a
