### PR TITLE
Use dockerized Cassandra in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1189,18 +1189,6 @@
 
             <dependency>
                 <groupId>io.prestosql.cassandra</groupId>
-                <artifactId>cassandra-server</artifactId>
-                <version>2.1.16-2</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-all</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>io.prestosql.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.1.4-2</version>
             </dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -13,8 +13,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-
-        <air.test.thread-count>1</air.test.thread-count>
     </properties>
 
     <dependencies>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -160,8 +160,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.prestosql.cassandra</groupId>
-            <artifactId>cassandra-server</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraQueryRunner.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraQueryRunner.java
@@ -35,7 +35,7 @@ public final class CassandraQueryRunner
     public static synchronized DistributedQueryRunner createCassandraQueryRunner()
             throws Exception
     {
-        EmbeddedCassandra.start();
+        CassandraServer.start();
 
         DistributedQueryRunner queryRunner = new DistributedQueryRunner(createCassandraSession("tpch"), 4);
 
@@ -44,16 +44,16 @@ public final class CassandraQueryRunner
 
         queryRunner.installPlugin(new CassandraPlugin());
         queryRunner.createCatalog("cassandra", "cassandra", ImmutableMap.of(
-                "cassandra.contact-points", EmbeddedCassandra.getHost(),
-                "cassandra.native-protocol-port", Integer.toString(EmbeddedCassandra.getPort()),
+                "cassandra.contact-points", CassandraServer.getHost(),
+                "cassandra.native-protocol-port", Integer.toString(CassandraServer.getPort()),
                 "cassandra.allow-drop-table", "true"));
 
         if (!tpchLoaded) {
-            createKeyspace(EmbeddedCassandra.getSession(), "tpch");
+            createKeyspace(CassandraServer.getSession(), "tpch");
             List<TpchTable<?>> tables = TpchTable.getTables();
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createCassandraSession("tpch"), tables);
             for (TpchTable<?> table : tables) {
-                EmbeddedCassandra.refreshSizeEstimates("tpch", table.getTableName());
+                CassandraServer.refreshSizeEstimates("tpch", table.getTableName());
             }
             tpchLoaded = true;
         }

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraTestingUtils.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraTestingUtils.java
@@ -76,12 +76,12 @@ public final class CassandraTestingUtils
 
     public static void insertIntoTableClusteringKeys(CassandraSession session, SchemaTableName table, int rowsCount)
     {
-        for (Integer rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
+        for (int rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
             Insert insert = QueryBuilder.insertInto(table.getSchemaName(), table.getTableName())
-                    .value("key", "key_" + rowNumber.toString())
+                    .value("key", "key_" + rowNumber)
                     .value("clust_one", "clust_one")
-                    .value("clust_two", "clust_two_" + rowNumber.toString())
-                    .value("clust_three", "clust_three_" + rowNumber.toString());
+                    .value("clust_two", "clust_two_" + rowNumber)
+                    .value("clust_three", "clust_three_" + rowNumber);
             session.execute(insert);
         }
         assertEquals(session.execute("SELECT COUNT(*) FROM " + table).all().get(0).getLong(0), rowsCount);
@@ -104,13 +104,13 @@ public final class CassandraTestingUtils
 
     public static void insertIntoTableMultiPartitionClusteringKeys(CassandraSession session, SchemaTableName table)
     {
-        for (Integer rowNumber = 1; rowNumber < 10; rowNumber++) {
+        for (int rowNumber = 1; rowNumber < 10; rowNumber++) {
             Insert insert = QueryBuilder.insertInto(table.getSchemaName(), table.getTableName())
-                    .value("partition_one", "partition_one_" + rowNumber.toString())
-                    .value("partition_two", "partition_two_" + rowNumber.toString())
+                    .value("partition_one", "partition_one_" + rowNumber)
+                    .value("partition_two", "partition_two_" + rowNumber)
                     .value("clust_one", "clust_one")
-                    .value("clust_two", "clust_two_" + rowNumber.toString())
-                    .value("clust_three", "clust_three_" + rowNumber.toString());
+                    .value("clust_two", "clust_two_" + rowNumber)
+                    .value("clust_three", "clust_three_" + rowNumber);
             session.execute(insert);
         }
         assertEquals(session.execute("SELECT COUNT(*) FROM " + table).all().get(0).getLong(0), 9);
@@ -132,7 +132,7 @@ public final class CassandraTestingUtils
 
     public static void insertIntoTableClusteringKeysInequality(CassandraSession session, SchemaTableName table, Date date, int rowsCount)
     {
-        for (Integer rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
+        for (int rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
             Insert insert = QueryBuilder.insertInto(table.getSchemaName(), table.getTableName())
                     .value("key", "key_1")
                     .value("clust_one", "clust_one")
@@ -223,12 +223,12 @@ public final class CassandraTestingUtils
 
     private static void insertTestData(CassandraSession session, SchemaTableName table, Date date, int rowsCount)
     {
-        for (Integer rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
+        for (int rowNumber = 1; rowNumber <= rowsCount; rowNumber++) {
             Insert insert = QueryBuilder.insertInto(table.getSchemaName(), table.getTableName())
-                    .value("key", "key " + rowNumber.toString())
+                    .value("key", "key " + rowNumber)
                     .value("typeuuid", UUID.fromString(format("00000000-0000-0000-0000-%012d", rowNumber)))
                     .value("typeinteger", rowNumber)
-                    .value("typelong", rowNumber.longValue() + 1000)
+                    .value("typelong", rowNumber + 1000)
                     .value("typebytes", ByteBuffer.wrap(Ints.toByteArray(rowNumber)).asReadOnlyBuffer())
                     .value("typetimestamp", date)
                     .value("typeansi", "ansi " + rowNumber)

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
@@ -92,16 +92,16 @@ public class TestCassandraConnector
     public void setup()
             throws Exception
     {
-        EmbeddedCassandra.start();
+        CassandraServer.start();
 
         String keyspace = "test_connector";
-        createTestTables(EmbeddedCassandra.getSession(), keyspace, DATE);
+        createTestTables(CassandraServer.getSession(), keyspace, DATE);
 
         CassandraConnectorFactory connectorFactory = new CassandraConnectorFactory();
 
         Connector connector = connectorFactory.create("test", ImmutableMap.of(
-                "cassandra.contact-points", EmbeddedCassandra.getHost(),
-                "cassandra.native-protocol-port", Integer.toString(EmbeddedCassandra.getPort())),
+                "cassandra.contact-points", CassandraServer.getHost(),
+                "cassandra.native-protocol-port", Integer.toString(CassandraServer.getPort())),
                 new TestingConnectorContext());
 
         metadata = connector.getMetadata(CassandraTransactionHandle.INSTANCE);

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
@@ -68,7 +68,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-@Test(singleThreaded = true)
 public class TestCassandraConnector
 {
     protected static final String INVALID_DATABASE = "totally_invalid_database";

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -17,15 +17,11 @@ import io.prestosql.testing.AbstractTestDistributedQueries;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.Test;
 
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
 
-//Integrations tests fail when parallel, due to a bug or configuration error in the embedded
-//cassandra instance. This problem results in either a hang in Thrift calls or broken sockets.
-@Test(singleThreaded = true)
 public class TestCassandraDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.cassandra;
 import io.prestosql.testing.AbstractTestDistributedQueries;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -28,11 +29,20 @@ import static io.prestosql.testing.assertions.Assert.assertEquals;
 public class TestCassandraDistributedQueries
         extends AbstractTestDistributedQueries
 {
+    private CassandraServer server;
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return CassandraQueryRunner.createCassandraQueryRunner();
+        this.server = new CassandraServer();
+        return CassandraQueryRunner.createCassandraQueryRunner(server);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        server.close();
     }
 
     @Override

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -79,7 +79,7 @@ public class TestCassandraIntegrationSmokeTest
     @BeforeClass
     public void setUp()
     {
-        session = EmbeddedCassandra.getSession();
+        session = CassandraServer.getSession();
         createTestTables(session, KEYSPACE, DATE_TIME_LOCAL);
     }
 

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -60,7 +60,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 
-@Test(singleThreaded = true)
 public class TestCassandraIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
@@ -37,8 +37,8 @@ public class TestCassandraTokenSplitManager
     public void setUp()
             throws Exception
     {
-        EmbeddedCassandra.start();
-        session = EmbeddedCassandra.getSession();
+        CassandraServer.start();
+        session = CassandraServer.getSession();
         createKeyspace(session, KEYSPACE);
         splitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.empty());
     }
@@ -49,7 +49,7 @@ public class TestCassandraTokenSplitManager
     {
         String tableName = "partition_count_override_table";
         session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, tableName);
+        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
 
         CassandraTokenSplitManager onlyConfigSplitsPerNode = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.of(12_345L));
         assertEquals(12_345L, onlyConfigSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()));
@@ -70,7 +70,7 @@ public class TestCassandraTokenSplitManager
     {
         String tableName = "empty_table";
         session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, tableName);
+        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
         List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
         // even for the empty table at least one split must be produced, in case the statistics are inaccurate
         assertEquals(splits.size(), 1);
@@ -86,7 +86,7 @@ public class TestCassandraTokenSplitManager
         for (int i = 0; i < PARTITION_COUNT; i++) {
             session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, tableName, "value" + i));
         }
-        EmbeddedCassandra.refreshSizeEstimates(KEYSPACE, tableName);
+        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
         List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
         assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);
         session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.cassandra;
 
 import io.prestosql.plugin.cassandra.CassandraTokenSplitManager.TokenSplit;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -30,6 +31,7 @@ public class TestCassandraTokenSplitManager
     private static final String KEYSPACE = "test_cassandra_token_split_manager_keyspace";
     private static final int PARTITION_COUNT = 1000;
 
+    private CassandraServer server;
     private CassandraSession session;
     private CassandraTokenSplitManager splitManager;
 
@@ -37,10 +39,16 @@ public class TestCassandraTokenSplitManager
     public void setUp()
             throws Exception
     {
-        CassandraServer.start();
-        session = CassandraServer.getSession();
+        server = new CassandraServer();
+        session = server.getSession();
         createKeyspace(session, KEYSPACE);
         splitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.empty());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        server.close();
     }
 
     @Test
@@ -49,7 +57,7 @@ public class TestCassandraTokenSplitManager
     {
         String tableName = "partition_count_override_table";
         session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
+        server.refreshSizeEstimates(KEYSPACE, tableName);
 
         CassandraTokenSplitManager onlyConfigSplitsPerNode = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.of(12_345L));
         assertEquals(12_345L, onlyConfigSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()));
@@ -70,7 +78,7 @@ public class TestCassandraTokenSplitManager
     {
         String tableName = "empty_table";
         session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
+        server.refreshSizeEstimates(KEYSPACE, tableName);
         List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
         // even for the empty table at least one split must be produced, in case the statistics are inaccurate
         assertEquals(splits.size(), 1);
@@ -86,7 +94,7 @@ public class TestCassandraTokenSplitManager
         for (int i = 0; i < PARTITION_COUNT; i++) {
             session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, tableName, "value" + i));
         }
-        CassandraServer.refreshSizeEstimates(KEYSPACE, tableName);
+        server.refreshSizeEstimates(KEYSPACE, tableName);
         List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
         assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);
         session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraTokenSplitManager.java
@@ -60,16 +60,16 @@ public class TestCassandraTokenSplitManager
         server.refreshSizeEstimates(KEYSPACE, tableName);
 
         CassandraTokenSplitManager onlyConfigSplitsPerNode = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.of(12_345L));
