### PR TITLE
Find preferred bash locally

### DIFF
--- a/presto-hive-hadoop2/bin/common.sh
+++ b/presto-hive-hadoop2/bin/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function retry() {
   local END

--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail -x
 

--- a/presto-hive-hadoop2/bin/run_hive_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail -x
 

--- a/presto-hive-hadoop2/bin/start_hive.sh
+++ b/presto-hive-hadoop2/bin/start_hive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/presto-kudu/bin/run_kudu_tests.sh
+++ b/presto-kudu/bin/run_kudu_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Runs all tests with Kudu server in docker containers.
 #

--- a/presto-main/bin/check_webui.sh
+++ b/presto-main/bin/check_webui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Perform basic validations on the Web UI Javascript code
 #

--- a/presto-product-tests/bin/lib.sh
+++ b/presto-product-tests/bin/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "${BASH_SOURCE%/*}/locations.sh"
 

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/presto-product-tests/bin/run_presto_cli_on_docker.sh
+++ b/presto-product-tests/bin/run_presto_cli_on_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/presto-product-tests/bin/run_tempto_on_docker.sh
+++ b/presto-product-tests/bin/run_tempto_on_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/presto-product-tests/bin/stop_all_containers.sh
+++ b/presto-product-tests/bin/stop_all_containers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Use `env bash` instead of `/bin/bash`. This allows finding preferred
Bash version when running locally (not in a docker container).

This is particularly important when OS provides Bash 3 (e.g. many recent
MacOS versions) while the scripts require Bash 4.