### PR TITLE
Benchmark for Hive Projection Pushdown

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
@@ -504,44 +504,6 @@ public class BenchmarkHiveFileFormat
         return new TestData(columnNames, columnTypes, pages.build());
     }
 
-    static class TestData
-    {
-        private final List<String> columnNames;
-        private final List<Type> columnTypes;
-
-        private final List<Page> pages;
-
-        private final int size;
-
-        public TestData(List<String> columnNames, List<Type> columnTypes, List<Page> pages)
-        {
-            this.columnNames = ImmutableList.copyOf(columnNames);
-            this.columnTypes = ImmutableList.copyOf(columnTypes);
-            this.pages = ImmutableList.copyOf(pages);
-            this.size = (int) pages.stream().mapToLong(Page::getSizeInBytes).sum();
-        }
-
-        public List<String> getColumnNames()
-        {
-            return columnNames;
-        }
-
-        public List<Type> getColumnTypes()
-        {
-            return columnTypes;
-        }
-
-        public List<Page> getPages()
-        {
-            return pages;
-        }
-
-        public int getSize()
-        {
-            return size;
-        }
-    }
-
     private static Type getColumnType(TpchColumn<?> input)
     {
         switch (input.getType().getBase()) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/BenchmarkProjectionPushdownHive.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.hadoop.HadoopNative;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.plugin.hive.HiveColumnHandle;
+import io.prestosql.plugin.hive.HiveCompressionCodec;
+import io.prestosql.plugin.hive.HiveType;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.RowBlock;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
+import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.prestosql.plugin.hive.HiveTestUtils.SESSION;
+import static io.prestosql.plugin.hive.HiveType.toHiveType;
+import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
+import static io.prestosql.plugin.hive.benchmark.FileFormat.PRESTO_ORC;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
+
+/**
+ * Benchmarks the read operations with projection pushdown in Hive. This is useful for comparing the following for different formats
+ * - Performance difference between reading row columns v/s reading projected VARCHAR subfields
+ * - Performance difference between reading base VARCHAR columns v/s reading projected VARCHAR subfields
+ */
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 50)
+@Warmup(iterations = 20)
+@Fork(3)
+public class BenchmarkProjectionPushdownHive
+{
+    static {
+        HadoopNative.requireHadoopNative();
+    }
+
+    private static final String LETTERS = "abcdefghijklmnopqrstuvwxyz";
+    private static final int TOTAL_ROW_COUNT = 10_000;
+    private static final int POSITIONS_PER_PAGE = 1_000;
+    private static final int DEFAULT_ARRAY_SIZE = 30;
+
+    // Write Strategies
+    private static final String TOP_LEVEL = "toplevel";
+    private static final String STRUCT = "struct";
+
+    // Read Strategies
+    private static final String WITH_PUSHDOWN = "with_pushdown";
+    private static final String WITHOUT_PUSHDOWN = "without_pushdown";
+
+    // Types
+    private static final String ROW_OF_STRINGS = "ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)";
+    private static final String NESTED_STRUCT = "ROW(" +
+            "f0 VARCHAR, " +
+            "f1 VARCHAR, " +
+            "f2 VARCHAR, " +
+            "f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))";
+
+    @State(Scope.Thread)
+    public static class BenchmarkContext
+    {
+        private final Random random = new Random();
+
+        private List<Type> columnTypesToWrite;
+        private List<String> columnNamesToWrite;
+        private List<HiveType> columnHiveTypesToWrite;
+
+        // Layout of the file columns: either in a single struct OR as "flattened" into top-level columns
+        @Param({STRUCT, TOP_LEVEL})
+        private String writeStrategy = STRUCT;
+
+        @Param({WITHOUT_PUSHDOWN, WITH_PUSHDOWN})
+        private String readStrategy = WITH_PUSHDOWN;
+
+        // This should be a row typed column
+        @Param({ROW_OF_STRINGS, NESTED_STRUCT})
+        private String columnTypeString = ROW_OF_STRINGS;
+
+        @Param("1")
+        private int readColumnCount = 1;
+
+        @Param({"PRESTO_ORC", "PRESTO_PARQUET"})
+        private FileFormat fileFormat = PRESTO_ORC;
+
+        private TestData dataToWrite;
+        private File dataFile;
+
+        private final File targetDir = createTempDir("presto-benchmark");
+
+        @Setup
+        public void setup()
+                throws IOException
+        {
+            Metadata metadata = createTestMetadataManager();
+            Type columnType = metadata.fromSqlType(columnTypeString);
+            checkState(columnType instanceof RowType, "expected column to have RowType");
+
+            if (STRUCT.equals(writeStrategy)) {
+                columnTypesToWrite = ImmutableList.of(columnType);
+                columnHiveTypesToWrite = ImmutableList.of(toHiveType(columnType));
+                columnNamesToWrite = ImmutableList.of("column_0");
+            }
+            else if (TOP_LEVEL.equals(writeStrategy)) {
+                List<Type> fieldTypes = ((RowType) columnType).getTypeParameters();
+                columnTypesToWrite = ImmutableList.copyOf(fieldTypes);
+                columnHiveTypesToWrite = columnTypesToWrite.stream()
+                        .map(HiveType::toHiveType)
+                        .collect(toImmutableList());
+                columnNamesToWrite = IntStream.range(0, columnTypesToWrite.size())
+                        .mapToObj(Integer::toString)
+                        .map("column_"::concat)
+                        .collect(toImmutableList());
+            }
+            else {
+                throw new UnsupportedOperationException(format("Write strategy %s not supported", writeStrategy));
+            }
+
+            checkState(columnTypesToWrite.stream().allMatch(BenchmarkProjectionPushdownHive::isSupportedType), "Type not supported for benchmark");
+            dataToWrite = createTestData(columnTypesToWrite, columnNamesToWrite);
+
+            targetDir.mkdirs();
+            dataFile = new File(targetDir, UUID.randomUUID().toString());
+            writeData(dataFile);
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(targetDir.toPath(), ALLOW_INSECURE);
+        }
+
+        private void writeData(File targetFile)
+                throws IOException
+        {
+            List<Page> inputPages = dataToWrite.getPages();
+            try (FormatWriter formatWriter = fileFormat.createFileFormatWriter(
+                    SESSION,
+                    targetFile,
+                    dataToWrite.getColumnNames(),
+                    dataToWrite.getColumnTypes(),
+                    HiveCompressionCodec.ZSTD)) {
+                for (Page page : inputPages) {
+                    formatWriter.writePage(page);
+                }
+            }
+        }
+
+        private ConnectorPageSource createPageSource()
+        {
+            if (TOP_LEVEL.equals(writeStrategy)) {
+                List<ColumnHandle> readColumns = IntStream.range(0, readColumnCount).boxed()
+                        .map(index -> HiveColumnHandle.createBaseColumn(
+                                columnNamesToWrite.get(index),
+                                0,
+                                columnHiveTypesToWrite.get(index),
+                                columnTypesToWrite.get(index),
+                                HiveColumnHandle.ColumnType.REGULAR,
+                                Optional.empty()))
+                        .collect(toImmutableList());
+
+                return fileFormat.createGenericReader(SESSION, HDFS_ENVIRONMENT, dataFile, readColumns, columnNamesToWrite, columnTypesToWrite);
+            }
+
+            if (STRUCT.equals(writeStrategy)) {
+                // Unflattened schema has one ROW type column
+                checkState(columnTypesToWrite.size() == 1);
+
+                HiveColumnHandle baseColumn = HiveColumnHandle.createBaseColumn(
+                        columnNamesToWrite.get(0),
+                        0,
+                        columnHiveTypesToWrite.get(0),
+                        columnTypesToWrite.get(0),
+                        HiveColumnHandle.ColumnType.REGULAR,
+                        Optional.empty());
+
+                List<ColumnHandle> readColumnHandles;
+                if (WITH_PUSHDOWN.equals(readStrategy)) {
+                    readColumnHandles = IntStream.range(0, readColumnCount).boxed()
+                            .map(i -> createProjectedColumnHandle(baseColumn, ImmutableList.of(i)))
+                            .collect(toImmutableList());
+                }
+                else if (WITHOUT_PUSHDOWN.equals(readStrategy)) {
+                    readColumnHandles = ImmutableList.of(baseColumn);
+                }
+                else {
+                    throw new UnsupportedOperationException(format("Read strategy %s not supported", readStrategy));
+                }
+
+                return fileFormat.createGenericReader(SESSION, HDFS_ENVIRONMENT, dataFile, readColumnHandles, columnNamesToWrite, columnTypesToWrite);
+            }
+
+            throw new UnsupportedOperationException(format("Write strategy %s not supported", writeStrategy));
+        }
+
+        private TestData createTestData(List<Type> columnTypes, List<String> columnNames)
+        {
+            ImmutableList.Builder<Page> pages = ImmutableList.builder();
+            int pageCount = TOTAL_ROW_COUNT / POSITIONS_PER_PAGE;
+
+            for (int i = 0; i < pageCount; i++) {
+                Block[] blocks = new Block[columnTypes.size()];
+
+                for (int column = 0; column < columnTypes.size(); column++) {
+                    Type type = columnTypes.get(column);
+                    blocks[column] = createBlock(type, POSITIONS_PER_PAGE);
+                }
+
+                pages.add(new Page(blocks));
+            }
+
+            return new TestData(columnNames, columnTypes, pages.build());
+        }
+
+        private Block createBlock(Type type, int rowCount)
+        {
+            checkState(isSupportedType(type), format("Type %s not supported", type.getDisplayName()));
+
+            if (type instanceof RowType) {
+                List<Type> parameters = type.getTypeParameters();
+                Block[] fieldBlocks = new Block[parameters.size()];
+
+                for (int field = 0; field < parameters.size(); field++) {
+                    fieldBlocks[field] = createBlock(parameters.get(field), rowCount);
+                }
+
+                return RowBlock.fromFieldBlocks(rowCount, Optional.empty(), fieldBlocks);
+            }
+            else if (type instanceof VarcharType) {
+                BlockBuilder builder = VARCHAR.createBlockBuilder(null, rowCount);
+                for (int i = 0; i < rowCount; i++) {
+                    VARCHAR.writeString(builder, generateRandomString(random, 500));
+                }
+                return builder.build();
+            }
+            else if (type instanceof ArrayType) {
+                ArrayType arrayType = (ArrayType) type;
+                Type elementType = arrayType.getElementType();
+
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, rowCount);
+                for (int i = 0; i < rowCount; i++) {
+                    Block elementBlock = createBlock(elementType, DEFAULT_ARRAY_SIZE);
+                    blockBuilder.appendStructure(elementBlock);
+                }
+
+                return blockBuilder.build();
+            }
+
+            throw new UnsupportedOperationException("Only VARCHAR, ROW and ARRAY types supported");
+        }
+    }
+
+    @Benchmark
+    public List<Page> readPages(BenchmarkContext context)
+    {
+        List<Page> pages = new ArrayList<>(100);
+        ConnectorPageSource pageSource = context.createPageSource();
+
+        while (!pageSource.isFinished()) {
+            Page page = pageSource.getNextPage();
+            if (page != null) {
+                pages.add(page.getLoadedPage());
+            }
+        }
+
+        return pages;
+    }
+
+    @Test
+    public void testBenchmark()
+            throws IOException
+    {
+        BenchmarkContext context = new BenchmarkContext();
+        try {
+            context.setup();
+            readPages(context);
+        }
+        catch (Throwable t) {
+            throw new RuntimeException("Benchmark execution failed", t);
+        }
+        finally {
+            context.tearDown();
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Options opt = new OptionsBuilder()
+                .include(".*\\." + BenchmarkProjectionPushdownHive.class.getSimpleName() + ".*")
+                .jvmArgsAppend("-Xmx4g", "-Xms4g", "-XX:+UseG1GC")
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static File createTempDir(String prefix)
+    {
+        try {
+            return createTempDirectory(prefix).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String generateRandomString(Random random, int length)
+    {
+        char[] chars = new char[length];
+        for (int i = 0; i < length; i++) {
+            chars[i] = LETTERS.charAt(random.nextInt(LETTERS.length()));
+        }
+        return new String(chars);
+    }
+
+    private static boolean isSupportedType(Type type)
+    {
+        if (type == VARCHAR) {
+            return true;
+        }
+        if (type instanceof RowType) {
+            return type.getTypeParameters().stream().allMatch(BenchmarkProjectionPushdownHive::isSupportedType);
+        }
+        if (type instanceof ArrayType) {
+            return isSupportedType(((ArrayType) type).getElementType());
+        }
+
+        return false;
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -13,7 +13,9 @@
  */
 package io.prestosql.plugin.hive.benchmark;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.prestosql.orc.OrcReaderOptions;
 import io.prestosql.orc.OrcWriter;
@@ -25,19 +27,23 @@ import io.prestosql.parquet.writer.ParquetSchemaConverter;
 import io.prestosql.parquet.writer.ParquetWriter;
 import io.prestosql.parquet.writer.ParquetWriterOptions;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
+import io.prestosql.plugin.hive.GenericHiveRecordCursorProvider;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveCompressionCodec;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
 import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
+import io.prestosql.plugin.hive.HivePageSourceProvider;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider.ReaderRecordCursorWithProjections;
+import io.prestosql.plugin.hive.HiveSplit;
 import io.prestosql.plugin.hive.HiveStorageFormat;
+import io.prestosql.plugin.hive.HiveTableHandle;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.HiveTypeName;
 import io.prestosql.plugin.hive.RecordFileWriter;
-import io.prestosql.plugin.hive.benchmark.BenchmarkHiveFileFormat.TestData;
+import io.prestosql.plugin.hive.TableToPartitionMapping;
 import io.prestosql.plugin.hive.orc.OrcPageSourceFactory;
 import io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
@@ -49,11 +55,13 @@ import io.prestosql.rcfile.RcFileWriter;
 import io.prestosql.rcfile.binary.BinaryRcFileEncoding;
 import io.prestosql.rcfile.text.TextRcFileEncoding;
 import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.RecordPageSource;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.TestingConnectorTransactionHandle;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
@@ -61,12 +69,15 @@ import org.apache.hadoop.mapred.JobConf;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
+import java.util.stream.IntStream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
@@ -87,10 +98,15 @@ public enum FileFormat
 {
     PRESTO_RCBINARY {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HivePageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HiveConfig().setRcfileTimeZone("UTC"));
-            return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCBINARY);
+            return HiveStorageFormat.RCBINARY;
+        }
+
+        @Override
+        public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HiveConfig().setRcfileTimeZone("UTC")));
         }
 
         @Override
@@ -112,10 +128,15 @@ public enum FileFormat
 
     PRESTO_RCTEXT {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HivePageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HiveConfig().setRcfileTimeZone("UTC"));
-            return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCTEXT);
+            return HiveStorageFormat.RCTEXT;
+        }
+
+        @Override
+        public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HiveConfig().setRcfileTimeZone("UTC")));
         }
 
         @Override
