### PR TITLE
Support more types in avro record decoder

### DIFF
--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
@@ -237,26 +237,26 @@ public class AvroColumnDecoder
         return null;
     }
 
-    private static Block serializeList(BlockBuilder blockBuilder, Object value, Type type, String columnName)
+    private static Block serializeList(BlockBuilder parentBlockBuilder, Object value, Type type, String columnName)
     {
         if (value == null) {
-            checkState(blockBuilder != null, "parent block builder is null");
-            blockBuilder.appendNull();
+            checkState(parentBlockBuilder != null, "parentBlockBuilder is null");
+            parentBlockBuilder.appendNull();
             return null;
         }
         List<?> list = (List<?>) value;
         List<Type> typeParameters = type.getTypeParameters();
         Type elementType = typeParameters.get(0);
 
-        BlockBuilder currentBlockBuilder = elementType.createBlockBuilder(null, list.size());
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, list.size());
         for (Object element : list) {
-            serializeObject(currentBlockBuilder, element, elementType, columnName);
+            serializeObject(blockBuilder, element, elementType, columnName);
         }
-        if (blockBuilder != null) {
-            type.writeObject(blockBuilder, currentBlockBuilder.build());
+        if (parentBlockBuilder != null) {
+            type.writeObject(parentBlockBuilder, blockBuilder.build());
             return null;
         }
-        return currentBlockBuilder.build();
+        return blockBuilder.build();
     }
 
     private static void serializePrimitive(BlockBuilder blockBuilder, Object value, Type type, String columnName)

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/AvroDecoderTestUtil.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/AvroDecoderTestUtil.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.decoder.avro;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.MapType;
+import io.prestosql.spi.type.SqlVarbinary;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class AvroDecoderTestUtil
+{
+    private AvroDecoderTestUtil() {}
+
+    public static void checkPrimitiveValue(Object actual, Object expected)
+    {
+        if (actual == null || expected == null) {
+            assertNull(expected);
+            assertNull(actual);
+        }
+        else if (actual instanceof CharSequence) {
+            assertTrue(expected instanceof CharSequence || expected instanceof GenericEnumSymbol);
+            assertEquals(actual.toString(), expected.toString());
+        }
+        else if (actual instanceof SqlVarbinary) {
+            if (expected instanceof GenericFixed) {
+                assertEquals(((SqlVarbinary) actual).getBytes(), ((GenericFixed) expected).bytes());
+            }
+            else if (expected instanceof ByteBuffer) {
+                assertEquals(((SqlVarbinary) actual).getBytes(), ((ByteBuffer) expected).array());
+            }
+            else {
+                fail(format("Unexpected value type %s", actual.getClass()));
+            }
+        }
+        else if (isIntegralType(actual) && isIntegralType(expected)) {
+            assertEquals(((Number) actual).longValue(), ((Number) expected).longValue());
+        }
+        else if (isRealType(actual) && isRealType(expected)) {
+            assertEquals(((Number) actual).doubleValue(), ((Number) expected).doubleValue());
+        }
+        else {
+            assertEquals(actual, expected);
+        }
+    }
+
+    public static boolean isIntegralType(Object value)
+    {
+        return value instanceof Long
+                || value instanceof Integer
+                || value instanceof Short
+                || value instanceof Byte;
+    }
+
+    public static boolean isRealType(Object value)
+    {
+        return value instanceof Float || value instanceof Double;
+    }
+
+    public static Object getObjectValue(Type type, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        return type.getObjectValue(SESSION, block, position);
+    }
+
+    public static void checkArrayValues(Block block, Type type, Object value)
+    {
+        assertNotNull(type, "Type is null");
+        assertTrue(type instanceof ArrayType, "Unexpected type");
+        assertNotNull(block, "Block is null");
+        assertNotNull(value, "Value is null");
+
+        List<?> list = (List<?>) value;
+
+        assertEquals(block.getPositionCount(), list.size());
+        Type elementType = ((ArrayType) type).getElementType();
+        if (elementType instanceof ArrayType) {
+            for (int index = 0; index < block.getPositionCount(); index++) {
+                if (block.isNull(index)) {
+                    assertNull(list.get(index));
+                    continue;
+                }
+                Block arrayBlock = block.getObject(index, Block.class);
+                checkArrayValues(arrayBlock, elementType, list.get(index));
+            }
+        }
+        else if (elementType instanceof MapType) {
+            for (int index = 0; index < block.getPositionCount(); index++) {
+                if (block.isNull(index)) {
+                    assertNull(list.get(index));
+                    continue;
+                }
+                Block mapBlock = block.getObject(index, Block.class);
+                checkMapValues(mapBlock, elementType, list.get(index));
+            }
+        }
+        else {
+            for (int index = 0; index < block.getPositionCount(); index++) {
+                checkPrimitiveValue(getObjectValue(elementType, block, index), list.get(index));
+            }
+        }
+    }
+
+    public static void checkMapValues(Block block, Type type, Object value)
+    {
+        assertNotNull(type, "Type is null");
+        assertTrue(type instanceof MapType, "Unexpected type");
+        assertTrue(((MapType) type).getKeyType() instanceof VarcharType, "Unexpected key type");
+        assertNotNull(block, "Block is null");
+        assertNotNull(value, "Value is null");
+
+        Map<String, ?> expected = (Map<String, ?>) value;
+
+        assertEquals(block.getPositionCount(), expected.size() * 2);
+        Type valueType = ((MapType) type).getValueType();
+        for (int index = 0; index < block.getPositionCount(); index += 2) {
+            String actualKey = VARCHAR.getSlice(block, index).toStringUtf8();
+            assertTrue(expected.containsKey(actualKey));
+            checkPrimitiveValue(getObjectValue(valueType, block, index + 1), expected.get(actualKey));
+        }
+    }
+}

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/util/DecoderTestUtil.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/util/DecoderTestUtil.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.decoder.util;
 
+import io.airlift.slice.Slice;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 
@@ -25,6 +26,13 @@ import static org.testng.Assert.assertTrue;
 public final class DecoderTestUtil
 {
     private DecoderTestUtil() {}
+
+    public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, Slice value)
+    {
+        FieldValueProvider provider = decodedRow.get(handle);
+        assertNotNull(provider);
+        assertEquals(provider.getSlice(), value);
+    }
 
     public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, String value)
     {


### PR DESCRIPTION
This pull request extends the avro record reader:
* Support struct type
* Support nested list, map and struct types
* Support for float, integer, smallint and tinyint