### PR TITLE
Remove redundant condition

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -758,7 +758,7 @@ public class QueryStateMachine
     {
         queryStateTimer.beginFinishing();
 
-        if (!queryState.setIf(FINISHING, currentState -> currentState != FINISHING && !currentState.isDone())) {
+        if (!queryState.setIf(FINISHING, currentState -> !currentState.isDone())) {
             return false;
         }
 

--- a/presto-main/src/main/java/io/prestosql/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/StageStateMachine.java
@@ -161,7 +161,7 @@ public class StageStateMachine
 
     public boolean transitionToRunning()
     {
-        return stageState.setIf(RUNNING, currentState -> currentState != RUNNING && !currentState.isDone());
+        return stageState.setIf(RUNNING, currentState -> !currentState.isDone());
     }
 
     public boolean transitionToFinished()


### PR DESCRIPTION
`newState != currentState` is checked in `StateMachine#setIf` directly,
so the callback doesn't need to check this.