### PR TITLE
Add support for money type in PostgreSQL connector

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -79,8 +79,6 @@ public final class StandardColumnMappings
 {
     private StandardColumnMappings() {}
 
-    private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
-
     public static ColumnMapping booleanColumnMapping()
     {
         return ColumnMapping.booleanMapping(BOOLEAN, ResultSet::getBoolean, booleanWriteFunction());


### PR DESCRIPTION
Previously, money values were mapped as double and reading would fail
for values great or equal to one thousand.

Relates to https://github.com/pgjdbc/pgjdbc/issues/425