### PR TITLE
Add extended record writers

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.hive;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.prestosql.plugin.hive.metastore.StorageFormat;
+import io.prestosql.plugin.hive.recordwriters.ExtendedRecordWriter;
 import io.prestosql.plugin.hive.util.HiveWriteUtils.FieldSetter;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
@@ -215,11 +216,5 @@ public class RecordFileWriter
         return toStringHelper(this)
                 .add("path", path)
                 .toString();
-    }
-
-    public interface ExtendedRecordWriter
-            extends RecordWriter
-    {
-        long getWrittenBytes();
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/avro/AvroOutputFormatRecordWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/avro/AvroOutputFormatRecordWriter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.avro;
+
+import io.prestosql.plugin.hive.recordwriters.ExtendedRecordWriter;
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
+import org.apache.hadoop.hive.ql.io.avro.AvroGenericRecordWriter;
+import org.apache.hadoop.hive.serde2.avro.AvroSerdeException;
+import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.apache.avro.file.CodecFactory.DEFAULT_DEFLATE_LEVEL;
+import static org.apache.avro.file.DataFileConstants.DEFLATE_CODEC;
+import static org.apache.avro.mapred.AvroJob.OUTPUT_CODEC;
+import static org.apache.avro.mapred.AvroOutputFormat.DEFLATE_LEVEL_KEY;
+
+public class AvroOutputFormatRecordWriter
+        implements ExtendedRecordWriter
+{
+    private final RecordWriter delegate;
+    private final FSDataOutputStream fsDataOutputStream;
+
+    public AvroOutputFormatRecordWriter(Path path, JobConf jobConf, boolean isCompressed, Properties properties) throws IOException
+    {
+        Schema schema;
+        try {
+            schema = AvroSerdeUtils.determineSchemaOrThrowException(jobConf, properties);
+        }
+        catch (AvroSerdeException e) {
+            throw new IOException(e);
+        }
+        GenericDatumWriter<GenericRecord> gdw = new GenericDatumWriter<>(schema);
+        DataFileWriter<GenericRecord> dfw = new DataFileWriter<>(gdw);
+
+        if (isCompressed) {
+            int level = jobConf.getInt(DEFLATE_LEVEL_KEY, DEFAULT_DEFLATE_LEVEL);
+            String codecName = jobConf.get(OUTPUT_CODEC, DEFLATE_CODEC);
+            CodecFactory factory = codecName.equals(DEFLATE_CODEC)
+                    ? CodecFactory.deflateCodec(level)
+                    : CodecFactory.fromString(codecName);
+            dfw.setCodec(factory);
+        }
+
+        fsDataOutputStream = path.getFileSystem(jobConf).create(path);
+        dfw.create(schema, fsDataOutputStream);
+        delegate = new AvroGenericRecordWriter(dfw);
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return fsDataOutputStream.getPos();
+    }
+
+    @Override
+    public void write(Writable writable) throws IOException
+    {
+        delegate.write(writable);
+    }
+
+    @Override
+    public void close(boolean b) throws IOException
+    {
+        delegate.close(b);
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/ExtendedRecordWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/ExtendedRecordWriter.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.recordwriters;
+
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
+
+public interface ExtendedRecordWriter
+        extends RecordWriter
+{
+    long getWrittenBytes();
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/SequenceFileFormatRecordWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/SequenceFileFormatRecordWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.recordwriters;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.SequenceFile.Writer;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+
+import java.io.IOException;
+
+public class SequenceFileFormatRecordWriter
+        implements ExtendedRecordWriter
+{
+    private long finalWrittenBytes = -1;
+    private final Writer sequenceFileWriter;
+    private static final BytesWritable EMPTY_KEY = new BytesWritable();
+
+    public SequenceFileFormatRecordWriter(Path path, JobConf jobConf, Class value, boolean isCompressed) throws IOException
+    {
+        sequenceFileWriter = Utilities.createSequenceWriter(jobConf, path.getFileSystem(jobConf), path, BytesWritable.class, value, isCompressed, Reporter.NULL);
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        if (finalWrittenBytes != -1) {
+            return finalWrittenBytes;
+        }
+        try {
+            return sequenceFileWriter.getLength();
+        }
+        catch (IOException e) {
+            return 0; // do nothing
+        }
+    }
+
+    @Override
+    public void write(Writable writable) throws IOException
+    {
+        sequenceFileWriter.append(EMPTY_KEY, writable);
+    }
+
+    @Override
+    public void close(boolean b) throws IOException
+    {
+        if (finalWrittenBytes == -1) {
+            sequenceFileWriter.hflush();
+            finalWrittenBytes = sequenceFileWriter.getLength();
+        }
+        sequenceFileWriter.close();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/TextOutputFormatRecordWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/TextOutputFormatRecordWriter.java
@@ -32,18 +32,20 @@ public class TextOutputFormatRecordWriter
 {
     private final FSDataOutputStream fsDataOutputStream;
     private final OutputStream wrappedOutputStream;
-    private int rowSeparator;
+    private final int rowSeparator;
 
-    public TextOutputFormatRecordWriter(Path path, JobConf jobConf, Properties properties, boolean isCompressed) throws IOException
+    public TextOutputFormatRecordWriter(Path path, JobConf jobConf, Properties properties, boolean isCompressed)
+            throws IOException
     {
-        String rowSeparatorString = properties.getProperty(
-                serdeConstants.LINE_DELIM, "\n");
+        String rowSeparatorString = properties.getProperty(serdeConstants.LINE_DELIM, "\n");
+        int rowSeparatorByte;
         try {
-            rowSeparator = Byte.parseByte(rowSeparatorString);
+            rowSeparatorByte = Byte.parseByte(rowSeparatorString);
         }
         catch (NumberFormatException e) {
-            rowSeparator = rowSeparatorString.charAt(0);
+            rowSeparatorByte = rowSeparatorString.charAt(0);
         }
+        rowSeparator = rowSeparatorByte;
         fsDataOutputStream = path.getFileSystem(jobConf).create(path, Reporter.NULL);
         wrappedOutputStream = Utilities.createCompressedStream(jobConf, fsDataOutputStream, isCompressed);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/TextOutputFormatRecordWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/recordwriters/TextOutputFormatRecordWriter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.recordwriters;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+public class TextOutputFormatRecordWriter
+        implements ExtendedRecordWriter
+{
+    private final FSDataOutputStream fsDataOutputStream;
+    private final OutputStream wrappedOutputStream;
+    private int rowSeparator;
+
+    public TextOutputFormatRecordWriter(Path path, JobConf jobConf, Properties properties, boolean isCompressed) throws IOException
+    {
+        String rowSeparatorString = properties.getProperty(
+                serdeConstants.LINE_DELIM, "\n");
+        try {
+            rowSeparator = Byte.parseByte(rowSeparatorString);
+        }
+        catch (NumberFormatException e) {
+            rowSeparator = rowSeparatorString.charAt(0);
+        }
+        fsDataOutputStream = path.getFileSystem(jobConf).create(path, Reporter.NULL);
+        wrappedOutputStream = Utilities.createCompressedStream(jobConf, fsDataOutputStream, isCompressed);
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return fsDataOutputStream.getPos();
+    }
+
+    @Override
+    public void write(Writable writable) throws IOException
+    {
+        if (writable instanceof Text) {
+            Text tr = (Text) writable;
+            wrappedOutputStream.write(tr.getBytes(), 0, tr.getLength());
+            wrappedOutputStream.write(rowSeparator);
+        }
+        else {
+            // DynamicSerDe always writes out BytesWritable
+            BytesWritable bw = (BytesWritable) writable;
+            wrappedOutputStream.write(bw.get(), 0, bw.getSize());
+            wrappedOutputStream.write(rowSeparator);
+        }
+    }
+
+    @Override
+    public void close(boolean b) throws IOException
+    {
+        wrappedOutputStream.close();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -26,6 +26,7 @@ import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Storage;
 import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.plugin.hive.recordwriters.TextOutputFormatRecordWriter;
 import io.prestosql.plugin.hive.s3.PrestoS3FileSystem;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
@@ -61,6 +62,7 @@ import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ProtectMode;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -179,6 +181,9 @@ public final class HiveWriteUtils
             boolean compress = HiveConf.getBoolVar(conf, COMPRESSRESULT);
             if (outputFormatName.equals(MapredParquetOutputFormat.class.getName())) {
                 return createParquetWriter(target, conf, properties, session);
+            }
+            if (outputFormatName.equals(HiveIgnoreKeyTextOutputFormat.class.getName())) {
+                return new TextOutputFormatRecordWriter(target, conf, properties, compress);
             }
             Object writer = Class.forName(outputFormatName).getConstructor().newInstance();
             return ((HiveOutputFormat<?, ?>) writer).getHiveRecordWriter(conf, target, Text.class, compress, properties, Reporter.NULL);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.HiveReadOnlyException;
 import io.prestosql.plugin.hive.HiveType;
+import io.prestosql.plugin.hive.avro.AvroOutputFormatRecordWriter;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
@@ -66,6 +67,7 @@ import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.Serializer;
@@ -189,6 +191,9 @@ public final class HiveWriteUtils
             }
             if (outputFormatName.equals(HiveSequenceFileOutputFormat.class.getName())) {
                 return new SequenceFileFormatRecordWriter(target, conf, Text.class, compress);
+            }
+            if (outputFormatName.equals(AvroContainerOutputFormat.class.getName())) {
+                return new AvroOutputFormatRecordWriter(target, conf, compress, properties);
             }
             Object writer = Class.forName(outputFormatName).getConstructor().newInstance();
             return ((HiveOutputFormat<?, ?>) writer).getHiveRecordWriter(conf, target, Text.class, compress, properties, Reporter.NULL);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -26,6 +26,7 @@ import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Storage;
 import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.plugin.hive.recordwriters.SequenceFileFormatRecordWriter;
 import io.prestosql.plugin.hive.recordwriters.TextOutputFormatRecordWriter;
 import io.prestosql.plugin.hive.s3.PrestoS3FileSystem;
 import io.prestosql.spi.Page;
@@ -64,6 +65,7 @@ import org.apache.hadoop.hive.metastore.ProtectMode;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
+import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.Serializer;
@@ -184,6 +186,9 @@ public final class HiveWriteUtils
             }
             if (outputFormatName.equals(HiveIgnoreKeyTextOutputFormat.class.getName())) {
                 return new TextOutputFormatRecordWriter(target, conf, properties, compress);
+            }
+            if (outputFormatName.equals(HiveSequenceFileOutputFormat.class.getName())) {
+                return new SequenceFileFormatRecordWriter(target, conf, Text.class, compress);
             }
             Object writer = Class.forName(outputFormatName).getConstructor().newInstance();
             return ((HiveOutputFormat<?, ?>) writer).getHiveRecordWriter(conf, target, Text.class, compress, properties, Reporter.NULL);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/ParquetRecordWriterUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/ParquetRecordWriterUtil.java
@@ -14,7 +14,7 @@
 package io.prestosql.plugin.hive.util;
 
 import com.google.common.base.Splitter;
-import io.prestosql.plugin.hive.RecordFileWriter.ExtendedRecordWriter;
+import io.prestosql.plugin.hive.recordwriters.ExtendedRecordWriter;
 import io.prestosql.spi.connector.ConnectorSession;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;


### PR DESCRIPTION
Adds extended record writers for hive output formats which do not support the ability to get written bytes during an ongoing write.