### PR TITLE
Add support for CREATE VIEW with comment

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1722,6 +1722,7 @@ public class HiveMetadata
                                 definition.getCatalog(),
                                 definition.getSchema(),
                                 definition.getColumns(),
+                                definition.getComment(),
                                 Optional.of(view.getOwner()),
                                 false);
                     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -3002,6 +3002,7 @@ public abstract class AbstractTestHive
                 Optional.empty(),
                 ImmutableList.of(new ViewColumn("test", BIGINT.getTypeId())),
                 Optional.empty(),
+                Optional.empty(),
                 true);
 
         try (Transaction transaction = newTransaction()) {

--- a/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
@@ -95,6 +95,7 @@ public class CreateViewTask
                 session.getCatalog(),
                 session.getSchema(),
                 columns,
+                statement.getComment(),
                 owner,
                 !owner.isPresent());
 

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
@@ -443,7 +443,7 @@ final class ShowQueriesRewrite
 
                 accessControl.checkCanShowColumnsMetadata(session.toSecurityContext(), new CatalogSchemaTableName(catalogName.getValue(), new SchemaTableName(schemaName.getValue(), tableName.getValue())));
 
-                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, Optional.empty())).trim();
+                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, viewDefinition.get().getComment(), Optional.empty())).trim();
                 return singleValueQuery("Create View", sql);
             }
 

--- a/presto-main/src/test/java/io/prestosql/metadata/TestInformationSchemaMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/TestInformationSchemaMetadata.java
@@ -77,6 +77,7 @@ public class TestInformationSchemaMetadata
                             Optional.of("test_catalog"),
                             Optional.of("test_schema"),
                             ImmutableList.of(new ViewColumn("test", BIGINT.getTypeId())),
+                            Optional.of("comment"),
                             Optional.empty(),
                             true);
                     SchemaTableName viewName = new SchemaTableName("test_schema", "test_view");

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -2108,6 +2108,7 @@ public class TestAnalyzer
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
+                Optional.of("comment"),
                 Optional.of("user"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v1"), viewData1, false));
@@ -2118,6 +2119,7 @@ public class TestAnalyzer
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", VARCHAR.getTypeId())),
+                Optional.of("comment"),
                 Optional.of("user"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2"), viewData2, false));
@@ -2128,6 +2130,7 @@ public class TestAnalyzer
                 Optional.of(SECOND_CATALOG),
                 Optional.of("s2"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
+                Optional.of("comment"),
                 Optional.of("owner"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(THIRD_CATALOG, "s3", "v3"), viewData3, false));
@@ -2138,6 +2141,7 @@ public class TestAnalyzer
                 Optional.of("tpch"),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
+                Optional.of("comment"),
                 Optional.of("user"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName("tpch", "s1", "v4"), viewData4, false));
@@ -2148,6 +2152,7 @@ public class TestAnalyzer
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
+                Optional.of("comment"),
                 Optional.of("user"),
                 false);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, false));

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemoryMetadata.java
@@ -345,6 +345,7 @@ public class TestMemoryMetadata
                 Optional.empty(),
                 ImmutableList.of(new ViewColumn("test", BIGINT.getTypeId())),
                 Optional.empty(),
+                Optional.empty(),
                 true);
     }
 }

--- a/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
@@ -63,6 +63,7 @@ statement
         ADD COLUMN column=columnDefinition                             #addColumn
     | ANALYZE qualifiedName (WITH properties)?                         #analyze
     | CREATE (OR REPLACE)? VIEW qualifiedName
+        (COMMENT string)?
         (SECURITY (DEFINER | INVOKER))? AS query                       #createView
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
     | ALTER VIEW from=qualifiedName RENAME TO to=qualifiedName         #renameView

--- a/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
@@ -592,6 +592,10 @@ public final class SqlFormatter
             builder.append("VIEW ")
                     .append(formatName(node.getName()));
 
