### PR TITLE
Always compact pages in OrderBy operator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/OrderByOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OrderByOperator.java
@@ -256,6 +256,9 @@ public class OrderByOperator
         requireNonNull(page, "page is null");
         checkSuccess(spillInProgress, "spilling failed");
 
+        // TODO: remove when retained memory accounting for pages does not
+        // count shared data structures multiple times
+        page.compact();
         pageIndex.addPage(page);
         updateMemoryUsage();
     }


### PR DESCRIPTION
Order by operator is used in distributed manner by default.
This means that there is RR remote exchange before order
by operators on nodes. Because of this OrderBy operator input
blocks are not compacted and their retained size
is greatly overestimated since they share the same
deserialized input slice.