### PR TITLE
Refactor StateMachine to use Predicate<T> instead of Set<T> of terminal states

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/QueryState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryState.java
@@ -13,11 +13,6 @@
  */
 package io.prestosql.execution;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 public enum QueryState
 {
     /**
@@ -56,8 +51,6 @@ public enum QueryState
      * Query execution failed.
      */
     FAILED(true);
-
-    public static final Set<QueryState> TERMINAL_QUERY_STATES = Stream.of(QueryState.values()).filter(QueryState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
 

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -80,7 +80,6 @@ import static io.prestosql.execution.QueryState.PLANNING;
 import static io.prestosql.execution.QueryState.QUEUED;
 import static io.prestosql.execution.QueryState.RUNNING;
 import static io.prestosql.execution.QueryState.STARTING;
-import static io.prestosql.execution.QueryState.TERMINAL_QUERY_STATES;
 import static io.prestosql.execution.QueryState.WAITING_FOR_RESOURCES;
 import static io.prestosql.execution.StageInfo.getAllStages;
 import static io.prestosql.memory.LocalMemoryManager.GENERAL_POOL;
@@ -173,7 +172,7 @@ public class QueryStateMachine
         this.queryStateTimer = new QueryStateTimer(ticker);
         this.metadata = requireNonNull(metadata, "metadata is null");
 
-        this.queryState = new StateMachine<>("query " + query, executor, QUEUED, TERMINAL_QUERY_STATES);
+        this.queryState = new StateMachine<>("query " + query, executor, QUEUED, QueryState::isDone);
         this.finalQueryInfo = new StateMachine<>("finalQueryInfo-" + queryId, executor, Optional.empty());
         this.outputManager = new QueryOutputManager(executor);
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");

--- a/presto-main/src/main/java/io/prestosql/execution/StageState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/StageState.java
@@ -13,11 +13,7 @@
  */
 package io.prestosql.execution;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 public enum StageState
 {
@@ -60,8 +56,6 @@ public enum StageState
      * Stage execution failed.
      */
     FAILED(true, true);
-
-    public static final Set<StageState> TERMINAL_STAGE_STATES = Stream.of(StageState.values()).filter(StageState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
     private final boolean failureState;

--- a/presto-main/src/main/java/io/prestosql/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/StageStateMachine.java
@@ -61,7 +61,6 @@ import static io.prestosql.execution.StageState.RUNNING;
 import static io.prestosql.execution.StageState.SCHEDULED;
 import static io.prestosql.execution.StageState.SCHEDULING;
 import static io.prestosql.execution.StageState.SCHEDULING_SPLITS;
-import static io.prestosql.execution.StageState.TERMINAL_STAGE_STATES;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
@@ -107,7 +106,7 @@ public class StageStateMachine
         this.tables = ImmutableMap.copyOf(requireNonNull(tables, "tables is null"));
         this.scheduledStats = requireNonNull(schedulerStats, "schedulerStats is null");
 
-        stageState = new StateMachine<>("stage " + stageId, executor, PLANNED, TERMINAL_STAGE_STATES);
+        stageState = new StateMachine<>("stage " + stageId, executor, PLANNED, StageState::isDone);
         stageState.addStateChangeListener(state -> log.debug("Stage %s is %s", stageId, state));
 
         finalStageInfo = new StateMachine<>("final stage " + stageId, executor, Optional.empty());

--- a/presto-main/src/main/java/io/prestosql/execution/TaskState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/TaskState.java
@@ -13,11 +13,6 @@
  */
 package io.prestosql.execution;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 public enum TaskState
 {
     /**
@@ -47,8 +42,6 @@ public enum TaskState
      * Task execution failed.
      */
     FAILED(true);
-
-    public static final Set<TaskState> TERMINAL_TASK_STATES = Stream.of(TaskState.values()).filter(TaskState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
 

--- a/presto-main/src/main/java/io/prestosql/execution/TaskStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/TaskStateMachine.java
@@ -26,7 +26,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
-import static io.prestosql.execution.TaskState.TERMINAL_TASK_STATES;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -43,7 +42,7 @@ public class TaskStateMachine
     public TaskStateMachine(TaskId taskId, Executor executor)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
-        taskState = new StateMachine<>("task " + taskId, executor, TaskState.RUNNING, TERMINAL_TASK_STATES);
+        taskState = new StateMachine<>("task " + taskId, executor, TaskState.RUNNING, TaskState::isDone);
         taskState.addStateChangeListener(new StateChangeListener<TaskState>()
         {
             @Override

--- a/presto-main/src/main/java/io/prestosql/execution/buffer/BufferState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/BufferState.java
@@ -13,11 +13,6 @@
  */
 package io.prestosql.execution.buffer;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 public enum BufferState
 {
     /**
@@ -53,8 +48,6 @@ public enum BufferState
      * This is the terminal state.
      */
     FAILED(false, false, true);
-
-    public static final Set<BufferState> TERMINAL_BUFFER_STATES = Stream.of(BufferState.values()).filter(BufferState::isTerminal).collect(toImmutableSet());
 
     private final boolean newPagesAllowed;
     private final boolean newBuffersAllowed;

--- a/presto-main/src/main/java/io/prestosql/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/LazyOutputBuffer.java
@@ -40,7 +40,6 @@ import static io.prestosql.execution.buffer.BufferResult.emptyResults;
 import static io.prestosql.execution.buffer.BufferState.FAILED;
 import static io.prestosql.execution.buffer.BufferState.FINISHED;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static java.util.Objects.requireNonNull;
 
 public class LazyOutputBuffer
@@ -71,7 +70,7 @@ public class LazyOutputBuffer
         requireNonNull(taskId, "taskId is null");
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
         this.executor = requireNonNull(executor, "executor is null");
-        state = new StateMachine<>(taskId + "-buffer", executor, OPEN, TERMINAL_BUFFER_STATES);
+        state = new StateMachine<>(taskId + "-buffer", executor, OPEN, BufferState::isTerminal);
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
         checkArgument(maxBufferSize.toBytes() > 0, "maxBufferSize must be at least 1");
         this.systemMemoryContextSupplier = requireNonNull(systemMemoryContextSupplier, "systemMemoryContextSupplier is null");

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
@@ -91,7 +91,6 @@ import static io.prestosql.block.BlockAssertions.createStringsBlock;
 import static io.prestosql.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static io.prestosql.execution.TaskTestUtils.createTestSplitMonitor;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.prestosql.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -609,7 +608,7 @@ public class TestSqlTaskExecution
     {
         return new PartitionedOutputBuffer(
                 TASK_ID.toString(),
-                new StateMachine<>("bufferState", taskNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", taskNotificationExecutor, OPEN, BufferState::isTerminal),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withBuffer(OUTPUT_BUFFER_ID, 0)
                         .withNoMoreBufferIds(),

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
@@ -34,7 +34,6 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.prestosql.execution.buffer.BufferResult.emptyResults;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.PAGES_SERDE;
@@ -1022,7 +1021,7 @@ public class TestArbitraryOutputBuffer
     {
         ArbitraryOutputBuffer buffer = new ArbitraryOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, BufferState::isTerminal),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestBroadcastOutputBuffer.java
@@ -38,7 +38,6 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.prestosql.execution.buffer.BufferResult.emptyResults;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
@@ -1082,7 +1081,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, BufferState::isTerminal),
                 dataSize,
                 () -> memoryContext.newLocalMemoryContext("test"),
                 notificationExecutor);
@@ -1143,7 +1142,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, BufferState::isTerminal),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestPartitionedOutputBuffer.java
@@ -33,7 +33,6 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.prestosql.execution.buffer.BufferResult.emptyResults;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.PAGES_SERDE;
@@ -840,7 +839,7 @@ public class TestPartitionedOutputBuffer
     {
         return new PartitionedOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, BufferState::isTerminal),
                 buffers,
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkPartitionedOutputOperator.java
@@ -16,6 +16,7 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.prestosql.execution.StateMachine;
+import io.prestosql.execution.buffer.BufferState;
 import io.prestosql.execution.buffer.OutputBuffers;
 import io.prestosql.execution.buffer.PagesSerdeFactory;
 import io.prestosql.execution.buffer.PartitionedOutputBuffer;
@@ -59,7 +60,6 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.prestosql.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -203,7 +203,7 @@ public class BenchmarkPartitionedOutputOperator
         {
             return new PartitionedOutputBuffer(
                     "task-instance-id",
-                    new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                    new StateMachine<>("bufferState", SCHEDULER, OPEN, BufferState::isTerminal),
                     buffers,
                     dataSize,
                     () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-main/src/test/java/io/prestosql/operator/TestPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestPartitionedOutputOperator.java
@@ -16,6 +16,7 @@ package io.prestosql.operator;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.prestosql.execution.StateMachine;
+import io.prestosql.execution.buffer.BufferState;
 import io.prestosql.execution.buffer.OutputBuffers;
 import io.prestosql.execution.buffer.PagesSerdeFactory;
 import io.prestosql.execution.buffer.PartitionedOutputBuffer;
@@ -47,7 +48,6 @@ import static io.prestosql.block.BlockAssertions.createLongDictionaryBlock;
 import static io.prestosql.block.BlockAssertions.createLongSequenceBlock;
 import static io.prestosql.block.BlockAssertions.createRLEBlock;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
-import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
@@ -195,7 +195,7 @@ public class TestPartitionedOutputOperator
         }
         PartitionedOutputBuffer buffer = new PartitionedOutputBuffer(
                 "task-instance-id",
-                new StateMachine<>("bufferState", scheduledExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", scheduledExecutor, OPEN, BufferState::isTerminal),
                 buffers.withNoMoreBufferIds(),
                 new DataSize(Long.MAX_VALUE, BYTE),
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-tests/src/test/java/io/prestosql/execution/resourcegroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/resourcegroups/db/H2TestUtil.java
@@ -15,7 +15,6 @@ package io.prestosql.execution.resourcegroups.db;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.prestosql.Session;
 import io.prestosql.execution.QueryManager;
@@ -32,11 +31,10 @@ import io.prestosql.testing.DistributedQueryRunner;
 
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
+import java.util.function.Predicate;
 
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.prestosql.execution.QueryState.RUNNING;
-import static io.prestosql.execution.QueryState.TERMINAL_QUERY_STATES;
 import static io.prestosql.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.prestosql.spi.resourcegroups.QueryType.EXPLAIN;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
@@ -81,21 +79,21 @@ final class H2TestUtil
     public static void waitForCompleteQueryCount(DistributedQueryRunner queryRunner, int expectedCount)
             throws InterruptedException
     {
-        waitForQueryCount(queryRunner, TERMINAL_QUERY_STATES, expectedCount);
+        waitForQueryCount(queryRunner, QueryState::isDone, expectedCount);
     }
 
     public static void waitForRunningQueryCount(DistributedQueryRunner queryRunner, int expectedCount)
             throws InterruptedException
     {
-        waitForQueryCount(queryRunner, ImmutableSet.of(RUNNING), expectedCount);
+        waitForQueryCount(queryRunner, RUNNING::equals, expectedCount);
     }
 
-    public static void waitForQueryCount(DistributedQueryRunner queryRunner, Set<QueryState> countingStates, int expectedCount)
+    public static void waitForQueryCount(DistributedQueryRunner queryRunner, Predicate<QueryState> countPredicate, int expectedCount)
             throws InterruptedException
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
         while (queryManager.getQueries().stream()
-                .filter(q -> countingStates.contains(q.getState())).count() != expectedCount) {
+                .filter(q -> countPredicate.test(q.getState())).count() != expectedCount) {
             MILLISECONDS.sleep(500);
         }
     }


### PR DESCRIPTION
Required for https://github.com/prestosql/presto/pull/2584