### PR TITLE
Fix predicate pushdown for Elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/BuiltinColumns.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/BuiltinColumns.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.elasticsearch;
 
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.type.Type;
 
@@ -20,14 +21,15 @@ import java.util.Arrays;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.elasticsearch.ElasticsearchMetadata.SUPPORTS_PREDICATES;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 
 enum BuiltinColumns
 {
-    ID("_id", VARCHAR),
-    SOURCE("_source", VARCHAR),
-    SCORE("_score", REAL);
+    ID("_id", VARCHAR, true),
+    SOURCE("_source", VARCHAR, false),
+    SCORE("_score", REAL, false);
 
     public static final Set<String> NAMES = Arrays.stream(values())
             .map(BuiltinColumns::getName)
@@ -35,11 +37,13 @@ enum BuiltinColumns
 
     private final String name;
     private final Type type;
+    private final boolean supportsPredicates;
 
-    BuiltinColumns(String name, Type type)
+    BuiltinColumns(String name, Type type, boolean supportsPredicates)
     {
         this.name = name;
         this.type = type;
+        this.supportsPredicates = supportsPredicates;
     }
 
     public String getName()
@@ -58,6 +62,7 @@ enum BuiltinColumns
                 .setName(name)
                 .setType(type)
                 .setHidden(true)
+                .setProperties(ImmutableMap.of(SUPPORTS_PREDICATES, supportsPredicates))
                 .build();
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchColumnHandle.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchColumnHandle.java
@@ -28,14 +28,17 @@ public final class ElasticsearchColumnHandle
 {
     private final String name;
     private final Type type;
+    private final boolean supportsPredicates;
 
     @JsonCreator
     public ElasticsearchColumnHandle(
             @JsonProperty("name") String name,
-            @JsonProperty("type") Type type)
+            @JsonProperty("type") Type type,
+            @JsonProperty("supportsPredicates") boolean supportsPredicates)
     {
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
+        this.supportsPredicates = supportsPredicates;
     }
 
     @JsonProperty
@@ -50,10 +53,16 @@ public final class ElasticsearchColumnHandle
         return type;
     }
 
+    @JsonProperty
+    public boolean isSupportsPredicates()
+    {
+        return supportsPredicates;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type);
+        return Objects.hash(name, type, supportsPredicates);
     }
 
     @Override
@@ -67,7 +76,8 @@ public final class ElasticsearchColumnHandle
         }
 
         ElasticsearchColumnHandle other = (ElasticsearchColumnHandle) obj;
-        return Objects.equals(this.getName(), other.getName()) &&
+        return this.supportsPredicates == other.supportsPredicates &&
+                Objects.equals(this.getName(), other.getName()) &&
                 Objects.equals(this.getType(), other.getType());
     }
 

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
@@ -31,12 +31,14 @@ import io.prestosql.spi.connector.Constraint;
 import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
+import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,12 +55,14 @@ import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class ElasticsearchMetadata
         implements ConnectorMetadata
 {
     private static final String ORIGINAL_NAME = "original-name";
+    public static final String SUPPORTS_PREDICATES = "supports-predicates";
 
     private final ElasticsearchClient client;
     private final String schemaName;
@@ -129,10 +133,33 @@ public class ElasticsearchMetadata
                 continue;
             }
 
-            result.add(makeColumnMetadata(field.getName(), type));
+            result.add(makeColumnMetadata(field.getName(), type, supportsPredicates(field.getType())));
         }
 
         return result.build();
