### PR TITLE
Fix null cast on insert

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
@@ -62,6 +62,7 @@ import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.planner.sanity.PlanSanityChecker;
 import io.prestosql.sql.tree.Analyze;
 import io.prestosql.sql.tree.Cast;
+import io.prestosql.sql.tree.CoalesceExpression;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.CreateTableAsSelect;
 import io.prestosql.sql.tree.Delete;
@@ -514,9 +515,11 @@ public class LogicalPlanner
                 new ComparisonExpression(
                         GREATER_THAN_OR_EQUAL,
                         new GenericLiteral("BIGINT", Integer.toString(targetLength)),
-                        new FunctionCall(
-                                spaceTrimmedLength.toQualifiedName(),
-                                ImmutableList.of(new Cast(expression, toSqlType(VARCHAR))))),
+                        new CoalesceExpression(
+                                new FunctionCall(
+                                        spaceTrimmedLength.toQualifiedName(),
+                                        ImmutableList.of(new Cast(expression, toSqlType(VARCHAR)))),
+                                new GenericLiteral("BIGINT", "0"))),
                 new Cast(expression, toSqlType(toType)),
                 new Cast(
                         new FunctionCall(

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -494,6 +494,8 @@ public abstract class AbstractTestDistributedQueries
 
         assertUpdate("INSERT INTO test_insert_with_coercion (tinyint_column, integer_column, decimal_column, real_column) VALUES (1e0, 2e0, 3e0, 4e0)", 1);
         assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST('aa     ' AS varchar), CAST('aa     ' AS varchar), CAST('aa     ' AS varchar))", 1);
+        assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (NULL, NULL, NULL)", 1);
+        assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST(NULL AS varchar), CAST(NULL AS varchar), CAST(NULL AS varchar))", 1);
         assertUpdate("INSERT INTO test_insert_with_coercion (date_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')", 1);
 
         assertQuery(
@@ -501,6 +503,8 @@ public abstract class AbstractTestDistributedQueries
                 "VALUES " +
                         "(1, 2, 3, 4, NULL, NULL, NULL, NULL), " +
                         "(NULL, NULL, NULL, NULL, 'aa ', 'aa ', 'aa     ', NULL), " +
+                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
+                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
                         "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, DATE '2019-11-18')");
 
         assertQueryFails("INSERT INTO test_insert_with_coercion (integer_column) VALUES (3e9)", "Out of range for integer: 3.0E9");


### PR DESCRIPTION
Before this change, when the target column was of bounded character
type (char or bounded varchar) and the null value required a cast,
it caused a failure.