### PR TITLE
Support pruning and reordering columns in Join

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/NestedLoopJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/NestedLoopJoinOperator.java
@@ -14,6 +14,7 @@
 package io.prestosql.operator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.execution.Lifespan;
 import io.prestosql.spi.Page;
@@ -42,14 +43,23 @@ public class NestedLoopJoinOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private final JoinBridgeManager<NestedLoopJoinBridge> joinBridgeManager;
+        private final List<Integer> probeChannels;
+        private final List<Integer> buildChannels;
         private boolean closed;
 
-        public NestedLoopJoinOperatorFactory(int operatorId, PlanNodeId planNodeId, JoinBridgeManager<NestedLoopJoinBridge> nestedLoopJoinBridgeManager)
+        public NestedLoopJoinOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                JoinBridgeManager<NestedLoopJoinBridge> nestedLoopJoinBridgeManager,
+                List<Integer> probeChannels,
+                List<Integer> buildChannels)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.joinBridgeManager = nestedLoopJoinBridgeManager;
             this.joinBridgeManager.incrementProbeFactoryCount();
+            this.probeChannels = ImmutableList.copyOf(requireNonNull(probeChannels, "probeChannels is null"));
+            this.buildChannels = ImmutableList.copyOf(requireNonNull(buildChannels, "buildChannels is null"));
         }
 
         private NestedLoopJoinOperatorFactory(NestedLoopJoinOperatorFactory other)
@@ -59,6 +69,9 @@ public class NestedLoopJoinOperator
             this.planNodeId = other.planNodeId;
 
             this.joinBridgeManager = other.joinBridgeManager;
+
+            this.probeChannels = ImmutableList.copyOf(other.probeChannels);
+            this.buildChannels = ImmutableList.copyOf(other.buildChannels);
 
             // closed is intentionally not copied
             closed = false;
@@ -78,6 +91,8 @@ public class NestedLoopJoinOperator
             return new NestedLoopJoinOperator(
                     operatorContext,
                     nestedLoopJoinBridge,
+                    probeChannels,
+                    buildChannels,
                     () -> joinBridgeManager.probeOperatorClosed(driverContext.getLifespan()));
         }
 
@@ -109,6 +124,8 @@ public class NestedLoopJoinOperator
     private final OperatorContext operatorContext;
     private final Runnable afterClose;
 
+    private final List<Integer> probeChannels;
+    private final List<Integer> buildChannels;
     private List<Page> buildPages;
     private Page probePage;
     private Iterator<Page> buildPageIterator;
@@ -116,10 +133,12 @@ public class NestedLoopJoinOperator
     private boolean finishing;
     private boolean closed;
 
-    private NestedLoopJoinOperator(OperatorContext operatorContext, NestedLoopJoinBridge joinBridge, Runnable afterClose)
+    private NestedLoopJoinOperator(OperatorContext operatorContext, NestedLoopJoinBridge joinBridge, List<Integer> probeChannels, List<Integer> buildChannels, Runnable afterClose)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.nestedLoopJoinPagesFuture = joinBridge.getPagesFuture();
+        this.probeChannels = ImmutableList.copyOf(requireNonNull(probeChannels, "probeChannels is null"));
+        this.buildChannels = ImmutableList.copyOf(requireNonNull(buildChannels, "buildChannels is null"));
         this.afterClose = requireNonNull(afterClose, "afterClose is null");
     }
 
@@ -196,7 +215,7 @@ public class NestedLoopJoinOperator
         }
 
         if (buildPageIterator.hasNext()) {
-            nestedLoopPageBuilder = new NestedLoopPageBuilder(probePage, buildPageIterator.next());
+            nestedLoopPageBuilder = new NestedLoopPageBuilder(probePage, buildPageIterator.next(), probeChannels, buildChannels);
             return nestedLoopPageBuilder.next();
         }
 
