### PR TITLE
Remove deprecated createExpression usage

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/ExpressionSerialization.java
+++ b/presto-main/src/main/java/io/prestosql/server/ExpressionSerialization.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.prestosql.sql.ExpressionFormatter;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.Expression;
 
@@ -59,7 +60,7 @@ public final class ExpressionSerialization
         public Expression deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException
         {
-            return rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class)));
+            return rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class), new ParsingOptions()));
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestScalarStatsCalculator.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.prestosql.Session;
 import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.FunctionCallBuilder;
 import io.prestosql.sql.planner.LiteralEncoder;
@@ -496,6 +497,6 @@ public class TestScalarStatsCalculator
 
     private Expression expression(String sqlExpression)
     {
-        return rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(sqlExpression));
+        return rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(sqlExpression, new ParsingOptions()));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -1466,7 +1466,7 @@ public class TestExpressionInterpreter
         for (Entry<Symbol, Type> entry : SYMBOL_TYPES.allTypes().entrySet()) {
             aliases.put(entry.getKey().getName(), new SymbolReference(entry.getKey().getName()));
         }
-        Expression rewrittenExpected = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected));
+        Expression rewrittenExpected = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected, new ParsingOptions()));
         assertExpressionEquals((Expression) actualOptimized, rewrittenExpected, aliases.build());
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestSortExpressionExtractor.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.ExpressionTestUtils;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.SymbolReference;
@@ -84,7 +85,7 @@ public class TestSortExpressionExtractor
 
     private Expression expression(String sql)
     {
-        return ExpressionTestUtils.planExpression(metadata, TEST_SESSION, TYPE_PROVIDER, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql)));
+        return ExpressionTestUtils.planExpression(metadata, TEST_SESSION, TYPE_PROVIDER, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql, new ParsingOptions())));
     }
 
     private void assertNoSortExpression(String expression)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
@@ -16,6 +16,7 @@ package io.prestosql.sql.planner.assertions;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.Session;
 import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.ApplyNode;
@@ -47,7 +48,7 @@ public class ExpressionMatcher
     private Expression expression(String sql)
     {
         SqlParser parser = new SqlParser();
-        return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql));
+        return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql, new ParsingOptions()));
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -393,7 +393,7 @@ public final class PlanMatchPattern
                 new JoinMatcher(
                         joinType,
                         expectedEquiCriteria,
-                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate))),
+                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate, new ParsingOptions()))),
                         expectedDistributionType,
                         expectedSpillable,
                         Optional.empty()));
@@ -413,7 +413,7 @@ public final class PlanMatchPattern
         DynamicFilterMatcher dynamicFilterMatcher = new DynamicFilterMatcher(
                 metadata,
                 expectedDynamicFilterAliases,
-                expectedStaticFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate))));
+                expectedStaticFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate, new ParsingOptions()))));
         JoinMatcher joinMatcher = new JoinMatcher(
                 joinType,
                 expectedEquiCriteria,
@@ -502,7 +502,7 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern filter(String expectedPredicate, PlanMatchPattern source)
     {
-        return filter(rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedPredicate)), source);
+        return filter(rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedPredicate, new ParsingOptions())), source);
     }
 
     public static PlanMatchPattern filter(Expression expectedPredicate, PlanMatchPattern source)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TestExpressionVerifier.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.sql.planner.assertions;
 
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.SymbolReference;
@@ -123,7 +124,7 @@ public class TestExpressionVerifier
 
     private Expression expression(String sql)
     {
-        return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql));
+        return rewriteIdentifiersToSymbolReferences(parser.createExpression(sql, new ParsingOptions()));
     }
 
     private static void assertThrows(Runnable runnable)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -15,6 +15,7 @@ package io.prestosql.sql.planner.iterative.rule;
 
 import io.prestosql.metadata.Metadata;
 import io.prestosql.spi.type.Type;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.LiteralEncoder;
 import io.prestosql.sql.planner.Symbol;
@@ -117,8 +118,9 @@ public class TestSimplifyExpressions
 
     private static void assertSimplifies(String expression, String expected)
     {
-        Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression));
-        Expression expectedExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected));
+        ParsingOptions parsingOptions = new ParsingOptions();
+        Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression, parsingOptions));
+        Expression expectedExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected, parsingOptions));
         Expression rewritten = rewrite(actualExpression, TEST_SESSION, new SymbolAllocator(booleanSymbolTypeMapFor(actualExpression)), METADATA, LITERAL_ENCODER, new TypeAnalyzer(SQL_PARSER, METADATA));
         assertEquals(
                 normalize(rewritten),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -31,6 +31,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.ExpressionUtils;
 import io.prestosql.sql.analyzer.TypeSignatureProvider;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.OrderingScheme;
 import io.prestosql.sql.planner.Partitioning;
@@ -828,7 +829,7 @@ public class PlanBuilder
 
     public static Expression expression(String sql)
     {
-        return ExpressionUtils.rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql));
+        return ExpressionUtils.rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql, new ParsingOptions()));
     }
 
     public static List<Expression> expressions(String... expressions)

--- a/presto-parser/src/main/java/io/prestosql/sql/ReservedIdentifiers.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/ReservedIdentifiers.java
@@ -15,6 +15,7 @@ package io.prestosql.sql;
 
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.sql.parser.ParsingException;
+import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlBaseLexer;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.tree.Identifier;
@@ -143,7 +144,7 @@ public final class ReservedIdentifiers
     private static boolean reserved(String name)
     {
         try {
-            return !(PARSER.createExpression(name) instanceof Identifier);
+            return !(PARSER.createExpression(name, new ParsingOptions()) instanceof Identifier);
         }
         catch (ParsingException ignored) {
             return true;

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
@@ -86,15 +86,6 @@ public class SqlParser
         return (Statement) invokeParser("statement", sql, SqlBaseParser::singleStatement, parsingOptions);
     }
 
-    /**
-     * Consider using {@link #createExpression(String, ParsingOptions)}
-     */
-    @Deprecated
-    public Expression createExpression(String expression)
-    {
-        return createExpression(expression, new ParsingOptions());
-    }
-
     public Expression createExpression(String expression, ParsingOptions parsingOptions)
     {
         return (Expression) invokeParser("expression", expression, SqlBaseParser::standaloneExpression, parsingOptions);

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
@@ -206,7 +206,7 @@ public class TestSqlParserErrorHandling
     public void testStackOverflowExpression()
     {
         for (int size = 3000; size <= 100_000; size *= 2) {
-            SQL_PARSER.createExpression(Joiner.on(" OR ").join(nCopies(size, "x = y")));
+            SQL_PARSER.createExpression(Joiner.on(" OR ").join(nCopies(size, "x = y")), new ParsingOptions());
         }
     }
 


### PR DESCRIPTION
As well as https://github.com/prestosql/presto/pull/2353, we can remove the deprecated usage of `createExpression` method safely. 