### PR TITLE
Add Hive session property for iam role

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsEnvironment.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsEnvironment.java
@@ -90,14 +90,16 @@ public class HdfsEnvironment
         private final Optional<String> queryId;
         private final Optional<String> schemaName;
         private final Optional<String> tableName;
+        private final Optional<ConnectorSession> session;
 
-        public HdfsContext(ConnectorIdentity identity)
+        public HdfsContext(ConnectorIdentity identity, Optional<ConnectorSession> session)
         {
             this.identity = requireNonNull(identity, "identity is null");
             this.source = Optional.empty();
             this.queryId = Optional.empty();
             this.schemaName = Optional.empty();
             this.tableName = Optional.empty();
+            this.session = session;
         }
 
         public HdfsContext(ConnectorSession session, String schemaName)
@@ -109,6 +111,7 @@ public class HdfsEnvironment
             this.queryId = Optional.of(session.getQueryId());
             this.schemaName = Optional.of(schemaName);
             this.tableName = Optional.empty();
+            this.session = Optional.of(session);
         }
 
         public HdfsContext(ConnectorSession session, String schemaName, String tableName)
@@ -121,6 +124,7 @@ public class HdfsEnvironment
             this.queryId = Optional.of(session.getQueryId());
             this.schemaName = Optional.of(schemaName);
             this.tableName = Optional.of(tableName);
+            this.session = Optional.of(session);
         }
 
         public ConnectorIdentity getIdentity()
@@ -148,6 +152,11 @@ public class HdfsEnvironment
             return tableName;
         }
 
+        public Optional<ConnectorSession> getSession()
+        {
+            return session;
+        }
+
         @Override
         public String toString()
         {
@@ -158,6 +167,7 @@ public class HdfsEnvironment
                     .add("queryId", queryId.orElse(null))
                     .add("schemaName", schemaName.orElse(null))
                     .add("tableName", tableName.orElse(null))
+                    .add("session", session.orElse(null))
                     .toString();
         }
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -20,6 +20,7 @@ import io.prestosql.plugin.hive.orc.OrcReaderConfig;
 import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
 import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
+import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.session.PropertyMetadata;
@@ -86,6 +87,7 @@ public final class HiveSessionProperties
     private static final String TEMPORARY_STAGING_DIRECTORY_ENABLED = "temporary_staging_directory_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_PATH = "temporary_staging_directory_path";
     private static final String IGNORE_ABSENT_PARTITIONS = "ignore_absent_partitions";
+    private static final String S3_IAM_ROLE = "s3_iam_role";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -110,6 +112,7 @@ public final class HiveSessionProperties
     @Inject
     public HiveSessionProperties(
             HiveConfig hiveConfig,
+            HiveS3Config hiveS3Config,
             OrcReaderConfig orcReaderConfig,
             OrcWriterConfig orcWriterConfig,
             ParquetReaderConfig parquetReaderConfig,
@@ -344,6 +347,11 @@ public final class HiveSessionProperties
                         IGNORE_ABSENT_PARTITIONS,
                         "Ignore partitions when the file system location does not exist rather than failing the query.",
                         hiveConfig.isIgnoreAbsentPartitions(),
+                        false),
+                stringProperty(
+                        S3_IAM_ROLE,
+                        "S3 IAM role",
+                        hiveS3Config.getS3IamRole(),
                         false));
     }
 
@@ -576,6 +584,11 @@ public final class HiveSessionProperties
     public static boolean isIgnoreAbsentPartitions(ConnectorSession session)
     {
         return session.getProperty(IGNORE_ABSENT_PARTITIONS, Boolean.class);
+    }
+
+    public static String getS3IamRole(ConnectorSession session)
+    {
+        return session.getProperty(S3_IAM_ROLE, String.class);
     }
 
     private static PropertyMetadata<DataSize> dataSizeProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -155,7 +155,7 @@ public class FileHiveMetastore
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.catalogDirectory = new Path(requireNonNull(catalogDirectory, "baseDirectory is null"));
-        this.hdfsContext = new HdfsContext(new ConnectorIdentity(metastoreUser, Optional.empty(), Optional.empty()));
+        this.hdfsContext = new HdfsContext(new ConnectorIdentity(metastoreUser, Optional.empty(), Optional.empty()), Optional.empty());
         try {
             metadataFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, this.catalogDirectory);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -163,7 +163,7 @@ public class GlueHiveMetastore
             @ForGlueHiveMetastore Executor executor)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()));
