### PR TITLE
Add hive bucket filtering by IN predicate

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
@@ -219,9 +219,9 @@ public final class HiveBucketing
         // Get bindings for bucket columns
         Map<String, Object> bucketBindings = new HashMap<>();
         for (Entry<ColumnHandle, NullableValue> entry : bindings.entrySet()) {
-            HiveColumnHandle colHandle = (HiveColumnHandle) entry.getKey();
-            if (!entry.getValue().isNull() && bucketColumns.contains(colHandle.getName())) {
-                bucketBindings.put(colHandle.getName(), entry.getValue().getValue());
+            HiveColumnHandle columnHandle = (HiveColumnHandle) entry.getKey();
+            if (!entry.getValue().isNull() && bucketColumns.contains(columnHandle.getName())) {
+                bucketBindings.put(columnHandle.getName(), entry.getValue().getValue());
             }
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slices;
 import io.prestosql.plugin.hive.HiveType;
@@ -22,6 +23,7 @@ import io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.predicate.NullableValue;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.BigintType;
 import io.prestosql.spi.type.BooleanType;
@@ -48,13 +50,18 @@ import org.testng.annotations.Test;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Lists.newArrayList;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V2;
+import static io.prestosql.plugin.hive.util.HiveBucketing.getHiveBuckets;
 import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.intBitsToFloat;
@@ -164,6 +171,86 @@ public class TestHiveBucketing
                 asList(null, ImmutableList.of((short) 5, (short) 8, (short) 13), null, ImmutableMap.of("key", 123L), null),
                 154207826,
                 -1120812524);
+    }
+
+    @Test
+    public void testBucketFilterFromDiscreteSets()
+    {
+        // multiple bucketing columns and multiple values for each bucketing column
+        assertBucketsEqual(
+                ImmutableList.of("int", "tinyint"),
+                ImmutableList.of(
+                        ImmutableList.of(1, 10),
+                        ImmutableList.of((byte) 5, (byte) 6)),
+                8,
+                Optional.of(ImmutableSet.of(3, 4, 5)),
+                Optional.of(ImmutableSet.of(0, 1, 5, 6)));
+
+        assertBucketsEqual(
+                ImmutableList.of("float", "array<smallint>", "map<string,bigint>"),
+                ImmutableList.of(
+                        ImmutableList.of(12.34F, 56.78F),
+                        ImmutableList.of(ImmutableList.of((short) 5, (short) 8, (short) 13), ImmutableList.of((short) 1, (short) 2, (short) 3)),
+                        ImmutableList.of(ImmutableMap.of("key1", 123L), ImmutableMap.of("key2", 456L))),
+                32,
+                Optional.of(ImmutableSet.of(3, 9, 11, 17, 21, 23, 29, 31)),
+                Optional.of(ImmutableSet.of(0, 8, 10, 20, 30)));
+
+        assertBucketsEqual(
+                ImmutableList.of("double", "array<smallint>", "boolean", "map<string,bigint>", "tinyint"),
+                ImmutableList.of(
+                        newArrayList(null, 12.3),
+                        newArrayList(null, ImmutableList.of((short) 1, (short) 2, (short) 3)),
+                        newArrayList(null, false),
+                        newArrayList(null, ImmutableMap.of("key", 123L)),
+                        newArrayList(null, (byte) 120)),
+                32,
+                Optional.of(ImmutableSet.of(0, 1, 3, 18, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)),
+                Optional.of(ImmutableSet.of(0, 2, 10, 11, 19, 21, 24, 29)));
+
+        // too many buckets to be enumerated compared to bucket count
+        List<Integer> intValues = new ArrayList<>(100);
+        for (int i = 0; i < 100; i++) {
+            intValues.add(i);
+        }
+        List<Byte> tinyIntValues = new ArrayList<>(100);
+        for (byte i = 0; i < 100; i++) {
+            tinyIntValues.add(i);
+        }
+        assertBucketsEqual(
+                ImmutableList.of("int", "tinyint"),
+                ImmutableList.of(
+                        ImmutableList.copyOf(intValues),
+                        ImmutableList.copyOf(tinyIntValues)),
+                32,
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static void assertBucketsEqual(List<String> hiveTypeStrings, List<List<Object>> hiveValues, int bucketCount, Optional<Set<Integer>> expectedBucketsV1, Optional<Set<Integer>> expectedBucketsV2)
+    {
+        List<HiveType> hiveTypes = hiveTypeStrings.stream()
+                .map(HiveType::valueOf)
+                .collect(toImmutableList());
+        List<TypeInfo> hiveTypeInfos = hiveTypes.stream()
+                .map(HiveType::getTypeInfo)
+                .collect(toImmutableList());
+        List<Type> prestoTypes = hiveTypes.stream()
+                .map(type -> type.getType(TYPE_MANAGER))
+                .collect(toImmutableList());
+
+        ImmutableList.Builder<List<NullableValue>> values = ImmutableList.builder();
+        for (int i = 0; i < hiveValues.size(); i++) {
+            List<Object> valueList = hiveValues.get(i);
+            Type prestoType = prestoTypes.get(i);
+            values.add(valueList.stream()
+                    .map(value -> new NullableValue(prestoType, toNativeContainerValue(prestoType, value)))
+                    .collect(toImmutableList()));
+        }
+
+        assertEquals(getHiveBuckets(BUCKETING_V1, bucketCount, hiveTypeInfos, values.build()), expectedBucketsV1);
+
+        assertEquals(getHiveBuckets(BUCKETING_V2, bucketCount, hiveTypeInfos, values.build()), expectedBucketsV2);
     }
 
     private static void assertBucketEquals(String hiveTypeString, Object hiveValue, int expectedHashCodeV1, int expectedHashCodeV2)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
@@ -235,8 +235,8 @@ public class TestHiveBucketing
             nativeContainerValues[i] = toNativeContainerValue(type, hiveValue);
         }
         ImmutableList<Block> blockList = blockListBuilder.build();
-        int result1 = HiveBucketing.getBucketHashCode(bucketingVersion, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
-        int result2 = HiveBucketing.getBucketHashCode(bucketingVersion, hiveTypeInfos, nativeContainerValues);
+        int result1 = bucketingVersion.getBucketHashCode(hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
+        int result2 = bucketingVersion.getBucketHashCode(hiveTypeInfos, nativeContainerValues);
         assertEquals(result1, result2, "overloads of getBucketHashCode produced different result");
         return result1;
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/AllOrNoneValueSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/AllOrNoneValueSet.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -79,6 +80,18 @@ public class AllOrNoneValueSet
 
     @Override
     public Object getSingleValue()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDiscreteSet()
+    {
+        return false;
+    }
+
+    @Override
+    public List<Object> getDiscreteSet()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/Domain.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/Domain.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -168,6 +169,22 @@ public final class Domain
         return value == null ? nullAllowed : values.containsValue(value);
     }
 
+    boolean isNullableDiscreteSet()
+    {
+        return values.isNone() ? nullAllowed : values.isDiscreteSet();
+    }
+
+    DiscreteSet getNullableDiscreteSet()
+    {
+        if (!isNullableDiscreteSet()) {
+            throw new IllegalStateException("Domain is not a nullable discrete set");
+        }
+
+        return new DiscreteSet(
+                values.isNone() ? unmodifiableList(new ArrayList<>()) : values.getDiscreteSet(),
+                nullAllowed);
+    }
+
     public boolean overlaps(Domain other)
     {
         checkCompatibility(other);
@@ -280,5 +297,30 @@ public final class Domain
     public String toString(ConnectorSession session)
     {
         return "[ " + (nullAllowed ? "NULL, " : "") + values.toString(session) + " ]";
+    }
+
+    static class DiscreteSet
+    {
+        private final List<Object> nonNullValues;
+        private final boolean containsNull;
+
+        DiscreteSet(List<Object> values, boolean containsNull)
+        {
+            this.nonNullValues = requireNonNull(values, "values is null");
+            this.containsNull = containsNull;
+            if (!containsNull && values.isEmpty()) {
+                throw new IllegalArgumentException("Discrete set cannot be empty");
+            }
+        }
+
+        List<Object> getNonNullValues()
+        {
+            return nonNullValues;
+        }
+
+        boolean containsNull()
+        {
+            return containsNull;
+        }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/EquatableValueSet.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -33,6 +34,7 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
@@ -148,6 +150,23 @@ public class EquatableValueSet
             throw new IllegalStateException("EquatableValueSet does not have just a single value");
         }
         return entries.iterator().next().getValue();
+    }
+
+    @Override
+    public boolean isDiscreteSet()
+    {
+        return whiteList && !entries.isEmpty();
+    }
+
+    @Override
+    public List<Object> getDiscreteSet()
+    {
+        if (!isDiscreteSet()) {
+            throw new IllegalStateException("EquatableValueSet is not a discrete set");
+        }
+        return unmodifiableList(entries.stream()
+                .map(ValueEntry::getValue)
+                .collect(Collectors.toList()));
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/SortedRangeSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/SortedRangeSet.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -153,6 +154,28 @@ public final class SortedRangeSet
             throw new IllegalStateException("SortedRangeSet does not have just a single value");
         }
         return lowIndexedRanges.values().iterator().next().getSingleValue();
+    }
+
+    @Override
+    public boolean isDiscreteSet()
+    {
+        for (Range range : lowIndexedRanges.values()) {
+            if (!range.isSingleValue()) {
+                return false;
+            }
+        }
+        return !isNone();
+    }
+
+    @Override
+    public List<Object> getDiscreteSet()
+    {
+        if (!isDiscreteSet()) {
+            throw new IllegalStateException("SortedRangeSet is not a discrete set");
+        }
+        return unmodifiableList(lowIndexedRanges.values().stream()
+                .map(Range::getSingleValue)
+                .collect(Collectors.toList()));
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/ValueSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/ValueSet.java
@@ -19,6 +19,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
 
 import java.util.Collection;
+import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
@@ -96,6 +97,10 @@ public interface ValueSet
     boolean isSingleValue();
 
     Object getSingleValue();
+
+    boolean isDiscreteSet();
+
+    List<Object> getDiscreteSet();
 
     boolean containsValue(Object value);
 


### PR DESCRIPTION
Enables bucket filtering in the case when bucketing columns' Domains are defined as sets of discrete values. A Domain can be a discrete set for any equatable type (including orderable types).

