### PR TITLE
Update S3 tests to Hive Metadata changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,17 @@ jobs:
         run: |
           source presto-product-tests/conf/product-tests-${{ matrix.config }}.sh &&
             presto-hive-hadoop2/bin/run_hive_tests.sh
+      - name: Run Hive S3 Tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AwsAccessKey }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AwsSecretKey }}
+          S3_BUCKET: "presto-ci-test"
+          S3_BUCKET_ENDPOINT: "s3.us-east-2.amazonaws.com"
+        run: |
+          if [ "AWS_ACCESS_KEY_ID" != "" ]; then
+            source presto-product-tests/conf/product-tests-${{ matrix.config }}.sh &&
+              presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+          fi
 
   kudu-tests:
     runs-on: ubuntu-latest

--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -18,10 +18,7 @@ exec_in_hadoop_master_container sed -i \
 # create test table
 table_path="s3a://${S3_BUCKET}/presto_test_external_fs/"
 exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.gz "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.lz4 "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.bz2 "${table_path}"
+exec_in_hadoop_master_container /docker/files/hadoop-put.sh /docker/files/test1.csv{,.gz,.bz2,.lz4} "${table_path}"
 exec_in_hadoop_master_container /usr/bin/hive -e "CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint) LOCATION '${table_path}'"
 
 stop_unnecessary_hadoop_services

--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -8,6 +8,7 @@ cleanup_docker_containers
 start_docker_containers
 
 # insert AWS credentials
+# TODO replace core-site.xml.s3-template with apply-site-xml-override.sh
 exec_in_hadoop_master_container cp /docker/files/core-site.xml.s3-template /etc/hadoop/conf/core-site.xml
 exec_in_hadoop_master_container sed -i \
   -e "s|%AWS_ACCESS_KEY%|${AWS_ACCESS_KEY_ID}|g" \
@@ -19,7 +20,9 @@ exec_in_hadoop_master_container sed -i \
 table_path="s3a://${S3_BUCKET}/presto_test_external_fs/"
 exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path}"
 exec_in_hadoop_master_container /docker/files/hadoop-put.sh /docker/files/test1.csv{,.gz,.bz2,.lz4} "${table_path}"
-exec_in_hadoop_master_container /usr/bin/hive -e "CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint) LOCATION '${table_path}'"
+exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -e "
+    CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint)
+    LOCATION '${table_path}'"
 
 stop_unnecessary_hadoop_services
 

--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -8,7 +8,7 @@ cleanup_docker_containers
 start_docker_containers
 
 # insert AWS credentials
-exec_in_hadoop_master_container cp /etc/hadoop/conf/core-site.xml.s3-template /etc/hadoop/conf/core-site.xml
+exec_in_hadoop_master_container cp /docker/files/core-site.xml.s3-template /etc/hadoop/conf/core-site.xml
 exec_in_hadoop_master_container sed -i \
   -e "s|%AWS_ACCESS_KEY%|${AWS_ACCESS_KEY_ID}|g" \
   -e "s|%AWS_SECRET_KEY%|${AWS_SECRET_ACCESS_KEY}|g" \
@@ -18,10 +18,10 @@ exec_in_hadoop_master_container sed -i \
 # create test table
 table_path="s3a://${S3_BUCKET}/presto_test_external_fs/"
 exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.gz "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.lz4 "${table_path}"
-exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.bz2 "${table_path}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv "${table_path}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.gz "${table_path}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.lz4 "${table_path}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /docker/files/test1.csv.bz2 "${table_path}"
 exec_in_hadoop_master_container /usr/bin/hive -e "CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint) LOCATION '${table_path}'"
 
 stop_unnecessary_hadoop_services

--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -22,6 +22,7 @@ exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path}"
 exec_in_hadoop_master_container /docker/files/hadoop-put.sh /docker/files/test1.csv{,.gz,.bz2,.lz4} "${table_path}"
 exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -e "
     CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint)
