### PR TITLE
Allow overriding required workers and required workers max wait time through system session properties

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -125,6 +125,8 @@ public final class SystemSessionProperties
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
     public static final String IGNORE_DOWNSTREAM_PREFERENCES = "ignore_downstream_preferences";
+    public static final String REQUIRED_WORKERS_COUNT = "required_workers_count";
+    public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -552,6 +554,16 @@ public final class SystemSessionProperties
                         IGNORE_DOWNSTREAM_PREFERENCES,
                         "Ignore Parent's PreferredProperties in AddExchange optimizer",
                         featuresConfig.isIgnoreDownstreamPreferences(),
+                        false),
+                integerProperty(
+                        REQUIRED_WORKERS_COUNT,
+                        "Minimum number of active workers that must be available before the query will start",
+                        queryManagerConfig.getRequiredWorkers(),
+                        false),
+                durationProperty(
+                        REQUIRED_WORKERS_MAX_WAIT_TIME,
+                        "Maximum time to wait for minimum number of workers before the query is failed",
+                        queryManagerConfig.getRequiredWorkersMaxWait(),
                         false));
     }
 
@@ -1007,5 +1019,15 @@ public final class SystemSessionProperties
                 hidden,
                 value -> Duration.valueOf((String) value),
                 Duration::toString);
+    }
+
+    public static int getRequiredWorkers(Session session)
+    {
+        return session.getSystemProperty(REQUIRED_WORKERS_COUNT, Integer.class);
+    }
+
+    public static Duration getRequiredWorkersMaxWait(Session session)
+    {
+        return session.getSystemProperty(REQUIRED_WORKERS_MAX_WAIT_TIME, Duration.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
@@ -41,6 +41,8 @@ import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.prestosql.SystemSessionProperties.getRequiredWorkers;
+import static io.prestosql.SystemSessionProperties.getRequiredWorkersMaxWait;
 import static io.prestosql.execution.QueryState.FAILED;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.util.Failures.toFailure;
@@ -93,10 +95,25 @@ public class LocalDispatchQuery
 
     private void waitForMinimumWorkers()
     {
-        ListenableFuture<?> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers();
-        // when worker requirement is met, wait for query execution to finish construction and then start the execution
-        addSuccessCallback(minimumWorkerFuture, () -> addSuccessCallback(queryExecutionFuture, this::startExecution));
-        addExceptionCallback(minimumWorkerFuture, throwable -> queryExecutor.execute(() -> stateMachine.transitionToFailed(throwable)));
+        // wait for query execution to finish construction
+        addSuccessCallback(queryExecutionFuture, queryExecution -> {
+            Session session = stateMachine.getSession();
+            int executionMinCount = 1; // always wait for 1 node to be up
+            if (queryExecution.shouldWaitForMinWorkers()) {
+                executionMinCount = getRequiredWorkers(session);
+            }
+            ListenableFuture<?> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
+            // when worker requirement is met, start the execution
+            addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution));
+            addExceptionCallback(minimumWorkerFuture, throwable -> queryExecutor.execute(() -> stateMachine.transitionToFailed(throwable)));
+
+            // cancel minimumWorkerFuture if query fails for some reason or is cancelled by user
+            stateMachine.addStateChangeListener(state -> {
+                if (state.isDone()) {
+                    minimumWorkerFuture.cancel(true);
+                }
+            });
+        });
     }
 
     private void startExecution(QueryExecution queryExecution)

--- a/presto-main/src/main/java/io/prestosql/execution/ClusterSizeMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/execution/ClusterSizeMonitor.java
@@ -22,23 +22,25 @@ import io.prestosql.execution.scheduler.NodeSchedulerConfig;
 import io.prestosql.metadata.AllNodes;
 import io.prestosql.metadata.InternalNodeManager;
 import io.prestosql.spi.PrestoException;
