### PR TITLE
Allow hive outstanding splits size limit larger than 2GB

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
@@ -63,7 +63,6 @@ import static io.prestosql.plugin.hive.HiveSplitSource.StateKind.INITIAL;
 import static io.prestosql.plugin.hive.HiveSplitSource.StateKind.NO_MORE_SPLITS;
 import static io.prestosql.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -77,7 +76,7 @@ class HiveSplitSource
     private final String tableName;
     private final PerBucket queues;
     private final AtomicInteger bufferedInternalSplitCount = new AtomicInteger();
-    private final int maxOutstandingSplitsBytes;
+    private final long maxOutstandingSplitsBytes;
 
     private final DataSize maxSplitSize;
     private final DataSize maxInitialSplitSize;
@@ -107,7 +106,7 @@ class HiveSplitSource
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.queues = requireNonNull(queues, "queues is null");
-        this.maxOutstandingSplitsBytes = toIntExact(maxOutstandingSplitsSize.toBytes());
+        this.maxOutstandingSplitsBytes = requireNonNull(maxOutstandingSplitsSize, "maxOutstandingSplitsSize is null").toBytes();
         this.splitLoader = requireNonNull(splitLoader, "splitLoader is null");
         this.stateReference = requireNonNull(stateReference, "stateReference is null");
         this.highMemorySplitSourceCounter = requireNonNull(highMemorySplitSourceCounter, "highMemorySplitSourceCounter is null");


### PR DESCRIPTION
The `hive.max-outstanding-splits-size` configuration passed into `HiveSplitSource` was previously stored as an int, prohibiting values >= 2GB to be used. Switching the representation to long removes the unnecessary restriction.