+    }
+
+    private static boolean supportsPredicates(IndexMetadata.Type type)
+    {
+        if (type instanceof DateTimeType) {
+            return true;
+        }
+
+        if (type instanceof PrimitiveType) {
+            switch (((PrimitiveType) type).getName().toLowerCase(ENGLISH)) {
+                case "boolean":
+                case "byte":
+                case "short":
+                case "integer":
+                case "long":
+                case "double":
+                case "float":
+                case "keyword":
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private Type toPrestoType(IndexMetadata.Type type)
@@ -201,7 +228,8 @@ public class ElasticsearchMetadata
         for (ColumnMetadata column : tableMetadata.getColumns()) {
             results.put(column.getName(), new ElasticsearchColumnHandle(
                     (String) column.getProperties().getOrDefault(ORIGINAL_NAME, column.getName()),
-                    column.getType()));
+                    column.getType(),
+                    (Boolean) column.getProperties().get(SUPPORTS_PREDICATES)));
         }
 
         return results.build();
@@ -211,7 +239,7 @@ public class ElasticsearchMetadata
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         ElasticsearchColumnHandle handle = (ElasticsearchColumnHandle) columnHandle;
-        return makeColumnMetadata(handle.getName(), handle.getType());
+        return makeColumnMetadata(handle.getName(), handle.getType(), handle.isSupportsPredicates());
     }
 
     @Override
@@ -240,7 +268,14 @@ public class ElasticsearchMetadata
     @Override
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle table)
     {
-        return new ConnectorTableProperties();
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+
+        return new ConnectorTableProperties(
+                handle.getConstraint(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     @Override
@@ -248,8 +283,23 @@ public class ElasticsearchMetadata
     {
         ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
 
+        Map<ColumnHandle, Domain> supported = new HashMap<>();
+        Map<ColumnHandle, Domain> unsupported = new HashMap<>();
+        if (constraint.getSummary().getDomains().isPresent()) {
+            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getSummary().getDomains().get().entrySet()) {
+                ElasticsearchColumnHandle column = (ElasticsearchColumnHandle) entry.getKey();
+
+                if (column.isSupportsPredicates()) {
+                    supported.put(column, entry.getValue());
+                }
+                else {
+                    unsupported.put(column, entry.getValue());
+                }
+            }
+        }
+
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
-        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(TupleDomain.withColumnDomains(supported));
         if (oldDomain.equals(newDomain)) {
             return Optional.empty();
         }
@@ -257,18 +307,20 @@ public class ElasticsearchMetadata
         handle = new ElasticsearchTableHandle(
                 handle.getSchema(),
                 handle.getIndex(),
-                handle.getConstraint(),
+                newDomain,
                 handle.getQuery());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary()));
+        return Optional.of(new ConstraintApplicationResult<>(handle, TupleDomain.withColumnDomains(unsupported)));
     }
 
