### PR TITLE
Deprecated method reference in presto-parser

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/parser/StatementSplitter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/StatementSplitter.java
@@ -15,8 +15,8 @@ package io.prestosql.sql.parser;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenSource;
 
@@ -107,7 +107,7 @@ public class StatementSplitter
     public static TokenSource getLexer(String sql, Set<String> terminators)
     {
         requireNonNull(sql, "sql is null");
-        CharStream stream = new CaseInsensitiveStream(new ANTLRInputStream(sql));
+        CharStream stream = new CaseInsensitiveStream(CharStreams.fromString(sql));
         return new DelimiterLexer(stream, terminators);
     }
 

--- a/presto-parser/src/main/java/io/prestosql/type/TypeCalculation.java
+++ b/presto-parser/src/main/java/io/prestosql/type/TypeCalculation.java
@@ -23,8 +23,8 @@ import io.prestosql.type.TypeCalculationParser.NullLiteralContext;
 import io.prestosql.type.TypeCalculationParser.NumericLiteralContext;
 import io.prestosql.type.TypeCalculationParser.ParenthesizedExpressionContext;
 import io.prestosql.type.TypeCalculationParser.TypeCalculationContext;
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
@@ -74,7 +74,7 @@ public final class TypeCalculation
 
     private static ParserRuleContext parseTypeCalculation(String calculation)
     {
-        TypeCalculationLexer lexer = new TypeCalculationLexer(new CaseInsensitiveStream(new ANTLRInputStream(calculation)));
+        TypeCalculationLexer lexer = new TypeCalculationLexer(new CaseInsensitiveStream(CharStreams.fromString(calculation)));
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);
         TypeCalculationParser parser = new TypeCalculationParser(tokenStream);
 
@@ -92,7 +92,7 @@ public final class TypeCalculation
         }
         catch (ParseCancellationException ex) {
             // if we fail, parse with LL mode
-            tokenStream.reset(); // rewind input stream
+            tokenStream.seek(0); // rewind input stream
             parser.reset();
 
             parser.getInterpreter().setPredictionMode(PredictionMode.LL);


### PR DESCRIPTION
Replace deprecated method usage in the presto-parser module.

- [BufferredTokenStream#reset](https://www.antlr.org/api/Java/org/antlr/v4/runtime/BufferedTokenStream.html#reset())
- [ParserRuleContext#addChild](https://www.antlr.org/api/Java/org/antlr/v4/runtime/ParserRuleContext.html#addChild(org.antlr.v4.runtime.Token))
- [ANTLRInputStream](https://www.antlr.org/api/Java/org/antlr/v4/runtime/ANTLRInputStream.html)