### PR TITLE
Remove deprecated equals usage in ST_Equals

### DIFF
--- a/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/io/prestosql/plugin/geospatial/GeoFunctions.java
@@ -1270,7 +1270,7 @@ public final class GeoFunctions
         OGCGeometry leftGeometry = deserialize(left);
         OGCGeometry rightGeometry = deserialize(right);
         verifySameSpatialReference(leftGeometry, rightGeometry);
-        return leftGeometry.equals(rightGeometry);
+        return leftGeometry.Equals(rightGeometry);
     }
 
     @SqlNullable

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -47,4 +47,16 @@
         <version>1.1</version>
         <comment>Prefer new Configuration(false)</comment>
     </violation>
+
+    <violation>
+        <name>com/esri/core/geometry/ogc/OGCGeometry.equals:(Lcom/esri/core/geometry/ogc/OGCGeometry;)Z</name>
+        <version>1.6</version>
+        <comment>Prefer OGCGeometry.Equals(OGCGeometry)</comment>
+    </violation>
+
+    <violation>
+        <name>com/esri/core/geometry/ogc/OGCGeometry.equals:(Ljava/lang/Object;)Z</name>
+        <version>1.6</version>
+        <comment>Prefer OGCGeometry.Equals(OGCGeometry)</comment>
+    </violation>
 </modernizer>


### PR DESCRIPTION
`OGCGeometry#equals` is deprecated in the latest ESRI library. We can use `Equals` method instead.

See: [OGCGeometry#Equals](https://esri.github.io/geometry-api-java/javadoc/com/esri/core/geometry/ogc/OGCGeometry.html#Equals-com.esri.core.geometry.ogc.OGCGeometry-)