### PR TITLE
Remove deprecated createStatement usage in test codes

### DIFF
--- a/presto-main/src/test/java/io/prestosql/execution/TestSetRoleTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSetRoleTask.java
@@ -23,6 +23,7 @@ import io.prestosql.security.AllowAllAccessControl;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.security.SelectedRole;
 import io.prestosql.sql.analyzer.FeaturesConfig;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.SetRole;
 import io.prestosql.transaction.TransactionManager;
@@ -88,7 +89,7 @@ public class TestSetRoleTask
 
     private void assertSetRole(String statement, Map<String, SelectedRole> expected)
     {
-        SetRole setRole = (SetRole) parser.createStatement(statement);
+        SetRole setRole = (SetRole) parser.createStatement(statement, new ParsingOptions());
         QueryStateMachine stateMachine = QueryStateMachine.begin(
                 statement,
                 Optional.empty(),

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -47,6 +47,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.Statement;
 import io.prestosql.testing.TestingMetadata;
@@ -2232,7 +2233,7 @@ public class TestAnalyzer
                 .readUncommitted()
                 .execute(clientSession, session -> {
                     Analyzer analyzer = createAnalyzer(session, metadata);
-                    Statement statement = SQL_PARSER.createStatement(query);
+                    Statement statement = SQL_PARSER.createStatement(query, new ParsingOptions());
                     analyzer.analyze(statement);
                 });
     }

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
@@ -81,15 +81,6 @@ public class SqlParser
         enhancedErrorHandlerEnabled = options.isEnhancedErrorHandlerEnabled();
     }
 
-    /**
-     * Consider using {@link #createStatement(String, ParsingOptions)}
-     */
-    @Deprecated
-    public Statement createStatement(String sql)
-    {
-        return createStatement(sql, new ParsingOptions());
-    }
-
     public Statement createStatement(String sql, ParsingOptions parsingOptions)
     {
         return (Statement) invokeParser("statement", sql, SqlBaseParser::singleStatement, parsingOptions);

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.fail;
 public class TestSqlParserErrorHandling
 {
     private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ParsingOptions PARSING_OPTIONS = new ParsingOptions();
 
     @DataProvider(name = "expressions")
     public Object[][] getExpressions()
@@ -166,7 +167,7 @@ public class TestSqlParserErrorHandling
     public void testStatement(String sql, String error)
     {
         try {
-            SQL_PARSER.createStatement(sql);
+            SQL_PARSER.createStatement(sql, PARSING_OPTIONS);
             fail("Expected parsing to fail");
         }
         catch (ParsingException e) {
@@ -178,7 +179,7 @@ public class TestSqlParserErrorHandling
     public void testExpression(String sql, String error)
     {
         try {
-            SQL_PARSER.createExpression(sql);
+            SQL_PARSER.createExpression(sql, PARSING_OPTIONS);
             fail("Expected parsing to fail");
         }
         catch (ParsingException e) {
@@ -190,7 +191,7 @@ public class TestSqlParserErrorHandling
     public void testParsingExceptionPositionInfo()
     {
         try {
-            SQL_PARSER.createStatement("select *\nfrom x\nwhere from");
+            SQL_PARSER.createStatement("select *\nfrom x\nwhere from", PARSING_OPTIONS);
             fail("expected exception");
         }
         catch (ParsingException e) {
@@ -213,7 +214,7 @@ public class TestSqlParserErrorHandling
     public void testStackOverflowStatement()
     {
         for (int size = 6000; size <= 100_000; size *= 2) {
-            SQL_PARSER.createStatement("SELECT " + Joiner.on(" OR ").join(nCopies(size, "x = y")));
+            SQL_PARSER.createStatement("SELECT " + Joiner.on(" OR ").join(nCopies(size, "x = y")), PARSING_OPTIONS);
         }
     }
 }

--- a/presto-verifier/src/test/java/io/prestosql/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/io/prestosql/verifier/TestShadowing.java
@@ -16,6 +16,7 @@ package io.prestosql.verifier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.CreateTable;
 import io.prestosql.sql.tree.CreateTableAsSelect;
@@ -49,6 +50,7 @@ public class TestShadowing
     private static final String CATALOG = "TEST_REWRITE";
     private static final String SCHEMA = "PUBLIC";
     private static final String URL = "jdbc:h2:mem:" + CATALOG;
+    private static final ParsingOptions PARSING_OPTIONS = new ParsingOptions();
 
     private final Handle handle;
 
@@ -75,7 +77,7 @@ public class TestShadowing
         assertEquals(rewrittenQuery.getPreQueries().size(), 1);
         assertEquals(rewrittenQuery.getPostQueries().size(), 1);
 
-        CreateTableAsSelect createTableAs = (CreateTableAsSelect) parser.createStatement(rewrittenQuery.getPreQueries().get(0));
+        CreateTableAsSelect createTableAs = (CreateTableAsSelect) parser.createStatement(rewrittenQuery.getPreQueries().get(0), PARSING_OPTIONS);
         assertEquals(createTableAs.getName().getParts().size(), 1);
         assertTrue(createTableAs.getName().getSuffix().startsWith("tmp_"));
         assertFalse(createTableAs.getName().getSuffix().contains("my_test_table"));
@@ -85,9 +87,9 @@ public class TestShadowing
         Table table = new Table(createTableAs.getName());
         SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("COLUMN1"))));
         SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("COLUMN2"), new LongLiteral("1"))))));