@@ -137,10 +158,15 @@ public enum FileFormat
 
     PRESTO_ORC {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HivePageSourceFactory pageSourceFactory = new OrcPageSourceFactory(new OrcReaderOptions(), hdfsEnvironment, new FileFormatDataSourceStats(), UTC);
-            return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.ORC);
+            return HiveStorageFormat.ORC;
+        }
+
+        @Override
+        public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(new OrcPageSourceFactory(new OrcReaderOptions(), hdfsEnvironment, new FileFormatDataSourceStats(), UTC));
         }
 
         @Override
@@ -162,10 +188,15 @@ public enum FileFormat
 
     PRESTO_PARQUET {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HivePageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(hdfsEnvironment, new FileFormatDataSourceStats(), new ParquetReaderConfig(), new HiveConfig().setParquetTimeZone("UTC"));
-            return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
+            return HiveStorageFormat.PARQUET;
+        }
+
+        @Override
+        public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(new ParquetPageSourceFactory(hdfsEnvironment, new FileFormatDataSourceStats(), new ParquetReaderConfig(), new HiveConfig().setParquetTimeZone("UTC")));
         }
 
         @Override
@@ -183,10 +214,15 @@ public enum FileFormat
 
     HIVE_RCBINARY {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HiveRecordCursorProvider cursorProvider = createGenericHiveRecordCursorProvider(hdfsEnvironment);
-            return createPageSource(cursorProvider, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCBINARY);
+            return HiveStorageFormat.RCBINARY;
+        }
+
+        @Override
+        public Optional<HiveRecordCursorProvider> getHiveRecordCursorProvider(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(createGenericHiveRecordCursorProvider(hdfsEnvironment));
         }
 
         @Override
