### PR TITLE
Load only required tables in CassandraQueryRunner

### DIFF
--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraQueryRunner.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraQueryRunner.java
@@ -13,13 +13,12 @@
  */
 package io.prestosql.plugin.cassandra;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import io.prestosql.Session;
 import io.prestosql.plugin.tpch.TpchPlugin;
 import io.prestosql.testing.DistributedQueryRunner;
-
-import java.util.List;
 
 import static io.prestosql.plugin.cassandra.CassandraTestingUtils.createKeyspace;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -30,7 +29,13 @@ public final class CassandraQueryRunner
 {
     private CassandraQueryRunner() {}
 
-    public static DistributedQueryRunner createCassandraQueryRunner(CassandraServer server)
+    public static DistributedQueryRunner createCassandraQueryRunner(CassandraServer server, TpchTable<?>... tables)
+            throws Exception
+    {
+        return createCassandraQueryRunner(server, ImmutableList.copyOf(tables));
+    }
+
+    public static DistributedQueryRunner createCassandraQueryRunner(CassandraServer server, Iterable<TpchTable<?>> tables)
             throws Exception
     {
         DistributedQueryRunner queryRunner = new DistributedQueryRunner(createCassandraSession("tpch"), 4);
@@ -45,7 +50,6 @@ public final class CassandraQueryRunner
                 "cassandra.allow-drop-table", "true"));
 
         createKeyspace(server.getSession(), "tpch");
-        List<TpchTable<?>> tables = TpchTable.getTables();
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createCassandraSession("tpch"), tables);
         for (TpchTable<?> table : tables) {
             server.refreshSizeEstimates("tpch", table.getTableName());

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.cassandra;
 
+import io.airlift.tpch.TpchTable;
 import io.prestosql.testing.AbstractTestDistributedQueries;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
@@ -32,7 +33,7 @@ public class TestCassandraDistributedQueries
             throws Exception
     {
         this.server = new CassandraServer();
-        return CassandraQueryRunner.createCassandraQueryRunner(server);
+        return CassandraQueryRunner.createCassandraQueryRunner(server, TpchTable.getTables());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -19,6 +19,7 @@ import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 
+import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
@@ -33,7 +34,7 @@ public class TestCassandraDistributedQueries
             throws Exception
     {
         this.server = new CassandraServer();
-        return CassandraQueryRunner.createCassandraQueryRunner(server, TpchTable.getTables());
+        return createCassandraQueryRunner(server, TpchTable.getTables());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static com.datastax.driver.core.utils.Bytes.toRawHexString;
 import static com.google.common.primitives.Ints.toByteArray;
+import static io.airlift.tpch.TpchTable.ORDERS;
 import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraSession;
 import static io.prestosql.plugin.cassandra.CassandraTestingUtils.TABLE_ALL_TYPES;
@@ -81,7 +82,7 @@ public class TestCassandraIntegrationSmokeTest
         this.server = server;
         this.session = server.getSession();
         createTestTables(session, KEYSPACE, DATE_TIME_LOCAL);
-        return createCassandraQueryRunner(server);
+        return createCassandraQueryRunner(server, ORDERS);
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Follow up of https://github.com/prestosql/presto/pull/2377#discussion_r362509519