### PR TITLE
Simplify test code & make more strict

### DIFF
--- a/presto-spi/src/test/java/io/prestosql/spi/testing/InterfaceTestUtils.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/testing/InterfaceTestUtils.java
@@ -64,23 +64,11 @@ public final class InterfaceTestUtils
                     }));
 
             try {
-                if (!defines(forwardingInstance, actualMethod)) {
-                    continue;
-                }
-
                 actualMethod.invoke(forwardingInstance, actualArguments);
             }
             catch (Exception e) {
                 throw new RuntimeException(format("Invocation of %s has failed", actualMethod), e);
             }
         }
-    }
-
-    private static boolean defines(Object forwardingInstance, Method actualMethod)
-            throws Exception
-    {
-        Class<?> forwardingClass = forwardingInstance.getClass();
-        Method forwardingMethod = forwardingClass.getMethod(actualMethod.getName(), actualMethod.getParameterTypes());
-        return forwardingClass == forwardingMethod.getDeclaringClass();
     }
 }


### PR DESCRIPTION
This reverts commit e770e4724872a4c5e79224601df0b21bafc3d269.

The code sanctioned forwarding class implementation that does not
implement all the interface method. Such implementation should never
exist as this would open possibility of subtle bugs (e.g. wrong overload
method being called when interface's has a default method delegating to
some other method).