### PR TITLE
Add convenience Launcher's launcher script

### DIFF
--- a/presto-product-tests-launcher/bin/run-launcher
+++ b/presto-product-tests-launcher/bin/run-launcher
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+target="${BASH_SOURCE%/*/*}/target"
+launcher_jar=( "${target}"/presto-product-tests-launcher-*-executable.jar )
+
+if test "${#launcher_jar[@]}" -ne 1; then
+    echo "Found ${#launcher_jar[@]} launcher jars in ${target}: ${launcher_jar[*]}" >&2
+    echo "Run \`./mvnw clean install -pl presto-product-tests-launcher\`" >&2
+    exit 3
+fi
+
+if ! test -x "${launcher_jar[0]}"; then
+    # Most likely `*` glob was not expanded, file does not exist
+    echo "Could not find launcher jar in ${target}." >&2
+    echo "Run \`./mvnw clean install -pl presto-product-tests-launcher\`" >&2
+    exit 3
+fi
+
+exec "${launcher_jar[0]}" "$@"

--- a/presto-product-tests/bin/product-tests-suite-1.sh
+++ b/presto-product-tests/bin/product-tests-suite-1.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 
 suite_exit_code=0
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment multinode \
     -- -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql,postgresql,kafka,hive_compression,"${DISTRO_SKIP_GROUP}" \
     || suite_exit_code=1

--- a/presto-product-tests/bin/product-tests-suite-2.sh
+++ b/presto-product-tests/bin/product-tests-suite-2.sh
@@ -4,22 +4,22 @@ set -xeuo pipefail
 
 suite_exit_code=0
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode \
     -- -g hdfs_no_impersonation,hive_compression -x "${DISTRO_SKIP_GROUP}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-kerberos-hdfs-no-impersonation \
     -- -g hdfs_no_impersonation \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-hdfs-impersonation \
     -- -g storage_formats,cli,hdfs_impersonation \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-kerberos-hdfs-impersonation \
     -- -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header \
     || suite_exit_code=1

--- a/presto-product-tests/bin/product-tests-suite-5.sh
+++ b/presto-product-tests/bin/product-tests-suite-5.sh
@@ -4,12 +4,12 @@ set -xeuo pipefail
 
 suite_exit_code=0
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-hive-impersonation \
     -- -g storage_formats,hdfs_impersonation \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-kerberos-hive-impersonation \
     -- -g storage_formats,hdfs_impersonation,authorization \
     || suite_exit_code=1

--- a/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
@@ -35,13 +35,13 @@ presto-product-tests/bin/run_on_docker.sh \
     -g storage_formats \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-cassandra \
     -- -g cassandra \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-kafka \
     -- -g kafka \
     || suite_exit_code=1

--- a/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
@@ -13,19 +13,19 @@ fi
 suite_exit_code=0
 
 # Does not use hadoop
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-mysql \
     -- -g mysql \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-postgresql \
     -- -g postgresql \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment singlenode-sqlserver \
     -- -g sqlserver \
     || suite_exit_code=1
@@ -36,12 +36,12 @@ presto-product-tests/bin/run_on_docker.sh \
     -g storage_formats,cli,hdfs_impersonation \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment two-mixed-hives \
     -- -g two_hives \
     || suite_exit_code=1
 
-presto-product-tests-launcher/target/presto-product-tests-launcher-*-executable.jar test run \
+presto-product-tests-launcher/bin/run-launcher test run \
     --environment two-kerberos-hives \
     -- -g two_hives \
     || suite_exit_code=1


### PR DESCRIPTION
This improves developer's experience when launcher jar has not yet been
created and they attempt to execute a product tests invocation copied
from a product tests suite file.

The script has been tested with Bash 4.4 and Bash 3.2.57.