### PR TITLE
Don't use fixed hash local exchange for single stream table writers

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
@@ -482,7 +482,7 @@ public class AddLocalExchanges
         {
             StreamPreferredProperties requiredProperties;
             StreamPreferredProperties preferredProperties;
-            if (getTaskWriterCount(session) > 1) {
+            if (getTaskWriterCount(session) > 1 && !node.getPartitioningScheme().isPresent()) {
                 requiredProperties = fixedParallelism();
                 preferredProperties = fixedParallelism();
             }


### PR DESCRIPTION
LocalExecutionPlanner.Visitor#visitTableWriter sets
setDriverInstanceCount to 1 when getPartitioningScheme is present.
This changes makes planner use gather local exchange in that case.