### PR TITLE
Add deprecated function warning

### DIFF
--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -282,3 +282,25 @@ function follows:
   is used when performing a ``GROUP BY`` aggregation, and an implementation
   will be automatically generated for you, if you don't specify a
   ``AccumulatorStateFactory``
+
+Deprecated Function
+-------------------
+
+The ``@Deprecated`` annotation has to be used on any function that should no longer be
+used. The annotation causes Presto to generate a warning whenever a SQL statement
+uses a deprecated function. When a function is deprecated, the ``@Description``
+needs to be replaced with a note about the deprecation and the replacement function:
+
+.. code-block:: java
+
+    public class ExampleDeprecatedFunction
+    {
+        @Deprecated
+        @ScalarFunction("bad_function")
+        @Description("(DEPRECATED) Use good_function() instead")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean bad_function()
+        {
+            return false;
+        }
+    }

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionMetadata.java
@@ -29,6 +29,7 @@ public class FunctionMetadata
     private final boolean deterministic;
     private final String description;
     private final FunctionKind kind;
+    private final boolean deprecated;
 
     public FunctionMetadata(
             Signature signature,
@@ -39,7 +40,20 @@ public class FunctionMetadata
             String description,
             FunctionKind kind)
     {
-        this(FunctionId.toFunctionId(signature), signature, nullable, argumentDefinitions, hidden, deterministic, description, kind);
+        this(FunctionId.toFunctionId(signature), signature, nullable, argumentDefinitions, hidden, deterministic, description, kind, false);
+    }
+
+    public FunctionMetadata(
+            Signature signature,
+            boolean nullable,
+            List<FunctionArgumentDefinition> argumentDefinitions,
+            boolean hidden,
+            boolean deterministic,
+            String description,
+            FunctionKind kind,
+            boolean deprecated)
+    {
+        this(FunctionId.toFunctionId(signature), signature, nullable, argumentDefinitions, hidden, deterministic, description, kind, deprecated);
     }
 
     public FunctionMetadata(
@@ -50,7 +64,8 @@ public class FunctionMetadata
             boolean hidden,
             boolean deterministic,
             String description,
-            FunctionKind kind)
+            FunctionKind kind,
+            boolean deprecated)
     {
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.signature = requireNonNull(signature, "signature is null");
@@ -60,6 +75,7 @@ public class FunctionMetadata
         this.deterministic = deterministic;
         this.description = requireNonNull(description, "description is null");
         this.kind = requireNonNull(kind, "kind is null");
+        this.deprecated = deprecated;
     }
 
     public FunctionId getFunctionId()
@@ -100,6 +116,11 @@ public class FunctionMetadata
     public FunctionKind getKind()
     {
         return kind;
+    }
+
+    public boolean isDeprecated()
+    {
+        return deprecated;
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -1409,7 +1409,8 @@ public final class MetadataManager
                 functionMetadata.isHidden(),
                 functionMetadata.isDeterministic(),
                 functionMetadata.getDescription(),
-                functionMetadata.getKind());
+                functionMetadata.getKind(),
+                functionMetadata.isDeprecated());
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -71,6 +71,7 @@ public final class AggregationFromAnnotationsParser
     {
         AggregationFunction aggregationAnnotation = aggregationDefinition.getAnnotation(AggregationFunction.class);
         requireNonNull(aggregationAnnotation, "aggregationAnnotation is null");
+        boolean deprecated = aggregationDefinition.getAnnotationsByType(Deprecated.class).length > 0;
 
         ImmutableList.Builder<ParametricAggregation> builder = ImmutableList.builder();
 
@@ -83,7 +84,7 @@ public final class AggregationFromAnnotationsParser
                     for (AggregationHeader header : parseHeaders(aggregationDefinition, outputFunction)) {
                         AggregationImplementation onlyImplementation = parseImplementation(aggregationDefinition, header, stateClass, inputFunction, removeInputFunction, outputFunction, combineFunction, aggregationStateSerializerFactory);
                         ParametricImplementationsGroup<AggregationImplementation> implementations = ParametricImplementationsGroup.of(onlyImplementation);
-                        builder.add(new ParametricAggregation(implementations.getSignature(), header, implementations));
+                        builder.add(new ParametricAggregation(implementations.getSignature(), header, implementations, deprecated));
                     }
                 }
             }