@@ -225,8 +244,8 @@ public class NestedLoopJoinOperator
     static class NestedLoopPageBuilder
             implements Iterator<Page>
     {
-        private final int numberOfProbeColumns;
-        private final int numberOfBuildColumns;
+        private final List<Integer> probeChannels;
+        private final List<Integer> buildChannels;
         private final boolean buildPageLarger;
         private final Page largePage;
         private final Page smallPage;
@@ -235,14 +254,14 @@ public class NestedLoopJoinOperator
         private int rowIndex; // Iterator on the rows in the page with less rows.
         private final int noColumnShortcutResult; // Only used if select count(*) from cross join.
 
-        NestedLoopPageBuilder(Page probePage, Page buildPage)
+        NestedLoopPageBuilder(Page probePage, Page buildPage, List<Integer> probeChannels, List<Integer> buildChannels)
         {
             requireNonNull(probePage, "probePage is null");
             checkArgument(probePage.getPositionCount() > 0, "probePage has no rows");
             requireNonNull(buildPage, "buildPage is null");
             checkArgument(buildPage.getPositionCount() > 0, "buildPage has no rows");
-            this.numberOfProbeColumns = probePage.getChannelCount();
-            this.numberOfBuildColumns = buildPage.getChannelCount();
+            this.probeChannels = ImmutableList.copyOf(requireNonNull(probeChannels, "probeChannels is null"));
+            this.buildChannels = ImmutableList.copyOf(requireNonNull(buildChannels, "buildChannels is null"));
 
             // We will loop through all rows in the page with less rows.
             this.rowIndex = -1;
@@ -251,7 +270,7 @@ public class NestedLoopJoinOperator
             this.largePage = buildPageLarger ? buildPage : probePage;
             this.smallPage = buildPageLarger ? probePage : buildPage;
 
-            this.noColumnShortcutResult = calculateUseNoColumnShortcut(numberOfProbeColumns, numberOfBuildColumns, probePage.getPositionCount(), buildPage.getPositionCount());
+            this.noColumnShortcutResult = calculateUseNoColumnShortcut(probeChannels.size(), buildChannels.size(), probePage.getPositionCount(), buildPage.getPositionCount());
         }
 
         private static int calculateUseNoColumnShortcut(
@@ -292,23 +311,27 @@ public class NestedLoopJoinOperator
 
             rowIndex++;
 
-            // Create an array of blocks for all columns in both pages.
-            Block[] blocks = new Block[numberOfProbeColumns + numberOfBuildColumns];
+            // Create an array of blocks for required columns from both pages.
+            Block[] blocks = new Block[probeChannels.size() + buildChannels.size()];
 
             // Make sure we always put the probe data on the left and build data on the right.
-            int indexForRleBlocks = buildPageLarger ? 0 : numberOfProbeColumns;
-            int indexForPageBlocks = buildPageLarger ? numberOfProbeColumns : 0;
+            int indexForRleBlocks = buildPageLarger ? 0 : probeChannels.size();
+            int indexForPageBlocks = buildPageLarger ? probeChannels.size() : 0;
+
+            List<Integer> smallPageChannels = buildPageLarger ? probeChannels : buildChannels;
+            List<Integer> largePageChannels = buildPageLarger ? buildChannels : probeChannels;
 
             // For the page with less rows, create RLE blocks and add them to the blocks array
-            for (int i = 0; i < smallPage.getChannelCount(); i++) {
-                Block block = smallPage.getBlock(i).getSingleValueBlock(rowIndex);
+            for (int channel : smallPageChannels) {
+                Block block = smallPage.getBlock(channel).getSingleValueBlock(rowIndex);
                 blocks[indexForRleBlocks] = new RunLengthEncodedBlock(block, largePage.getPositionCount());
                 indexForRleBlocks++;
             }
 
-            // Put the page with more rows in the blocks array
-            for (int i = 0; i < largePage.getChannelCount(); i++) {
-                blocks[indexForPageBlocks + i] = largePage.getBlock(i);
+            // Put the required blocks from the page with more rows in the blocks array
+            for (int channel : largePageChannels) {
+                blocks[indexForPageBlocks] = largePage.getBlock(channel);
+                indexForPageBlocks++;
             }
 
             return new Page(largePage.getPositionCount(), blocks);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -1796,17 +1796,29 @@ public class LocalExecutionPlanner
                     buildContext.getDriverInstanceCount(),
                     buildSource.getPipelineExecutionStrategy());
 
-            ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
-            outputMappings.putAll(probeSource.getLayout());
+            // Extract probe and build symbols required for output, in their required order
+            List<Symbol> probeSymbols = node.getOutputSymbols().stream()
+                    .filter(ImmutableSet.copyOf(node.getLeft().getOutputSymbols())::contains)
+                    .collect(toImmutableList());
+            List<Symbol> buildSymbols = node.getOutputSymbols().stream()
+                    .filter(ImmutableSet.copyOf(node.getRight().getOutputSymbols())::contains)
+                    .collect(toImmutableList());
 
-            // inputs from build side of the join are laid out following the input from the probe side,
-            // so adjust the channel ids but keep the field layouts intact
-            int offset = probeSource.getTypes().size();
-            for (Map.Entry<Symbol, Integer> entry : buildSource.getLayout().entrySet()) {
-                outputMappings.put(entry.getKey(), offset + entry.getValue());
+            // NestedLoopJoinOperator returns probe data on the left and build data on the right.
+            // Need to map output symbols accordingly to the actual order of channels.
+            ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
+            List<Symbol> symbolsInOrderOfOperatorOutput = ImmutableList.<Symbol>builder()
+                    .addAll(probeSymbols)
+                    .addAll(buildSymbols)
+                    .build();
+            for (int i = 0; i < symbolsInOrderOfOperatorOutput.size(); i++) {
+                outputMappings.put(symbolsInOrderOfOperatorOutput.get(i), i);
             }
 
-            OperatorFactory operatorFactory = new NestedLoopJoinOperatorFactory(context.getNextOperatorId(), node.getId(), nestedLoopJoinBridgeManager);
+            List<Integer> probeChannels = getChannelsForSymbols(probeSymbols, probeSource.getLayout());
+            List<Integer> buildChannels = getChannelsForSymbols(buildSymbols, buildSource.getLayout());
+
+            OperatorFactory operatorFactory = new NestedLoopJoinOperatorFactory(context.getNextOperatorId(), node.getId(), nestedLoopJoinBridgeManager, probeChannels, buildChannels);
             return new PhysicalOperation(operatorFactory, outputMappings.build(), context, probeSource);
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -1957,11 +1957,15 @@ public class LocalExecutionPlanner
 
             OperatorFactory operator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, lookupSourceFactory, context, spillEnabled);
 
+            // LookupJoinOperator returns probe data on the left and build data on the right.
+            // Need to map output symbols accordingly to the actual order of channels.
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
-            List<Symbol> outputSymbols = node.getOutputSymbols();
-            for (int i = 0; i < outputSymbols.size(); i++) {
-                Symbol symbol = outputSymbols.get(i);
-                outputMappings.put(symbol, i);
+            List<Symbol> symbolsInOrderOfOperatorOutput = ImmutableList.<Symbol>builder()
+                    .addAll(extractJoinOutputsFromSource(node, node.getLeft()))
+                    .addAll(extractJoinOutputsFromSource(node, node.getRight()))
+                    .build();
+            for (int i = 0; i < symbolsInOrderOfOperatorOutput.size(); i++) {
+                outputMappings.put(symbolsInOrderOfOperatorOutput.get(i), i);
             }
 
             return new PhysicalOperation(operator, outputMappings.build(), context, probeSource);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
@@ -106,7 +106,6 @@ public class JoinNode
                 .addAll(rightSymbols)
                 .build();
         checkArgument(new HashSet<>(inputSymbols).containsAll(outputSymbols), "Left and right join inputs do not contain all output symbols");
-        checkArgument(!isCrossJoin() || inputSymbols.size() == outputSymbols.size(), "Cross join does not support output symbols pruning or reordering");
 
         checkArgument(!(criteria.isEmpty() && leftHashSymbol.isPresent()), "Left hash symbol is only valid in an equijoin");
         checkArgument(!(criteria.isEmpty() && rightHashSymbol.isPresent()), "Right hash symbol is only valid in an equijoin");

--- a/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -69,14 +69,11 @@ import io.prestosql.sql.planner.plan.WindowNode;
 import io.prestosql.sql.tree.Expression;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -363,7 +360,6 @@ public final class ValidateDependenciesChecker
                         allInputs);
             });
 
-            checkLeftOutputSymbolsBeforeRight(node.getLeft().getOutputSymbols(), node.getOutputSymbols());
             return null;
         }
 
