### PR TITLE
Allow for CTAS  table creation to external tables when write are enabled

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1173,8 +1173,8 @@ public class HiveMetadata
     {
         verifyJvmTimeZone();
 
-        if (getExternalLocation(tableMetadata.getProperties()) != null) {
-            throw new PrestoException(NOT_SUPPORTED, "External tables cannot be created using CREATE TABLE AS");
+        if ((!writesToNonManagedTablesEnabled || !createsOfNonManagedTablesEnabled) && getExternalLocation(tableMetadata.getProperties()) != null) {
+            throw new PrestoException(NOT_SUPPORTED, "Cannot create a non-managed Hive table using CREATE TABLE AS");
         }
 
         if (getAvroSchemaUrl(tableMetadata.getProperties()) != null) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTable.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTable.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.prestosql.tpch.TpchTable.CUSTOMER;
+import static io.prestosql.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+
+public class TestHiveCreateExternalTable
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER),
+                ImmutableMap.of(),
+                "sql-standard",
+                ImmutableMap.of("hive.non-managed-table-writes-enabled", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testCreateExternalTableWithData()
+            throws IOException
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+
+        assertUpdate(createTableSql, 25);
+
+        MaterializedResult expected = computeActual("SELECT * FROM tpch.tiny.nation");
+        MaterializedResult actual = computeActual("SELECT * FROM test_create_external");
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+
+        assertUpdate("DROP TABLE test_create_external");
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTableDisabled.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTableDisabled.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.tpch.TpchTable.CUSTOMER;
+import static io.prestosql.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+
+public class TestHiveCreateExternalTableDisabled
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER),
+                ImmutableMap.of(),
+                "sql-standard",
+                ImmutableMap.of("hive.non-managed-table-writes-enabled", "true", "hive.non-managed-table-creates-enabled", "false"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testCreateExternalTableWithData()
+            throws Exception
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+        assertQueryFails(createTableSql, "Cannot create a non-managed Hive table using CREATE TABLE AS");
+
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTable()
+            throws Exception
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external (n TINYINT) " +
+                        "WITH (external_location = '%s')",
+                tempDir.toURI().toASCIIString());
+        assertQueryFails(createTableSql, "Cannot create non-managed Hive table");
+
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -58,6 +58,7 @@ import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -2282,6 +2283,22 @@ public class TestHiveIntegrationSmokeTest
         // file should still exist after drop
         assertFile(dataFile);
 
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTableWithDataNotAllowed()
+            throws IOException
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+
+        assertQueryFails(createTableSql, "Cannot create a non-managed Hive table using CREATE TABLE AS");
         deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
     }
 


### PR DESCRIPTION
Duplicates https://github.com/prestosql/presto/pull/2556 with tests added.

When `hive.non-managed-table-writes-enabled` and `hive.non-managed-table-creates-enabled`
are both set to true, external tables can be created and inserted into. This change
allows for that to be done in one step using the `CREATE TABLE AS` syntax.