@@ -96,6 +97,7 @@ public final class AggregationFromAnnotationsParser
     {
         ParametricImplementationsGroup.Builder<AggregationImplementation> implementationsBuilder = ParametricImplementationsGroup.builder();
         AggregationHeader header = parseHeader(aggregationDefinition);
+        boolean deprecated = aggregationDefinition.getAnnotationsByType(Deprecated.class).length > 0;
 
         for (Class<?> stateClass : getStateClasses(aggregationDefinition)) {
             Method combineFunction = getCombineFunction(aggregationDefinition, stateClass);
@@ -109,7 +111,7 @@ public final class AggregationFromAnnotationsParser
         }
 
         ParametricImplementationsGroup<AggregationImplementation> implementations = implementationsBuilder.build();
-        return new ParametricAggregation(implementations.getSignature(), header, implementations);
+        return new ParametricAggregation(implementations.getSignature(), header, implementations, deprecated);
     }
 
     private static Optional<Method> getAggregationStateSerializerFactory(Class<?> aggregationDefinition, Class<?> stateClass)

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ParametricAggregation.java
@@ -57,7 +57,8 @@ public class ParametricAggregation
     public ParametricAggregation(
             Signature signature,
             AggregationHeader details,
-            ParametricImplementationsGroup<AggregationImplementation> implementations)
+            ParametricImplementationsGroup<AggregationImplementation> implementations,
+            boolean deprecated)
     {
         super(
                 new FunctionMetadata(
@@ -67,7 +68,8 @@ public class ParametricAggregation
                         details.isHidden(),
                         true,
                         details.getDescription().orElse(""),
-                        AGGREGATE),
+                        AGGREGATE,
+                        deprecated),
                 details.isDecomposable(),
                 details.isOrderSensitive());
         requireNonNull(details, "details is null");

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ParametricScalar.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ParametricScalar.java
@@ -43,7 +43,8 @@ public class ParametricScalar
     public ParametricScalar(
             Signature signature,
             ScalarHeader details,
-            ParametricImplementationsGroup<ParametricScalarImplementation> implementations)
+            ParametricImplementationsGroup<ParametricScalarImplementation> implementations,
+            boolean deprecated)
     {
         super(new FunctionMetadata(
                 signature,
@@ -52,7 +53,8 @@ public class ParametricScalar
                 details.isHidden(),
                 details.isDeterministic(),
                 details.getDescription().orElse(""),
-                SCALAR));
+                SCALAR,
+                deprecated));
         this.details = requireNonNull(details);
         this.implementations = requireNonNull(implementations);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/window/SqlWindowFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/SqlWindowFunction.java
@@ -31,7 +31,7 @@ public class SqlWindowFunction
     private final WindowFunctionSupplier supplier;
     private final FunctionMetadata functionMetadata;
 
-    public SqlWindowFunction(WindowFunctionSupplier supplier)
+    public SqlWindowFunction(WindowFunctionSupplier supplier, boolean deprecated)
     {
         this.supplier = requireNonNull(supplier, "supplier is null");
         Signature signature = supplier.getSignature();
@@ -42,7 +42,8 @@ public class SqlWindowFunction
                 false,
                 true,
                 nullToEmpty(supplier.getDescription()),
-                WINDOW);
+                WINDOW,
+                deprecated);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/operator/window/WindowAnnotationsParser.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/WindowAnnotationsParser.java
@@ -61,6 +61,7 @@ public final class WindowAnnotationsParser
                 argumentTypes,
                 false);
 
-        return new SqlWindowFunction(new ReflectionWindowFunctionSupplier<>(signature, clazz));
+        boolean deprecated = clazz.getAnnotationsByType(Deprecated.class).length > 0;
+        return new SqlWindowFunction(new ReflectionWindowFunctionSupplier<>(signature, clazz), deprecated);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -21,6 +21,7 @@ import io.airlift.slice.SliceUtf8;
 import io.prestosql.Session;
 import io.prestosql.SystemSessionProperties;
 import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.metadata.FunctionMetadata;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.OperatorNotFoundException;
 import io.prestosql.metadata.QualifiedObjectName;
@@ -31,6 +32,7 @@ import io.prestosql.security.AccessControl;
 import io.prestosql.security.DenyAllAccessControl;
 import io.prestosql.spi.ErrorCodeSupplier;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalParseResult;
@@ -129,6 +131,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TOO_MANY_ARGUMENTS;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.prestosql.spi.StandardErrorCode.TYPE_NOT_FOUND;
+import static io.prestosql.spi.connector.StandardWarningCode.DEPRECATED_FUNCTION;
 import static io.prestosql.spi.function.OperatorType.SUBSCRIPT;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
@@ -943,6 +946,14 @@ public class ExpressionAnalyzer
                 }
             }
             resolvedFunctions.put(NodeRef.of(node), function);
