### PR TITLE
Flattening optimizer for set operations

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -51,12 +51,15 @@ import io.prestosql.sql.planner.iterative.rule.ImplementIntersectAsUnion;
 import io.prestosql.sql.planner.iterative.rule.ImplementLimitWithTies;
 import io.prestosql.sql.planner.iterative.rule.ImplementOffset;
 import io.prestosql.sql.planner.iterative.rule.InlineProjections;
+import io.prestosql.sql.planner.iterative.rule.MergeExcept;
 import io.prestosql.sql.planner.iterative.rule.MergeFilters;
+import io.prestosql.sql.planner.iterative.rule.MergeIntersect;
 import io.prestosql.sql.planner.iterative.rule.MergeLimitOverProjectWithSort;
 import io.prestosql.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import io.prestosql.sql.planner.iterative.rule.MergeLimitWithSort;
 import io.prestosql.sql.planner.iterative.rule.MergeLimitWithTopN;
 import io.prestosql.sql.planner.iterative.rule.MergeLimits;
+import io.prestosql.sql.planner.iterative.rule.MergeUnion;
 import io.prestosql.sql.planner.iterative.rule.MultipleDistinctAggregationToMarkDistinct;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationSourceColumns;
@@ -66,6 +69,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneAssignUniqueIdColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import io.prestosql.sql.planner.iterative.rule.PruneDeleteSourceColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneDistinctAggregation;
 import io.prestosql.sql.planner.iterative.rule.PruneDistinctLimitSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneEnforceSingleRowColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneExceptSourceColumns;