-    private static ColumnMetadata makeColumnMetadata(String name, Type type)
+    private static ColumnMetadata makeColumnMetadata(String name, Type type, boolean supportsPredicates)
     {
         return ColumnMetadata.builder()
                 .setName(name)
                 .setType(type)
-                .setProperties(ImmutableMap.of(ORIGINAL_NAME, name))
+                .setProperties(ImmutableMap.of(
+                        ORIGINAL_NAME, name,
+                        SUPPORTS_PREDICATES, supportsPredicates))
                 .build();
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
@@ -125,7 +125,7 @@ public class ElasticsearchPageSource
         SearchResponse searchResponse = client.beginSearch(
                 table.getIndex(),
                 split.getShard(),
-                buildSearchQuery(table.getConstraint(), columns, table.getQuery()),
+                buildSearchQuery(session, table.getConstraint().transform(ElasticsearchColumnHandle.class::cast), table.getQuery()),
                 needAllFields ? Optional.empty() : Optional.of(requiredFields),
                 documentFields);
         readTimeNanos += System.nanoTime() - start;

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -14,7 +14,7 @@
 package io.prestosql.elasticsearch;
 
 import io.airlift.slice.Slice;
-import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -27,8 +27,10 @@ import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,37 +41,42 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
-public class ElasticsearchQueryBuilder
+public final class ElasticsearchQueryBuilder
 {
     private ElasticsearchQueryBuilder() {}
 
-    public static QueryBuilder buildSearchQuery(TupleDomain<ColumnHandle> constraint, List<ElasticsearchColumnHandle> columns, Optional<String> query)
+    public static QueryBuilder buildSearchQuery(ConnectorSession session, TupleDomain<ElasticsearchColumnHandle> constraint, Optional<String> query)
     {
-        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
-        for (ElasticsearchColumnHandle column : columns) {
-            BoolQueryBuilder columnQueryBuilder = new BoolQueryBuilder();
-            Type type = column.getType();
-            if (constraint.getDomains().isPresent()) {
-                Domain domain = constraint.getDomains().get().get(column);
-                if (domain != null) {
-                    columnQueryBuilder.should(buildPredicate(column.getName(), domain, type));
+        BoolQueryBuilder queryBuilder = new BoolQueryBuilder();
+        if (constraint.getDomains().isPresent()) {
+            for (Map.Entry<ElasticsearchColumnHandle, Domain> entry : constraint.getDomains().get().entrySet()) {
+                ElasticsearchColumnHandle column = entry.getKey();
+                Domain domain = entry.getValue();
+
+                checkArgument(!domain.isNone(), "Unexpected NONE domain for %s", column.getName());
+                if (!domain.isAll()) {
+                    queryBuilder.must(new BoolQueryBuilder().must(buildPredicate(session, column.getName(), domain, column.getType())));
                 }
             }
-            boolQueryBuilder.must(columnQueryBuilder);
         }
-
         query.map(QueryStringQueryBuilder::new)
-                .ifPresent(boolQueryBuilder::must);
+                .ifPresent(queryBuilder::must);
 
-        if (boolQueryBuilder.hasClauses()) {
-            return boolQueryBuilder;
+        if (queryBuilder.hasClauses()) {
+            return queryBuilder;
         }
         return new MatchAllQueryBuilder();
     }
 
-    private static QueryBuilder buildPredicate(String columnName, Domain domain, Type type)
+    private static QueryBuilder buildPredicate(ConnectorSession session, String columnName, Domain domain, Type type)
     {
         checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
@@ -84,10 +91,10 @@ public class ElasticsearchQueryBuilder
             return boolQueryBuilder;
         }
 
-        return buildTermQuery(boolQueryBuilder, columnName, domain, type);
+        return buildTermQuery(boolQueryBuilder, session, columnName, domain, type);
     }
 
-    private static QueryBuilder buildTermQuery(BoolQueryBuilder queryBuilder, String columnName, Domain domain, Type type)
+    private static QueryBuilder buildTermQuery(BoolQueryBuilder queryBuilder, ConnectorSession session, String columnName, Domain domain, Type type)
     {
         for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
             BoolQueryBuilder rangeQueryBuilder = new BoolQueryBuilder();
@@ -100,10 +107,10 @@ public class ElasticsearchQueryBuilder
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
                         case ABOVE:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gt(getValue(type, range.getLow().getValue())));
+                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gt(getValue(session, type, range.getLow().getValue())));
                             break;
                         case EXACTLY:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gte(getValue(type, range.getLow().getValue())));
+                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gte(getValue(session, type, range.getLow().getValue())));
                             break;
                         case BELOW:
                             throw new IllegalArgumentException("Low marker should never use BELOW bound");
@@ -114,10 +121,10 @@ public class ElasticsearchQueryBuilder
                 if (!range.getHigh().isUpperUnbounded()) {
                     switch (range.getHigh().getBound()) {
                         case EXACTLY:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lte(getValue(type, range.getHigh().getValue())));
+                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lte(getValue(session, type, range.getHigh().getValue())));
                             break;
                         case BELOW:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lt(getValue(type, range.getHigh().getValue())));
+                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lt(getValue(session, type, range.getHigh().getValue())));
                             break;
                         case ABOVE:
                             throw new IllegalArgumentException("High marker should never use ABOVE bound");
@@ -128,20 +135,36 @@ public class ElasticsearchQueryBuilder
             }
 
             if (valuesToInclude.size() == 1) {
-                rangeQueryBuilder.must(new TermQueryBuilder(columnName, getValue(type, getOnlyElement(valuesToInclude))));
+                rangeQueryBuilder.must(new TermQueryBuilder(columnName, getValue(session, type, getOnlyElement(valuesToInclude))));
             }
             queryBuilder.should(rangeQueryBuilder);
         }
         return queryBuilder;
     }
 
