### PR TITLE
Explicitly check pre-grouped symbols for aggregation to be streamable

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/AggregationNode.java
@@ -253,7 +253,9 @@ public class AggregationNode
 
     public boolean isStreamable()
     {
-        return !preGroupedSymbols.isEmpty() && groupingSets.getGroupingSetCount() == 1 && groupingSets.getGlobalGroupingSets().isEmpty();
+        return ImmutableSet.copyOf(preGroupedSymbols).equals(ImmutableSet.copyOf(groupingSets.getGroupingKeys()))
+                && groupingSets.getGroupingSetCount() == 1
+                && groupingSets.getGlobalGroupingSets().isEmpty();
     }
 
     public static GroupingSetDescriptor globalAggregation()

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/AggregationMatcher.java
@@ -104,6 +104,10 @@ public class AggregationMatcher
             return NO_MATCH;
         }
 
+        if (!preGroupedSymbols.isEmpty() && !aggregationNode.isStreamable()) {
+            return NO_MATCH;
+        }
+
         return match();
     }
 


### PR DESCRIPTION
StreamingAggregationOperator requires group by symbols
to be fully pre-grouped.