+            node.getComment().ifPresent(comment ->
+                    builder.append(" COMMENT ")
+                            .append(formatStringLiteral(comment)));
+
             node.getSecurity().ifPresent(security ->
                     builder.append(" SECURITY ")
                             .append(security.toString()));

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
@@ -429,6 +429,11 @@ class AstBuilder
     @Override
     public Node visitCreateView(SqlBaseParser.CreateViewContext context)
     {
+        Optional<String> comment = Optional.empty();
+        if (context.COMMENT() != null) {
+            comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
+        }
+
         Optional<CreateView.Security> security = Optional.empty();
         if (context.DEFINER() != null) {
             security = Optional.of(CreateView.Security.DEFINER);
@@ -442,6 +447,7 @@ class AstBuilder
                 getQualifiedName(context.qualifiedName()),
                 (Query) visit(context.query()),
                 context.REPLACE() != null,
+                comment,
                 security);
     }
 

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/CreateView.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/CreateView.java
@@ -33,24 +33,26 @@ public class CreateView
     private final QualifiedName name;
     private final Query query;
     private final boolean replace;
+    private final Optional<String> comment;
     private final Optional<Security> security;
 
-    public CreateView(QualifiedName name, Query query, boolean replace, Optional<Security> security)
+    public CreateView(QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
     {
-        this(Optional.empty(), name, query, replace, security);
+        this(Optional.empty(), name, query, replace, comment, security);
     }
 
-    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<Security> security)
+    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
     {
-        this(Optional.of(location), name, query, replace, security);
+        this(Optional.of(location), name, query, replace, comment, security);
     }
 
-    private CreateView(Optional<NodeLocation> location, QualifiedName name, Query query, boolean replace, Optional<Security> security)
+    private CreateView(Optional<NodeLocation> location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.query = requireNonNull(query, "query is null");
         this.replace = replace;
+        this.comment = requireNonNull(comment, "comment is null");
         this.security = requireNonNull(security, "security is null");
     }
 
@@ -67,6 +69,11 @@ public class CreateView
     public boolean isReplace()
     {
         return replace;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
     }
 
     public Optional<Security> getSecurity()
@@ -105,6 +112,7 @@ public class CreateView
         return Objects.equals(name, o.name)
                 && Objects.equals(query, o.query)
                 && Objects.equals(replace, o.replace)
+                && Objects.equals(comment, o.comment)
                 && Objects.equals(security, o.security);
     }
 
@@ -115,6 +123,7 @@ public class CreateView
                 .add("name", name)
                 .add("query", query)
                 .add("replace", replace)
+                .add("comment", comment)
                 .add("security", security)
                 .toString();
     }

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
@@ -1585,15 +1585,21 @@ public class TestSqlParser
     {
         Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")));
 
-        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty()));
-        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, true, Optional.empty()));
+        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty()));
+        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, true, Optional.empty(), Optional.empty()));
 
-        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(CreateView.Security.DEFINER)));
-        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(CreateView.Security.INVOKER)));
+        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.DEFINER)));
+        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.INVOKER)));
 
-        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(QualifiedName.of("bar", "foo"), query, false, Optional.empty()));
-        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome view"), query, false, Optional.empty()));
-        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty()));
+        assertStatement("CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.of(CreateView.Security.DEFINER)));
+        assertStatement("CREATE VIEW a COMMENT '' SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.of(CreateView.Security.INVOKER)));
+
+        assertStatement("CREATE VIEW a COMMENT 'comment' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.empty()));
+        assertStatement("CREATE VIEW a COMMENT '' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.empty()));
+
+        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(QualifiedName.of("bar", "foo"), query, false, Optional.empty(), Optional.empty()));
+        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome view"), query, false, Optional.empty(), Optional.empty()));
+        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty(), Optional.empty()));
     }
 
     @Test

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
@@ -842,6 +842,7 @@ public class TestRaptorMetadata
                 Optional.empty(),
                 ImmutableList.of(new ViewColumn("test", BIGINT.getTypeId())),
                 Optional.empty(),
+                Optional.empty(),
                 true);
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorViewDefinition.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorViewDefinition.java
@@ -31,6 +31,7 @@ public class ConnectorViewDefinition
     private final Optional<String> catalog;
     private final Optional<String> schema;
     private final List<ViewColumn> columns;