@@ -203,10 +239,15 @@ public enum FileFormat
 
     HIVE_RCTEXT {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HiveRecordCursorProvider cursorProvider = createGenericHiveRecordCursorProvider(hdfsEnvironment);
-            return createPageSource(cursorProvider, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCTEXT);
+            return HiveStorageFormat.RCTEXT;
+        }
+
+        @Override
+        public Optional<HiveRecordCursorProvider> getHiveRecordCursorProvider(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(createGenericHiveRecordCursorProvider(hdfsEnvironment));
         }
 
         @Override
@@ -223,10 +264,15 @@ public enum FileFormat
 
     HIVE_ORC {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HiveRecordCursorProvider cursorProvider = createGenericHiveRecordCursorProvider(hdfsEnvironment);
-            return createPageSource(cursorProvider, session, targetFile, columnNames, columnTypes, HiveStorageFormat.ORC);
+            return HiveStorageFormat.ORC;
+        }
+
+        @Override
+        public Optional<HiveRecordCursorProvider> getHiveRecordCursorProvider(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(createGenericHiveRecordCursorProvider(hdfsEnvironment));
         }
 
         @Override
@@ -243,10 +289,15 @@ public enum FileFormat
 
     HIVE_PARQUET {
         @Override
-        public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
+        public HiveStorageFormat getFormat()
         {
-            HivePageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(hdfsEnvironment, new FileFormatDataSourceStats(), new ParquetReaderConfig(), new HiveConfig().setParquetTimeZone("UTC"));
-            return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
+            return HiveStorageFormat.PARQUET;
+        }
+
+        @Override
+        public Optional<HiveRecordCursorProvider> getHiveRecordCursorProvider(HdfsEnvironment hdfsEnvironment)
+        {
+            return Optional.of(createGenericHiveRecordCursorProvider(hdfsEnvironment));
         }
 
         @Override
@@ -266,12 +317,7 @@ public enum FileFormat
         return true;
     }
 