+import org.weakref.jmx.Managed;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.PriorityQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.String.format;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -47,8 +49,6 @@ public class ClusterSizeMonitor
 {
     private final InternalNodeManager nodeManager;
     private final boolean includeCoordinator;
-    private final int executionMinCount;
-    private final Duration executionMaxWait;
     private final ScheduledExecutorService executor;
 
     private final Consumer<AllNodes> listener = this::updateAllNodes;
@@ -57,29 +57,22 @@ public class ClusterSizeMonitor
     private int currentCount;
 
     @GuardedBy("this")
-    private final List<SettableFuture<?>> futures = new ArrayList<>();
+    private final PriorityQueue<MinNodesFuture> futuresQueue = new PriorityQueue<>(comparing(MinNodesFuture::getExecutionMinCount));
 
     @Inject
-    public ClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig, QueryManagerConfig queryManagerConfig)
+    public ClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig)
     {
         this(
                 nodeManager,
-                requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator(),
-                requireNonNull(queryManagerConfig, "queryManagerConfig is null").getRequiredWorkers(),
-                queryManagerConfig.getRequiredWorkersMaxWait());
+                requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator());
     }
 
     public ClusterSizeMonitor(
             InternalNodeManager nodeManager,
-            boolean includeCoordinator,
-            int executionMinCount,
-            Duration executionMaxWait)
+            boolean includeCoordinator)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.includeCoordinator = includeCoordinator;
-        checkArgument(executionMinCount >= 0, "executionMinCount is negative");
-        this.executionMinCount = executionMinCount;
-        this.executionMaxWait = requireNonNull(executionMaxWait, "executionMaxWait is null");
         this.executor = newSingleThreadScheduledExecutor(threadsNamed("node-monitor-%s"));
     }
 
@@ -101,14 +94,18 @@ public class ClusterSizeMonitor
      * Note: caller should not add a listener using the direct executor, as this can delay the
      * notifications for other listeners.
      */
