### PR TITLE
Correct the message in case of type mismatch error

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TinyintDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TinyintDecoder.java
@@ -42,7 +42,7 @@ public class TinyintDecoder
             TINYINT.writeLong(output, decoded);
         }
         else {
-            throw new PrestoException(TYPE_MISMATCH, "Expected a numeric value for SMALLINT field");
+            throw new PrestoException(TYPE_MISMATCH, "Expected a numeric value for TINYINT field");
         }
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/VarbinaryDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/VarbinaryDecoder.java
@@ -38,7 +38,7 @@ public class VarbinaryDecoder
             VARBINARY.writeSlice(output, Slices.wrappedBuffer(Base64.getDecoder().decode(value.toString())));
         }
         else {
-            throw new PrestoException(TYPE_MISMATCH, "Expected a string value for VARCHAR field");
+            throw new PrestoException(TYPE_MISMATCH, "Expected a string value for VARBINARY field");
         }
     }
 }


### PR DESCRIPTION
Decoders in Elasticsearch connector for `tinyint` and `varbinary` show incorrect type names in case of type mismatch error. 