### PR TITLE
Wait for running queries issued during grace period to finish

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/io/prestosql/server/GracefulShutdownHandler.java
@@ -87,6 +87,10 @@ public class GracefulShutdownHandler
         //wait for a grace period to start the shutdown sequence
         shutdownHandler.schedule(() -> {
             List<TaskInfo> activeTasks = getActiveTasks();
+
+            // wait for grace period for shutting down state to be observed by the coordinator
+            sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
+
             while (activeTasks.size() > 0) {
                 CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
 
@@ -109,6 +113,9 @@ public class GracefulShutdownHandler
                 }
 
                 activeTasks = getActiveTasks();
+
+                // wait for another grace period for all task states to be observed by the coordinator
+                sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
             }
 
             // wait for another grace period for all task states to be observed by the coordinator


### PR DESCRIPTION
Related to: https://github.com/prestosql/presto/issues/2621
Fixes one race condition between worker shutting down and issuing new queries by coordinator