-    public abstract ConnectorPageSource createFileFormatReader(
-            ConnectorSession session,
-            HdfsEnvironment hdfsEnvironment,
-            File targetFile,
-            List<String> columnNames,
-            List<Type> columnTypes);
+    public abstract HiveStorageFormat getFormat();
 
     public abstract FormatWriter createFileFormatWriter(
             ConnectorSession session,
@@ -280,6 +326,81 @@ public enum FileFormat
             List<Type> columnTypes,
             HiveCompressionCodec compressionCodec)
             throws IOException;
+
+    public Optional<HivePageSourceFactory> getHivePageSourceFactory(HdfsEnvironment environment)
+    {
+        return Optional.empty();
+    }
+
+    public Optional<HiveRecordCursorProvider> getHiveRecordCursorProvider(HdfsEnvironment environment)
+    {
+        return Optional.empty();
+    }
+
+    public final ConnectorPageSource createFileFormatReader(
+            ConnectorSession session,
+            HdfsEnvironment hdfsEnvironment,
+            File targetFile,
+            List<String> columnNames,
+            List<Type> columnTypes)
+    {
+        Optional<HivePageSourceFactory> pageSourceFactory = getHivePageSourceFactory(hdfsEnvironment);
+        Optional<HiveRecordCursorProvider> recordCursorProvider = getHiveRecordCursorProvider(hdfsEnvironment);
+
+        checkArgument(pageSourceFactory.isPresent() ^ recordCursorProvider.isPresent());
+
+        if (pageSourceFactory.isPresent()) {
+            return createPageSource(pageSourceFactory.get(), session, targetFile, columnNames, columnTypes, getFormat());
+        }
+
+        return createPageSource(recordCursorProvider.get(), session, targetFile, columnNames, columnTypes, getFormat());
+    }
+
+    public final ConnectorPageSource createGenericReader(
+            ConnectorSession session,
+            HdfsEnvironment hdfsEnvironment,
+            File targetFile,
+            List<ColumnHandle> readColumns,
+            List<String> schemaColumnNames,
+            List<Type> schemaColumnTypes)
+    {
+        HivePageSourceProvider factory = new HivePageSourceProvider(
+                TYPE_MANAGER,
+                hdfsEnvironment,
+                getHivePageSourceFactory(hdfsEnvironment).map(ImmutableSet::of).orElse(ImmutableSet.of()),
+                getHiveRecordCursorProvider(hdfsEnvironment).map(ImmutableSet::of).orElse(ImmutableSet.of()),
+                new GenericHiveRecordCursorProvider(hdfsEnvironment, new HiveConfig()));
+
+        Properties schema = createSchema(getFormat(), schemaColumnNames, schemaColumnTypes);
+
+        HiveSplit split = new HiveSplit(
+                "schema_name",
+                "table_name",
+                "",
+                targetFile.getPath(),
+                0,
+                targetFile.length(),
+                targetFile.length(),
+                targetFile.lastModified(),
+                schema,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                OptionalInt.empty(),
+                false,
+                TableToPartitionMapping.empty(),
+                Optional.empty(),
+                false,
+                Optional.empty());
+
+        ConnectorPageSource hivePageSource = factory.createPageSource(
+                TestingConnectorTransactionHandle.INSTANCE,
+                session, split,
+                new HiveTableHandle("schema_name", "table_name", ImmutableMap.of(), ImmutableList.of(), Optional.empty()),
+                readColumns,
+                TupleDomain.all());
+
+        return hivePageSource;
+    }
 
     private static final JobConf conf;
 
