### PR TITLE
Allow dynamic filtering with comparison operators

### DIFF
--- a/presto-docs/src/main/sphinx/admin/dynamic-filtering.rst
+++ b/presto-docs/src/main/sphinx/admin/dynamic-filtering.rst
@@ -46,7 +46,7 @@ Analysis and confirmation
 Dynamic filtering depends on a number of factors:
 
 * Planner support for dynamic filtering for a given join operation in Presto.
-  Currently inner and right joins with equality join conditions and semi-joins with IN conditions are supported.
+  Currently inner and right joins with comparison join conditions and semi-joins with IN conditions are supported.
 * Connector support for utilizing dynamic filters pushed into the table scan at runtime.
   For example, the Hive connector can push dynamic filters into ORC and Parquet readers
   to perform stripe or row-group pruning.
@@ -87,7 +87,7 @@ down to the connector in the query plan.
            │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
            │   Distribution: REPLICATED
            │   dynamicFilterAssignments = {d_date_sk -> df_370}
-           ├─ ScanFilterProject[table = hive:default:store_sales, grouped = false, filterPredicate = true, dynamicFilter = {df_370 -> ""ss_sold_date_sk""}]
+           ├─ ScanFilterProject[table = hive:default:store_sales, grouped = false, filterPredicate = true, dynamicFilter = {""ss_sold_date_sk"" = #df_370}]
            │      Layout: [ss_sold_date_sk:bigint, $hashvalue:bigint]
            │      Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
            │      $hashvalue := combine_hash(bigint '0', COALESCE(""$operator$hash_code""(""ss_sold_date_sk""), 0))

--- a/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
@@ -67,7 +67,8 @@ public final class JoinUtils
             return PlanNodeSearcher.searchFrom(((JoinNode) node).getRight())
                     .recurseOnlyWhen(
                             MorePredicates.<PlanNode>isInstanceOfAny(ProjectNode.class)
-                                    .or(JoinUtils::isLocalRepartitionExchange))
+                                    .or(JoinUtils::isLocalRepartitionExchange)
+                                    .or(JoinUtils::isLocalGatherExchange))  // used in cross join case
                     .where(joinNode -> isRemoteReplicatedExchange(joinNode) || isRemoteReplicatedSourceNode(joinNode))
                     .matches();
         }

--- a/presto-main/src/main/java/io/prestosql/sql/DynamicFilters.java
+++ b/presto-main/src/main/java/io/prestosql/sql/DynamicFilters.java
@@ -22,12 +22,16 @@ import io.prestosql.metadata.ResolvedFunction;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.function.TypeParameter;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.planner.FunctionCallBuilder;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.DynamicFilterId;
 import io.prestosql.sql.tree.Cast;
+import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FunctionCall;
 import io.prestosql.sql.tree.QualifiedName;
@@ -45,25 +49,33 @@ import static com.google.common.collect.ImmutableListMultimap.toImmutableListMul
 import static io.prestosql.spi.type.StandardTypes.BOOLEAN;
 import static io.prestosql.spi.type.StandardTypes.VARCHAR;
 import static io.prestosql.sql.ExpressionUtils.extractConjuncts;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static java.util.Objects.requireNonNull;
 
 public final class DynamicFilters
 {
     private DynamicFilters() {}
 
-    public static Expression createDynamicFilterExpression(Metadata metadata, DynamicFilterId id, Type inputType, SymbolReference input)
+    public static Expression createDynamicFilterExpression(Metadata metadata, DynamicFilterId id, Type inputType, SymbolReference input, ComparisonExpression.Operator operator)
     {
-        return createDynamicFilterExpression(metadata, id, inputType, (Expression) input);
+        return createDynamicFilterExpression(metadata, id, inputType, (Expression) input, operator);
+    }
+
+    @VisibleForTesting
+    public static Expression createDynamicFilterExpression(Metadata metadata, DynamicFilterId id, Type inputType, Expression input, ComparisonExpression.Operator operator)
+    {
+        return new FunctionCallBuilder(metadata)
+                .setName(QualifiedName.of(Function.NAME))
+                .addArgument(inputType, input)
+                .addArgument(VarcharType.VARCHAR, new StringLiteral(operator.toString()))
+                .addArgument(VarcharType.VARCHAR, new StringLiteral(id.toString()))
+                .build();
     }
 
     @VisibleForTesting
     public static Expression createDynamicFilterExpression(Metadata metadata, DynamicFilterId id, Type inputType, Expression input)
     {
-        return new FunctionCallBuilder(metadata)
-                .setName(QualifiedName.of(Function.NAME))
-                .addArgument(VarcharType.VARCHAR, new StringLiteral(id.toString()))
-                .addArgument(inputType, input)
-                .build();
+        return createDynamicFilterExpression(metadata, id, inputType, input, EQUAL);
     }
 
     public static ExtractResult extractDynamicFilters(Expression expression)
@@ -86,20 +98,23 @@ public final class DynamicFilters
         return new ExtractResult(staticConjuncts.build(), dynamicConjuncts.build());
     }
 
