### PR TITLE
Preserve char padding in format() function

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
@@ -27,6 +27,7 @@ import io.prestosql.metadata.SqlScalarFunction;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
@@ -57,6 +58,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.Chars.isCharType;
+import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.prestosql.spi.type.DateType.DATE;
@@ -202,8 +204,12 @@ public final class FormatFunction
             int scale = ((DecimalType) type).getScale();
             return (session, block) -> new BigDecimal(decodeUnscaledValue(type.getSlice(block, position)), scale);
         }
-        if (isVarcharType(type) || isCharType(type)) {
+        if (isVarcharType(type)) {
             return (session, block) -> type.getSlice(block, position).toStringUtf8();
+        }
+        if (isCharType(type)) {
+            CharType charType = (CharType) type;
+            return (session, block) -> padSpaces(type.getSlice(block, position), charType).toStringUtf8();
         }
 
         BiFunction<ConnectorSession, Block, Object> function;

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestFormatFunction.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestFormatFunction.java
@@ -56,6 +56,7 @@ public class TestFormatFunction
         assertFormat("format('%1$s %1$tc', cast('1969-07-20 16:17:00 America/New_York' AS timestamp with time zone))", "1969-07-20T16:17-04:00[America/New_York] Sun Jul 20 16:17:00 EDT 1969");
         assertFormat("format('%1$s %1$tc', cast('1969-07-20 20:17:00 UTC' AS timestamp with time zone))", "1969-07-20T20:17Z[UTC] Sun Jul 20 20:17:00 UTC 1969");
         assertFormat("format('%s', cast('16:17:13 -05:00' AS time with time zone))", "16:17:13.000 -05:00");
+        assertFormat("format('%s', cast('test' AS char(5)))", "test ");
 
         assertInvalidFunction("format('%.4d', 8)", "Invalid format string: %.4d (IllegalFormatPrecision: 4)");
         assertInvalidFunction("format('%-02d', 8)", "Invalid format string: %-02d (IllegalFormatFlags: Flags = '-0')");


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/2629