-        assertEquals(12_345L, onlyConfigSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()));
+        assertEquals(onlyConfigSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()), 12_345L);
 
         CassandraTokenSplitManager onlySessionSplitsPerNode = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.empty());
-        assertEquals(67_890L, onlySessionSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.of(67_890L)));
+        assertEquals(onlySessionSplitsPerNode.getTotalPartitionsCount(KEYSPACE, tableName, Optional.of(67_890L)), 67_890L);
 
         CassandraTokenSplitManager sessionOverrideConfig = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.of(12_345L));
-        assertEquals(67_890L, sessionOverrideConfig.getTotalPartitionsCount(KEYSPACE, tableName, Optional.of(67_890L)));
+        assertEquals(sessionOverrideConfig.getTotalPartitionsCount(KEYSPACE, tableName, Optional.of(67_890L)), 67_890L);
 
         CassandraTokenSplitManager defaultSplitManager = new CassandraTokenSplitManager(session, SPLIT_SIZE, Optional.empty());
-        assertEquals(0, defaultSplitManager.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()));
+        assertEquals(defaultSplitManager.getTotalPartitionsCount(KEYSPACE, tableName, Optional.empty()), 0);
     }
 
     @Test

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/util/TestCassandraCqlUtils.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/util/TestCassandraCqlUtils.java
@@ -33,40 +33,40 @@ public class TestCassandraCqlUtils
     @Test
     public void testValidSchemaName()
     {
-        assertEquals("foo", validSchemaName("foo"));
-        assertEquals("\"select\"", validSchemaName("select"));
+        assertEquals(validSchemaName("foo"), "foo");
+        assertEquals(validSchemaName("select"), "\"select\"");
     }
 
     @Test
     public void testValidTableName()
     {
-        assertEquals("foo", validTableName("foo"));
-        assertEquals("\"Foo\"", validTableName("Foo"));
-        assertEquals("\"select\"", validTableName("select"));
+        assertEquals(validTableName("foo"), "foo");
+        assertEquals(validTableName("Foo"), "\"Foo\"");
+        assertEquals(validTableName("select"), "\"select\"");
     }
 
     @Test
     public void testValidColumnName()
     {
-        assertEquals("foo", validColumnName("foo"));
-        assertEquals("\"\"", validColumnName(CassandraCqlUtils.EMPTY_COLUMN_NAME));
-        assertEquals("\"\"", validColumnName(""));
-        assertEquals("\"select\"", validColumnName("select"));
+        assertEquals(validColumnName("foo"), "foo");
+        assertEquals(validColumnName(CassandraCqlUtils.EMPTY_COLUMN_NAME), "\"\"");
+        assertEquals(validColumnName(""), "\"\"");
+        assertEquals(validColumnName("select"), "\"select\"");
     }
 
     @Test
     public void testQuote()
     {
-        assertEquals("'foo'", quoteStringLiteral("foo"));
-        assertEquals("'Presto''s'", quoteStringLiteral("Presto's"));
+        assertEquals(quoteStringLiteral("foo"), "'foo'");
+        assertEquals(quoteStringLiteral("Presto's"), "'Presto''s'");
     }
 
     @Test
     public void testQuoteJson()
     {
-        assertEquals("\"foo\"", quoteStringLiteralForJson("foo"));
-        assertEquals("\"Presto's\"", quoteStringLiteralForJson("Presto's"));
-        assertEquals("\"xx\\\"xx\"", quoteStringLiteralForJson("xx\"xx"));
+        assertEquals(quoteStringLiteralForJson("foo"), "\"foo\"");
+        assertEquals(quoteStringLiteralForJson("Presto's"), "\"Presto's\"");
+        assertEquals(quoteStringLiteralForJson("xx\"xx"), "\"xx\\\"xx\"");
     }
 
     @Test
