### PR TITLE
Support the elasticSearch authentication for elasticsearch connector

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConfig.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchConfig.java
@@ -70,6 +70,10 @@ public class ElasticsearchConfig
 
     private Security security;
 
+    private boolean authenticationEnabled;
+    private String username;
+    private String password;
+
     @NotNull
     public String getHost()
     {
@@ -279,6 +283,43 @@ public class ElasticsearchConfig
     public ElasticsearchConfig setSecurity(Security security)
     {
         this.security = security;
+        return this;
+    }
+
+    public boolean isAuthenticationEnabled()
+    {
+        return authenticationEnabled;
+    }
+
+    @Config("elasticsearch.authentication.enabled")
+    public ElasticsearchConfig setAuthenticationEnabled(boolean authenticationEnabled)
+    {
+        this.authenticationEnabled = authenticationEnabled;
+        return this;
+    }
+
+    public Optional<String> getUsername()
+    {
+        return Optional.ofNullable(username);
+    }
+
+    @Config("elasticsearch.username")
+    public ElasticsearchConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @Config("elasticsearch.password")
+    @ConfigSecuritySensitive
+    public ElasticsearchConfig setPassword(String password)
+    {
+        this.password = password;
         return this;
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
@@ -32,7 +32,11 @@ import io.prestosql.elasticsearch.ElasticsearchConfig;
 import io.prestosql.spi.PrestoException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.search.ClearScrollRequest;
@@ -190,6 +194,12 @@ public class ElasticsearchClient
                 if (config.isVerifyHostnames()) {
                     clientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
                 }
+            }
+
+            if (config.isAuthenticationEnabled()) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(config.getUsername().get(), config.getPassword().get()));
+                clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
             }
 
             awsSecurityConfig.ifPresent(securityConfig -> clientBuilder.addInterceptorLast(new AwsRequestSigner(


### PR DESCRIPTION
Support the elasticsearch authentication for elasticsearch connector(fix issue prestosql#2127) , it worked in our cluster with this fix.