-    public static Multimap<DynamicFilterId, Symbol> extractSourceSymbols(List<DynamicFilters.Descriptor> dynamicFilters)
+    public static Multimap<DynamicFilterId, Descriptor> extractSourceSymbols(List<DynamicFilters.Descriptor> dynamicFilters)
     {
         return dynamicFilters.stream()
                 .collect(toImmutableListMultimap(
                         DynamicFilters.Descriptor::getId,
-                        descriptor -> {
-                            Expression dynamicFilterExpression = descriptor.getInput();
-                            if (dynamicFilterExpression instanceof SymbolReference) {
-                                return Symbol.from(dynamicFilterExpression);
-                            }
-                            checkState(dynamicFilterExpression instanceof Cast);
-                            checkState(((Cast) dynamicFilterExpression).getExpression() instanceof SymbolReference);
-                            return Symbol.from(((Cast) dynamicFilterExpression).getExpression());
-                        }));
+                        descriptor -> new DynamicFilters.Descriptor(descriptor.getId(), extractSourceSymbol(descriptor).toSymbolReference(), descriptor.getOperator())));
+    }
+
+    private static Symbol extractSourceSymbol(DynamicFilters.Descriptor descriptor)
+    {
+        Expression dynamicFilterExpression = descriptor.getInput();
+        if (dynamicFilterExpression instanceof SymbolReference) {
+            return Symbol.from(dynamicFilterExpression);
+        }
+        checkState(dynamicFilterExpression instanceof Cast);
+        checkState(((Cast) dynamicFilterExpression).getExpression() instanceof SymbolReference);
+        return Symbol.from(((Cast) dynamicFilterExpression).getExpression());
     }
 
     public static boolean isDynamicFilter(Expression expression)
@@ -120,12 +135,19 @@ public final class DynamicFilters
         }
 
         List<Expression> arguments = functionCall.getArguments();
-        checkArgument(arguments.size() == 2, "invalid arguments count: %s", arguments.size());
+        checkArgument(arguments.size() == 3, "invalid arguments count: %s", arguments.size());
 
-        Expression firstArgument = arguments.get(0);
-        checkArgument(firstArgument instanceof StringLiteral, "firstArgument is expected to be an instance of StringLiteral: %s", firstArgument.getClass().getSimpleName());
-        String id = ((StringLiteral) firstArgument).getValue();
-        return Optional.of(new Descriptor(new DynamicFilterId(id), arguments.get(1)));
+        Expression probeSymbol = arguments.get(0);
+
+        Expression operatorExpression = arguments.get(1);
+        checkArgument(operatorExpression instanceof StringLiteral, "operatorExpression is expected to be an instance of StringLiteral: %s", operatorExpression.getClass().getSimpleName());
+        String operatorExpressionString = ((StringLiteral) operatorExpression).getValue();
+        ComparisonExpression.Operator operator = ComparisonExpression.Operator.valueOf(operatorExpressionString);
+
+        Expression idExpression = arguments.get(2);
+        checkArgument(idExpression instanceof StringLiteral, "id is expected to be an instance of StringLiteral: %s", idExpression.getClass().getSimpleName());
+        String id = ((StringLiteral) idExpression).getValue();
+        return Optional.of(new Descriptor(new DynamicFilterId(id), probeSymbol, operator));
     }
 
     public static class ExtractResult