-        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), simpleQuery(selectList(column1, column2), table));
+        assertEquals(parser.createStatement(rewrittenQuery.getQuery(), PARSING_OPTIONS), simpleQuery(selectList(column1, column2), table));
 
-        assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0)), new DropTable(createTableAs.getName(), true));
+        assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0), PARSING_OPTIONS), new DropTable(createTableAs.getName(), true));
     }
 
     @Test
@@ -100,7 +102,7 @@ public class TestShadowing
         QueryRewriter rewriter = new QueryRewriter(parser, URL, QualifiedName.of("other_catalog", "other_schema", "tmp_"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), 1, new Duration(10, SECONDS));
         Query rewrittenQuery = rewriter.shadowQuery(query);
         assertEquals(rewrittenQuery.getPreQueries().size(), 1);
-        CreateTableAsSelect createTableAs = (CreateTableAsSelect) parser.createStatement(rewrittenQuery.getPreQueries().get(0));
+        CreateTableAsSelect createTableAs = (CreateTableAsSelect) parser.createStatement(rewrittenQuery.getPreQueries().get(0), PARSING_OPTIONS);
         assertEquals(createTableAs.getName().getParts().size(), 3);
         assertEquals(createTableAs.getName().getPrefix().get(), QualifiedName.of("other_catalog", "other_schema"));
         assertTrue(createTableAs.getName().getSuffix().startsWith("tmp_"));
@@ -118,13 +120,13 @@ public class TestShadowing
         Query rewrittenQuery = rewriter.shadowQuery(query);
 
         assertEquals(rewrittenQuery.getPreQueries().size(), 2);
-        CreateTable createTable = (CreateTable) parser.createStatement(rewrittenQuery.getPreQueries().get(0));
+        CreateTable createTable = (CreateTable) parser.createStatement(rewrittenQuery.getPreQueries().get(0), PARSING_OPTIONS);
         assertEquals(createTable.getName().getParts().size(), 3);
         assertEquals(createTable.getName().getPrefix().get(), QualifiedName.of("other_catalog", "other_schema"));
         assertTrue(createTable.getName().getSuffix().startsWith("tmp_"));
         assertFalse(createTable.getName().getSuffix().contains("test_insert_table"));
 
-        Insert insert = (Insert) parser.createStatement(rewrittenQuery.getPreQueries().get(1));
+        Insert insert = (Insert) parser.createStatement(rewrittenQuery.getPreQueries().get(1), PARSING_OPTIONS);
         assertEquals(insert.getTarget(), createTable.getName());
         assertEquals(insert.getColumns(), Optional.of(ImmutableList.of(identifier("b"), identifier("a"), identifier("c"))));
 
@@ -132,9 +134,9 @@ public class TestShadowing
         SingleColumn columnA = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("A"))));
         SingleColumn columnB = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("B"), new LongLiteral("1"))))));
         SingleColumn columnC = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("C"))));
-        assertEquals(parser.createStatement(rewrittenQuery.getQuery()), simpleQuery(selectList(columnA, columnB, columnC), table));
+        assertEquals(parser.createStatement(rewrittenQuery.getQuery(), PARSING_OPTIONS), simpleQuery(selectList(columnA, columnB, columnC), table));
 
         assertEquals(rewrittenQuery.getPostQueries().size(), 1);
-        assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0)), new DropTable(createTable.getName(), true));
+        assertEquals(parser.createStatement(rewrittenQuery.getPostQueries().get(0), PARSING_OPTIONS), new DropTable(createTable.getName(), true));
     }
 }


### PR DESCRIPTION
`SqlParser#createStatement` is deprecated. Although the method can be used by the external libraries, we should be able to remove the usage safely from the test codes in `prestosql/presto` repository. 