@@ -406,25 +402,7 @@ public final class ValidateDependenciesChecker
                     predicateSymbols,
                     allInputs);
 
-            checkLeftOutputSymbolsBeforeRight(node.getLeft().getOutputSymbols(), node.getOutputSymbols());
             return null;
-        }
-
-        private void checkLeftOutputSymbolsBeforeRight(List<Symbol> leftSymbols, List<Symbol> outputSymbols)
-        {
-            int leftMaxPosition = -1;
-            Optional<Integer> rightMinPosition = Optional.empty();
-            Set<Symbol> leftSymbolsSet = new HashSet<>(leftSymbols);
-            for (int i = 0; i < outputSymbols.size(); i++) {
-                Symbol symbol = outputSymbols.get(i);
-                if (leftSymbolsSet.contains(symbol)) {
-                    leftMaxPosition = i;
-                }
-                else if (!rightMinPosition.isPresent()) {
-                    rightMinPosition = Optional.of(i);
-                }
-            }
-            checkState(!rightMinPosition.isPresent() || rightMinPosition.get() > leftMaxPosition, "Not all left output symbols are before right output symbols");
         }
 
         @Override


### PR DESCRIPTION
Adds support for columns pruning in cross join.
Adds support for arbitrary order of outputColumns in SpatialJoinNode and JoinNode of any join type.