### PR TITLE
Start environment without presto-master

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -68,11 +68,13 @@ public final class EnvironmentUp
             implements Runnable
     {
         private final SelectedEnvironmentProvider selectedEnvironmentProvider;
+        private final boolean withoutPrestoMaster;
 
         @Inject
-        public Execution(SelectedEnvironmentProvider selectedEnvironmentProvider)
+        public Execution(SelectedEnvironmentProvider selectedEnvironmentProvider, EnvironmentOptions options)
         {
             this.selectedEnvironmentProvider = requireNonNull(selectedEnvironmentProvider, "selectedEnvironmentProvider is null");
+            this.withoutPrestoMaster = options.withoutPrestoMaster;
         }
 
         @Override
@@ -81,9 +83,14 @@ public final class EnvironmentUp
             log.info("Pruning old environment(s)");
             Environments.pruneEnvironment();
 
-            Environment environment = selectedEnvironmentProvider.getEnvironment()
-                    .removeContainer("tests")
-                    .build();
+            Environment.Builder builder = selectedEnvironmentProvider.getEnvironment()
+                    .removeContainer("tests");
+
+            if (withoutPrestoMaster) {
+                builder.removeContainer("presto-master");
+            }
+
+            Environment environment = builder.build();
 
             log.info("Starting the environment '%s'", selectedEnvironmentProvider.getEnvironmentName());
             environment.start();

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -38,6 +38,9 @@ public final class EnvironmentOptions
     @Option(name = "--environment", title = "environment", description = "the name of the environment to start", required = true)
     public String environment;
 
+    @Option(name = "--without-presto", title = "without Presto", description = "do not start presto-master")
+    public boolean withoutPrestoMaster;
+
     public Module toModule()
     {
         return binder -> {


### PR DESCRIPTION
This change allows to start environment without presto-master, like this:

```
./presto-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-presto
```