### PR TITLE
Port streaming aggregation and assign unique id to work processor

### DIFF
--- a/presto-benchmark/src/main/java/io/prestosql/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/io/prestosql/benchmark/AbstractOperatorBenchmark.java
@@ -239,7 +239,7 @@ public abstract class AbstractOperatorBenchmark
         PageFunctionCompiler functionCompiler = new PageFunctionCompiler(localQueryRunner.getMetadata(), 0);
         projections.add(functionCompiler.compileProjection(translated, Optional.empty()).get());
 
-        return new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        return FilterAndProjectOperator.createOperatorFactory(
                 operatorId,
                 planNodeId,
                 () -> new PageProcessor(Optional.empty(), projections.build()),

--- a/presto-benchmark/src/main/java/io/prestosql/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/io/prestosql/benchmark/HandTpchQuery6.java
@@ -73,7 +73,7 @@ public class HandTpchQuery6
 
         Supplier<PageProjection> projection = new PageFunctionCompiler(localQueryRunner.getMetadata(), 0).compileProjection(field(0, BIGINT), Optional.empty());
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory tpchQuery6Operator = FilterAndProjectOperator.createOperatorFactory(
                 1,
                 new PlanNodeId("test"),
                 () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(projection.get())),

--- a/presto-benchmark/src/main/java/io/prestosql/benchmark/PredicateFilterBenchmark.java
+++ b/presto-benchmark/src/main/java/io/prestosql/benchmark/PredicateFilterBenchmark.java
@@ -56,7 +56,7 @@ public class PredicateFilterBenchmark
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(localQueryRunner.getMetadata(), new PageFunctionCompiler(localQueryRunner.getMetadata(), 0));
         Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, DOUBLE)));
 