@@ -295,32 +416,31 @@ public enum FileFormat
 
     private static ConnectorPageSource createPageSource(
             HiveRecordCursorProvider cursorProvider,
-            ConnectorSession session, File targetFile, List<String> columnNames, List<Type> columnTypes, HiveStorageFormat format)
+            ConnectorSession session,
+            File targetFile,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            HiveStorageFormat format)
     {
-        List<HiveColumnHandle> columnHandles = new ArrayList<>(columnNames.size());
-        for (int i = 0; i < columnNames.size(); i++) {
-            String columnName = columnNames.get(i);
-            Type columnType = columnTypes.get(i);
-            columnHandles.add(createBaseColumn(columnName, i, toHiveType(columnType), columnType, REGULAR, Optional.empty()));
-        }
+        checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes should have the same size");
 
-        Optional<ReaderRecordCursorWithProjections> recordCursorWithProjections = cursorProvider
-                .createRecordCursor(
-                        conf,
-                        session,
-                        new Path(targetFile.getAbsolutePath()),
-                        0,
-                        targetFile.length(),
-                        targetFile.length(),
-                        createSchema(format, columnNames, columnTypes),
-                        columnHandles,
-                        TupleDomain.all(),
-                        TYPE_MANAGER,
-                        false);
+        List<HiveColumnHandle> readColumns = getBaseColumns(columnNames, columnTypes);
 
-        checkState(recordCursorWithProjections.isPresent(), "recordCursorWithProjections is not present");
-        checkState(recordCursorWithProjections.get().getProjectedReaderColumns().isEmpty(), "projections should not be required");
+        Optional<ReaderRecordCursorWithProjections> recordCursorWithProjections = cursorProvider.createRecordCursor(
+                conf,
+                session,
+                new Path(targetFile.getAbsolutePath()),
+                0,
+                targetFile.length(),
+                targetFile.length(),
+                createSchema(format, columnNames, columnTypes),
+                readColumns,
+                TupleDomain.all(),
+                TYPE_MANAGER,
+                false);
 
+        checkState(recordCursorWithProjections.isPresent(), "readerPageSourceWithProjections is not present");
+        checkState(!recordCursorWithProjections.get().getProjectedReaderColumns().isPresent(), "projection should not be required");
         return new RecordPageSource(columnTypes, recordCursorWithProjections.get().getRecordCursor());
     }
 