+    STORED AS TEXTFILE
     LOCATION '${table_path}'"
 
 stop_unnecessary_hadoop_services

--- a/presto-hive-hadoop2/bin/run_hive_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_tests.sh
@@ -8,8 +8,8 @@ cleanup_docker_containers
 start_docker_containers
 
 # generate test data
-exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f /files/sql/create-test.sql
-exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f "/files/sql/create-test-hive-${TESTS_HIVE_VERSION_MAJOR}.sql"
+exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f /docker/sql/create-test.sql
+exec_in_hadoop_master_container sudo -Eu hive beeline -u jdbc:hive2://localhost:10000/default -n hive -f "/docker/sql/create-test-hive-${TESTS_HIVE_VERSION_MAJOR}.sql"
 
 stop_unnecessary_hadoop_services
 

--- a/presto-hive-hadoop2/conf/docker-compose.yml
+++ b/presto-hive-hadoop2/conf/docker-compose.yml
@@ -16,11 +16,6 @@ services:
       - '50070:50070' # NameNode Web UI prior to Hadoop 3
       - '50075:50075' # DataNode Web UI prior to Hadoop 3
     volumes:
-      - ../../presto-hive/src/test/sql:/files/sql:ro
-      - ./files/words:/usr/share/dict/words:ro
-      - ./files/core-site.xml.s3-template:/etc/hadoop/conf/core-site.xml.s3-template:ro
+      - ../../presto-hive/src/test/sql:/docker/sql:ro
+      - ./files:/docker/files:ro
       - ./files/tez-site.xml:/etc/tez/conf/tez-site.xml:ro
-      - ./files/test1.csv:/tmp/test1.csv:ro
-      - ./files/test1.csv.gz:/tmp/test1.csv.gz:ro
-      - ./files/test1.csv.lz4:/tmp/test1.csv.lz4:ro
-      - ./files/test1.csv.bz2:/tmp/test1.csv.bz2:ro

--- a/presto-hive-hadoop2/conf/files/core-site.xml.s3-template
+++ b/presto-hive-hadoop2/conf/files/core-site.xml.s3-template
@@ -17,6 +17,17 @@
 -->
 <configuration>
 
+    <!-- Hive impersonation -->
+    <property>
+        <name>hadoop.proxyuser.hive.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.hive.groups</name>
+        <value>*</value>
+    </property>
+
     <property>
         <name>fs.defaultFS</name>
         <value>hdfs://hadoop-master:9000</value>

