### PR TITLE
Consistent naming for CLI

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -70,7 +70,7 @@ import static org.jline.terminal.TerminalBuilder.terminal;
 import static org.jline.utils.AttributedStyle.CYAN;
 import static org.jline.utils.AttributedStyle.DEFAULT;
 
-@Command(name = "presto", description = "Presto interactive console")
+@Command(name = "presto", description = "Presto command line interface")
 public class Console
 {
     public static final Set<String> STATEMENT_DELIMITERS = ImmutableSet.of(";", "\\G");


### PR DESCRIPTION
Docker image and other install methods I have seen always mention the filename to be presto-cli.

We also use the name Presto CLI in the codebase itself.

```
$ presto-cli --version
Presto CLI 326
```

And fyi I have not yet tested this or worked on any improvements to the docs if necessary ... just throwing this here as an idea for starters. 