@@ -81,6 +81,6 @@ public class TestCassandraCqlUtils
         appendSelectColumns(sb, columns);
         String str = sb.toString();
 
-        assertEquals("foo,bar,\"table\"", str);
+        assertEquals(str, "foo,bar,\"table\"");
     }
 }

--- a/presto-cassandra/src/test/resources/cu-cassandra.yaml
+++ b/presto-cassandra/src/test/resources/cu-cassandra.yaml
@@ -94,10 +94,10 @@ partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
 # directories where Cassandra should store data on disk.
 data_file_directories:
-    - ${data_directory}/data
+    - /var/lib/cassandra/data
 
 # commit log
-commitlog_directory: ${data_directory}/commitlog
+commitlog_directory: /var/lib/cassandra/commitlog
 
 # policy for data disk failures:
 # stop: shut down gossip and Thrift, leaving the node effectively dead, but
@@ -160,7 +160,7 @@ row_cache_save_period: 0
 # row_cache_keys_to_save: 100
 
 # saved caches
-saved_caches_directory: ${data_directory}/saved_caches
+saved_caches_directory: /var/lib/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch."
 # When in batch mode, Cassandra won't ack writes until the commit log
@@ -279,6 +279,12 @@ start_rpc: false
 rpc_address: localhost
 # port for Thrift to listen for clients on
 rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+broadcast_rpc_address: localhost
 
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true


