### PR TITLE
Support multiple event listener plugins

### DIFF
--- a/presto-docs/src/main/sphinx/develop/event-listener.rst
+++ b/presto-docs/src/main/sphinx/develop/event-listener.rst
@@ -46,3 +46,10 @@ Example configuration file:
     event-listener.name=custom-event-listener
     custom-property1=custom-value1
     custom-property2=custom-value2
+
+Multiple Event Listeners
+------------------------
+
+Multiple instances of the same, or different event listeners can be
+installed and configured by setting ``event-listener.config-files``
+to a comma separated list of config files.

--- a/presto-main/src/main/java/io/prestosql/eventlistener/EventListenerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/eventlistener/EventListenerConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.eventlistener;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class EventListenerConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private List<File> eventListenerFiles = ImmutableList.of();
+
+    @NotNull
+    public List<File> getEventListenerFiles()
+    {
+        return eventListenerFiles;
+    }
+
+    @Config("event-listener.config-files")
+    public EventListenerConfig setEventListenerFiles(String eventListenerFiles)
+    {
+        this.eventListenerFiles = SPLITTER.splitToList(eventListenerFiles).stream()
+                .map(File::new)
+                .collect(toImmutableList());
+        return this;
+    }
+
+    public EventListenerConfig setEventListenerFiles(List<File> eventListenerFiles)
+    {
+        this.eventListenerFiles = ImmutableList.copyOf(eventListenerFiles);
+        return this;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/eventlistener/EventListenerModule.java
+++ b/presto-main/src/main/java/io/prestosql/eventlistener/EventListenerModule.java
@@ -17,12 +17,17 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
 public class EventListenerModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
+        configBinder(binder).bindConfig(EventListenerConfig.class);
         binder.bind(EventListenerManager.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(EventListenerManager.class).withGeneratedName();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoServer.java
@@ -139,7 +139,7 @@ public class PrestoServer
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
-            injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
+            injector.getInstance(EventListenerManager.class).loadConfiguredEventListeners();
 
             injector.getInstance(Announcer.class).start();
 

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -41,6 +41,7 @@ import io.prestosql.connector.CatalogName;
 import io.prestosql.connector.ConnectorManager;
 import io.prestosql.cost.StatsCalculator;
 import io.prestosql.dispatcher.DispatchManager;
+import io.prestosql.eventlistener.EventListenerConfig;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.execution.QueryInfo;
 import io.prestosql.execution.QueryManager;
@@ -227,6 +228,7 @@ public class TestingPrestoServer
                 .add(binder -> {
                     binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(TestingEventListenerManager.class).in(Scopes.SINGLETON);
+                    binder.bind(EventListenerConfig.class).in(Scopes.SINGLETON);
                     binder.bind(AccessControlManager.class).to(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(EventListenerManager.class).to(TestingEventListenerManager.class).in(Scopes.SINGLETON);
                     binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -41,6 +41,7 @@ import io.prestosql.cost.CostCalculatorWithEstimatedExchanges;
 import io.prestosql.cost.CostComparator;
 import io.prestosql.cost.StatsCalculator;
 import io.prestosql.cost.TaskCountEstimator;
+import io.prestosql.eventlistener.EventListenerConfig;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.execution.CommentTask;
 import io.prestosql.execution.CommitTask;
@@ -373,7 +374,7 @@ public class LocalQueryRunner
                 new NoOpResourceGroupManager(),
                 accessControl,
                 new PasswordAuthenticatorManager(),
-                new EventListenerManager(),
+                new EventListenerManager(new EventListenerConfig()),
                 new SessionPropertyDefaults(nodeInfo));
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory, globalSystemConnectorFactory.getClass()::getClassLoader);

--- a/presto-main/src/main/java/io/prestosql/testing/TestingEventListenerManager.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingEventListenerManager.java
@@ -14,6 +14,8 @@
 package io.prestosql.testing;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.prestosql.eventlistener.EventListenerConfig;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.spi.eventlistener.EventListener;
 import io.prestosql.spi.eventlistener.EventListenerFactory;
@@ -21,41 +23,49 @@ import io.prestosql.spi.eventlistener.QueryCompletedEvent;
 import io.prestosql.spi.eventlistener.QueryCreatedEvent;
 import io.prestosql.spi.eventlistener.SplitCompletedEvent;
 
-import java.util.Optional;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestingEventListenerManager
         extends EventListenerManager
 {
-    private final AtomicReference<Optional<EventListener>> configuredEventListener = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<Set<EventListener>> configuredEventListeners = new AtomicReference(new HashSet());
+
+    @Inject
+    public TestingEventListenerManager(EventListenerConfig config)
+    {
+        super(config);
+    }
 
     @Override
     public void addEventListenerFactory(EventListenerFactory eventListenerFactory)
     {
-        configuredEventListener.set(Optional.of(eventListenerFactory.create(ImmutableMap.of())));
+        configuredEventListeners.set(Collections.singleton(eventListenerFactory.create(ImmutableMap.of())));
     }
 
     @Override
     public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
     {
-        if (configuredEventListener.get().isPresent()) {
-            configuredEventListener.get().get().queryCompleted(queryCompletedEvent);
+        for (EventListener listener : configuredEventListeners.get()) {
+            listener.queryCompleted(queryCompletedEvent);
         }
     }
 
     @Override
     public void queryCreated(QueryCreatedEvent queryCreatedEvent)
     {
-        if (configuredEventListener.get().isPresent()) {
-            configuredEventListener.get().get().queryCreated(queryCreatedEvent);
+        for (EventListener listener : configuredEventListeners.get()) {
+            listener.queryCreated(queryCreatedEvent);
         }
     }
 
     @Override
     public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
     {
-        if (configuredEventListener.get().isPresent()) {
-            configuredEventListener.get().get().splitCompleted(splitCompletedEvent);
+        for (EventListener listener : configuredEventListeners.get()) {
+            listener.splitCompleted(splitCompletedEvent);
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/eventlistener/TestEventListenerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/eventlistener/TestEventListenerConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.eventlistener;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestEventListenerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(EventListenerConfig.class)
+                .setEventListenerFiles(""));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("event-listener.config-files", "a,b,c")
+                .build();
+
+        EventListenerConfig expected = new EventListenerConfig()
+                .setEventListenerFiles("a,b,c");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TaskTestUtils.java
@@ -19,6 +19,7 @@ import io.airlift.json.ObjectMapperProvider;
 import io.prestosql.connector.CatalogName;
 import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.event.SplitMonitor;
+import io.prestosql.eventlistener.EventListenerConfig;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.execution.TestSqlTaskManager.MockExchangeClientSupplier;
 import io.prestosql.execution.buffer.OutputBuffers;
@@ -152,7 +153,7 @@ public final class TaskTestUtils
     public static SplitMonitor createTestSplitMonitor()
     {
         return new SplitMonitor(
-                new EventListenerManager(),
+                new EventListenerManager(new EventListenerConfig()),
                 new ObjectMapperProvider().get());
     }
 }


### PR DESCRIPTION
Per #2299 it would be helpful to be able to declare both multiple instances of the same event listener as well as multiple instances of different event listeners. I've tested this locally with two simple logging plugins but I still need to write proper tests.