@@ -154,11 +176,18 @@ public final class DynamicFilters
     {
         private final DynamicFilterId id;
         private final Expression input;
+        private final ComparisonExpression.Operator operator;
 
-        public Descriptor(DynamicFilterId id, Expression input)
+        public Descriptor(DynamicFilterId id, Expression input, ComparisonExpression.Operator operator)
         {
             this.id = requireNonNull(id, "id is null");
             this.input = requireNonNull(input, "input is null");
+            this.operator = requireNonNull(operator, "operator is null");
+        }
+
+        public Descriptor(DynamicFilterId id, Expression input)
+        {
+            this(id, input, EQUAL);
         }
 
         public DynamicFilterId getId()
@@ -169,6 +198,11 @@ public final class DynamicFilters
         public Expression getInput()
         {
             return input;
+        }
+
+        public ComparisonExpression.Operator getOperator()
+        {
+            return operator;
         }
 
         @Override
@@ -182,13 +216,14 @@ public final class DynamicFilters
             }
             Descriptor that = (Descriptor) o;
             return Objects.equals(id, that.id) &&
-                    Objects.equals(input, that.input);
+                    Objects.equals(input, that.input) &&
+                    Objects.equals(operator, that.operator);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(id, input);
+            return Objects.hash(id, input, operator);
         }
 
         @Override
@@ -197,7 +232,38 @@ public final class DynamicFilters
             return toStringHelper(this)
                     .add("id", id)
                     .add("input", input)
+                    .add("operator", operator)
                     .toString();
+        }
+
+        public Domain applyComparison(Domain domain)
+        {
+            if (domain.isNone() || domain.isAll()) {
+                return domain;
+            }
+            Range span = domain.getValues().getRanges().getSpan();
+            switch (operator) {
+                case EQUAL:
+                    return domain;
+                case LESS_THAN: {
+                    Range range = Range.lessThan(span.getType(), span.getHigh().getValue());
+                    return Domain.create(ValueSet.ofRanges(range), false);
+                }
+                case LESS_THAN_OR_EQUAL: {
+                    Range range = Range.lessThanOrEqual(span.getType(), span.getHigh().getValue());
+                    return Domain.create(ValueSet.ofRanges(range), false);
+                }
+                case GREATER_THAN: {
+                    Range range = Range.greaterThan(span.getType(), span.getLow().getValue());
+                    return Domain.create(ValueSet.ofRanges(range), false);
+                }
+                case GREATER_THAN_OR_EQUAL: {
+                    Range range = Range.greaterThanOrEqual(span.getType(), span.getLow().getValue());
+                    return Domain.create(ValueSet.ofRanges(range), false);
+                }
+                default:
+                    throw new IllegalArgumentException("Unsupported dynamic filtering comparison operator: " + operator);
+            }
         }
     }
 