### PR DESCRIPTION
Fixes #2182 

I tried org.testcontainers:cassandra at first, but it conflicted with the existing library and I couldn't find the benefit to use `CassandraContainer` instead of `GenericContainer`. I mean, even if we use CassandraContainer, the code will be almost the same in our test code.
```
2020-01-01T10:17:53.5606938Z +-io.prestosql:presto-cassandra:328-SNAPSHOT
2020-01-01T10:17:53.5607907Z   +-io.prestosql.cassandra:cassandra-driver:3.1.4-2
2020-01-01T10:17:53.5609386Z     +-io.netty:netty-handler:4.0.37.Final
2020-01-01T10:17:53.5610012Z and
2020-01-01T10:17:53.5612375Z +-io.prestosql:presto-cassandra:328-SNAPSHOT
2020-01-01T10:17:53.5653490Z   +-org.testcontainers:cassandra:1.12.3
2020-01-01T10:17:53.5654227Z     +-com.datastax.cassandra:cassandra-driver-core:3.7.1
2020-01-01T10:17:53.5655207Z       +-io.netty:netty-handler:4.0.56.Final
2020-01-01T10:17:53.5655323Z , 
2020-01-01T10:17:53.5655672Z Require upper bound dependencies error for io.dropwizard.metrics:metrics-core:3.1.2 paths to dependency are:
2020-01-01T10:17:53.5656098Z +-io.prestosql:presto-cassandra:328-SNAPSHOT
2020-01-01T10:17:53.5656330Z   +-io.prestosql.cassandra:cassandra-driver:3.1.4-2
2020-01-01T10:17:53.5767977Z     +-io.dropwizard.metrics:metrics-core:3.1.2
2020-01-01T10:17:53.5768427Z and
2020-01-01T10:17:53.5768962Z +-io.prestosql:presto-cassandra:328-SNAPSHOT
2020-01-01T10:17:53.5769501Z   +-org.testcontainers:cassandra:1.12.3
2020-01-01T10:17:53.5770041Z     +-com.datastax.cassandra:cassandra-driver-core:3.7.1
2020-01-01T10:17:53.5770587Z       +-io.dropwizard.metrics:metrics-core:3.2.2
```