@@ -396,7 +400,16 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
-                new SetFlatteningOptimizer(),
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableList.of(new SetFlatteningOptimizer()),
+                        ImmutableSet.of(
+                                new MergeUnion(),
+                                new MergeIntersect(),
+                                new MergeExcept(),
+                                new PruneDistinctAggregation())),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeExcept.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeExcept.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.ExceptNode;
+import io.prestosql.sql.planner.plan.SetOperationNode;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.plan.Patterns.except;
+
+public class MergeExcept
+        implements Rule<ExceptNode>
+{
+    private static final Pattern<ExceptNode> PATTERN = except();
+
+    @Override
+    public Pattern<ExceptNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Rule.Result apply(ExceptNode node, Captures captures, Rule.Context context)
+    {
+        SetOperationMerge mergeOperation = new SetOperationMerge(node, context, ExceptNode::new);
+        Optional<SetOperationNode> result = mergeOperation.mergeFirstSource();
+        return result.map(Result::ofPlanNode).orElseGet(Result::empty);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeIntersect.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeIntersect.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.IntersectNode;
+import io.prestosql.sql.planner.plan.SetOperationNode;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.plan.Patterns.intersect;
+
+/**
+ * Transforms:
+ * <pre>
+ * - Intersect
+ *   - Intersect
+ *     - Relation1
+ *     - Relation2
+ *   - Intersect
+ *     - Relation3
+ *     - Relation4
+ * </pre>
+ * Into
+ * <pre>
+ * - Intersect
+ *   - Relation1
+ *   - Relation2
+ *   - Relation3
+ *   - Relation4
+ * </pre>
+ */
+public class MergeIntersect
+        implements Rule<IntersectNode>
+{
+    private static final Pattern<IntersectNode> PATTERN = intersect();
+
+    @Override
+    public Pattern<IntersectNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(IntersectNode node, Captures captures, Context context)
+    {
+        SetOperationMerge mergeOperation = new SetOperationMerge(node, context, IntersectNode::new);
+        Optional<SetOperationNode> result = mergeOperation.merge();
+        return result.map(Result::ofPlanNode).orElseGet(Result::empty);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeUnion.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/MergeUnion.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.SetOperationNode;
+import io.prestosql.sql.planner.plan.UnionNode;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.plan.Patterns.union;
+
+/**
+ * Transforms:
+ * <pre>
+ * - Union
+ *   - Union
+ *     - Relation1
+ *     - Relation2
+ *   - Union
+ *     - Relation3
+ *     - Relation4
+ * </pre>
+ * Into
+ * <pre>
+ * - Union
+ *   - Relation1
+ *   - Relation2
+ *   - Relation3
+ *   - Relation4
+ * </pre>
+ */
+public class MergeUnion
+        implements Rule<UnionNode>
+{
+    private static final Pattern<UnionNode> PATTERN = union();
+
+    @Override
+    public Pattern<UnionNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(UnionNode node, Captures captures, Context context)
+    {
+        SetOperationMerge mergeOperation = new SetOperationMerge(node, context, UnionNode::new);
+        Optional<SetOperationNode> result = mergeOperation.merge();
+        return result.map(Result::ofPlanNode).orElseGet(Result::empty);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneDistinctAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneDistinctAggregation.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Lookup;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import io.prestosql.sql.planner.plan.ExceptNode;
+import io.prestosql.sql.planner.plan.IntersectNode;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.PlanVisitor;
+import io.prestosql.sql.planner.plan.UnionNode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.prestosql.sql.planner.plan.Patterns.aggregation;
+
+public class PruneDistinctAggregation
+        implements Rule<AggregationNode>
+{
+    private static final Pattern<AggregationNode> PATTERN = aggregation()
+            .matching(PruneDistinctAggregation::isDistinctOperator);
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        Lookup lookup = context.getLookup();
+        DistinctAggregationRewriter rewriter = new DistinctAggregationRewriter(lookup);
+
+        List<PlanNode> newSources = node.getSources().stream()
+                .flatMap(lookup::resolveGroup)
+                .map(source -> source.accept(rewriter, true))
+                .collect(Collectors.toList());
+
+        if (rewriter.isRewritten()) {
+            return Result.ofPlanNode(replaceChildren(node, newSources));
+        }
+        else {
+            return Result.empty();
+        }
+    }
+
+    private static boolean isDistinctOperator(AggregationNode node)
+    {
+        return node.getAggregations().isEmpty();
+    }
+
+    private static class DistinctAggregationRewriter
+            extends PlanVisitor<PlanNode, Boolean>
+    {
+        private final Lookup lookup;
+        private boolean rewritten;
+
+        public DistinctAggregationRewriter(Lookup lookup)
+        {
+            this.lookup = lookup;
+            this.rewritten = false;
+        }
+
+        public boolean isRewritten()
+        {
+            return rewritten;
+        }
+
+        private PlanNode rewriteChildren(PlanNode node, Boolean context)
+        {
+            List<PlanNode> newSources = node.getSources().stream()
+                    .flatMap(lookup::resolveGroup)
+                    .map(source -> source.accept(this, context)).collect(Collectors.toList());
+
+            return replaceChildren(node, newSources);
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, Boolean context)
+        {
+            // Unable to remove distinct aggregation anymore.
+            return rewriteChildren(node, false);
+        }
+
+        @Override
+        public PlanNode visitUnion(UnionNode node, Boolean context)
+        {
+            return rewriteChildren(node, context);
+        }
+
+        @Override
+        public PlanNode visitIntersect(IntersectNode node, Boolean context)
+        {
+            return rewriteChildren(node, context);
+        }
+
+        @Override
+        public PlanNode visitExcept(ExceptNode node, Boolean context)
+        {
+            return rewriteChildren(node, context);
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, Boolean context)
+        {
+            boolean distinct = isDistinctOperator(node);
+
+            PlanNode rewrittenNode = getOnlyElement(lookup.resolveGroup(node.getSource())
+                    .map(source -> source.accept(this, distinct)).collect(Collectors.toList()));
+
+            if (context && distinct) {
+                this.rewritten = true;
+                // Assumes underlying node has same output symbols as this distinct node
+                return rewrittenNode;
+            }
+
+            return new AggregationNode(
+                    node.getId(),
+                    rewrittenNode,
+                    node.getAggregations(),
+                    node.getGroupingSets(),
+                    ImmutableList.of(),
+                    node.getStep(),
+                    node.getHashSymbol(),
+                    node.getGroupIdSymbol());
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/SetOperationMerge.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/SetOperationMerge.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Lookup;
+import io.prestosql.sql.planner.iterative.Rule.Context;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.SetOperationNode;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class SetOperationMerge
+{
+    private final Context context;
+    private final SetOperationNode node;
+    private List<PlanNode> newSources;
+    private final SetOperationNodeInstantiator instantiator;
+
+    public SetOperationMerge(SetOperationNode node, Context context, SetOperationNodeInstantiator instantiator)
+    {
+        this.node = node;
+        this.context = context;
+        this.newSources = new ArrayList<>();
+        this.instantiator = instantiator;
+    }
+
+    /**
+     * Only merge first source node, which is assumed to be used for non-associative set operation.
+     * @return Merged plan node if applied.
+     */
+    public Optional<SetOperationNode> mergeFirstSource()
+    {
+        Lookup lookup = context.getLookup();
+        List<PlanNode> sources = node.getSources().stream()
+                .flatMap(lookup::resolveGroup)
+                .collect(Collectors.toList());
+
+        // If the first child is not the same with the parent, do nothing.
+        if (!sources.get(0).getClass().equals(node.getClass())) {
+            return Optional.empty();
+        }
+
+        ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder = ImmutableListMultimap.builder();
+
+        SetOperationNode child = (SetOperationNode) sources.get(0);
+        // Merge all sources of the first source.
+        addMergedMappings(child, 0, newMappingsBuilder);
+
+        // Keep remaining as it is
+        for (int i = 1; i < sources.size(); i++) {
+            PlanNode source = sources.get(i);
+            addOriginalMappings(source, i, newMappingsBuilder);
+        }
+
+        return Optional.of(instantiator.create(node.getId(), newSources, newMappingsBuilder.build(), node.getOutputSymbols()));
+    }
+
+    /**
+     * Constructs the new mapping and source nodes
+     * @return Merged plan node if applied.
+     */
+    public Optional<SetOperationNode> merge()
+    {
+        Lookup lookup = context.getLookup();
+        List<PlanNode> sources = node.getSources().stream()
+                .flatMap(lookup::resolveGroup)
+                .collect(Collectors.toList());
+
+        // There must be one same source node at least.
+        if (sources.stream().noneMatch(node.getClass()::isInstance)) {
+            return Optional.empty();
+        }
+
+        ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder = ImmutableListMultimap.builder();
+
+        for (int i = 0; i < sources.size(); i++) {
+            PlanNode source = sources.get(i);
+            if (node.getClass().equals(source.getClass())) {
+                SetOperationNode setOperationNode = (SetOperationNode) source;
+                addMergedMappings(setOperationNode, i, newMappingsBuilder);
+            }
+            else {
+                // Keep mapping as it is
+                addOriginalMappings(source, i, newMappingsBuilder);
+            }
+        }
+
+        return Optional.of(instantiator.create(node.getId(), newSources, newMappingsBuilder.build(), node.getOutputSymbols()));
+    }
+
+    private void addMergedMappings(SetOperationNode child, int childIndex, ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder)
+    {
+        newSources.addAll(child.getSources());
+        for (Map.Entry<Symbol, Collection<Symbol>> mapping : node.getSymbolMapping().asMap().entrySet()) {
+            Symbol input = Iterables.get(mapping.getValue(), childIndex);
+            newMappingsBuilder.putAll(mapping.getKey(), child.getSymbolMapping().get(input));
+        }
+    }
+
+    private void addOriginalMappings(PlanNode child, int childIndex, ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder)
+    {
+        newSources.add(child);
+        for (Map.Entry<Symbol, Collection<Symbol>> mapping : node.getSymbolMapping().asMap().entrySet()) {
+            newMappingsBuilder.put(mapping.getKey(), Iterables.get(mapping.getValue(), childIndex));
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/SetOperationNodeInstantiator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/SetOperationNodeInstantiator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.PlanNodeId;
+import io.prestosql.sql.planner.plan.SetOperationNode;
+
+import java.util.List;
+
+interface SetOperationNodeInstantiator
+{
+    SetOperationNode create(PlanNodeId id, List<PlanNode> sources, ListMultimap<Symbol, Symbol> outputToInputs, List<Symbol> outputs);
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeExcept.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeExcept.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.ExceptNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.except;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestMergeExcept
+        extends BaseRuleTest
+{
+    @Test
+    public void testFlattening()
+    {
+        tester().assertThat(new MergeExcept())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    ExceptNode u1 = p.except(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    ExceptNode u2 = p.except(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(d, a)
+                                    .put(d, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.except(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(u1, u2));
+                })
+                .matches(
+                        except(values("a"), values("b"), except(values("a"), values("b"))));
+    }
+
+    @Test
+    public void testNotFlattening()
+    {
+        tester().assertThat(new MergeExcept())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    ExceptNode u2 = p.except(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(d, a)
+                                    .put(d, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.except(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(p.values(1, c), u2));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeIntersect.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeIntersect.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.IntersectNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.intersect;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestMergeIntersect
+        extends BaseRuleTest
+{
+    @Test
+    public void testFlattening()
+    {
+        tester().assertThat(new MergeIntersect())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    IntersectNode u1 = p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    IntersectNode u2 = p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(d, a)
+                                    .put(d, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(u1, u2));
+                })
+                .matches(
+                        intersect(values("a"), values("b"), values("a"), values("b")));
+    }
+
+    @Test
+    public void testMixedFlattening()
+    {
+        tester().assertThat(new MergeIntersect())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    IntersectNode u1 = p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(u1, p.values(1, d)));
+                })
+                .matches(intersect(values("a"), values("b"), values("d")));
+    }
+
+    @Test
+    public void testNotFlattening()
+    {
+        tester().assertThat(new MergeIntersect())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.intersect(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(p.values(1, a), p.values(1, b)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeUnion.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestMergeUnion.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.UnionNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.union;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestMergeUnion
+        extends BaseRuleTest
+{
+    @Test
+    public void testFlattening()
+    {
+        tester().assertThat(new MergeUnion())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    UnionNode u1 = p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    UnionNode u2 = p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(d, a)
+                                    .put(d, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(u1, u2));
+                })
+                .matches(
+                        union(values("a"), values("b"), values("a"), values("b")));
+    }
+
+    @Test
+    public void testMixedFlattening()
+    {
+        tester().assertThat(new MergeUnion())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    UnionNode u1 = p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(
+                                    p.values(1, a),
+                                    p.values(1, b)));
+                    return p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(e, c)
+                                    .put(e, d)
+                                    .build(),
+                            ImmutableList.of(u1, p.values(1, d)));
+                })
+                .matches(union(values("a"), values("b"), values("d")));
+    }
+
+    @Test
+    public void testNotFlattening()
+    {
+        tester().assertThat(new MergeUnion())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.union(
+                            ImmutableListMultimap.<Symbol, Symbol>builder()
+                                    .put(c, a)
+                                    .put(c, b)
+                                    .build(),
+                            ImmutableList.of(p.values(1, a), p.values(1, b)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneDistinctAggregation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneDistinctAggregation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestPruneDistinctAggregation
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruning()
+    {
+        tester().assertThat(new PruneDistinctAggregation())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    AggregationNode child = p.aggregation(aggregationBuilder ->
+                            aggregationBuilder.globalGrouping()
+                                    .source(p.values(1, a)));
+                    return p.aggregation(aggregationBuilder ->
+                            aggregationBuilder.globalGrouping()
+                                    .source(child));
+                })
+                .matches(
+                        aggregation(ImmutableMap.of(), values("a")));
+    }
+
+    @Test
+    public void testNonPruning()
+    {
+        tester().assertThat(new PruneDistinctAggregation())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    AggregationNode child = p.aggregation(aggregationBuilder ->
+                            aggregationBuilder.globalGrouping()
+                                    .addAggregation(p.symbol("sum", BIGINT), expression("sum(a)"), ImmutableList.of(BIGINT))
+                                    .source(p.values(1, a)));
+                    return p.aggregation(aggregationBuilder ->
+                            aggregationBuilder.globalGrouping()
+                                    .source(child));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
# Purpose
Migrate legacy `SetFlatteningOptimizer` to new rule.

See: https://github.com/prestosql/presto/issues/811

# Overview
- Add `MergeUnion`
- Add `MergeIntersect`
- Add `MergeExcept`
- Add `PruneDistrinctAggregation`