-    public synchronized ListenableFuture<?> waitForMinimumWorkers()
+    public synchronized ListenableFuture<?> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
     {
+        checkArgument(executionMinCount > 0, "executionMinCount should be greater than 0");
+        requireNonNull(executionMaxWait, "executionMaxWait is null");
+
         if (currentCount >= executionMinCount) {
             return immediateFuture(null);
         }
 
         SettableFuture<?> future = SettableFuture.create();
-        futures.add(future);
+        MinNodesFuture minNodesFuture = new MinNodesFuture(executionMinCount, future);
+        futuresQueue.add(minNodesFuture);
 
         // if future does not finish in wait period, complete with an exception
         ScheduledFuture<?> timeoutTask = executor.schedule(
@@ -125,15 +122,15 @@ public class ClusterSizeMonitor
         // remove future if finished (e.g., canceled, timed out)
         future.addListener(() -> {
             timeoutTask.cancel(true);
-            removeFuture(future);
+            removeFuture(minNodesFuture);
         }, executor);
 
         return future;
     }
 
-    private synchronized void removeFuture(SettableFuture<?> future)
+    private synchronized void removeFuture(MinNodesFuture minNodesFuture)
     {
-        futures.remove(future);
+        futuresQueue.remove(minNodesFuture);
     }
 
     private synchronized void updateAllNodes(AllNodes allNodes)
@@ -144,10 +141,49 @@ public class ClusterSizeMonitor
         else {
             currentCount = Sets.difference(allNodes.getActiveNodes(), allNodes.getActiveCoordinators()).size();
         }
-        if (currentCount >= executionMinCount) {
-            ImmutableList<SettableFuture<?>> listeners = ImmutableList.copyOf(futures);
-            futures.clear();
-            executor.submit(() -> listeners.forEach(listener -> listener.set(null)));
+
+        ImmutableList.Builder<SettableFuture<?>> listenersBuilder = new ImmutableList.Builder<>();
+        while (!futuresQueue.isEmpty()) {
+            MinNodesFuture minNodesFuture = futuresQueue.peek();
+            if (minNodesFuture == null || minNodesFuture.getExecutionMinCount() > currentCount) {
+                break;
+            }
+            listenersBuilder.add(minNodesFuture.getFuture());
+            // this should not happen since we have a lock
+            checkState(futuresQueue.poll() == minNodesFuture, "Unexpected modifications to MinNodesFuture queue");
+        }
+        ImmutableList<SettableFuture<?>> listeners = listenersBuilder.build();
+        executor.submit(() -> listeners.forEach(listener -> listener.set(null)));
+    }
+
+    @Managed
+    public synchronized int getRequiredWorkers()
+    {
+        return futuresQueue.stream()
+                .map(MinNodesFuture::getExecutionMinCount)
+                .max(Integer::compareTo)
+                .orElse(0);
+    }
+
+    private static class MinNodesFuture
+    {
+        private final int executionMinCount;
+        private final SettableFuture<?> future;
+
+        MinNodesFuture(int executionMinCount, SettableFuture<?> future)
+        {
+            this.executionMinCount = executionMinCount;
+            this.future = future;
+        }
+
+        int getExecutionMinCount()
+        {
+            return executionMinCount;
+        }
+
+        SettableFuture<?> getFuture()
+        {
+            return future;
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DataDefinitionExecution.java
@@ -242,6 +242,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public boolean shouldWaitForMinWorkers()
+    {
+        return false;
+    }
+
+    @Override
     public void pruneInfo()
     {
         // no-op

--- a/presto-main/src/main/java/io/prestosql/execution/QueryExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryExecution.java
@@ -72,6 +72,8 @@ public interface QueryExecution
 
     void recordHeartbeat();
 
+    boolean shouldWaitForMinWorkers();
+
     /**
      * Add a listener for the final query info.  This notification is guaranteed to be fired only once.
      * Listener is always notified asynchronously using a dedicated notification thread pool so, care should

--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -254,6 +254,7 @@ public class CoordinatorModule
 
         // node monitor
         binder.bind(ClusterSizeMonitor.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ClusterSizeMonitor.class).withGeneratedName();
 
         // statistics calculator
         binder.install(new StatsCalculatorModule());

--- a/presto-testing/src/main/java/io/prestosql/testing/DistributedQueryRunner.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/DistributedQueryRunner.java
@@ -80,7 +80,7 @@ public class DistributedQueryRunner
 
     private final TestingDiscoveryServer discoveryServer;
     private final TestingPrestoServer coordinator;
-    private final List<TestingPrestoServer> servers;
+    private List<TestingPrestoServer> servers;
 
     private final Closer closer = Closer.create();
 
@@ -139,14 +139,9 @@ public class DistributedQueryRunner
         defaultSession = defaultSession.toSessionRepresentation().toSession(coordinator.getMetadata().getSessionPropertyManager(), defaultSession.getIdentity().getExtraCredentials());
         this.prestoClient = closer.register(new TestingPrestoClient(coordinator, defaultSession));
 
-        long start = System.nanoTime();
-        while (!allNodesGloballyVisible()) {
-            Assertions.assertLessThan(nanosSince(start), new Duration(10, SECONDS));
-            MILLISECONDS.sleep(10);
-        }
-        log.info("Announced servers in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
+        waitForAllNodesGloballyVisible();
 
-        start = System.nanoTime();
+        long start = System.nanoTime();
         for (TestingPrestoServer server : servers) {
             server.getMetadata().addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
         }
@@ -154,12 +149,7 @@ public class DistributedQueryRunner
 
         for (TestingPrestoServer server : servers) {
             // add bogus catalog for testing procedures and session properties
-            Catalog bogusTestingCatalog = createBogusTestingCatalog(TESTING_CATALOG);
-            server.getCatalogManager().registerCatalog(bogusTestingCatalog);
-
-            SessionPropertyManager sessionPropertyManager = server.getMetadata().getSessionPropertyManager();
-            sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
-            sessionPropertyManager.addConnectorSessionProperties(bogusTestingCatalog.getConnectorCatalogName(), TEST_CATALOG_PROPERTIES);
+            addTestingCatalog(server);
         }
     }
 
@@ -186,6 +176,44 @@ public class DistributedQueryRunner
         log.info("Created %s TestingPrestoServer in %s: %s", nodeRole, nanosSince(start).convertToMostSuccinctTimeUnit(), server.getBaseUrl());
 
         return server;
+    }
+
+    public void addServers(int nodeCount)
+            throws Exception
+    {
+        ImmutableList.Builder<TestingPrestoServer> serverBuilder = new ImmutableList.Builder<TestingPrestoServer>()
+                .addAll(servers);
+        for (int i = 0; i < nodeCount; i++) {
+            TestingPrestoServer server = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), false, ImmutableMap.of(), DEFAULT_SQL_PARSER_OPTIONS, ENVIRONMENT, Optional.empty()));
+            serverBuilder.add(server);
+            // add functions
+            server.getMetadata().addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
+            addTestingCatalog(server);
+        }
+        servers = serverBuilder.build();
+        waitForAllNodesGloballyVisible();
+    }
+
+    private void waitForAllNodesGloballyVisible()
+            throws InterruptedException
+    {
+        long start = System.nanoTime();
+        while (!allNodesGloballyVisible()) {
+            Assertions.assertLessThan(nanosSince(start), new Duration(10, SECONDS));
+            MILLISECONDS.sleep(10);
+        }
+        log.info("Announced servers in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    private void addTestingCatalog(TestingPrestoServer server)
+    {
+        // add bogus catalog for testing procedures and session properties
+        Catalog bogusTestingCatalog = createBogusTestingCatalog(TESTING_CATALOG);
+        server.getCatalogManager().registerCatalog(bogusTestingCatalog);
+
+        SessionPropertyManager sessionPropertyManager = server.getMetadata().getSessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
+        sessionPropertyManager.addConnectorSessionProperties(bogusTestingCatalog.getConnectorCatalogName(), TEST_CATALOG_PROPERTIES);
     }
 
     private boolean allNodesGloballyVisible()

--- a/presto-tests/src/test/java/io/prestosql/tests/TestMinWorkerRequirement.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestMinWorkerRequirement.java
@@ -14,11 +14,27 @@
 package io.prestosql.tests;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.prestosql.Session;
+import io.prestosql.execution.QueryInfo;
+import io.prestosql.execution.QueryManager;
 import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.ResultWithQueryId;
 import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
 import org.testng.annotations.Test;
 
+import static io.prestosql.SystemSessionProperties.REQUIRED_WORKERS_COUNT;
+import static io.prestosql.SystemSessionProperties.REQUIRED_WORKERS_MAX_WAIT_TIME;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 // run single threaded to avoid creating multiple query runners at once
@@ -36,7 +52,7 @@ public class TestMinWorkerRequirement
                         .build())
                 .setNodeCount(4)
                 .build()) {
-            queryRunner.execute("SELECT 1");
+            queryRunner.execute("SELECT COUNT(*) from lineitem");
             fail("Expected exception due to insufficient active worker nodes");
         }
     }
@@ -53,8 +69,30 @@ public class TestMinWorkerRequirement
                         .build())
                 .setNodeCount(4)
                 .build()) {
-            queryRunner.execute("SELECT 1");
+            queryRunner.execute("SELECT COUNT(*) from lineitem");
             fail("Expected exception due to insufficient active worker nodes");
+        }
+    }
+
+    @Test
+    public void testInsufficientWorkerNodesInternalSystemQuery()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
+                .setCoordinatorProperties(ImmutableMap.<String, String>builder()
+                        .put("query-manager.required-workers", "5")
+                        .put("query-manager.required-workers-max-wait", "1ns")
+                        .build())
+                .setNodeCount(4)
+                .build()) {
+            queryRunner.execute("SELECT 1");
+            queryRunner.execute("DESCRIBE lineitem");
+            queryRunner.execute("SHOW TABLES");
+            queryRunner.execute("SHOW SCHEMAS");
+            queryRunner.execute("SHOW CATALOGS");
+            queryRunner.execute("SET SESSION required_workers_count=5");
+            queryRunner.execute("SELECT * from system.runtime.nodes");
+            queryRunner.execute("EXPLAIN SELECT count(*) from lineitem");
         }
     }
 
@@ -69,18 +107,136 @@ public class TestMinWorkerRequirement
                         .build())
                 .setNodeCount(4)
                 .build()) {
-            queryRunner.execute("SELECT 1");
+            queryRunner.execute("SELECT COUNT(*) from lineitem");
             assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 4);
 
             try {
-                // Query should still be allowed to run if active workers drop down below the minimum required nodes
+                // Query should not be allowed to run if active workers drop down below the minimum required nodes
                 queryRunner.getServers().get(0).close();
                 assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 3);
-                queryRunner.execute("SELECT 1");
+                queryRunner.execute("SELECT COUNT(*) from lineitem");
+                fail("Expected exception due to insufficient active worker nodes");
             }
             catch (RuntimeException e) {
                 assertEquals(e.getMessage(), "Insufficient active worker nodes. Waited 1.00ns for at least 4 workers, but only 3 workers are active");
             }
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Insufficient active worker nodes. Waited 99.00ns for at least 3 workers, but only 2 workers are active")
+    public void testRequiredNodesMaxWaitSessionOverride()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
+                .setCoordinatorProperties(ImmutableMap.<String, String>builder()
+                        .put("query-manager.required-workers", "3")
+                        .put("query-manager.required-workers-max-wait", "1ns")
+                        .build())
+                .setNodeCount(2)
+                .build()) {
+            Session session = testSessionBuilder()
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "3")
+                    .setSystemProperty(REQUIRED_WORKERS_MAX_WAIT_TIME, "99ns")
+                    .setCatalog("tpch")
+                    .setSchema("tiny")
+                    .build();
+            queryRunner.execute(session, "SELECT COUNT(*) from lineitem");
+            fail("Expected exception due to insufficient active worker nodes");
+        }
+    }
+
+    @Test
+    public void testRequiredWorkerNodesSessionOverride()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
+                .setCoordinatorProperties(ImmutableMap.<String, String>builder()
+                        .put("query-manager.required-workers", "5")
+                        .put("query-manager.required-workers-max-wait", "1ns")
+                        .build())
+                .setNodeCount(4)
+                .build()) {
+            // Query should be allowed to run if session override allows it
+            Session session = testSessionBuilder()
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "4")
+                    .setCatalog("tpch")
+                    .setSchema("tiny")
+                    .build();
+            queryRunner.execute(session, "SELECT COUNT(*) from lineitem");
+
+            // Query should not be allowed to run because we are 2 nodes short of requirement
+            session = Session.builder(session)
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "6")
+                    .build();
+            try {
+                queryRunner.execute(session, "SELECT COUNT(*) from lineitem");
+                fail("Expected exception due to insufficient active worker nodes");
+            }
+            catch (RuntimeException e) {
+                assertEquals(e.getMessage(), "Insufficient active worker nodes. Waited 1.00ns for at least 6 workers, but only 4 workers are active");
+            }
+
+            // After adding 2 nodes, query should run
+            queryRunner.addServers(2);
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 6);
+            queryRunner.execute(session, "SELECT COUNT(*) from lineitem");
+        }
+    }
+
+    @Test
+    public void testMultipleRequiredWorkerNodesSessionOverride()
+            throws Exception
+    {
+        ListeningExecutorService service = MoreExecutors.listeningDecorator(newFixedThreadPool(3));
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().setNodeCount(1).build()) {
+            Session session1 = testSessionBuilder()
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "2")
+                    .setCatalog("tpch")
+                    .setSchema("tiny")
+                    .build();
+            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture1 = service.submit(() -> queryRunner.executeWithQueryId(session1, "SELECT COUNT(*) from lineitem"));
+
+            Session session2 = Session.builder(session1)
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "3")
+                    .build();
+            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture2 = service.submit(() -> queryRunner.executeWithQueryId(session2, "SELECT COUNT(*) from lineitem"));
+
+            Session session3 = Session.builder(session1)
+                    .setSystemProperty(REQUIRED_WORKERS_COUNT, "4")
+                    .build();
+            ListenableFuture<ResultWithQueryId<MaterializedResult>> queryFuture3 = service.submit(() -> queryRunner.executeWithQueryId(session3, "SELECT COUNT(*) from lineitem"));
+
+            MILLISECONDS.sleep(1000);
+            // None of the queries should run
+            assertFalse(queryFuture1.isDone());
+            assertFalse(queryFuture2.isDone());
+            assertFalse(queryFuture3.isDone());
+
+            queryRunner.addServers(1);
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 2);
+            // After adding 1 node, only 1st query should run
+            MILLISECONDS.sleep(1000);
+            assertTrue(queryFuture1.get().getResult().getRowCount() > 0);
+            QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+            QueryInfo completedQueryInfo = queryManager.getFullQueryInfo(queryFuture1.get().getQueryId());
+            assertTrue(completedQueryInfo.getQueryStats().getResourceWaitingTime().roundTo(SECONDS) >= 1);
+
+            assertFalse(queryFuture2.isDone());
+            assertFalse(queryFuture3.isDone());
+
+            // After adding 2 nodes, 2nd and 3rd query should also run
+            queryRunner.addServers(2);
+            assertEquals(queryRunner.getCoordinator().refreshNodes().getActiveNodes().size(), 4);
+            assertTrue(queryFuture2.get().getResult().getRowCount() > 0);
+            completedQueryInfo = queryManager.getFullQueryInfo(queryFuture2.get().getQueryId());
+            assertTrue(completedQueryInfo.getQueryStats().getResourceWaitingTime().roundTo(SECONDS) >= 2);
+
+            assertTrue(queryFuture3.get().getResult().getRowCount() > 0);
+            completedQueryInfo = queryManager.getFullQueryInfo(queryFuture3.get().getQueryId());
+            assertTrue(completedQueryInfo.getQueryStats().getResourceWaitingTime().roundTo(SECONDS) >= 2);
+        }
+        finally {
+            service.shutdown();
         }
     }
 }


### PR DESCRIPTION
Added `required_workers` and `required_workers_max_wait` session properties.
Modified `waitForMinimumWorkers` to avoid waiting for more than 1 node for `set session` statements and queries on system and information schema connectors.
Modified `ClusterSizeMonitor` to support waiting on different number of nodes for each query.
Modified `DistributedQueryRunner` to support adding nodes in tests.