@@ -210,28 +276,28 @@ public final class DynamicFilters
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType(VARCHAR) Slice id, @SqlType("T") Object input)
+        public static boolean dynamicFilter(@SqlType("T") Object input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType(VARCHAR) Slice id, @SqlType("T") long input)
+        public static boolean dynamicFilter(@SqlType("T") long input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType(VARCHAR) Slice id, @SqlType("T") boolean input)
+        public static boolean dynamicFilter(@SqlType("T") boolean input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType(VARCHAR) Slice id, @SqlType("T") double input)
+        public static boolean dynamicFilter(@SqlType("T") double input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -88,6 +88,7 @@ import static io.prestosql.sql.ExpressionUtils.extractConjuncts;
 import static io.prestosql.sql.ExpressionUtils.filterDeterministicConjuncts;
 import static io.prestosql.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.prestosql.sql.planner.ExpressionSymbolInliner.inlineSymbols;
+import static io.prestosql.sql.planner.SymbolsExtractor.extractUnique;
 import static io.prestosql.sql.planner.iterative.rule.CanonicalizeExpressionRewriter.canonicalizeExpression;
 import static io.prestosql.sql.planner.iterative.rule.UnwrapCastInComparison.unwrapCasts;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
@@ -239,7 +240,7 @@ public class PredicatePushDown
             // pre-projected symbols.
             Predicate<Expression> isSupported = conjunct ->
                     isDeterministic(conjunct, metadata) &&
-                            SymbolsExtractor.extractUnique(conjunct).stream()
+                            extractUnique(conjunct).stream()
                                     .allMatch(partitionSymbols::contains);
 
             Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream().collect(Collectors.partitioningBy(isSupported));
@@ -261,7 +262,7 @@ public class PredicatePushDown
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toSet());
 
-            Predicate<Expression> deterministic = conjunct -> SymbolsExtractor.extractUnique(conjunct).stream()
+            Predicate<Expression> deterministic = conjunct -> extractUnique(conjunct).stream()
                     .allMatch(deterministicSymbols::contains);
 
             Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream().collect(Collectors.partitioningBy(deterministic));
@@ -324,7 +325,7 @@ public class PredicatePushDown
                     .filter(entry -> node.getCommonGroupingColumns().contains(entry.getKey()))
                     .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().toSymbolReference()));
 
-            Predicate<Expression> pushdownEligiblePredicate = conjunct -> commonGroupingSymbolMapping.keySet().containsAll(SymbolsExtractor.extractUnique(conjunct));
+            Predicate<Expression> pushdownEligiblePredicate = conjunct -> commonGroupingSymbolMapping.keySet().containsAll(extractUnique(conjunct));
 
             Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream().collect(Collectors.partitioningBy(pushdownEligiblePredicate));
 
