### PR TITLE
Disable socket factory for pre JDK11

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
@@ -17,7 +17,6 @@ import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
 import io.prestosql.client.ClientSession;
 import io.prestosql.client.OkHttpUtil;
-import io.prestosql.client.SocketChannelSocketFactory;
 import io.prestosql.client.StatementClient;
 import okhttp3.OkHttpClient;
 
@@ -30,6 +29,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.client.ClientSession.stripTransactionId;
 import static io.prestosql.client.OkHttpUtil.basicAuth;
+import static io.prestosql.client.OkHttpUtil.setupChannelSocket;
 import static io.prestosql.client.OkHttpUtil.setupCookieJar;
 import static io.prestosql.client.OkHttpUtil.setupHttpProxy;
 import static io.prestosql.client.OkHttpUtil.setupKerberos;
@@ -84,8 +84,7 @@ public class QueryRunner
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
-        builder.socketFactory(new SocketChannelSocketFactory());
-
+        setupChannelSocket(builder);
         setupTimeouts(builder, 30, SECONDS);
         setupCookieJar(builder);
         setupSocksProxy(builder, socksProxy);

--- a/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
@@ -14,6 +14,8 @@
 package io.prestosql.client;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.net.HostAndPort;
 import io.airlift.security.pem.PemReader;
 import okhttp3.Credentials;
@@ -235,6 +237,25 @@ public final class OkHttpUtil
         }
         catch (GeneralSecurityException | IOException e) {
             throw new ClientException("Error setting up SSL: " + e.getMessage(), e);
+        }
+    }
+
+    public static void setupChannelSocket(OkHttpClient.Builder clientBuilder)
+    {
+        // Enable socket factory only for pre JDK 11
+        if (!isAtLeastJava11()) {
+            clientBuilder.socketFactory(new SocketChannelSocketFactory());
+        }
+    }
+
+    private static boolean isAtLeastJava11()
+    {
+        String feature = Splitter.on(".").split(StandardSystemProperty.JAVA_VERSION.value()).iterator().next();
+        try {
+            return Integer.parseInt(feature) >= 11;
+        }
+        catch (NumberFormatException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
# Purpose
As discussed in https://github.com/prestosql/presto/issues/1169, the socket channel is the cause of the slowdown with JDK 11. As [JDK-8131133](https://bugs.openjdk.java.net/browse/JDK-8131133) is fixed from JDK 9, the workaround is not necessary anymore. We can safely disable the socket factory usage if the runtime is JDK 11 or later. Confirmed the communication between server and client works well even with HTTP 2.

# Overview
- Add `JavaVersion` class from presto-server module to parse Java version string. Although we expected to use `Runtime.getVersion`, it does not exist in pre-JDK 9. 
- Check runtime version and disable socket factory if JDK 11 or later. 
