### PR TITLE
Update AWS S3 SDK to 1.11.700 in Kinesis

### DIFF
--- a/presto-kinesis/pom.xml
+++ b/presto-kinesis/pom.xml
@@ -13,9 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <!--TODO: move to latest aws version-->
-        <dep.aws-sdk.version>1.11.12</dep.aws-sdk.version>
-
+        <dep.aws-sdk.version>1.11.700</dep.aws-sdk.version>
     </properties>
 
     <dependencies>
@@ -101,7 +99,18 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>2.10.0</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisConnectorFactory.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisConnectorFactory.java
@@ -41,8 +41,6 @@ public class KinesisConnectorFactory
 {
     public KinesisConnectorFactory()
     {
-        //TODO: Remove this when once aws version is upgraded to latest
-        System.setProperty("com.amazonaws.sdk.disableCbor", "true");
     }
 
     @Override

--- a/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/TestMinimalFunctionality.java
+++ b/presto-kinesis/src/test/java/io/prestosql/plugin/kinesis/TestMinimalFunctionality.java
@@ -100,7 +100,6 @@ public class TestMinimalFunctionality
     public void spinUp(String accessKey, String secretKey)
             throws Exception
     {
-        System.setProperty("com.amazonaws.sdk.disableCbor", "true"); // TODO remove; see comment in KinesisConnectorFactory constructor
         streamName = "test_" + UUID.randomUUID().toString().replaceAll("-", "_");
 
         embeddedKinesisStream.createStream(2, streamName);


### PR DESCRIPTION
Updated AWS version to 1.11.700. After the change, TestMinimalFunctionality and TestS3TableConfigClient works.