@@ -344,7 +345,7 @@ public class PredicatePushDown
         {
             Set<Symbol> pushDownableSymbols = ImmutableSet.copyOf(node.getDistinctSymbols());
             Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream()
-                    .collect(Collectors.partitioningBy(conjunct -> SymbolsExtractor.extractUnique(conjunct).stream().allMatch(pushDownableSymbols::contains)));
+                    .collect(Collectors.partitioningBy(conjunct -> extractUnique(conjunct).stream().allMatch(pushDownableSymbols::contains)));
 
             PlanNode rewrittenNode = context.defaultRewrite(node, combineConjuncts(metadata, conjuncts.get(true)));
 
@@ -487,7 +488,7 @@ public class PredicatePushDown
                 if (joinEqualityExpression(conjunct, node.getLeft().getOutputSymbols(), node.getRight().getOutputSymbols())) {
                     ComparisonExpression equality = (ComparisonExpression) conjunct;
 
-                    boolean alignedComparison = node.getLeft().getOutputSymbols().containsAll(SymbolsExtractor.extractUnique(equality.getLeft()));
+                    boolean alignedComparison = node.getLeft().getOutputSymbols().containsAll(extractUnique(equality.getLeft()));
                     Expression leftExpression = (alignedComparison) ? equality.getLeft() : equality.getRight();
                     Expression rightExpression = (alignedComparison) ? equality.getRight() : equality.getLeft();
 
@@ -738,8 +739,8 @@ public class PredicatePushDown
                 Collection<Symbol> outerSymbols,
                 Collection<Symbol> innerSymbols)
         {
-            checkArgument(outerSymbols.containsAll(SymbolsExtractor.extractUnique(outerEffectivePredicate)), "outerEffectivePredicate must only contain symbols from outerSymbols");
-            checkArgument(innerSymbols.containsAll(SymbolsExtractor.extractUnique(innerEffectivePredicate)), "innerEffectivePredicate must only contain symbols from innerSymbols");
+            checkArgument(outerSymbols.containsAll(extractUnique(outerEffectivePredicate)), "outerEffectivePredicate must only contain symbols from outerSymbols");
+            checkArgument(innerSymbols.containsAll(extractUnique(innerEffectivePredicate)), "innerEffectivePredicate must only contain symbols from innerSymbols");
 
             ImmutableList.Builder<Expression> outerPushdownConjuncts = ImmutableList.builder();
             ImmutableList.Builder<Expression> innerPushdownConjuncts = ImmutableList.builder();
@@ -873,8 +874,8 @@ public class PredicatePushDown
                 Collection<Symbol> leftSymbols,
                 Collection<Symbol> rightSymbols)
         {
-            checkArgument(leftSymbols.containsAll(SymbolsExtractor.extractUnique(leftEffectivePredicate)), "leftEffectivePredicate must only contain symbols from leftSymbols");
-            checkArgument(rightSymbols.containsAll(SymbolsExtractor.extractUnique(rightEffectivePredicate)), "rightEffectivePredicate must only contain symbols from rightSymbols");
+            checkArgument(leftSymbols.containsAll(extractUnique(leftEffectivePredicate)), "leftEffectivePredicate must only contain symbols from leftSymbols");
+            checkArgument(rightSymbols.containsAll(extractUnique(rightEffectivePredicate)), "rightEffectivePredicate must only contain symbols from rightSymbols");
 
             ImmutableList.Builder<Expression> leftPushDownConjuncts = ImmutableList.builder();
             ImmutableList.Builder<Expression> rightPushDownConjuncts = ImmutableList.builder();
@@ -1139,8 +1140,8 @@ public class PredicatePushDown
             if (expression instanceof ComparisonExpression && isDeterministic(expression, metadata)) {
                 ComparisonExpression comparison = (ComparisonExpression) expression;
                 if (comparison.getOperator() == ComparisonExpression.Operator.EQUAL) {
-                    Set<Symbol> symbols1 = SymbolsExtractor.extractUnique(comparison.getLeft());
-                    Set<Symbol> symbols2 = SymbolsExtractor.extractUnique(comparison.getRight());
+                    Set<Symbol> symbols1 = extractUnique(comparison.getLeft());
+                    Set<Symbol> symbols2 = extractUnique(comparison.getRight());
                     if (symbols1.isEmpty() || symbols2.isEmpty()) {
                         return false;
                     }
@@ -1337,7 +1338,7 @@ public class PredicatePushDown
             // Sort non-equality predicates by those that can be pushed down and those that cannot
             Set<Symbol> groupingKeys = ImmutableSet.copyOf(node.getGroupingKeys());
             for (Expression conjunct : EqualityInference.nonInferrableConjuncts(metadata, inheritedPredicate)) {
-                if (node.getGroupIdSymbol().isPresent() && SymbolsExtractor.extractUnique(conjunct).contains(node.getGroupIdSymbol().get())) {
+                if (node.getGroupIdSymbol().isPresent() && extractUnique(conjunct).contains(node.getGroupIdSymbol().get())) {
                     // aggregation operator synthesizes outputs for group ids corresponding to the global grouping set (i.e., ()), so we
                     // need to preserve any predicates that evaluate the group id to run after the aggregation
                     // TODO: we should be able to infer if conditions on grouping() correspond to global grouping sets to determine whether
@@ -1451,7 +1452,7 @@ public class PredicatePushDown
         @Override
         public PlanNode visitAssignUniqueId(AssignUniqueId node, RewriteContext<Expression> context)
         {
-            Set<Symbol> predicateSymbols = SymbolsExtractor.extractUnique(context.get());
+            Set<Symbol> predicateSymbols = extractUnique(context.get());
             checkState(!predicateSymbols.contains(node.getIdColumn()), "UniqueId in predicate is not yet supported");
             return context.defaultRewrite(node, context.get());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -820,14 +820,14 @@ public class PlanPrinter
         private String printDynamicFilters(Collection<DynamicFilters.Descriptor> filters)
         {
             return filters.stream()
-                    .map(filter -> filter.getId() + " -> " + filter.getInput())
+                    .map(filter -> filter.getInput() + " " + filter.getOperator().getValue() + " #" + filter.getId())
                     .collect(Collectors.joining(", ", "{", "}"));
         }
 
         private String printDynamicFilterAssignments(Map<DynamicFilterId, Symbol> filters)
         {
             return filters.entrySet().stream()
-                    .map(filter -> filter.getValue() + " -> " + filter.getKey())
+                    .map(filter -> filter.getValue() + " -> #" + filter.getKey())
                     .collect(Collectors.joining(", ", "{", "}"));
         }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/JoinMatcher.java
@@ -24,9 +24,10 @@ import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.JoinNode.DistributionType;
 import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,11 +35,12 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.sql.DynamicFilters.extractDynamicFilters;
 import static io.prestosql.sql.planner.ExpressionExtractor.extractExpressions;
 import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.DynamicFilterPattern;
 import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +53,7 @@ final class JoinMatcher
     private final Optional<DistributionType> distributionType;
     private final Optional<Boolean> spillable;
     // LEFT_SYMBOL -> RIGHT_SYMBOL
-    private final Optional<Map<SymbolAlias, SymbolAlias>> expectedDynamicFilterAliases;
+    private final Optional<List<DynamicFilterPattern>> expectedDynamicFilter;
 
     JoinMatcher(
             JoinNode.Type joinType,
@@ -59,14 +61,14 @@ final class JoinMatcher
             Optional<Expression> filter,
             Optional<DistributionType> distributionType,
             Optional<Boolean> spillable,
-            Optional<Map<SymbolAlias, SymbolAlias>> expectedDynamicFilterAliases)
+            Optional<List<DynamicFilterPattern>> expectedDynamicFilter)
     {
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
         this.filter = requireNonNull(filter, "filter cannot be null");
         this.distributionType = requireNonNull(distributionType, "distributionType is null");
         this.spillable = requireNonNull(spillable, "spillable is null");
-        this.expectedDynamicFilterAliases = requireNonNull(expectedDynamicFilterAliases, "expectedDynamicFilterAliases is null");
+        this.expectedDynamicFilter = requireNonNull(expectedDynamicFilter, "expectedDynamicFilter is null");
     }
 
     @Override
@@ -132,34 +134,33 @@ final class JoinMatcher
 
     private boolean matchDynamicFilters(JoinNode joinNode, SymbolAliases symbolAliases)
     {
-        if (expectedDynamicFilterAliases.isEmpty()) {
+        if (expectedDynamicFilter.isEmpty()) {
             return true;
         }
         Set<DynamicFilterId> dynamicFilterIds = joinNode.getDynamicFilters().keySet();
-        Map<Symbol, DynamicFilterId> probeSymbolToFilterId = searchFrom(joinNode.getLeft())
+        List<DynamicFilters.Descriptor> descriptors = searchFrom(joinNode.getLeft())
                 .where(FilterNode.class::isInstance)
                 .findAll()
                 .stream()
                 .flatMap(filterNode -> extractExpressions(filterNode).stream())
                 .flatMap(expression -> extractDynamicFilters(expression).getDynamicConjuncts().stream())
                 .filter(descriptor -> dynamicFilterIds.contains(descriptor.getId()))
-                .collect(toImmutableMap(filter -> Symbol.from(filter.getInput()), DynamicFilters.Descriptor::getId));
+                .collect(toImmutableList());
 
         Map<DynamicFilterId, Symbol> idToBuildSymbolMap = joinNode.getDynamicFilters();
-        Map<Symbol, Symbol> actual = new HashMap<>();
-        for (Map.Entry<Symbol, DynamicFilterId> entry : probeSymbolToFilterId.entrySet()) {
-            Symbol probe = entry.getKey();
-            DynamicFilterId id = entry.getValue();
-
-            Symbol build = idToBuildSymbolMap.get(id);
+        Set<Expression> actual = new HashSet<>();
+        for (DynamicFilters.Descriptor descriptor : descriptors) {
+            Symbol probe = Symbol.from(descriptor.getInput());
+            Symbol build = idToBuildSymbolMap.get(descriptor.getId());
             if (build == null) {
                 return false;
             }
-            actual.put(probe, build);
+            actual.add(new ComparisonExpression(descriptor.getOperator(), probe.toSymbolReference(), build.toSymbolReference()));
         }
 
-        Map<Symbol, Symbol> expected = expectedDynamicFilterAliases.get().entrySet().stream()
-                .collect(toImmutableMap(entry -> entry.getKey().toSymbol(symbolAliases), entry -> entry.getValue().toSymbol(symbolAliases)));
+        Set<Expression> expected = expectedDynamicFilter.get().stream()
+                .map(pattern -> pattern.getComparisonExpression(symbolAliases))
+                .collect(toImmutableSet());
 
         return expected.equals(actual);
     }
@@ -173,8 +174,7 @@ final class JoinMatcher
                 .add("equiCriteria", equiCriteria)
                 .add("filter", filter.orElse(null))
                 .add("distributionType", distributionType)
-                .add("dynamicFilter", expectedDynamicFilterAliases.map(aliases -> aliases.values().stream()
-                        .collect(toImmutableMap(rightSymbol -> rightSymbol.toString() + "_alias", SymbolAlias::toString))))
+                .add("dynamicFilter", expectedDynamicFilter)
                 .toString();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -60,6 +60,7 @@ import io.prestosql.sql.planner.plan.UnionNode;
 import io.prestosql.sql.planner.plan.UnnestNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FrameBound;
 import io.prestosql.sql.tree.FunctionCall;
@@ -91,6 +92,7 @@ import static io.prestosql.sql.planner.assertions.MatchResult.match;
 import static io.prestosql.sql.planner.assertions.StrictAssignedSymbolsMatcher.actualAssignments;
 import static io.prestosql.sql.planner.assertions.StrictSymbolsMatcher.actualOutputs;
 import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.prestosql.sql.tree.SortItem.NullOrdering.FIRST;
 import static io.prestosql.sql.tree.SortItem.NullOrdering.UNDEFINED;
 import static io.prestosql.sql.tree.SortItem.Ordering.ASCENDING;
@@ -484,6 +486,19 @@ public final class PlanMatchPattern
             PlanMatchPattern left,
             PlanMatchPattern right)
     {
+        List<DynamicFilterPattern> pattern = expectedDynamicFilter.entrySet().stream()
+                .map(entry -> new DynamicFilterPattern(entry.getKey(), EQUAL, entry.getValue()))
+                .collect(toImmutableList());
+        return join(joinType, expectedEquiCriteria, Optional.empty(), Optional.of(pattern), Optional.empty(), Optional.empty(), left, right);
+    }
+
+    public static PlanMatchPattern join(
+            Type joinType,
+            List<ExpectedValueProvider<EquiJoinClause>> expectedEquiCriteria,
+            List<DynamicFilterPattern> expectedDynamicFilter,
+            PlanMatchPattern left,
+            PlanMatchPattern right)
+    {
         return join(joinType, expectedEquiCriteria, Optional.empty(), Optional.of(expectedDynamicFilter), Optional.empty(), Optional.empty(), left, right);
     }
 
@@ -491,14 +506,12 @@ public final class PlanMatchPattern
             JoinNode.Type joinType,
             List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria,
             Optional<String> expectedFilter,
-            Optional<Map<String, String>> expectedDynamicFilter,
+            Optional<List<DynamicFilterPattern>> expectedDynamicFilter,
             Optional<JoinNode.DistributionType> expectedDistributionType,
             Optional<Boolean> expectedSpillable,
             PlanMatchPattern left,
             PlanMatchPattern right)
     {
-        Optional<Map<SymbolAlias, SymbolAlias>> expectedDynamicFilterAliases = expectedDynamicFilter.map(dynamicFilter -> dynamicFilter.entrySet().stream()
-                .collect(toImmutableMap(entry -> new SymbolAlias(entry.getKey()), entry -> new SymbolAlias(entry.getValue()))));
         return node(JoinNode.class, left, right).with(
                 new JoinMatcher(
                         joinType,
@@ -506,7 +519,7 @@ public final class PlanMatchPattern
                         expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate, new ParsingOptions()))),
                         expectedDistributionType,
                         expectedSpillable,
-                        expectedDynamicFilterAliases));
+                        expectedDynamicFilter));
     }
 
     public static PlanMatchPattern spatialJoin(String expectedFilter, PlanMatchPattern left, PlanMatchPattern right)
@@ -1049,6 +1062,38 @@ public final class PlanMatchPattern
         }
 
         return new GroupingSetDescriptor(groupingKeys, 1, globalGroupingSets);
+    }
+
+    public static class DynamicFilterPattern
+    {
+        private final SymbolAlias probe;
+        private final ComparisonExpression.Operator operator;
+        private final SymbolAlias build;
+
+        public DynamicFilterPattern(String probeAlias, ComparisonExpression.Operator operator, String buildAlias)
+        {
+            this.probe = new SymbolAlias(requireNonNull(probeAlias, "probeAlias is null"));
+            this.operator = requireNonNull(operator, "operator is null");
+            this.build = new SymbolAlias(requireNonNull(buildAlias, "buildAlias is null"));
+        }
+
+        ComparisonExpression getComparisonExpression(SymbolAliases aliases)
+        {
+            return new ComparisonExpression(
+                    operator,
+                    probe.toSymbol(aliases).toSymbolReference(),
+                    build.toSymbol(aliases).toSymbolReference());
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("probe", probe)
+                    .add("operator", operator)
+                    .add("build", build)
+                    .toString();
+        }
     }
 
     public static class GroupingSetDescriptor