+
+            FunctionMetadata functionMetadata = metadata.getFunctionMetadata(function);
+            if (functionMetadata.isDeprecated()) {
+                warningCollector.add(new PrestoWarning(DEPRECATED_FUNCTION,
+                        String.format("Use of deprecated function: %s: %s",
+                                functionMetadata.getSignature().getName(),
+                                functionMetadata.getDescription())));
+            }
 
             Type type = metadata.getType(signature.getReturnType());
             return setExpressionType(node, type);

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -2314,7 +2314,7 @@ class StatementAnalyzer
                     scope,
                     analysis,
                     expression,
-                    WarningCollector.NOOP);
+                    warningCollector);
         }
 
         private List<Expression> descriptorToFields(Scope scope)

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -88,6 +88,7 @@ import io.prestosql.metadata.QualifiedTablePrefix;
 import io.prestosql.metadata.SchemaPropertyManager;
 import io.prestosql.metadata.SessionPropertyManager;
 import io.prestosql.metadata.Split;
+import io.prestosql.metadata.SqlFunction;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.metadata.TablePropertyManager;
 import io.prestosql.operator.Driver;
@@ -527,6 +528,12 @@ public class LocalQueryRunner
     public void installPlugin(Plugin plugin)
     {
         pluginManager.installPlugin(plugin, plugin.getClass()::getClassLoader);
+    }
+
+    @Override
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        metadata.addFunctions(functions);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/testing/QueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/QueryRunner.java
@@ -18,6 +18,7 @@ import io.prestosql.cost.StatsCalculator;
 import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.SqlFunction;
 import io.prestosql.spi.Plugin;
 import io.prestosql.split.PageSourceManager;
 import io.prestosql.split.SplitManager;
@@ -74,6 +75,8 @@ public interface QueryRunner
     boolean tableExists(Session session, String table);
 
     void installPlugin(Plugin plugin);
+
+    void addFunctions(List<? extends SqlFunction> functions);
 
     void createCatalog(String catalogName, String connectorName, Map<String, String> properties);
 

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/StandardWarningCode.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/StandardWarningCode.java
@@ -21,6 +21,7 @@ public enum StandardWarningCode
 {
     TOO_MANY_STAGES(0x0000_0001),
     REDUNDANT_ORDER_BY(0x0000_0002),
+    DEPRECATED_FUNCTION(0x0000_0003),
 
     /**/;
     private final WarningCode warningCode;

--- a/presto-testing/src/main/java/io/prestosql/testing/DistributedQueryRunner.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/DistributedQueryRunner.java
@@ -32,6 +32,7 @@ import io.prestosql.metadata.InternalNode;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.metadata.SessionPropertyManager;
+import io.prestosql.metadata.SqlFunction;
 import io.prestosql.server.BasicQueryInfo;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.Plugin;
@@ -276,6 +277,12 @@ public class DistributedQueryRunner
             server.installPlugin(plugin);
         }
         log.info("Installed plugin %s in %s", plugin.getClass().getSimpleName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    @Override
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        servers.forEach(server -> server.getMetadata().addFunctions(functions));
     }
 
     public void createCatalog(String catalogName, String connectorName)

--- a/presto-testing/src/main/java/io/prestosql/testing/StandaloneQueryRunner.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/StandaloneQueryRunner.java
@@ -23,6 +23,7 @@ import io.prestosql.metadata.InternalNode;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.metadata.SessionPropertyManager;
+import io.prestosql.metadata.SqlFunction;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.Plugin;
 import io.prestosql.split.PageSourceManager;
@@ -196,6 +197,12 @@ public final class StandaloneQueryRunner
     public void installPlugin(Plugin plugin)
     {
         server.installPlugin(plugin);
+    }
+
+    @Override
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        server.getMetadata().addFunctions(functions);
     }
 
     public void createCatalog(String catalogName, String connectorName)

--- a/presto-tests/src/test/java/io/prestosql/execution/DeprecatedFunctionsPlugin.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/DeprecatedFunctionsPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.StandardTypes;
+
+import java.util.Set;
+
+public class DeprecatedFunctionsPlugin
+        implements Plugin
+{
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.<Class<?>>builder()
+                .add(TestPluginScalaFunction.class)
+                .build();
+    }
+
+    public static class TestPluginScalaFunction
+    {
+        @Deprecated
+        @ScalarFunction("plugin_deprecated_scalar")
+        @Description("Returns TRUE")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedScalar()
+        {
+            return true;
+        }
+
+        @ScalarFunction("plugin_non_deprecated_scalar")
+        @Description("Returns TRUE")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean nonDeprecatedScalar()
+        {
+            return true;
+        }
+    }
+}

