### PR TITLE
Remove hiding of last chapter content in all toctrees

### DIFF
--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -4,7 +4,7 @@ Presto Documentation
 
 .. toctree::
     :maxdepth: 2
-    :numbered: 2
+    :numbered:
 
     overview
     installation
@@ -17,6 +17,9 @@ Presto Documentation
     sql
     migration
     develop
-    release
 
-.. Note: If "release" is not the last item, the CSS must be updated.
+.. toctree::
+    :caption: Appendix
+    :maxdepth: 1
+
+    release

--- a/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
+++ b/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
@@ -140,11 +140,6 @@ tt.docutils.literal, code.docutils.literal {
     white-space: nowrap;
 }
 
-/* hide children of Release Notes */
-div.toctree-wrapper > ul > li:last-child > ul {
-    display: none;
-}
-
 table.docutils col {
     width: auto;
 }


### PR DESCRIPTION
While this hides the release notes list in the global ToC as commented, it also does that for all other ToC pages. 

I believe the drawbacks outweigh the benefits and suggest we just have the release notes list in the global ToC. The page size does not change since we were just hiding the content with the css and the list is at the bottom so it does not really hinder the reader.

I also had a look at Sphinx docs to see if there is a way to exclude something in the toctree but could not find anything that works smoothly.