### PR TITLE
Optionally allow creating external tables with data

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1173,7 +1173,7 @@ public class HiveMetadata
     {
         verifyJvmTimeZone();
 
-        if (getExternalLocation(tableMetadata.getProperties()) != null) {
+        if (!writesToNonManagedTablesEnabled && getExternalLocation(tableMetadata.getProperties()) != null) {
             throw new PrestoException(NOT_SUPPORTED, "External tables cannot be created using CREATE TABLE AS");
         }
 


### PR DESCRIPTION
Currently it's possible to create an external table and then `INSERT`
into it (when `hive.non-managed-table-writes-enabled` is set). This
provides for consistent behavior when the operation is done in one step
("CTAS").