@@ -332,13 +452,11 @@ public enum FileFormat
             List<Type> columnTypes,
             HiveStorageFormat format)
     {
-        List<HiveColumnHandle> columnHandles = new ArrayList<>(columnNames.size());
-        for (int i = 0; i < columnNames.size(); i++) {
-            String columnName = columnNames.get(i);
-            Type columnType = columnTypes.get(i);
-            columnHandles.add(createBaseColumn(columnName, i, toHiveType(columnType), columnType, REGULAR, Optional.empty()));
-        }
+        checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes should have the same size");
 
+        List<HiveColumnHandle> readColumns = getBaseColumns(columnNames, columnTypes);
+
+        Properties schema = createSchema(format, columnNames, columnTypes);
         Optional<ReaderPageSourceWithProjections> readerPageSourceWithProjections = pageSourceFactory
                 .createPageSource(
                         conf,
@@ -347,15 +465,28 @@ public enum FileFormat
                         0,
                         targetFile.length(),
                         targetFile.length(),
-                        createSchema(format, columnNames, columnTypes),
-                        columnHandles,
+                        schema,
+                        readColumns,
                         TupleDomain.all(),
                         Optional.empty());
 
         checkState(readerPageSourceWithProjections.isPresent(), "readerPageSourceWithProjections is not present");
-        checkState(readerPageSourceWithProjections.get().getProjectedReaderColumns().isEmpty(), "projection should not be required");
-
+        checkState(!readerPageSourceWithProjections.get().getProjectedReaderColumns().isPresent(), "projection should not be required");
         return readerPageSourceWithProjections.get().getConnectorPageSource();
+    }
+
+    private static List<HiveColumnHandle> getBaseColumns(List<String> columnNames, List<Type> columnTypes)
+    {
+        return IntStream.range(0, columnNames.size())
+                .boxed()
+                .map(index -> createBaseColumn(
+                        columnNames.get(index),
+                        index,
+                        toHiveType(columnTypes.get(index)),
+                        columnTypes.get(index),
+                        REGULAR,
+                        Optional.empty()))
+                .collect(toImmutableList());
     }
 
     private static class RecordFormatWriter

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/TestData.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/TestData.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+
+public class TestData
+{
+    private final List<String> columnNames;
+    private final List<Type> columnTypes;
+
+    private final List<Page> pages;
+
+    private final int size;
+
+    public TestData(List<String> columnNames, List<Type> columnTypes, List<Page> pages)
+    {
+        this.columnNames = ImmutableList.copyOf(columnNames);
+        this.columnTypes = ImmutableList.copyOf(columnTypes);
+        this.pages = ImmutableList.copyOf(pages);
+        this.size = (int) pages.stream().mapToLong(Page::getSizeInBytes).sum();
+    }
+
+    public List<String> getColumnNames()
+    {
+        return columnNames;
+    }
+
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    public List<Page> getPages()
+    {
+        return pages;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+}


### PR DESCRIPTION
This PR adds benchmarks for the Hive Projection pushdown changes in #1720. The change in #1720 enables reading only the projected subfields for row type columns.  cc @martint 

This benchmark can be run to validate the dereference projection pushdown performance for different file formats, as they are implemented. I think the following comparisons can help us be confident about the anticipated benefits of projection pushdown.

- Dereference projection pushdown into readers results in performance gain proportional to the size of the row type column. i.e. if we have a column `a` of row type containing `N` varchar fields, then accessing the virtual column for "a.b" should be ~N times faster than accessing column `a`. With nested row type, the throughput increase should be even more drastic.
- Performance comparison between accessing a dereferenced field v/s accessing a base column of the same type (eg. "a.b" of type VARCHAR vs "c" of type VARCHAR)

## Benchmark Setup and parameters

The benchmark writes some data in the setup phase and then measures throughput of operations while reading pages. Here's some explanation of parameters used in the benchmark. 

* `columnTypeString` : type of `STRUCT` column to write. 

* `writeStrategy`: Decides the writing schema
- `STRUCT` :  the schema is a single column with the `columnTypeString` type
- `TOP_LEVEL` : the schema consists of columns with types given by the fields of `columnTypeString`.

* `readStrategy`: Decides whether we project columns or not. No difference in case of `TOP_LEVEL` write strategy
- `WITH_PUSHDOWN` : read projected columns
- `WITHOUT_PUSHDOWN` : read struct column 

* `readColumnCount` : Number of columns/fields to read

## Some benchmark Results

Say `a` represents the struct, `a.x` represents the primitive field. `b` represents the primitive top-level column.

### ORC
![2307_orc](https://user-images.githubusercontent.com/6829746/88015896-1fe37080-cad7-11ea-819f-16396cb84846.png)

### Parquet
![2307_parquet](https://user-images.githubusercontent.com/6829746/88015888-1a862600-cad7-11ea-9655-4981fce22f2c.png)


```
Benchmark                                                                                                          (columnTypeString)    (fileFormat)  (readColumnCount)    (readStrategy)  (writeStrategy)   Mode  Cnt   Score   Error  Units
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)      PRESTO_ORC                  1  without_pushdown           struct  thrpt  150  16.931 ± 0.228  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)      PRESTO_ORC                  1  without_pushdown         toplevel  thrpt  150  49.408 ± 0.736  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)      PRESTO_ORC                  1     with_pushdown           struct  thrpt  150  45.070 ± 1.316  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)      PRESTO_ORC                  1     with_pushdown         toplevel  thrpt  150  48.390 ± 0.524  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)  PRESTO_PARQUET                  1  without_pushdown           struct  thrpt  150  21.359 ± 0.238  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)  PRESTO_PARQUET                  1  without_pushdown         toplevel  thrpt  150  61.866 ± 0.774  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)  PRESTO_PARQUET                  1     with_pushdown           struct  thrpt  150  59.709 ± 0.853  ops/s
BenchmarkProjectionPushdownHive.readPages                                                     ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)  PRESTO_PARQUET                  1     with_pushdown         toplevel  thrpt  150  60.416 ± 0.826  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))      PRESTO_ORC                  1  without_pushdown           struct  thrpt  150   0.544 ± 0.006  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))      PRESTO_ORC                  1  without_pushdown         toplevel  thrpt  150  44.182 ± 0.551  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))      PRESTO_ORC                  1     with_pushdown           struct  thrpt  150  41.744 ± 0.474  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))      PRESTO_ORC                  1     with_pushdown         toplevel  thrpt  150  43.299 ± 0.575  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))  PRESTO_PARQUET                  1  without_pushdown           struct  thrpt  150   0.597 ± 0.008  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))  PRESTO_PARQUET                  1  without_pushdown         toplevel  thrpt  150  58.687 ± 0.491  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))  PRESTO_PARQUET                  1     with_pushdown           struct  thrpt  150  59.964 ± 0.590  ops/s
BenchmarkProjectionPushdownHive.readPages  ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR, f3 ARRAY(ROW(f0 VARCHAR, f1 VARCHAR, f2 VARCHAR)))  PRESTO_PARQUET                  1     with_pushdown         toplevel  thrpt  150  56.636 ± 1.347  ops/s
```
