### PR TITLE
Add callback in FileSingleStreamSpiller to clear Factory cache on disk error

### DIFF
--- a/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpiller.java
@@ -71,6 +71,8 @@ public class FileSingleStreamSpiller
     private long spilledPagesInMemorySize;
     private ListenableFuture<?> spillInProgress = Futures.immediateFuture(null);
 
+    private final Runnable fileSystemErrorHandler;
+
     public FileSingleStreamSpiller(
             PagesSerde serde,
             ListeningExecutorService executor,
@@ -78,7 +80,8 @@ public class FileSingleStreamSpiller
             SpillerStats spillerStats,
             SpillContext spillContext,
             LocalMemoryContext memoryContext,
-            Optional<SpillCipher> spillCipher)
+            Optional<SpillCipher> spillCipher,
+            Runnable fileSystemErrorHandler)
     {
         this.serde = requireNonNull(serde, "serde is null");
         this.executor = requireNonNull(executor, "executor is null");
@@ -99,10 +102,12 @@ public class FileSingleStreamSpiller
         // before/after the spiller thread allocates that memory -- -- whether before or after depends on whether writePages() is in the
         // middle of execution when close() is called (note that this applies to both readPages() and writePages() methods).
         this.memoryContext.setBytes(BUFFER_SIZE);
+        this.fileSystemErrorHandler = requireNonNull(fileSystemErrorHandler, "filesystemErrorHandler is null");
         try {
             this.targetFile = closer.register(new FileHolder(Files.createTempFile(spillPath, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX)));
         }
         catch (IOException e) {
+            this.fileSystemErrorHandler.run();
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to create spill file", e);
         }
     }
@@ -150,6 +155,7 @@ public class FileSingleStreamSpiller
             }
         }
         catch (UncheckedIOException | IOException e) {
+            fileSystemErrorHandler.run();
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to spill pages", e);
         }
     }
@@ -165,6 +171,7 @@ public class FileSingleStreamSpiller
             return closeWhenExhausted(pages, input);
         }
         catch (IOException e) {
+            fileSystemErrorHandler.run();
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);
         }
     }
@@ -178,6 +185,7 @@ public class FileSingleStreamSpiller
             closer.close();
         }
         catch (IOException e) {
+            fileSystemErrorHandler.run();
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to close spiller", e);
         }
     }

--- a/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpillerFactory.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpillerFactory.java
@@ -168,7 +168,15 @@ public class FileSingleStreamSpillerFactory
             spillCipher = Optional.of(new AesSpillCipher());
         }
         PagesSerde serde = serdeFactory.createPagesSerdeForSpill(spillCipher);
-        return new FileSingleStreamSpiller(serde, executor, getNextSpillPath(), spillerStats, spillContext, memoryContext, spillCipher);
+        return new FileSingleStreamSpiller(
+                serde,
+                executor,
+                getNextSpillPath(),
+                spillerStats,
+                spillContext,
+                memoryContext,
+                spillCipher,
+                spillPathHealthCache::invalidateAll);
     }
 
     private synchronized Path getNextSpillPath()
@@ -214,5 +222,11 @@ public class FileSingleStreamSpillerFactory
             log.warn(e, "Health check failed for spill %s", path);
             return false;
         }
+    }
+
+    @VisibleForTesting
+    long getSpillPathCacheSize()
+    {
+        return spillPathHealthCache.size();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -81,14 +81,7 @@ public class TestFileSingleStreamSpillerFactory
     {
         List<Type> types = ImmutableList.of(BIGINT);
         List<Path> spillPaths = ImmutableList.of(spillPath1.toPath(), spillPath2.toPath());
-        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
-                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
-                blockEncodingSerde,
-                new SpillerStats(),
-                spillPaths,
-                1.0,
-                false,
-                false);
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 0);
         assertEquals(listFiles(spillPath2.toPath()).size(), 0);
@@ -114,14 +107,7 @@ public class TestFileSingleStreamSpillerFactory
     {
         List<Type> types = ImmutableList.of(BIGINT);
         List<Path> spillPaths = ImmutableList.of(spillPath1.toPath(), spillPath2.toPath());
-        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
-                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
-                blockEncodingSerde,
-                new SpillerStats(),
-                spillPaths,
-                1.0,
-                false,
-                false);
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 0);
         assertEquals(listFiles(spillPath2.toPath()).size(), 0);
@@ -159,14 +145,7 @@ public class TestFileSingleStreamSpillerFactory
     {
         List<Type> types = ImmutableList.of(BIGINT);
         List<Path> spillPaths = ImmutableList.of(spillPath1.toPath(), spillPath2.toPath());
-        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
-                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
-                blockEncodingSerde,
-                new SpillerStats(),
-                spillPaths,
-                0.0,
-                false,
-                false);
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths, 0.0);
 
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
@@ -176,14 +155,8 @@ public class TestFileSingleStreamSpillerFactory
     {
         List<Path> spillPaths = emptyList();
         List<Type> types = ImmutableList.of(BIGINT);
-        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
-                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
-                blockEncodingSerde,
-                new SpillerStats(),
-                spillPaths,
-                1.0,
-                false,
-                false);
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
+
         spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
 