-        FilterAndProjectOperator.FilterAndProjectOperatorFactory filterAndProjectOperator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory filterAndProjectOperator = FilterAndProjectOperator.createOperatorFactory(
                 1,
                 new PlanNodeId("test"),
                 pageProcessor,

--- a/presto-benchmark/src/main/java/io/prestosql/benchmark/Top100Benchmark.java
+++ b/presto-benchmark/src/main/java/io/prestosql/benchmark/Top100Benchmark.java
@@ -15,7 +15,7 @@ package io.prestosql.benchmark;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.operator.OperatorFactory;
-import io.prestosql.operator.TopNOperator.TopNOperatorFactory;
+import io.prestosql.operator.TopNOperator;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 import io.prestosql.testing.LocalQueryRunner;
@@ -38,7 +38,7 @@ public class Top100Benchmark
     {
         List<Type> tableScanTypes = getColumnTypes("orders", "totalprice");
         OperatorFactory tableScanOperator = createTableScanOperator(0, new PlanNodeId("test"), "orders", "totalprice");
-        TopNOperatorFactory topNOperator = new TopNOperatorFactory(
+        OperatorFactory topNOperator = TopNOperator.createOperatorFactory(
                 1,
                 new PlanNodeId("test"),
                 tableScanTypes,

--- a/presto-main/src/main/java/io/prestosql/operator/BasicWorkProcessorOperatorAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/BasicWorkProcessorOperatorAdapter.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator;
+
+import io.prestosql.execution.Lifespan;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperator;
+import io.prestosql.operator.WorkProcessorOperatorAdapter.AdapterWorkProcessorOperatorFactory;
+import io.prestosql.spi.Page;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This {@link WorkProcessorOperator} adapter allows to adapt {@link WorkProcessor} operators
+ * that do not require special input handling (e.g streaming operators).
+ */
+public class BasicWorkProcessorOperatorAdapter
+        implements AdapterWorkProcessorOperator
+{
+    public interface BasicAdapterWorkProcessorOperatorFactory
+            extends WorkProcessorOperatorFactory
+    {
+        default WorkProcessorOperator createAdapterOperator(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
+        {
+            return create(processorContext, sourcePages);
+        }
+
+        BasicAdapterWorkProcessorOperatorFactory duplicate();
+    }
+
+    public static OperatorFactory createAdapterOperatorFactory(BasicAdapterWorkProcessorOperatorFactory operatorFactory)
+    {
+        return WorkProcessorOperatorAdapter.createAdapterOperatorFactory(new Factory(operatorFactory));
+    }
+
+    private static class Factory
+            implements AdapterWorkProcessorOperatorFactory
+    {
+        private final BasicAdapterWorkProcessorOperatorFactory operatorFactory;
+
+        Factory(BasicAdapterWorkProcessorOperatorFactory operatorFactory)
+        {
+            this.operatorFactory = requireNonNull(operatorFactory, "operatorFactory is null");
+        }
+
+        @Override
+        public AdapterWorkProcessorOperatorFactory duplicate()
+        {
+            return new Factory(operatorFactory.duplicate());
+        }
+
+        @Override
+        public int getOperatorId()
+        {
+            return operatorFactory.getOperatorId();
+        }
+
+        @Override
+        public PlanNodeId getPlanNodeId()
+        {
+            return operatorFactory.getPlanNodeId();
+        }
+
+        @Override
+        public String getOperatorType()
+        {
+            return operatorFactory.getOperatorType();
+        }
+
+        @Override
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
+        {
+            return operatorFactory.create(processorContext, sourcePages);
+        }
+
+        @Override
+        public AdapterWorkProcessorOperator createAdapterOperator(ProcessorContext processorContext)
+        {
+            return new BasicWorkProcessorOperatorAdapter(processorContext, operatorFactory);
+        }
+
+        @Override
+        public void lifespanFinished(Lifespan lifespan)
+        {
+            operatorFactory.lifespanFinished(lifespan);
+        }
+
+        @Override
+        public void close()
+        {
+            operatorFactory.close();
+        }
+    }
+
+    private final PageBuffer pageBuffer;
+    private final WorkProcessorOperator operator;
+
+    private BasicWorkProcessorOperatorAdapter(
+            ProcessorContext processorContext,
+            BasicAdapterWorkProcessorOperatorFactory operatorFactory)
+    {
+        this.pageBuffer = new PageBuffer();
+        this.operator = requireNonNull(operatorFactory, "operator is null").createAdapterOperator(processorContext, pageBuffer.pages());
+    }
+
+    @Override
+    public void finish()
+    {
+        pageBuffer.finish();
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return pageBuffer.isEmpty() && !pageBuffer.isFinished();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        pageBuffer.add(page);
+    }
+
+    @Override
+    public WorkProcessor<Page> getOutputPages()
+    {
+        return operator.getOutputPages();
+    }
+
+    @Override
+    public Optional<OperatorInfo> getOperatorInfo()
+    {
+        return operator.getOperatorInfo();
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        operator.close();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/FilterAndProjectOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/FilterAndProjectOperator.java
@@ -90,11 +90,6 @@ public class FilterAndProjectOperator
         return pages;
     }
 
-    @Override
-    public void close()
-            throws Exception
-    {}
-
     public static OperatorFactory createOperatorFactory(
             int operatorId,
             PlanNodeId planNodeId,

--- a/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
@@ -168,12 +168,6 @@ public class HashSemiJoinOperator
         return pages;
     }
 
-    @Override
-    public void close()
-            throws Exception
-    {
-    }
-
     private static class SemiJoinPages
             implements WorkProcessor.Transformation<Page, Page>
     {

--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperator.java
@@ -69,7 +69,7 @@ public class LookupJoinOperator
     private final JoinProcessor joinProcessor;
     private final JoinStatisticsCounter statisticsCounter;
 
-    public LookupJoinOperator(List<Type> probeTypes,
+    LookupJoinOperator(List<Type> probeTypes,
             List<Type> buildOutputTypes,
             JoinType joinType,
             LookupSourceFactory lookupSourceFactory,

--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
@@ -129,6 +129,35 @@ public class LookupJoinOperatorFactory
     }
 
     @Override
+    public Optional<OuterOperatorFactoryResult> createOuterOperatorFactory()
+    {
+        return outerOperatorFactoryResult;
+    }
+
+    // Methods from OperatorFactory
+
+    @Override
+    public Operator createOperator(DriverContext driverContext)
+    {
+        OperatorContext operatorContext = driverContext.addOperatorContext(getOperatorId(), getPlanNodeId(), getOperatorType());
+        return new WorkProcessorOperatorAdapter(operatorContext, this);
+    }
+
+    @Override
+    public void noMoreOperators()
+    {
+        close();
+    }
+
+    @Override
+    public void noMoreOperators(Lifespan lifespan)
+    {
+        lifespanFinished(lifespan);
+    }
+
+    // Methods from AdapterWorkProcessorOperatorFactory
+
+    @Override
     public int getOperatorId()
     {
         return operatorId;
@@ -149,6 +178,7 @@ public class LookupJoinOperatorFactory
     @Override
     public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
     {
+        checkState(!closed, "Factory is already closed");
         LookupSourceFactory lookupSourceFactory = joinBridgeManager.getJoinBridge(processorContext.getLifespan());
 
         joinBridgeManager.probeOperatorCreated(processorContext.getLifespan());
@@ -167,42 +197,9 @@ public class LookupJoinOperatorFactory
     }
 
     @Override
-    public Operator createOperator(DriverContext driverContext)
-    {
-        checkState(!closed, "Factory is already closed");
-        OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, getOperatorType());
-        return new WorkProcessorOperatorAdapter(operatorContext, this);
-    }
-
-    @Override
-    public void noMoreOperators()
-    {
-        checkState(!closed);
-        closed = true;
-        joinBridgeManager.probeOperatorFactoryClosedForAllLifespans();
-    }
-
-    @Override
-    public void noMoreOperators(Lifespan lifespan)
-    {
-        joinBridgeManager.probeOperatorFactoryClosed(lifespan);
-    }
-
-    @Override
-    public OperatorFactory duplicate()
-    {
-        return new LookupJoinOperatorFactory(this);
-    }
-
-    @Override
-    public Optional<OuterOperatorFactoryResult> createOuterOperatorFactory()
-    {
-        return outerOperatorFactoryResult;
-    }
-
-    @Override
     public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
     {
+        checkState(!closed, "Factory is already closed");
         LookupSourceFactory lookupSourceFactory = joinBridgeManager.getJoinBridge(processorContext.getLifespan());
 
         joinBridgeManager.probeOperatorCreated(processorContext.getLifespan());
@@ -223,12 +220,20 @@ public class LookupJoinOperatorFactory
     @Override
     public void lifespanFinished(Lifespan lifespan)
     {
-        noMoreOperators(lifespan);
+        joinBridgeManager.probeOperatorFactoryClosed(lifespan);
     }
 
     @Override
     public void close()
     {
-        noMoreOperators();
+        checkState(!closed);
+        closed = true;
+        joinBridgeManager.probeOperatorFactoryClosedForAllLifespans();
+    }
+
+    @Override
+    public LookupJoinOperatorFactory duplicate()
+    {
+        return new LookupJoinOperatorFactory(this);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinOperatorFactory.java
@@ -197,7 +197,7 @@ public class LookupJoinOperatorFactory
     }
 
     @Override
-    public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
+    public AdapterWorkProcessorOperator createAdapterOperator(ProcessorContext processorContext)
     {
         checkState(!closed, "Factory is already closed");
         LookupSourceFactory lookupSourceFactory = joinBridgeManager.getJoinBridge(processorContext.getLifespan());

--- a/presto-main/src/main/java/io/prestosql/operator/ProcessorContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ProcessorContext.java
@@ -15,6 +15,7 @@ package io.prestosql.operator;
 
 import io.prestosql.Session;
 import io.prestosql.execution.Lifespan;
+import io.prestosql.execution.TaskId;
 import io.prestosql.memory.context.MemoryTrackingContext;
 
 import static java.util.Objects.requireNonNull;
@@ -26,6 +27,7 @@ public class ProcessorContext
     private final DriverYieldSignal driverYieldSignal;
     private final Lifespan lifespan;
     private final SpillContext spillContext;
+    private final TaskId taskId;
 
     public ProcessorContext(Session session, MemoryTrackingContext memoryTrackingContext, OperatorContext operatorContext)
     {
@@ -35,6 +37,7 @@ public class ProcessorContext
         this.driverYieldSignal = operatorContext.getDriverContext().getYieldSignal();
         this.lifespan = operatorContext.getDriverContext().getLifespan();
         this.spillContext = operatorContext.getSpillContext();
+        this.taskId = operatorContext.getDriverContext().getTaskId();
     }
 
     public Session getSession()
@@ -60,5 +63,10 @@ public class ProcessorContext
     public SpillContext getSpillContext()
     {
         return spillContext;
+    }
+
+    public TaskId getTaskId()
+    {
+        return taskId;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/StreamingAggregationOperator.java
@@ -16,6 +16,9 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.operator.BasicWorkProcessorOperatorAdapter.BasicAdapterWorkProcessorOperatorFactory;
+import io.prestosql.operator.WorkProcessor.Transformation;
+import io.prestosql.operator.WorkProcessor.TransformationState;
 import io.prestosql.operator.aggregation.AccumulatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
@@ -25,6 +28,8 @@ import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.sql.planner.plan.AggregationNode.Step;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
+import javax.annotation.Nullable;
+
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -33,13 +38,38 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.operator.BasicWorkProcessorOperatorAdapter.createAdapterOperatorFactory;
+import static io.prestosql.operator.WorkProcessor.TransformationState.finished;
+import static io.prestosql.operator.WorkProcessor.TransformationState.needsMoreData;
+import static io.prestosql.operator.WorkProcessor.TransformationState.ofResult;
 import static java.util.Objects.requireNonNull;
 
 public class StreamingAggregationOperator
-        implements Operator
+        implements WorkProcessorOperator
 {
-    public static class StreamingAggregationOperatorFactory
-            implements OperatorFactory
+    public static OperatorFactory createOperatorFactory(
+            int operatorId,
+            PlanNodeId planNodeId,
+            List<Type> sourceTypes,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Step step,
+            List<AccumulatorFactory> accumulatorFactories,
+            JoinCompiler joinCompiler)
+    {
+        return createAdapterOperatorFactory(new Factory(
+                operatorId,
+                planNodeId,
+                sourceTypes,
+                groupByTypes,
+                groupByChannels,
+                step,
+                accumulatorFactories,
+                joinCompiler));
+    }
+
+    private static class Factory
+            implements BasicAdapterWorkProcessorOperatorFactory
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;
@@ -51,7 +81,15 @@ public class StreamingAggregationOperator
         private final JoinCompiler joinCompiler;
         private boolean closed;
 
-        public StreamingAggregationOperatorFactory(int operatorId, PlanNodeId planNodeId, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
+        private Factory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> sourceTypes,
+                List<Type> groupByTypes,
+                List<Integer> groupByChannels,
+                Step step,
+                List<AccumulatorFactory> accumulatorFactories,
+                JoinCompiler joinCompiler)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -64,235 +102,268 @@ public class StreamingAggregationOperator
         }
 
         @Override
-        public Operator createOperator(DriverContext driverContext)
+        public int getOperatorId()
         {
-            checkState(!closed, "Factory is already closed");
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, StreamingAggregationOperator.class.getSimpleName());
-            return new StreamingAggregationOperator(operatorContext, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
+            return operatorId;
         }
 
         @Override
-        public void noMoreOperators()
+        public PlanNodeId getPlanNodeId()
+        {
+            return planNodeId;
+        }
+
+        @Override
+        public String getOperatorType()
+        {
+            return StreamingAggregationOperator.class.getSimpleName();
+        }
+
+        @Override
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
+        {
+            checkState(!closed, "Factory is already closed");
+            return new StreamingAggregationOperator(processorContext, sourcePages, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
+        }
+
+        @Override
+        public void close()
         {
             closed = true;
         }
 
         @Override
-        public OperatorFactory duplicate()
+        public Factory duplicate()
         {
-            return new StreamingAggregationOperatorFactory(operatorId, planNodeId, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
+            return new Factory(operatorId, planNodeId, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
         }
     }
 
-    private final OperatorContext operatorContext;
-    private final LocalMemoryContext systemMemoryContext;
-    private final LocalMemoryContext userMemoryContext;
-    private final List<Type> groupByTypes;
-    private final int[] groupByChannels;
-    private final List<AccumulatorFactory> accumulatorFactories;
-    private final Step step;
-    private final PagesHashStrategy pagesHashStrategy;
+    private final WorkProcessor<Page> pages;
 
-    private List<Aggregator> aggregates;
-    private final PageBuilder pageBuilder;
-    private final Deque<Page> outputPages = new LinkedList<>();
-    private Page currentGroup;
-    private boolean finishing;
-
-    public StreamingAggregationOperator(OperatorContext operatorContext, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
+    private StreamingAggregationOperator(
+            ProcessorContext processorContext,
+            WorkProcessor<Page> sourcePages,
+            List<Type> sourceTypes,
+            List<Type> groupByTypes,
+            List<Integer> groupByChannels,
+            Step step,
+            List<AccumulatorFactory> accumulatorFactories,
+            JoinCompiler joinCompiler)
     {
-        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(StreamingAggregationOperator.class.getSimpleName());
-        this.userMemoryContext = operatorContext.localUserMemoryContext();
-        this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
-        this.groupByChannels = Ints.toArray(requireNonNull(groupByChannels, "groupByChannels is null"));
-        this.accumulatorFactories = requireNonNull(accumulatorFactories, "accumulatorFactories is null");
-        this.step = requireNonNull(step, "step is null");
-
-        this.aggregates = setupAggregates(step, accumulatorFactories);
-        this.pageBuilder = new PageBuilder(toTypes(groupByTypes, aggregates));
-        requireNonNull(joinCompiler, "joinCompiler is null");
-
-        requireNonNull(sourceTypes, "sourceTypes is null");
-        pagesHashStrategy = joinCompiler.compilePagesHashStrategyFactory(sourceTypes, groupByChannels, Optional.empty())
-                .createPagesHashStrategy(
-                        sourceTypes.stream()
-                                .map(type -> ImmutableList.<Block>of())
-                                .collect(toImmutableList()), OptionalInt.empty());
-    }
-
-    private List<Aggregator> setupAggregates(Step step, List<AccumulatorFactory> accumulatorFactories)
-    {
-        ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
-        for (AccumulatorFactory factory : accumulatorFactories) {
-            builder.add(new Aggregator(factory, step));
-        }
-        return builder.build();
-    }
-
-    private static List<Type> toTypes(List<Type> groupByTypes, List<Aggregator> aggregates)
-    {
-        ImmutableList.Builder<Type> builder = ImmutableList.builder();
-        builder.addAll(groupByTypes);
-        aggregates.stream()
-                .map(Aggregator::getType)
-                .forEach(builder::add);
-        return builder.build();
+        pages = sourcePages
+                .transform(new StreamingAggregation(
+                        processorContext,
+                        sourceTypes,
+                        groupByTypes,
+                        groupByChannels,
+                        step,
+                        accumulatorFactories,
+                        joinCompiler));
     }
 
     @Override
-    public OperatorContext getOperatorContext()
+    public WorkProcessor<Page> getOutputPages()
     {
-        return operatorContext;
+        return pages;
     }
 
-    @Override
-    public boolean needsInput()
+    private static class StreamingAggregation
+            implements Transformation<Page, Page>
     {
-        return !finishing && outputPages.isEmpty();
-    }
+        private final LocalMemoryContext systemMemoryContext;
+        private final LocalMemoryContext userMemoryContext;
+        private final List<Type> groupByTypes;
+        private final int[] groupByChannels;
+        private final List<AccumulatorFactory> accumulatorFactories;
+        private final Step step;
+        private final PagesHashStrategy pagesHashStrategy;
 
-    @Override
-    public void addInput(Page page)
-    {
-        checkState(!finishing, "Operator is already finishing");
-        requireNonNull(page, "page is null");
+        private List<Aggregator> aggregates;
+        private final PageBuilder pageBuilder;
+        private final Deque<Page> outputPages = new LinkedList<>();
+        private Page currentGroup;
 
-        processInput(page);
-        updateMemoryUsage();
-    }
+        private StreamingAggregation(
+                ProcessorContext processorContext,
+                List<Type> sourceTypes,
+                List<Type> groupByTypes,
+                List<Integer> groupByChannels,
+                Step step,
+                List<AccumulatorFactory> accumulatorFactories,
+                JoinCompiler joinCompiler)
+        {
+            requireNonNull(processorContext, "processorContext is null");
+            this.systemMemoryContext = processorContext.getMemoryTrackingContext().localSystemMemoryContext();
+            this.userMemoryContext = processorContext.getMemoryTrackingContext().localUserMemoryContext();
+            this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
+            this.groupByChannels = Ints.toArray(requireNonNull(groupByChannels, "groupByChannels is null"));
+            this.accumulatorFactories = requireNonNull(accumulatorFactories, "accumulatorFactories is null");
+            this.step = requireNonNull(step, "step is null");
 
-    private void updateMemoryUsage()
-    {
-        long memorySize = pageBuilder.getRetainedSizeInBytes();
-        for (Page output : outputPages) {
-            memorySize += output.getRetainedSizeInBytes();
-        }
-        for (Aggregator aggregator : aggregates) {
-            memorySize += aggregator.getEstimatedSize();
-        }
+            this.aggregates = setupAggregates(step, accumulatorFactories);
+            this.pageBuilder = new PageBuilder(toTypes(groupByTypes, aggregates));
+            requireNonNull(joinCompiler, "joinCompiler is null");
 
-        if (currentGroup != null) {
-            memorySize += currentGroup.getRetainedSizeInBytes();
-        }
-
-        if (step.isOutputPartial()) {
-            systemMemoryContext.setBytes(memorySize);
-        }
-        else {
-            userMemoryContext.setBytes(memorySize);
-        }
-    }
-
-    private void processInput(Page page)
-    {
-        requireNonNull(page, "page is null");
-
-        Page groupByPage = extractColumns(page, groupByChannels);
-        if (currentGroup != null) {
-            if (!pagesHashStrategy.rowEqualsRow(0, extractColumns(currentGroup, groupByChannels), 0, groupByPage)) {
-                // page starts with new group, so flush it
-                evaluateAndFlushGroup(currentGroup, 0);
-            }
-            currentGroup = null;
+            requireNonNull(sourceTypes, "sourceTypes is null");
+            pagesHashStrategy = joinCompiler.compilePagesHashStrategyFactory(sourceTypes, groupByChannels, Optional.empty())
+                    .createPagesHashStrategy(
+                            sourceTypes.stream()
+                                    .map(type -> ImmutableList.<Block>of())
+                                    .collect(toImmutableList()), OptionalInt.empty());
         }
 
-        int startPosition = 0;
-        while (true) {
-            // may be equal to page.getPositionCount() if the end is not found in this page
-            int nextGroupStart = findNextGroupStart(startPosition, groupByPage);
-            addRowsToAggregates(page, startPosition, nextGroupStart - 1);
+        @Override
+        public TransformationState<Page> process(@Nullable Page inputPage)
+        {
+            boolean finishing = inputPage == null;
 
-            if (nextGroupStart < page.getPositionCount()) {
-                // current group stops somewhere in the middle of the page, so flush it
-                evaluateAndFlushGroup(page, startPosition);
-                startPosition = nextGroupStart;
+            if (finishing) {
+                if (currentGroup != null) {
+                    evaluateAndFlushGroup(currentGroup, 0);
+                    currentGroup = null;
+                }
+
+                if (!pageBuilder.isEmpty()) {
+                    outputPages.add(pageBuilder.build());
+                    pageBuilder.reset();
+                }
+
+                if (outputPages.isEmpty()) {
+                    return finished();
+                }
             }
             else {
-                currentGroup = page.getRegion(page.getPositionCount() - 1, 1);
-                return;
+                processInput(inputPage);
+                updateMemoryUsage();
             }
-        }
-    }
 
-    private static Page extractColumns(Page page, int[] channels)
-    {
-        Block[] newBlocks = new Block[channels.length];
-        for (int i = 0; i < channels.length; i++) {
-            newBlocks[i] = page.getBlock(channels[i]);
-        }
-        return new Page(page.getPositionCount(), newBlocks);
-    }
+            if (outputPages.isEmpty()) {
+                return needsMoreData();
+            }
 
-    private void addRowsToAggregates(Page page, int startPosition, int endPosition)
-    {
-        Page region = page.getRegion(startPosition, endPosition - startPosition + 1);
-        for (Aggregator aggregator : aggregates) {
-            aggregator.processPage(region);
-        }
-    }
-
-    private void evaluateAndFlushGroup(Page page, int position)
-    {
-        pageBuilder.declarePosition();
-        for (int i = 0; i < groupByTypes.size(); i++) {
-            Block block = page.getBlock(groupByChannels[i]);
-            Type type = groupByTypes.get(i);
-            type.appendTo(block, position, pageBuilder.getBlockBuilder(i));
-        }
-        int offset = groupByTypes.size();
-        for (int i = 0; i < aggregates.size(); i++) {
-            aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i));
+            return ofResult(outputPages.removeFirst(), !finishing);
         }
 
-        if (pageBuilder.isFull()) {
-            outputPages.add(pageBuilder.build());
-            pageBuilder.reset();
-        }
+        private void updateMemoryUsage()
+        {
+            long memorySize = pageBuilder.getRetainedSizeInBytes();
+            for (Page output : outputPages) {
+                memorySize += output.getRetainedSizeInBytes();
+            }
+            for (Aggregator aggregator : aggregates) {
+                memorySize += aggregator.getEstimatedSize();
+            }
 
-        aggregates = setupAggregates(step, accumulatorFactories);
-    }
+            if (currentGroup != null) {
+                memorySize += currentGroup.getRetainedSizeInBytes();
+            }
 
-    private int findNextGroupStart(int startPosition, Page page)
-    {
-        for (int i = startPosition + 1; i < page.getPositionCount(); i++) {
-            if (!pagesHashStrategy.rowEqualsRow(startPosition, page, i, page)) {
-                return i;
+            if (step.isOutputPartial()) {
+                systemMemoryContext.setBytes(memorySize);
+            }
+            else {
+                userMemoryContext.setBytes(memorySize);
             }
         }
 
-        return page.getPositionCount();
-    }
+        private void processInput(Page page)
+        {
+            requireNonNull(page, "page is null");
 
-    @Override
-    public Page getOutput()
-    {
-        if (!outputPages.isEmpty()) {
-            return outputPages.removeFirst();
+            Page groupByPage = extractColumns(page, groupByChannels);
+            if (currentGroup != null) {
+                if (!pagesHashStrategy.rowEqualsRow(0, extractColumns(currentGroup, groupByChannels), 0, groupByPage)) {
+                    // page starts with new group, so flush it
+                    evaluateAndFlushGroup(currentGroup, 0);
+                }
+                currentGroup = null;
+            }
+
+            int startPosition = 0;
+            while (true) {
+                // may be equal to page.getPositionCount() if the end is not found in this page
+                int nextGroupStart = findNextGroupStart(startPosition, groupByPage);
+                addRowsToAggregates(page, startPosition, nextGroupStart - 1);
+
+                if (nextGroupStart < page.getPositionCount()) {
+                    // current group stops somewhere in the middle of the page, so flush it
+                    evaluateAndFlushGroup(page, startPosition);
+                    startPosition = nextGroupStart;
+                }
+                else {
+                    currentGroup = page.getRegion(page.getPositionCount() - 1, 1);
+                    return;
+                }
+            }
         }
 
-        return null;
-    }
-
-    @Override
-    public void finish()
-    {
-        finishing = true;
-
-        if (currentGroup != null) {
-            evaluateAndFlushGroup(currentGroup, 0);
-            currentGroup = null;
+        private static Page extractColumns(Page page, int[] channels)
+        {
+            Block[] newBlocks = new Block[channels.length];
+            for (int i = 0; i < channels.length; i++) {
+                newBlocks[i] = page.getBlock(channels[i]);
+            }
+            return new Page(page.getPositionCount(), newBlocks);
         }
 
-        if (!pageBuilder.isEmpty()) {
-            outputPages.add(pageBuilder.build());
-            pageBuilder.reset();
+        private void addRowsToAggregates(Page page, int startPosition, int endPosition)
+        {
+            Page region = page.getRegion(startPosition, endPosition - startPosition + 1);
+            for (Aggregator aggregator : aggregates) {
+                aggregator.processPage(region);
+            }
         }
-    }
 
-    @Override
-    public boolean isFinished()
-    {
-        return finishing && outputPages.isEmpty() && currentGroup == null && pageBuilder.isEmpty();
+        private void evaluateAndFlushGroup(Page page, int position)
+        {
+            pageBuilder.declarePosition();
+            for (int i = 0; i < groupByTypes.size(); i++) {
+                Block block = page.getBlock(groupByChannels[i]);
+                Type type = groupByTypes.get(i);
+                type.appendTo(block, position, pageBuilder.getBlockBuilder(i));
+            }
+            int offset = groupByTypes.size();
+            for (int i = 0; i < aggregates.size(); i++) {
+                aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i));
+            }
+
+            if (pageBuilder.isFull()) {
+                outputPages.add(pageBuilder.build());
+                pageBuilder.reset();
+            }
+
+            aggregates = setupAggregates(step, accumulatorFactories);
+        }
+
+        private int findNextGroupStart(int startPosition, Page page)
+        {
+            for (int i = startPosition + 1; i < page.getPositionCount(); i++) {
+                if (!pagesHashStrategy.rowEqualsRow(startPosition, page, i, page)) {
+                    return i;
+                }
+            }
+
+            return page.getPositionCount();
+        }
+
+        private static List<Aggregator> setupAggregates(Step step, List<AccumulatorFactory> accumulatorFactories)
+        {
+            ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
+            for (AccumulatorFactory factory : accumulatorFactories) {
+                builder.add(new Aggregator(factory, step));
+            }
+            return builder.build();
+        }
+
+        private static List<Type> toTypes(List<Type> groupByTypes, List<Aggregator> aggregates)
+        {
+            ImmutableList.Builder<Type> builder = ImmutableList.builder();
+            builder.addAll(groupByTypes);
+            aggregates.stream()
+                    .map(Aggregator::getType)
+                    .forEach(builder::add);
+            return builder.build();
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
@@ -184,11 +184,6 @@ public class TopNOperator
         pageBuffer.finish();
     }
 
-    @Override
-    public void close()
-            throws Exception
-    {}
-
     private void addPage(Page page)
     {
         topNProcessor.addInput(page);

--- a/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNOperator.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.prestosql.operator.WorkProcessorOperatorAdapter.createAdapterOperatorFactory;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -35,8 +36,19 @@ import static java.util.Objects.requireNonNull;
 public class TopNOperator
         implements AdapterWorkProcessorOperator
 {
-    public static class TopNOperatorFactory
-            implements OperatorFactory, AdapterWorkProcessorOperatorFactory
+    public static OperatorFactory createOperatorFactory(
+            int operatorId,
+            PlanNodeId planNodeId,
+            List<? extends Type> types,
+            int n,
+            List<Integer> sortChannels,
+            List<SortOrder> sortOrders)
+    {
+        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, sortChannels, sortOrders));
+    }
+
+    private static class Factory
+            implements AdapterWorkProcessorOperatorFactory
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;
@@ -46,7 +58,7 @@ public class TopNOperator
         private final List<SortOrder> sortOrders;
         private boolean closed;
 
-        public TopNOperatorFactory(
+        private Factory(
                 int operatorId,
                 PlanNodeId planNodeId,
                 List<? extends Type> types,
@@ -60,6 +72,34 @@ public class TopNOperator
             this.n = n;
             this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
             this.sortOrders = ImmutableList.copyOf(requireNonNull(sortOrders, "sortOrders is null"));
+        }
+
+        @Override
+        public WorkProcessorOperator create(
+                ProcessorContext processorContext,
+                WorkProcessor<Page> sourcePages)
+        {
+            checkState(!closed, "Factory is already closed");
+            return new TopNOperator(
+                    processorContext.getMemoryTrackingContext(),
+                    Optional.of(sourcePages),
+                    sourceTypes,
+                    n,
+                    sortChannels,
+                    sortOrders);
+        }
+
+        @Override
+        public AdapterWorkProcessorOperator createAdapterOperator(ProcessorContext processorContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            return new TopNOperator(
+                    processorContext.getMemoryTrackingContext(),
+                    Optional.empty(),
+                    sourceTypes,
+                    n,
+                    sortChannels,
+                    sortOrders);
         }
 
         @Override
@@ -81,49 +121,15 @@ public class TopNOperator
         }
 
         @Override
-        public Operator createOperator(DriverContext driverContext)
-        {
-            checkState(!closed, "Factory is already closed");
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, getOperatorType());
-            return new WorkProcessorOperatorAdapter(operatorContext, this);
-        }
-
-        @Override
-        public void noMoreOperators()
+        public void close()
         {
             closed = true;
         }
 
         @Override
-        public OperatorFactory duplicate()
+        public Factory duplicate()
         {
-            return new TopNOperatorFactory(operatorId, planNodeId, sourceTypes, n, sortChannels, sortOrders);
-        }
-
-        @Override
-        public WorkProcessorOperator create(
-                ProcessorContext processorContext,
-                WorkProcessor<Page> sourcePages)
-        {
-            return new TopNOperator(
-                    processorContext.getMemoryTrackingContext(),
-                    Optional.of(sourcePages),
-                    sourceTypes,
-                    n,
-                    sortChannels,
-                    sortOrders);
-        }
-
-        @Override
-        public AdapterWorkProcessorOperator create(ProcessorContext processorContext)
-        {
-            return new TopNOperator(
-                    processorContext.getMemoryTrackingContext(),
-                    Optional.empty(),
-                    sourceTypes,
-                    n,
-                    sortChannels,
-                    sortOrders);
+            return new Factory(operatorId, planNodeId, sourceTypes, n, sortChannels, sortOrders);
         }
     }
 
@@ -131,7 +137,7 @@ public class TopNOperator
     private final WorkProcessor<Page> pages;
     private final PageBuffer pageBuffer = new PageBuffer();
 
-    public TopNOperator(
+    private TopNOperator(
             MemoryTrackingContext memoryTrackingContext,
             Optional<WorkProcessor<Page>> sourcePages,
             List<Type> types,

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperator.java
@@ -32,4 +32,11 @@ public interface WorkProcessorOperator
     {
         return Optional.empty();
     }
+
+    @Override
+    default void close()
+            throws Exception
+    {
+        // do nothing
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
@@ -14,8 +14,10 @@
 package io.prestosql.operator;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.prestosql.execution.Lifespan;
 import io.prestosql.memory.context.MemoryTrackingContext;
 import io.prestosql.spi.Page;
+import io.prestosql.sql.planner.plan.PlanNodeId;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +37,96 @@ public class WorkProcessorOperatorAdapter
     public interface AdapterWorkProcessorOperatorFactory
             extends WorkProcessorOperatorFactory
     {
-        AdapterWorkProcessorOperator create(ProcessorContext processorContext);
+        AdapterWorkProcessorOperator createAdapterOperator(ProcessorContext processorContext);
+
+        AdapterWorkProcessorOperatorFactory duplicate();
+    }
+
+    public static OperatorFactory createAdapterOperatorFactory(AdapterWorkProcessorOperatorFactory operatorFactory)
+    {
+        return new Factory(operatorFactory);
+    }
+
+    /**
+     * Provides dual {@link OperatorFactory} and {@link WorkProcessorOperatorFactory} interface.
+     */
+    private static class Factory
+            implements OperatorFactory, WorkProcessorOperatorFactory
+    {
+        final AdapterWorkProcessorOperatorFactory operatorFactory;
+
+        Factory(AdapterWorkProcessorOperatorFactory operatorFactory)
+        {
+            this.operatorFactory = requireNonNull(operatorFactory, "operatorFactory is null");
+        }
+
+        // Methods from OperatorFactory
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            OperatorContext operatorContext = driverContext.addOperatorContext(
+                    operatorFactory.getOperatorId(),
+                    operatorFactory.getPlanNodeId(),
+                    operatorFactory.getOperatorType());
+            return new WorkProcessorOperatorAdapter(operatorContext, operatorFactory);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            close();
+        }
+
+        @Override
+        public void noMoreOperators(Lifespan lifespan)
+        {
+            lifespanFinished(lifespan);
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new Factory(operatorFactory.duplicate());
+        }
+
+        // Methods from WorkProcessorOperatorFactory
+
+        @Override
+        public int getOperatorId()
+        {
+            return operatorFactory.getOperatorId();
+        }
+
+        @Override
+        public PlanNodeId getPlanNodeId()
+        {
+            return operatorFactory.getPlanNodeId();
+        }
+
+        @Override
+        public String getOperatorType()
+        {
+            return operatorFactory.getOperatorType();
+        }
+
+        @Override
+        public WorkProcessorOperator create(ProcessorContext processorContext, WorkProcessor<Page> sourcePages)
+        {
+            return operatorFactory.create(processorContext, sourcePages);
+        }
+
+        @Override
+        public void lifespanFinished(Lifespan lifespan)
+        {
+            operatorFactory.lifespanFinished(lifespan);
+        }
+
+        @Override
+        public void close()
+        {
+            operatorFactory.close();
+        }
     }
 
     private final OperatorContext operatorContext;
@@ -51,7 +142,7 @@ public class WorkProcessorOperatorAdapter
                 operatorContext.aggregateSystemMemoryContext());
         memoryTrackingContext.initializeLocalMemoryContexts(workProcessorOperatorFactory.getOperatorType());
         this.workProcessorOperator = requireNonNull(workProcessorOperatorFactory, "workProcessorOperatorFactory is null")
-                .create(new ProcessorContext(operatorContext.getSession(), memoryTrackingContext, operatorContext));
+                .createAdapterOperator(new ProcessorContext(operatorContext.getSession(), memoryTrackingContext, operatorContext));
         this.pages = workProcessorOperator.getOutputPages();
         operatorContext.setInfoSupplier(() -> workProcessorOperator.getOperatorInfo().orElse(null));
     }

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
@@ -22,10 +22,6 @@ import static java.util.Objects.requireNonNull;
 public class WorkProcessorOperatorAdapter
         implements Operator
 {
-    private final OperatorContext operatorContext;
-    private final AdapterWorkProcessorOperator workProcessorOperator;
-    private final WorkProcessor<Page> pages;
-
     public interface AdapterWorkProcessorOperator
             extends WorkProcessorOperator
     {
@@ -41,6 +37,10 @@ public class WorkProcessorOperatorAdapter
     {
         AdapterWorkProcessorOperator create(ProcessorContext processorContext);
     }
+
+    private final OperatorContext operatorContext;
+    private final AdapterWorkProcessorOperator workProcessorOperator;
+    private final WorkProcessor<Page> pages;
 
     public WorkProcessorOperatorAdapter(OperatorContext operatorContext, AdapterWorkProcessorOperatorFactory workProcessorOperatorFactory)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorOperatorAdapter.java
@@ -21,6 +21,13 @@ import io.prestosql.sql.planner.plan.PlanNodeId;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This {@link WorkProcessorOperator} adapter allows to adapt {@link WorkProcessor} operators
+ * that require customization of input handling (e.g aggregation operators that want to skip extra
+ * buffering step or operators that require more sophisticated initial blocking condition).
+ * If such customization is not required, it's recommended to use {@link BasicWorkProcessorOperatorAdapter}
+ * instead.
+ */
 public class WorkProcessorOperatorAdapter
         implements Operator
 {

--- a/presto-main/src/main/java/io/prestosql/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/index/DynamicTupleFilterFactory.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
+import io.prestosql.operator.FilterAndProjectOperator;
 import io.prestosql.operator.OperatorFactory;
 import io.prestosql.operator.project.PageProcessor;
 import io.prestosql.operator.project.PageProjection;
@@ -35,7 +36,6 @@ import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
 import static java.util.Objects.requireNonNull;
 
 public class DynamicTupleFilterFactory
@@ -86,7 +86,7 @@ public class DynamicTupleFilterFactory
     {
         Page filterTuple = getFilterTuple(tuplePage);
         Supplier<PageProcessor> processor = createPageProcessor(filterTuple, OptionalInt.empty());
-        return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, DataSize.ofBytes(0), 0);
+        return FilterAndProjectOperator.createOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, DataSize.ofBytes(0), 0);
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -2419,7 +2419,7 @@ public class LocalExecutionPlanner
         {
             PhysicalOperation source = node.getSource().accept(this, context);
 
-            OperatorFactory operatorFactory = new AssignUniqueIdOperator.AssignUniqueIdOperatorFactory(
+            OperatorFactory operatorFactory = AssignUniqueIdOperator.createOperatorFactory(
                     context.getNextOperatorId(),
                     node.getId());
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, source);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -87,7 +87,7 @@ import io.prestosql.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import io.prestosql.operator.SpatialJoinOperator.SpatialJoinOperatorFactory;
 import io.prestosql.operator.StageExecutionDescriptor;
 import io.prestosql.operator.StatisticsWriterOperator.StatisticsWriterOperatorFactory;
-import io.prestosql.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
+import io.prestosql.operator.StreamingAggregationOperator;
 import io.prestosql.operator.TableDeleteOperator.TableDeleteOperatorFactory;
 import io.prestosql.operator.TableScanOperator.TableScanOperatorFactory;
 import io.prestosql.operator.TaskContext;
@@ -2806,7 +2806,7 @@ public class LocalExecutionPlanner
                     .collect(toImmutableList());
 
             if (isStreamable) {
-                return new StreamingAggregationOperatorFactory(
+                return StreamingAggregationOperator.createOperatorFactory(
                         context.getNextOperatorId(),
                         planNodeId,
                         source.getTypes(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -55,7 +55,7 @@ import io.prestosql.operator.FilterAndProjectOperator;
 import io.prestosql.operator.GroupIdOperator;
 import io.prestosql.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import io.prestosql.operator.HashBuilderOperator.HashBuilderOperatorFactory;
-import io.prestosql.operator.HashSemiJoinOperator.HashSemiJoinOperatorFactory;
+import io.prestosql.operator.HashSemiJoinOperator;
 import io.prestosql.operator.JoinBridgeManager;
 import io.prestosql.operator.JoinOperatorFactory;
 import io.prestosql.operator.JoinOperatorFactory.OuterOperatorFactoryResult;
@@ -92,7 +92,7 @@ import io.prestosql.operator.TableDeleteOperator.TableDeleteOperatorFactory;
 import io.prestosql.operator.TableScanOperator.TableScanOperatorFactory;
 import io.prestosql.operator.TaskContext;
 import io.prestosql.operator.TaskOutputOperator.TaskOutputFactory;
-import io.prestosql.operator.TopNOperator.TopNOperatorFactory;
+import io.prestosql.operator.TopNOperator;
 import io.prestosql.operator.TopNRowNumberOperator;
 import io.prestosql.operator.ValuesOperator.ValuesOperatorFactory;
 import io.prestosql.operator.WindowFunctionDefinition;
@@ -984,7 +984,7 @@ public class LocalExecutionPlanner
                 sortOrders.add(node.getOrderingScheme().getOrdering(symbol));
             }
 
-            OperatorFactory operator = new TopNOperatorFactory(
+            OperatorFactory operator = TopNOperator.createOperatorFactory(
                     context.getNextOperatorId(),
                     node.getId(),
                     source.getTypes(),
@@ -1294,7 +1294,7 @@ public class LocalExecutionPlanner
                 else {
                     Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(translatedFilter, translatedProjections, Optional.of(context.getStageId() + "_" + planNodeId));
 
-                    OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                    OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
                             context.getNextOperatorId(),
                             planNodeId,
                             pageProcessor,
@@ -2216,7 +2216,7 @@ public class LocalExecutionPlanner
                     .put(node.getSemiJoinOutput(), probeSource.getLayout().size())
                     .build();
 
-            HashSemiJoinOperatorFactory operator = new HashSemiJoinOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel, probeHashChannel);
+            OperatorFactory operator = HashSemiJoinOperator.createOperatorFactory(context.getNextOperatorId(), node.getId(), setProvider, probeSource.getTypes(), probeChannel, probeHashChannel);
             return new PhysicalOperation(operator, outputMappings, context, probeSource);
         }
 

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -18,7 +18,6 @@ import io.airlift.units.DataSize;
 import io.prestosql.RowPagesBuilder;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.operator.HashAggregationOperator.HashAggregationOperatorFactory;
-import io.prestosql.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
 import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.BlockBuilder;
@@ -141,7 +140,7 @@ public class BenchmarkHashAndStreamingAggregationOperators
 
         private OperatorFactory createStreamingAggregationOperatorFactory()
         {
-            return new StreamingAggregationOperatorFactory(
+            return StreamingAggregationOperator.createOperatorFactory(
                     0,
                     new PlanNodeId("test"),
                     ImmutableList.of(VARCHAR),

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkTopNOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkTopNOperator.java
@@ -15,7 +15,6 @@ package io.prestosql.operator;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
-import io.prestosql.operator.TopNOperator.TopNOperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
 import io.prestosql.spi.type.Type;
@@ -93,7 +92,7 @@ public class BenchmarkTopNOperator
 
             List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE);
             pages = createInputPages(Integer.valueOf(positionsPerPage), types);
-            operatorFactory = new TopNOperatorFactory(
+            operatorFactory = TopNOperator.createOperatorFactory(
                     0,
                     new PlanNodeId("test"),
                     types,

--- a/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
@@ -102,7 +102,7 @@ public class TestFilterAndProjectOperator
         ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
         Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field0, add5));
 
-        OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 processor,
@@ -146,7 +146,7 @@ public class TestFilterAndProjectOperator
         ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
         Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(1, BIGINT)));
 
-        OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+        OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 processor,

--- a/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestHashSemiJoinOperator.java
@@ -18,7 +18,6 @@ import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
 import io.prestosql.ExceededMemoryLimitException;
 import io.prestosql.RowPagesBuilder;
-import io.prestosql.operator.HashSemiJoinOperator.HashSemiJoinOperatorFactory;
 import io.prestosql.operator.SetBuilderOperator.SetBuilderOperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.type.Type;
@@ -126,7 +125,7 @@ public class TestHashSemiJoinOperator
                 .addSequencePage(10, 30, 0)
                 .build();
         Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
-        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+        OperatorFactory joinOperatorFactory = HashSemiJoinOperator.createOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
@@ -190,7 +189,7 @@ public class TestHashSemiJoinOperator
                 .addSequencePage(10, 30, 0)
                 .build();
         Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
-        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+        OperatorFactory joinOperatorFactory = HashSemiJoinOperator.createOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
@@ -283,7 +282,7 @@ public class TestHashSemiJoinOperator
                 .addSequencePage(4, 1)
                 .build();
         Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
-        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+        OperatorFactory joinOperatorFactory = HashSemiJoinOperator.createOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
@@ -341,7 +340,7 @@ public class TestHashSemiJoinOperator
                 .row(2L)
                 .build();
         Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
-        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+        OperatorFactory joinOperatorFactory = HashSemiJoinOperator.createOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),
@@ -400,7 +399,7 @@ public class TestHashSemiJoinOperator
                 .row(2L)
                 .build();
         Optional<Integer> probeHashChannel = hashEnabled ? Optional.of(probeTypes.size()) : Optional.empty();
-        HashSemiJoinOperatorFactory joinOperatorFactory = new HashSemiJoinOperatorFactory(
+        OperatorFactory joinOperatorFactory = HashSemiJoinOperator.createOperatorFactory(
                 2,
                 new PlanNodeId("test"),
                 setBuilderOperatorFactory.getSetProvider(),

--- a/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
@@ -16,7 +16,6 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.RowPagesBuilder;
 import io.prestosql.metadata.Metadata;
-import io.prestosql.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
 import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.spi.Page;
 import io.prestosql.sql.gen.JoinCompiler;
@@ -58,7 +57,7 @@ public class TestStreamingAggregationOperator
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
     private DriverContext driverContext;
-    private StreamingAggregationOperatorFactory operatorFactory;
+    private OperatorFactory operatorFactory;
 
     @BeforeMethod
     public void setUp()
@@ -70,7 +69,7 @@ public class TestStreamingAggregationOperator
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();
 
-        operatorFactory = new StreamingAggregationOperatorFactory(
+        operatorFactory = StreamingAggregationOperator.createOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 ImmutableList.of(BOOLEAN, VARCHAR, BIGINT),

--- a/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestTopNOperator.java
@@ -16,7 +16,6 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.prestosql.ExceededMemoryLimitException;
-import io.prestosql.operator.TopNOperator.TopNOperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.SortOrder;
 import io.prestosql.spi.type.Type;
@@ -212,7 +211,7 @@ public class TestTopNOperator
             List<Integer> sortChannels,
             List<SortOrder> sortOrders)
     {
-        return new TopNOperatorFactory(
+        return TopNOperator.createOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 types,

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/FunctionAssertions.java
@@ -29,7 +29,7 @@ import io.prestosql.metadata.Split;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.operator.DriverContext;
 import io.prestosql.operator.DriverYieldSignal;
-import io.prestosql.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
+import io.prestosql.operator.FilterAndProjectOperator;
 import io.prestosql.operator.Operator;
 import io.prestosql.operator.OperatorFactory;
 import io.prestosql.operator.ScanFilterAndProjectOperator;
@@ -744,7 +744,7 @@ public final class FunctionAssertions
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of());
 
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(), DataSize.ofBytes(0), 0);
+            return FilterAndProjectOperator.createOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(), DataSize.ofBytes(0), 0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -758,7 +758,7 @@ public final class FunctionAssertions
     {
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(filter, ImmutableList.of(projection));
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()), DataSize.ofBytes(0), 0);
+            return FilterAndProjectOperator.createOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()), DataSize.ofBytes(0), 0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {


### PR DESCRIPTION
Goal: Late materialization for complex correlated subqueries

Next steps:
1. Make streaming aggregation preserve input block laziness
2. cleanup join operator factory code (specifically make `LookupJoinOperatorFactory` not implement `JoinOperatorFactory`, but rather explicitly keep track of outer join factories)