-    private static Object getValue(Type type, Object value)
+    private static Object getValue(ConnectorSession session, Type type, Object value)
     {
-        if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DOUBLE) || type.equals(BOOLEAN)) {
+        if (type.equals(BOOLEAN) ||
+                type.equals(TINYINT) ||
+                type.equals(SMALLINT) ||
+                type.equals(INTEGER) ||
+                type.equals(BIGINT) ||
+                type.equals(DOUBLE)) {
             return value;
+        }
+        if (type.equals(REAL)) {
+            return Float.intBitsToFloat(toIntExact(((Long) value)));
         }
         if (type.equals(VARCHAR)) {
             return ((Slice) value).toStringUtf8();
+        }
+        if (type.equals(TIMESTAMP)) {
+            checkState(session.isLegacyTimestamp(), "New timestamp semantics not yet supported");
+
+            return Instant.ofEpochMilli((Long) value)
+                    .atZone(ZoneId.of(session.getTimeZoneKey().getId()))
+                    .toLocalDateTime()
+                    .format(ISO_DATE_TIME);
         }
         throw new IllegalArgumentException("Unhandled type: " + type);
     }

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -223,6 +223,123 @@ public class TestElasticsearchIntegrationSmokeTest
     }
 
     @Test
+    public void testFilters()
+    {
+        String indexName = "filter_pushdown";
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .prepareCreate(indexName)
+                .addMapping("doc",
+                        "boolean_column", "type=boolean",
+                        "byte_column", "type=byte",
+                        "short_column", "type=short",
+                        "integer_column", "type=integer",
+                        "long_column", "type=long",
+                        "float_column", "type=float",
+                        "double_column", "type=double",
+                        "keyword_column", "type=keyword",
+                        "text_column", "type=text",
+                        "binary_column", "type=binary",
+                        "timestamp_column", "type=date")
+                .get();
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", true)
+                .put("byte_column", 1)
+                .put("short_column", 2)
+                .put("integer_column", 3)
+                .put("long_column", 4L)
+                .put("float_column", 1.0f)
+                .put("double_column", 1.0d)
+                .put("keyword_column", "cool")
+                .put("text_column", "some text")
+                .put("binary_column", new byte[] {(byte) 0xCA, (byte) 0xFE})
+                .put("timestamp_column", 1569888000000L)
+                .build());
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .refresh(refreshRequest(indexName))
+                .actionGet();
+
+        // _score column
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE _score = 1.0", "VALUES 1");
+
+        // boolean
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE boolean_column = true", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE boolean_column = false", "VALUES 0");
+
+        // tinyint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column = 1", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column > 1", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column < 1", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column < 10", "VALUES 1");
+
+        // smallint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column = 2", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column > 2", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column < 2", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column < 10", "VALUES 1");
+
+        // integer
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column = 3", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column > 3", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column < 3", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column < 10", "VALUES 1");
+
+        // bigint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column = 4", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column > 4", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column < 4", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column < 10", "VALUES 1");
+
+        // real
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column = 1.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column > 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column < 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column = 0.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column > 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column < 10.0", "VALUES 1");
+
+        // double
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column = 1.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column > 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column < 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column = 0.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column > 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column < 10.0", "VALUES 1");
+
+        // varchar
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = 'cool'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = 'bar'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE text_column = 'some text'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE text_column = 'some'", "VALUES 0");
+
+        // binary
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE binary_column = x'CAFE'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE binary_column = x'ABCD'", "VALUES 0");
+
+        // timestamp
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column = TIMESTAMP '2019-10-01 00:00:00'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column > TIMESTAMP '2019-10-01 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column < TIMESTAMP '2019-10-01 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column = TIMESTAMP '2019-10-02 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column > TIMESTAMP '2001-01-01 00:00:00'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column < TIMESTAMP '2030-01-01 00:00:00'", "VALUES 1");
+    }
+
+    @Test
     public void testDataTypesNested()
     {
         String indexName = "types_nested";


### PR DESCRIPTION
There were are few issues with the previous implementation:
- It wasn't holding on to the pushed-down constraint, so the filtering
  was being done on the engine side
- The Elasticsearch query was being built with "should" instead of "must", which
  only alters the score of resulting documents
- The Elasticsearch query only contained filters for columns that were listed
  in the set of outputs