### PR TITLE
Use testcontainers for SQLServer tests

### DIFF
--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -106,8 +106,14 @@
         </dependency>
 
         <dependency>
-            <groupId>io.prestosql</groupId>
-            <artifactId>presto-testing-docker</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerDistributedQueries.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerDistributedQueries.java
@@ -33,6 +33,7 @@ public class TestSqlServerDistributedQueries
             throws Exception
     {
         this.sqlServer = new TestingSqlServer();
+        sqlServer.start();
         return createSqlServerQueryRunner(
                 sqlServer,
                 ImmutableMap.<String, String>builder()

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.sqlserver;
 
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -28,17 +29,15 @@ import static org.testng.Assert.assertTrue;
 public class TestSqlServerIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final TestingSqlServer sqlServer;
+    private TestingSqlServer sqlServer;
 
-    public TestSqlServerIntegrationSmokeTest()
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
-        this(new TestingSqlServer());
-    }
-
-    public TestSqlServerIntegrationSmokeTest(TestingSqlServer testingSqlServer)
-    {
-        super(() -> createSqlServerQueryRunner(testingSqlServer, ORDERS));
-        this.sqlServer = testingSqlServer;
+        sqlServer = new TestingSqlServer();
+        sqlServer.start();
+        return createSqlServerQueryRunner(sqlServer, ORDERS);
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestingSqlServer.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestingSqlServer.java
@@ -13,68 +13,27 @@
  */
 package io.prestosql.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableMap;
-import io.prestosql.testing.docker.DockerContainer;
-import io.prestosql.testing.docker.DockerContainer.HostPortProvider;
+import org.testcontainers.containers.MSSQLServerContainer;
 
-import java.io.Closeable;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
 
-import static java.lang.String.format;
-
 public final class TestingSqlServer
-        implements Closeable
+        extends MSSQLServerContainer<TestingSqlServer>
 {
-    private static final int SQL_SERVER_PORT = 1433;
-
-    public static final String USER = "sa";
-    public static final String PASSWORD = "SQLServerPass1";
-
-    private final DockerContainer dockerContainer;
-
     public TestingSqlServer()
     {
-        this.dockerContainer = DockerContainer.forImage("microsoft/mssql-server-linux:2017-CU13")
-                .setPorts(SQL_SERVER_PORT)
-                .setEnvironment(ImmutableMap.of(
-                        "ACCEPT_EULA", "Y",
-                        "SA_PASSWORD", "SQLServerPass1"))
-                .setHealthCheck(portProvider -> TestingSqlServer.execute(portProvider, "SELECT 1"))
-                .start();
+        super("microsoft/mssql-server-linux:2017-CU13");
     }
 
     public void execute(String sql)
     {
-        execute(dockerContainer::getHostPort, sql);
-    }
-
-    private static void execute(HostPortProvider hostPortProvider, String sql)
-    {
-        String jdbcUrl = getJdbcUrl(hostPortProvider.getHostPort(SQL_SERVER_PORT));
-        try (Connection conn = DriverManager.getConnection(jdbcUrl, USER, PASSWORD);
-                Statement stmt = conn.createStatement()) {
-            stmt.execute(sql);
+        try (Connection connection = createConnection("");
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
         }
         catch (Exception e) {
             throw new RuntimeException("Failed to execute statement: " + sql, e);
         }
-    }
-
-    public String getJdbcUrl()
-    {
-        return getJdbcUrl(dockerContainer.getHostPort(SQL_SERVER_PORT));
-    }
-
-    private static String getJdbcUrl(int port)
-    {
-        return format("jdbc:sqlserver://localhost:%s", port);
-    }
-
-    @Override
-    public void close()
-    {
-        dockerContainer.close();
     }
 }

--- a/presto-sqlserver/src/test/resources/container-license-acceptance.txt
+++ b/presto-sqlserver/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+microsoft/mssql-server-linux:2017-CU13


### PR DESCRIPTION
Both `ACCEPT_EULA` and `SA_PASSWORD` are handled in [MSSQLServerContainer](https://github.com/testcontainers/testcontainers-java/blob/master/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java#L51-L53). 

Reference: https://www.testcontainers.org/modules/databases/mssqlserver/