--- a/presto-tests/src/test/java/io/prestosql/execution/TestDeprecatedFunctionWarning.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestDeprecatedFunctionWarning.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.client.Warning;
+import io.prestosql.operator.aggregation.state.LongAndDoubleState;
+import io.prestosql.operator.window.RankFunction;
+import io.prestosql.spi.WarningCode;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.connector.StandardWarningCode;
+import io.prestosql.spi.function.AggregationFunction;
+import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.InputFunction;
+import io.prestosql.spi.function.OutputFunction;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlNullable;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.function.TypeParameter;
+import io.prestosql.spi.function.WindowFunctionSignature;
+import io.prestosql.spi.type.StandardTypes;
+import io.prestosql.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.execution.TestQueryRunnerUtil.createQueryRunner;
+import static io.prestosql.metadata.FunctionExtractor.extractFunctions;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.fail;
+
+public class TestDeprecatedFunctionWarning
+{
+    private static final WarningCode DEPRECATED_FUNCTION_WARNING_CODE = StandardWarningCode.DEPRECATED_FUNCTION.toWarningCode();
+    private static final String EXPECTED_WARNING_MSG = "(DEPRECATED) Use foo() instead.";
+
+    private QueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner(ImmutableMap.of());
+        ImmutableList.of(
+                TestScalaFunction.class,
+                TestDeprecatedParametericScalaFunction.class,
+                TestNonDeprecatedParametericScalaFunction.class,
+                TestDeprecatedAggregation.class,
+                TestNonDeprecatedAggregation.class,
+                TestDeprecatedWindow.class,
+                TestNonDeprecatedWindow.class)
+                .forEach(udfClass -> queryRunner.addFunctions(extractFunctions(udfClass)));
+        queryRunner.installPlugin(new DeprecatedFunctionsPlugin());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+    }
+
+    @Test
+    public void testDeprecatedScalaFunction()
+    {
+        assertPlannerWarnings(queryRunner,
+                "SELECT 123",
+                ImmutableList.of());
+        assertPlannerWarnings(queryRunner,
+                "SELECT lower('A')",
+                ImmutableList.of());
+        assertPlannerWarnings(queryRunner,
+                "SELECT deprecated_scalar()",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT non_deprecated_scalar()",
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testDeprecatedDescription()
+    {
+        String sql = "SELECT deprecated_scalar()";
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+        List<Warning> warnings = queryRunner.execute(session, sql).getWarnings();
+        if (warnings.size() != 1 || !warnings.get(0).getMessage().contains(EXPECTED_WARNING_MSG)) {
+            fail("Expected warning: " + EXPECTED_WARNING_MSG);
+        }
+    }
+
+    @Test
+    public void testPluginDeprecatedScalaFunction()
+    {
+        assertPlannerWarnings(queryRunner,
+                "SELECT plugin_deprecated_scalar()",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT plugin_non_deprecated_scalar()",
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testDeprecatedParametericScalaFunction()
+    {
+        assertPlannerWarnings(queryRunner,
+                "SELECT deprecated_parameteric_scala(1.2)",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT deprecated_parameteric_scala(123)",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT non_deprecated_parameteric_scala(1.2)",
+                ImmutableList.of());
+        assertPlannerWarnings(queryRunner,
+                "SELECT non_deprecated_parameteric_scala(123)",
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testDeprecatedAggregationFunction()
+    {
+        assertPlannerWarnings(queryRunner,
+                "SELECT deprecated_aggregation(val) from (VALUES (1),(2),(3)) AS t(val)",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT non_deprecated_aggregation(val) from (VALUES (1),(2),(3)) AS t(val)",
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testDeprecatedWindowFunction()
+    {
+        assertPlannerWarnings(queryRunner,
+                "SELECT deprecated_window() OVER (PARTITION BY id) FROM (VALUES (1,10),(2,20),(3,30)) AS t(id, val)",
+                ImmutableList.of(DEPRECATED_FUNCTION_WARNING_CODE));
+        assertPlannerWarnings(queryRunner,
+                "SELECT non_deprecated_window() OVER (PARTITION BY id) FROM (VALUES (1,10),(2,20),(3,30)) AS t(id, val)",
+                ImmutableList.of());
+    }
+
+    private static void assertPlannerWarnings(QueryRunner queryRunner, @Language("SQL") String sql, List<WarningCode> expectedWarnings)
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+        Set<Integer> warnings = queryRunner.execute(session, sql).getWarnings().stream()
+                .map(Warning::getWarningCode)
+                .map(Warning.Code::getCode)
+                .collect(toImmutableSet());
+        expectedWarnings.stream()
+                .map(WarningCode::getCode)
+                .forEach(expectedWarning -> {
+                    if (!warnings.contains(expectedWarning)) {
+                        fail("Expected warning: " + expectedWarning);
+                    }
+                });
+        if (expectedWarnings.isEmpty() && !warnings.isEmpty()) {
+            fail("Expect no warning");
+        }
+    }
+
+    public static class TestScalaFunction
+    {
+        @Deprecated
+        @ScalarFunction("deprecated_scalar")
+        @Description(EXPECTED_WARNING_MSG)
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedScalar()
+        {
+            return true;
+        }
+
+        @ScalarFunction("non_deprecated_scalar")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean nonDeprecatedScalar()
+        {
+            return true;
+        }
+    }
+
+    @Deprecated
+    @ScalarFunction("deprecated_parameteric_scala")
+    public static class TestDeprecatedParametericScalaFunction
+    {
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedParametericScalaDouble(@SqlNullable @SqlType("T") Double value)
+        {
+            return (value == null);
+        }
+
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedParametericScalaLong(@SqlNullable @SqlType("T") Long value)
+        {
+            return (value == null);
+        }
+    }
+
+    @ScalarFunction("non_deprecated_parameteric_scala")
+    public static class TestNonDeprecatedParametericScalaFunction
+    {
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedParametericScalaDouble(@SqlNullable @SqlType("T") Double value)
+        {
+            return (value == null);
+        }
+
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean deprecatedParametericScalaLong(@SqlNullable @SqlType("T") Long value)
+        {
+            return (value == null);
+        }
+    }
+
+    @Deprecated
+    @AggregationFunction("deprecated_aggregation")
+    public static class TestDeprecatedAggregation
+    {
+        @InputFunction
+        public static void input(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+        {
+        }
+
+        @CombineFunction
+        public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+        {
+        }
+
+        @OutputFunction(StandardTypes.DOUBLE)
+        public static void output(LongAndDoubleState state, BlockBuilder out)
+        {
+            DOUBLE.writeDouble(out, 1.0);
+        }
+    }
+
+    @AggregationFunction("non_deprecated_aggregation")
+    public static class TestNonDeprecatedAggregation
+    {
+        @InputFunction
+        public static void input(LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+        {
+        }
+
+        @CombineFunction
+        public static void combine(LongAndDoubleState state, LongAndDoubleState otherState)
+        {
+        }
+
+        @OutputFunction(StandardTypes.DOUBLE)
+        public static void output(LongAndDoubleState state, BlockBuilder out)
+        {
+            DOUBLE.writeDouble(out, 1.0);
+        }
+    }
+
+    @Deprecated
+    @WindowFunctionSignature(name = "deprecated_window", returnType = "bigint")
+    public static class TestDeprecatedWindow
+            extends RankFunction
+    {
+    }
+
+    @WindowFunctionSignature(name = "non_deprecated_window", returnType = "bigint")
+    public static class TestNonDeprecatedWindow
+            extends RankFunction
+    {
+    }
+}

--- a/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift/src/test/java/io/prestosql/plugin/thrift/integration/ThriftQueryRunner.java
@@ -29,6 +29,7 @@ import io.prestosql.Session;
 import io.prestosql.cost.StatsCalculator;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.metadata.SqlFunction;
 import io.prestosql.plugin.thrift.ThriftPlugin;
 import io.prestosql.plugin.thrift.server.ThriftIndexedTpchService;
 import io.prestosql.plugin.thrift.server.ThriftTpchService;
@@ -260,6 +261,12 @@ public final class ThriftQueryRunner
         public void installPlugin(Plugin plugin)
         {
             source.installPlugin(plugin);
+        }
+
+        @Override
+        public void addFunctions(List<? extends SqlFunction> functions)
+        {
+            source.getMetadata().addFunctions(functions);
         }
 
         @Override


### PR DESCRIPTION
Generate a warning when a query is using a `@Deprecated` function.
This works for annotated `Scalar`, `Parametric Scalar`, `Aggregation`, `Window` functions.
Both built-in UDFs and UDFs from plugin are supported.
Doesn't work for classes that are directly implements `SqlFunction` without using annotation.

This feature can be enabled by the feature flag `analyzer.query-diagnosis-warning-enabled` or `enable_query_diagnosis_warning` session. Default is not enabled.

I have two questions:
* Is the feature flag needed?
* Should this function be default ON / OFF?

```java
@Deprecated
@ScalarFunction("deprecated_function")
public static Slice funcABC() { ... }
```
```sql
presto> SELECT deprecated_function();
.....
(1 row)

WARNING: Detected use of deprecated function: deprecated_function
```

Supersedes #1006