--- a/presto-main/src/test/java/io/prestosql/sql/planner/sanity/TestDynamicFiltersChecker.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/sanity/TestDynamicFiltersChecker.java
@@ -144,7 +144,7 @@ public class TestDynamicFiltersChecker
         validatePlan(root);
     }
 
-    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "Dynamic filters \\[Descriptor\\{id=DF, input=\"ORDERS_OK\"\\}\\] present in filter predicate whose source is not a table scan.")
+    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "Dynamic filters \\[Descriptor\\{id=DF, input=\"ORDERS_OK\", operator=EQUAL\\}\\] present in filter predicate whose source is not a table scan.")
     public void testDynamicFilterNotAboveTableScan()
     {
         PlanNode root = builder.output(
@@ -306,7 +306,7 @@ public class TestDynamicFiltersChecker
         validatePlan(root);
     }
 
-    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "Dynamic filters \\[Descriptor\\{id=DF, input=\"ORDERS_OK\"\\}\\] present in filter predicate whose source is not a table scan.")
+    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "Dynamic filters \\[Descriptor\\{id=DF, input=\"ORDERS_OK\", operator=EQUAL\\}\\] present in filter predicate whose source is not a table scan.")
     public void testDynamicFilterNotAboveTableScanWithSemiJoin()
     {
         PlanNode root = builder.semiJoin(


### PR DESCRIPTION
Following #52, we would like to support dynamic filtering for cross joins (e.g. having inequality predicates in the join criteria). For example, the following query should benefit from this feature:

```sql
SELECT
	count() 
FROM
	orders o, part p 
WHERE
	p.comment = "Very expensive part" AND 
	o.totalprice > p.retailprice 
```

The following PR proposes a possible implementation - please let us know what do you think :)