--- a/presto-hive-hadoop2/conf/files/hadoop-put.sh
+++ b/presto-hive-hadoop2/conf/files/hadoop-put.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+# Hadoop 3 without -d (don't create _COPYING_ temporary file) requires additional S3 permissions
+# Hadoop 2 doesn't have '-d' switch
+hadoop fs -put -f -d "$@" ||
+hadoop fs -put -f "$@"

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -55,6 +55,7 @@ public abstract class AbstractTestHiveFileSystemS3
     @Override
     protected Path getBasePath()
     {
-        return new Path(format("s3://%s/", writableBucket));
+        // HDP 3.1 does not understand s3:// out of the box.
+        return new Path(format("s3a://%s/", writableBucket));
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
@@ -88,10 +88,6 @@ public class HiveModule
         binder.bind(CachingDirectoryLister.class).in(Scopes.SINGLETON);
         newExporter(binder).export(CachingDirectoryLister.class).withGeneratedName();
 
-        Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = newSetBinder(binder, HiveRecordCursorProvider.class);
-        recordCursorProviderBinder.addBinding().to(S3SelectRecordCursorProvider.class).in(Scopes.SINGLETON);
-        recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
-
         binder.bind(HiveWriterStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(HiveWriterStats.class).withGeneratedName();
 
@@ -116,6 +112,11 @@ public class HiveModule
         pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
+
+        Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = newSetBinder(binder, HiveRecordCursorProvider.class);
+        recordCursorProviderBinder.addBinding().to(S3SelectRecordCursorProvider.class).in(Scopes.SINGLETON);
+
+        binder.bind(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
 
         Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
         binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -72,13 +72,17 @@ public class HivePageSourceProvider
             HiveConfig hiveConfig,
             HdfsEnvironment hdfsEnvironment,
             Set<HivePageSourceFactory> pageSourceFactories,
-            Set<HiveRecordCursorProvider> cursorProviders)
+            Set<HiveRecordCursorProvider> cursorProviders,
+            GenericHiveRecordCursorProvider genericCursorProvider)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.hiveStorageTimeZone = requireNonNull(hiveConfig, "hiveConfig is null").getDateTimeZone();
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.pageSourceFactories = ImmutableSet.copyOf(requireNonNull(pageSourceFactories, "pageSourceFactories is null"));
-        this.cursorProviders = ImmutableSet.copyOf(requireNonNull(cursorProviders, "cursorProviders is null"));
+        this.cursorProviders = ImmutableSet.<HiveRecordCursorProvider>builder()
+                .addAll(requireNonNull(cursorProviders, "cursorProviders is null"))
+                .add(genericCursorProvider) // generic should be last, as a fallback option
+                .build();
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -60,27 +60,25 @@ import static java.util.stream.Collectors.toList;
 public class HivePageSourceProvider
         implements ConnectorPageSourceProvider
 {
+    private final TypeManager typeManager;
     private final DateTimeZone hiveStorageTimeZone;
     private final HdfsEnvironment hdfsEnvironment;
-    private final Set<HiveRecordCursorProvider> cursorProviders;
-    private final TypeManager typeManager;
-
     private final Set<HivePageSourceFactory> pageSourceFactories;
+    private final Set<HiveRecordCursorProvider> cursorProviders;
 
     @Inject
     public HivePageSourceProvider(
+            TypeManager typeManager,
             HiveConfig hiveConfig,
             HdfsEnvironment hdfsEnvironment,
-            Set<HiveRecordCursorProvider> cursorProviders,
             Set<HivePageSourceFactory> pageSourceFactories,
-            TypeManager typeManager)
+            Set<HiveRecordCursorProvider> cursorProviders)
     {
-        requireNonNull(hiveConfig, "hiveConfig is null");
-        this.hiveStorageTimeZone = hiveConfig.getDateTimeZone();
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.cursorProviders = ImmutableSet.copyOf(requireNonNull(cursorProviders, "cursorProviders is null"));
-        this.pageSourceFactories = ImmutableSet.copyOf(requireNonNull(pageSourceFactories, "pageSourceFactories is null"));
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.hiveStorageTimeZone = requireNonNull(hiveConfig, "hiveConfig is null").getDateTimeZone();
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.pageSourceFactories = ImmutableSet.copyOf(requireNonNull(pageSourceFactories, "pageSourceFactories is null"));
+        this.cursorProviders = ImmutableSet.copyOf(requireNonNull(cursorProviders, "cursorProviders is null"));
     }
 
     @Override
@@ -104,8 +102,8 @@ public class HivePageSourceProvider
         Configuration configuration = hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path);
 
         Optional<ConnectorPageSource> pageSource = createHivePageSource(
-                cursorProviders,
                 pageSourceFactories,
+                cursorProviders,
                 configuration,
                 session,
                 path,
@@ -130,8 +128,8 @@ public class HivePageSourceProvider
     }
 
     public static Optional<ConnectorPageSource> createHivePageSource(
-            Set<HiveRecordCursorProvider> cursorProviders,
             Set<HivePageSourceFactory> pageSourceFactories,
+            Set<HiveRecordCursorProvider> cursorProviders,
             Configuration configuration,
             ConnectorSession session,
             Path path,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -200,7 +200,7 @@ import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveTestUtils.arrayType;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveFileWriterFactories;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHivePageSourceFactories;
-import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvider;
+import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProviders;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.prestosql.plugin.hive.HiveTestUtils.getTypes;
@@ -787,7 +787,8 @@ public abstract class AbstractTestHive
                 hiveConfig,
                 hdfsEnvironment,
                 getDefaultHivePageSourceFactories(hiveConfig, hdfsEnvironment),
-                getDefaultHiveRecordCursorProvider(hiveConfig, hdfsEnvironment));
+                getDefaultHiveRecordCursorProviders(hiveConfig, hdfsEnvironment),
+                new GenericHiveRecordCursorProvider(hdfsEnvironment, hiveConfig));
     }
 
     /**

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -783,11 +783,11 @@ public abstract class AbstractTestHive
                 getHiveSessionProperties(hiveConfig),
                 new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(
+                TYPE_MANAGER,
                 hiveConfig,
                 hdfsEnvironment,
-                getDefaultHiveRecordCursorProvider(hiveConfig, hdfsEnvironment),
                 getDefaultHivePageSourceFactories(hiveConfig, hdfsEnvironment),
-                TYPE_MANAGER);
+                getDefaultHiveRecordCursorProvider(hiveConfig, hdfsEnvironment));
     }
 
     /**

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -786,7 +786,7 @@ public abstract class AbstractTestHive
                 TYPE_MANAGER,
                 hiveConfig,
                 hdfsEnvironment,
-                getDefaultHivePageSourceFactories(hiveConfig, hdfsEnvironment),
+                getDefaultHivePageSourceFactories(hdfsEnvironment),
                 getDefaultHiveRecordCursorProviders(hiveConfig, hdfsEnvironment),
                 new GenericHiveRecordCursorProvider(hdfsEnvironment, hiveConfig));
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -92,7 +92,7 @@ import static io.prestosql.plugin.hive.HiveTestUtils.PAGE_SORTER;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveFileWriterFactories;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHivePageSourceFactories;
-import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvider;
+import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProviders;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.prestosql.plugin.hive.HiveTestUtils.getTypes;
@@ -226,7 +226,8 @@ public abstract class AbstractTestHiveFileSystem
                 config,
                 hdfsEnvironment,
                 getDefaultHivePageSourceFactories(config, hdfsEnvironment),
-                getDefaultHiveRecordCursorProvider(config, hdfsEnvironment));
+                getDefaultHiveRecordCursorProviders(config, hdfsEnvironment),
+                new GenericHiveRecordCursorProvider(hdfsEnvironment, config));
     }
 
     protected ConnectorSession newSession()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -251,6 +251,7 @@ public abstract class AbstractTestHiveFileSystem
             List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, table).values());
             Map<String, Integer> columnIndex = indexColumns(columnHandles);
 
+            metadata.beginQuery(session);
             ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, table, UNGROUPED_SCHEDULING);
 
             List<ConnectorSplit> splits = getAllSplits(splitSource);
@@ -269,6 +270,8 @@ public abstract class AbstractTestHiveFileSystem
             // The test table is made up of multiple S3 objects with same data and different compression codec
             // formats: uncompressed | .gz | .lz4 | .bz2
             assertEquals(sum, 78300 * 4);
+
+            metadata.cleanupQuery(session);
         }
     }
 
@@ -421,6 +424,7 @@ public abstract class AbstractTestHiveFileSystem
             assertEquals(filterNonHiddenColumnMetadata(tableMetadata.getColumns()), columns);
 
             // verify the data
+            metadata.beginQuery(session);
             ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableHandle, UNGROUPED_SCHEDULING);
             ConnectorSplit split = getOnlyElement(getAllSplits(splitSource));
 
@@ -428,6 +432,8 @@ public abstract class AbstractTestHiveFileSystem
                 MaterializedResult result = materializeSourceDataStream(session, pageSource, getTypes(columnHandles));
                 assertEqualsIgnoreOrder(result.getMaterializedRows(), data.getMaterializedRows());
             }
+
+            metadata.cleanupQuery(session);
         }
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -222,11 +222,11 @@ public abstract class AbstractTestHiveFileSystem
                 getHiveSessionProperties(config),
                 new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(
+                TYPE_MANAGER,
                 config,
                 hdfsEnvironment,
-                getDefaultHiveRecordCursorProvider(config, hdfsEnvironment),
                 getDefaultHivePageSourceFactories(config, hdfsEnvironment),
-                TYPE_MANAGER);
+                getDefaultHiveRecordCursorProvider(config, hdfsEnvironment));
     }
 
     protected ConnectorSession newSession()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -225,7 +225,7 @@ public abstract class AbstractTestHiveFileSystem
                 TYPE_MANAGER,
                 config,
                 hdfsEnvironment,
-                getDefaultHivePageSourceFactories(config, hdfsEnvironment),
+                getDefaultHivePageSourceFactories(hdfsEnvironment),
                 getDefaultHiveRecordCursorProviders(config, hdfsEnvironment),
                 new GenericHiveRecordCursorProvider(hdfsEnvironment, config));
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -34,6 +34,8 @@ import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
 import io.prestosql.plugin.hive.rcfile.RcFilePageSourceFactory;
 import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.plugin.hive.s3.PrestoS3ConfigurationInitializer;
+import io.prestosql.plugin.hive.s3select.PrestoS3ClientFactory;
+import io.prestosql.plugin.hive.s3select.S3SelectRecordCursorProvider;
 import io.prestosql.spi.PageSorter;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -110,8 +112,8 @@ public final class HiveTestUtils
 
     public static Set<HiveRecordCursorProvider> getDefaultHiveRecordCursorProviders(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)
     {
-        // TODO reconcile this with HiveModule
         return ImmutableSet.<HiveRecordCursorProvider>builder()
+                .add(new S3SelectRecordCursorProvider(hdfsEnvironment, new PrestoS3ClientFactory(hiveConfig)))
                 .build();
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -100,7 +100,7 @@ public final class HiveTestUtils
                 new ParquetWriterConfig());
     }
 
-    public static Set<HivePageSourceFactory> getDefaultHivePageSourceFactories(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)
+    public static Set<HivePageSourceFactory> getDefaultHivePageSourceFactories(HdfsEnvironment hdfsEnvironment)
     {
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
         return ImmutableSet.<HivePageSourceFactory>builder()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -108,10 +108,10 @@ public final class HiveTestUtils
                 .build();
     }
 
-    public static Set<HiveRecordCursorProvider> getDefaultHiveRecordCursorProvider(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)
+    public static Set<HiveRecordCursorProvider> getDefaultHiveRecordCursorProviders(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)
     {
+        // TODO reconcile this with HiveModule
         return ImmutableSet.<HiveRecordCursorProvider>builder()
-                .add(new GenericHiveRecordCursorProvider(hdfsEnvironment, hiveConfig))
                 .build();
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -559,8 +559,8 @@ public class TestHiveFileFormats
         Configuration configuration = new Configuration(false);
         configuration.set("io.compression.codecs", LzoCodec.class.getName() + "," + LzopCodec.class.getName());
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
-                ImmutableSet.of(cursorProvider),
                 ImmutableSet.of(),
+                ImmutableSet.of(cursorProvider),
                 configuration,
                 session,
                 split.getPath(),
@@ -617,8 +617,8 @@ public class TestHiveFileFormats
         List<HiveColumnHandle> columnHandles = getColumnHandles(testColumns);
 
         Optional<ConnectorPageSource> pageSource = HivePageSourceProvider.createHivePageSource(
-                ImmutableSet.of(),
                 ImmutableSet.of(sourceFactory),
+                ImmutableSet.of(),
                 new Configuration(false),
                 session,
                 split.getPath(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -65,7 +65,7 @@ import static io.prestosql.plugin.hive.HiveTestUtils.PAGE_SORTER;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveFileWriterFactories;
 import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHivePageSourceFactories;
-import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvider;
+import static io.prestosql.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProviders;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.prestosql.plugin.hive.HiveType.HIVE_DATE;
@@ -242,7 +242,8 @@ public class TestHivePageSink
                 config,
                 HDFS_ENVIRONMENT,
                 getDefaultHivePageSourceFactories(config, HDFS_ENVIRONMENT),
-                getDefaultHiveRecordCursorProvider(config, HDFS_ENVIRONMENT));
+                getDefaultHiveRecordCursorProviders(config, HDFS_ENVIRONMENT),
+                new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT, config));
         return provider.createPageSource(transaction, getHiveSession(config), split, table, ImmutableList.copyOf(getColumnHandles()));
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -238,11 +238,11 @@ public class TestHivePageSink
                 false);
         ConnectorTableHandle table = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), Optional.empty());
         HivePageSourceProvider provider = new HivePageSourceProvider(
+                TYPE_MANAGER,
                 config,
                 HDFS_ENVIRONMENT,
-                getDefaultHiveRecordCursorProvider(config, HDFS_ENVIRONMENT),
                 getDefaultHivePageSourceFactories(config, HDFS_ENVIRONMENT),
-                TYPE_MANAGER);
+                getDefaultHiveRecordCursorProvider(config, HDFS_ENVIRONMENT));
         return provider.createPageSource(transaction, getHiveSession(config), split, table, ImmutableList.copyOf(getColumnHandles()));
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -241,7 +241,7 @@ public class TestHivePageSink
                 TYPE_MANAGER,
                 config,
                 HDFS_ENVIRONMENT,
-                getDefaultHivePageSourceFactories(config, HDFS_ENVIRONMENT),
+                getDefaultHivePageSourceFactories(HDFS_ENVIRONMENT),
                 getDefaultHiveRecordCursorProviders(config, HDFS_ENVIRONMENT),
                 new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT, config));
         return provider.createPageSource(transaction, getHiveSession(config), split, table, ImmutableList.copyOf(getColumnHandles()));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -476,8 +476,8 @@ public class TestOrcPageSourceMemoryTracking
         {
             OrcPageSourceFactory orcPageSourceFactory = new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_ENVIRONMENT, stats);
             return HivePageSourceProvider.createHivePageSource(
-                    ImmutableSet.of(),
                     ImmutableSet.of(orcPageSourceFactory),
+                    ImmutableSet.of(),
                     new Configuration(false),
                     session,
                     fileSplit.getPath(),

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -120,7 +120,7 @@ AS SELECT * FROM presto_test_unpartitioned
 
 DROP TABLE IF EXISTS tmp_presto_test_load;
 CREATE TABLE tmp_presto_test_load (word STRING) STORED AS TEXTFILE;
-LOAD DATA LOCAL INPATH '/usr/share/dict/words'
+LOAD DATA LOCAL INPATH '/docker/files/words'
 INTO TABLE tmp_presto_test_load
 ;
 

--- a/presto-main/src/test/java/io/prestosql/cost/StatsCalculatorAssertion.java
+++ b/presto-main/src/test/java/io/prestosql/cost/StatsCalculatorAssertion.java
@@ -92,6 +92,7 @@ public class StatsCalculatorAssertion
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     private static <T extends PlanNode> Optional<PlanNodeStatsEstimate> calculatedStats(Rule<T> rule, PlanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
     {
         return rule.calculate((T) node, sourceStats, lookup, session, types);


### PR DESCRIPTION
Update S3 tests code to accommodate for `SemiTransactionalHiveMetastore`
changes related to transactional tables support.

Part of https://github.com/prestosql/presto/issues/274