+    private final Optional<String> comment;
     private final Optional<String> owner;
     private final boolean runAsInvoker;
 
@@ -40,6 +41,7 @@ public class ConnectorViewDefinition
             @JsonProperty("catalog") Optional<String> catalog,
             @JsonProperty("schema") Optional<String> schema,
             @JsonProperty("columns") List<ViewColumn> columns,
+            @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("runAsInvoker") boolean runAsInvoker)
     {
@@ -47,6 +49,7 @@ public class ConnectorViewDefinition
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.columns = unmodifiableList(new ArrayList<>(requireNonNull(columns, "columns is null")));
+        this.comment = requireNonNull(comment, "comment is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.runAsInvoker = runAsInvoker;
         if (!catalog.isPresent() && schema.isPresent()) {
@@ -85,6 +88,12 @@ public class ConnectorViewDefinition
     }
 
     @JsonProperty
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
+    @JsonProperty
     public Optional<String> getOwner()
     {
         return owner;
@@ -101,6 +110,7 @@ public class ConnectorViewDefinition
     {
         StringJoiner joiner = new StringJoiner(", ", "[", "]");
         owner.ifPresent(value -> joiner.add("owner=" + value));
+        comment.ifPresent(value -> joiner.add("comment=" + value));
         joiner.add("runAsInvoker=" + runAsInvoker);
         joiner.add("columns=" + columns);
         catalog.ifPresent(value -> joiner.add("catalog=" + value));

--- a/presto-spi/src/test/java/io/prestosql/spi/connector/TestConnectorViewDefinition.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/connector/TestConnectorViewDefinition.java
@@ -71,6 +71,14 @@ public class TestConnectorViewDefinition
     }
 
     @Test
+    public void testViewComment()
+    {
+        ConnectorViewDefinition view = CODEC.fromJson("{" + BASE_JSON + ", \"comment\": \"hello\"}");
+        assertBaseView(view);
+        assertEquals(view.getComment(), Optional.of("hello"));
+    }
+
+    @Test
     public void testViewSecurityDefiner()
     {
         ConnectorViewDefinition view = CODEC.fromJson("{" + BASE_JSON + ", \"owner\": \"abc\", \"runAsInvoker\": false}");
@@ -98,6 +106,7 @@ public class TestConnectorViewDefinition
                 ImmutableList.of(
                         new ViewColumn("abc", BIGINT.getTypeId()),
                         new ViewColumn("xyz", new ArrayType(createVarcharType(32)).getTypeId())),
+                Optional.of("comment"),
                 Optional.of("test_owner"),
                 false));
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -702,7 +702,14 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("CREATE VIEW test_view AS SELECT 123 x");
         assertUpdate("CREATE OR REPLACE VIEW test_view AS " + query);
 
+        assertUpdate("CREATE VIEW test_view_with_comment COMMENT 'orders' AS SELECT 123 x");
+        assertUpdate("CREATE OR REPLACE VIEW test_view_with_comment COMMENT 'orders' AS " + query);
+
+        MaterializedResult materializedRows = computeActual("SHOW CREATE VIEW test_view_with_comment");
+        assertTrue(materializedRows.getMaterializedRows().get(0).getField(0).toString().contains("COMMENT 'orders'"));
+
         assertQuery("SELECT * FROM test_view", query);
+        assertQuery("SELECT * FROM test_view_with_comment", query);
 
         assertQuery(
                 "SELECT * FROM test_view a JOIN test_view b on a.orderkey = b.orderkey",
@@ -714,6 +721,7 @@ public abstract class AbstractTestDistributedQueries
         assertQuery("SELECT * FROM " + name, query);
 
         assertUpdate("DROP VIEW test_view");
+        assertUpdate("DROP VIEW test_view_with_comment");
     }
 
     @Test


### PR DESCRIPTION
Related to #2241

```g4
    | CREATE (OR REPLACE)? VIEW qualifiedName
        (COMMENT string)?
        (SECURITY (DEFINER | INVOKER))? AS query                       #createView
```