@@ -205,17 +178,27 @@ public class TestFileSingleStreamSpillerFactory
         assertEquals(listFiles(spillPath1.toPath()).size(), 3);
         assertEquals(listFiles(spillPath2.toPath()).size(), 3);
 
-        FileSingleStreamSpillerFactory spillerFactory = new FileSingleStreamSpillerFactory(
-                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
-                blockEncodingSerde,
-                new SpillerStats(),
-                spillPaths,
-                1.0,
-                false,
-                false);
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
         spillerFactory.cleanupOldSpillFiles();
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 1);
         assertEquals(listFiles(spillPath2.toPath()).size(), 2);
+    }
+
+    private FileSingleStreamSpillerFactory spillerFactoryFactory(List<Path> paths)
+    {
+        return spillerFactoryFactory(paths, 1.0);
+    }
+
+    private FileSingleStreamSpillerFactory spillerFactoryFactory(List<Path> paths, Double maxUsedSpaceThreshold)
+    {
+        return new FileSingleStreamSpillerFactory(
+                executor, // executor won't be closed, because we don't call destroy() on the spiller factory
+                blockEncodingSerde,
+                new SpillerStats(),
+                paths,
+                maxUsedSpaceThreshold,
+                false,
+                false);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestFileSingleStreamSpillerFactory.java
@@ -45,6 +45,7 @@ import static io.prestosql.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_PRE
 import static io.prestosql.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_SUFFIX;
 import static java.nio.file.Files.setPosixFilePermissions;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
@@ -183,6 +184,73 @@ public class TestFileSingleStreamSpillerFactory
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 1);
         assertEquals(listFiles(spillPath2.toPath()).size(), 2);
+    }
+
+    @Test
+    public void testCacheInvalidatedOnBadDisk()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT);
+        List<Path> spillPaths = ImmutableList.of(spillPath1.toPath(), spillPath2.toPath());
+
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
+
+        assertEquals(listFiles(spillPath1.toPath()).size(), 0);
+        assertEquals(listFiles(spillPath2.toPath()).size(), 0);
+
+        Page page = buildPage();
+        List<SingleStreamSpiller> spillers = new ArrayList<>();
+
+        SingleStreamSpiller singleStreamSpiller = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
+        getUnchecked(singleStreamSpiller.spill(page));
+        spillers.add(singleStreamSpiller);
+
+        SingleStreamSpiller singleStreamSpiller2 = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
+        // Set second spiller path to read-only after initialization to emulate a disk failing during runtime
+        setPosixFilePermissions(spillPath2.toPath(), ImmutableSet.of(PosixFilePermission.OWNER_READ));
+
+        assertThatThrownBy(() -> { getUnchecked(singleStreamSpiller2.spill(page)); })
+                .isInstanceOf(com.google.common.util.concurrent.UncheckedExecutionException.class)
+                .hasMessageContaining("Failed to spill pages");
+        spillers.add(singleStreamSpiller2);
+
+        assertEquals(spillerFactory.getSpillPathCacheSize(), 0, "cache still contains entries");
+
+        // restore permissions to allow cleanup
+        setPosixFilePermissions(spillPath2.toPath(), ImmutableSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE));
+        spillers.forEach(SingleStreamSpiller::close);
+        assertEquals(listFiles(spillPath1.toPath()).size(), 0);
+        assertEquals(listFiles(spillPath2.toPath()).size(), 0);
+    }
+
+    @Test
+    public void testCacheFull()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT);
+        List<Path> spillPaths = ImmutableList.of(spillPath1.toPath(), spillPath2.toPath());
+
+        FileSingleStreamSpillerFactory spillerFactory = spillerFactoryFactory(spillPaths);
+
+        assertEquals(listFiles(spillPath1.toPath()).size(), 0);
+        assertEquals(listFiles(spillPath2.toPath()).size(), 0);
+
+        Page page = buildPage();
+        List<SingleStreamSpiller> spillers = new ArrayList<>();
+
+        SingleStreamSpiller singleStreamSpiller = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
+        getUnchecked(singleStreamSpiller.spill(page));
+        spillers.add(singleStreamSpiller);
+
+        SingleStreamSpiller singleStreamSpiller2 = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
+        getUnchecked(singleStreamSpiller2.spill(page));
+        spillers.add(singleStreamSpiller2);
+
+        assertEquals(spillerFactory.getSpillPathCacheSize(), 2, "cache contains no entries");
+
+        spillers.forEach(SingleStreamSpiller::close);
+        assertEquals(listFiles(spillPath1.toPath()).size(), 0);
+        assertEquals(listFiles(spillPath2.toPath()).size(), 0);
     }
 
     private FileSingleStreamSpillerFactory spillerFactoryFactory(List<Path> paths)


### PR DESCRIPTION
Follow up work to #2444 

Not married to the callback structure. It seemed the most efficient way to get it done without refactoring a bunch of code. If a better way comes to mind, let me know.