+        this.hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()), Optional.empty());
         this.glueClient = requireNonNull(createAsyncGlueClient(glueConfig), "glueClient is null");
         this.defaultDir = glueConfig.getDefaultWarehouseDir();
         this.catalogId = glueConfig.getCatalogId().orElse(null);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -171,7 +171,7 @@ public class ThriftHiveMetastore
     @Inject
     public ThriftHiveMetastore(MetastoreLocator metastoreLocator, ThriftMetastoreConfig thriftConfig, HiveAuthenticationConfig authenticationConfig, HdfsEnvironment hdfsEnvironment)
     {
-        this.hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()));
+        this.hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()), Optional.empty());
         this.clientProvider = requireNonNull(metastoreLocator, "metastoreLocator is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.backoffScaleFactor = thriftConfig.getBackoffScaleFactor();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
@@ -39,7 +39,7 @@ public class HiveS3Config
     private String s3SignerClass;
     private boolean s3PathStyleAccess;
     private boolean s3UseInstanceCredentials = true;
-    private String s3IamRole;
+    private String s3IamRole = "";
     private boolean s3SslEnabled = true;
     private boolean s3SseEnabled;
     private PrestoS3SseType s3SseType = PrestoS3SseType.S3;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
@@ -17,6 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.prestosql.plugin.hive.ConfigurationInitializer;
+import io.prestosql.plugin.hive.DynamicConfigurationProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JavaUtils;
 
@@ -40,6 +41,7 @@ public class HiveS3Module
             binder.bind(PrestoS3FileSystemStats.class).toInstance(PrestoS3FileSystem.getFileSystemStats());
             newExporter(binder).export(PrestoS3FileSystemStats.class)
                     .as(generator -> generator.generatedNameOf(PrestoS3FileSystem.class));
+            newSetBinder(binder, DynamicConfigurationProvider.class).addBinding().to(S3ConfigurationProvider.class).in(Scopes.SINGLETON);
         }
         else if (type == S3FileSystemType.EMRFS) {
             validateEmrFsClass();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -226,7 +226,7 @@ public class PrestoS3FileSystem
         this.isPathStyleAccess = conf.getBoolean(S3_PATH_STYLE_ACCESS, defaults.isS3PathStyleAccess());
         this.useInstanceCredentials = conf.getBoolean(S3_USE_INSTANCE_CREDENTIALS, defaults.isS3UseInstanceCredentials());
         this.iamRole = conf.get(S3_IAM_ROLE, defaults.getS3IamRole());
-        verify(!(useInstanceCredentials && this.iamRole != null),
+        verify(!(useInstanceCredentials && !this.iamRole.isEmpty()),
                 "Invalid configuration: either use instance credentials or specify an iam role");
         this.pinS3ClientToCurrentRegion = conf.getBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, defaults.isPinS3ClientToCurrentRegion());
         verify(!pinS3ClientToCurrentRegion || conf.get(S3_ENDPOINT) == null,
@@ -798,7 +798,7 @@ public class PrestoS3FileSystem
             return InstanceProfileCredentialsProvider.getInstance();
         }
 
-        if (iamRole != null) {
+        if (!iamRole.isEmpty()) {
             return new STSAssumeRoleSessionCredentialsProvider.Builder(this.iamRole, "presto-session").build();
         }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3ConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3ConfigurationProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.s3;
+
+import io.prestosql.plugin.hive.DynamicConfigurationProvider;
+import io.prestosql.plugin.hive.HiveSessionProperties;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
+import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_IAM_ROLE;
+
+public class S3ConfigurationProvider
+        implements DynamicConfigurationProvider
+{
+    @Override
+    public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
+    {
+        Optional<String> iamRole = context.getSession().map(session -> HiveSessionProperties.getS3IamRole(session)).filter(role -> role != null && !role.isEmpty());
+        if (iamRole.isPresent()) {
+            configuration.set(S3_IAM_ROLE, iamRole.get());
+            setCacheKey(configuration, iamRole.get());
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3ConfigurationProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/S3ConfigurationProvider.java
@@ -13,12 +13,14 @@
  */
 package io.prestosql.plugin.hive.s3;
 
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.hive.DynamicConfigurationProvider;
 import io.prestosql.plugin.hive.HiveSessionProperties;
 import org.apache.hadoop.conf.Configuration;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
 import static io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
@@ -27,9 +29,15 @@ import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_IAM_ROLE;
 public class S3ConfigurationProvider
         implements DynamicConfigurationProvider
 {
+    private static final Set<String> SUPPORTED_S3_SCHEMES = ImmutableSet.of("s3", "s3a", "s3n");
+
     @Override
     public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
     {
+        if (!SUPPORTED_S3_SCHEMES.contains(uri.getScheme())) {
+            return;
+        }
+
         Optional<String> iamRole = context.getSession().map(session -> HiveSessionProperties.getS3IamRole(session)).filter(role -> role != null && !role.isEmpty());
         if (iamRole.isPresent()) {
             configuration.set(S3_IAM_ROLE, iamRole.get());

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -111,7 +111,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestHiveFileSystem
 {
-    protected static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
+    protected static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()), Optional.empty());
 
     protected String database;
     protected SchemaTableName table;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveTestUtils.java
@@ -98,6 +98,7 @@ public final class HiveTestUtils
     {
         return new HiveSessionProperties(
                 hiveConfig,
+                new HiveS3Config(),
                 orcReaderConfig,
                 new OrcWriterConfig(),
                 new ParquetReaderConfig(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -29,6 +29,7 @@ import io.prestosql.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
 import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
 import io.prestosql.plugin.hive.rcfile.RcFilePageSourceFactory;
+import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
@@ -313,6 +314,7 @@ public class TestHiveFileFormats
     {
         HiveSessionProperties hiveSessionProperties = new HiveSessionProperties(
                 new HiveConfig(),
+                new HiveS3Config(),
                 new OrcReaderConfig(),
                 new OrcWriterConfig()
                         .setValidationPercentage(100.0),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -36,6 +36,7 @@ import io.prestosql.plugin.hive.orc.OrcReaderConfig;
 import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
 import io.prestosql.plugin.hive.parquet.ParquetWriterConfig;
+import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
@@ -258,6 +259,7 @@ public class TestOrcPageSourceMemoryTracking
         int maxReadBytes = 1_000;
         HiveSessionProperties hiveSessionProperties = new HiveSessionProperties(
                 new HiveConfig(),
+                new HiveS3Config(),
                 new OrcReaderConfig()
                         .setMaxBlockSize(new DataSize(maxReadBytes, BYTE)),
                 new OrcWriterConfig(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
@@ -30,6 +30,7 @@ import io.prestosql.plugin.hive.parquet.write.MapKeyValuesSchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.SingleLevelArrayMapKeyValuesSchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.SingleLevelArraySchemaConverter;
 import io.prestosql.plugin.hive.parquet.write.TestMapredParquetOutputFormat;
+import io.prestosql.plugin.hive.s3.HiveS3Config;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSource;
@@ -341,6 +342,7 @@ public class ParquetTester
                 new HiveConfig()
                         .setHiveStorageFormat(HiveStorageFormat.PARQUET)
                         .setUseParquetColumnNames(false),
+                new HiveS3Config(),
                 new OrcReaderConfig(),
                 new OrcWriterConfig(),
                 new ParquetReaderConfig()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
@@ -41,7 +41,7 @@ public class TestHiveS3Config
                 .setS3SignerClass(null)
                 .setS3PathStyleAccess(false)
                 .setS3UseInstanceCredentials(true)
-                .setS3IamRole(null)
+                .setS3IamRole("")
                 .setS3SslEnabled(true)
                 .setS3SseEnabled(false)
                 .setS3SseType(PrestoS3SseType.S3)


### PR DESCRIPTION
It adds the ability to set IAM role in session.

On Presto cli, run:

set session hive.s3_iam_role='arn:aws:iam::"account-id":role/"role-name"';

Requirements:
1. The role should be assumable from the attached instance role.
2. Hive property "hive.s3.use-instance-credentials" should be disabled.