### PR TITLE
Add register_partition, unregister_partition procedures

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -738,6 +738,15 @@ Procedures
     ``create_empty_partition``). A null value for the ``partition_values`` argument indicates that stats
     should be dropped for the entire table.
 
+* ``system.register_partition(schema_name, table_name, partition_columns, partition_values, location)``
+
+    Registers existing location as a new partition in the metastore for the specified table.
+
+* ``system.unregister_partition(schema_name, table_name, partition_columns, partition_values)``
+
+    Unregisters given, existing partition in the metastore for the specified table.
+    The partition data is not deleted.
+
 Examples
 --------
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1547,7 +1547,7 @@ public class HiveMetadata
                     throw new PrestoException(HIVE_CONCURRENT_MODIFICATION_DETECTED, "Partition format changed during insert");
                 }
                 if (partitionUpdate.getUpdateMode() == OVERWRITE) {
-                    metastore.dropPartition(session, handle.getSchemaName(), handle.getTableName(), partition.getValues());
+                    metastore.dropPartition(session, handle.getSchemaName(), handle.getTableName(), partition.getValues(), true);
                 }
                 PartitionStatistics partitionStatistics = createPartitionStatistics(
                         session,
@@ -1763,7 +1763,7 @@ public class HiveMetadata
         }
         else {
             for (HivePartition hivePartition : partitionManager.getOrLoadPartitions(metastore, new HiveIdentity(session), handle)) {
-                metastore.dropPartition(session, handle.getSchemaName(), handle.getTableName(), toPartitionValues(hivePartition.getPartitionId()));
+                metastore.dropPartition(session, handle.getSchemaName(), handle.getTableName(), toPartitionValues(hivePartition.getPartitionId()), true);
             }
         }
         // it is too expensive to determine the exact number of deleted rows

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveProcedureModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveProcedureModule.java
@@ -29,6 +29,8 @@ public class HiveProcedureModule
     {
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(CreateEmptyPartitionProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RegisterPartitionProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(UnregisterPartitionProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SyncPartitionMetadataProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(DropStatsProcedure.class).in(Scopes.SINGLETON);
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ProceduresUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ProceduresUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import io.prestosql.plugin.hive.metastore.Column;
+import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.spi.PrestoException;
+import org.apache.hadoop.hive.metastore.TableType;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+
+final class ProceduresUtil
+{
+    private ProceduresUtil() {}
+
+    static void checkIsPartitionedTable(Table table)
+    {
+        if (table.getTableType().equals(TableType.VIRTUAL_VIEW.name())) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Table is a view: " + table.getSchemaTableName());
+        }
+
+        if (table.getTableType().equals(TableType.MATERIALIZED_VIEW.name())) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Table is a materialized view: " + table.getSchemaTableName());
+        }
+
+        if (table.getPartitionColumns().isEmpty()) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Table is not partitioned: " + table.getSchemaTableName());
+        }
+    }
+
+    static void checkPartitionColumns(Table table, List<String> expectedPartitions)
+    {
+        List<String> actualPartitionColumnNames = table.getPartitionColumns().stream()
+                .map(Column::getName)
+                .collect(toImmutableList());
+
+        if (!Objects.equals(expectedPartitions, actualPartitionColumnNames)) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Provided partition column names do not match actual partition column names: " + actualPartitionColumnNames);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RegisterPartitionProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RegisterPartitionProcedure.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.Partition;
+import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
+import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.plugin.hive.util.HiveWriteUtils;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.procedure.Procedure;
+import io.prestosql.spi.type.ArrayType;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.FileUtils;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
+import static io.prestosql.plugin.hive.ProceduresUtil.checkIsPartitionedTable;
+import static io.prestosql.plugin.hive.ProceduresUtil.checkPartitionColumns;
+import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.prestosql.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RegisterPartitionProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle REGISTER_PARTITION = methodHandle(
+            RegisterPartitionProcedure.class,
+            "registerPartition",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            List.class,
+            List.class,
+            String.class);
+
+    private final Supplier<TransactionalMetadata> hiveMetadataFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HiveMetastoreClosure metastore;
+
+    @Inject
+    public RegisterPartitionProcedure(Supplier<TransactionalMetadata> hiveMetadataFactory, HiveMetastore metastore, HdfsEnvironment hdfsEnvironment)
+    {
+        this.hiveMetadataFactory = requireNonNull(hiveMetadataFactory, "hiveMetadataFactory is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.metastore = new HiveMetastoreClosure(requireNonNull(metastore, "metastore is null"));
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "register_partition",
+                ImmutableList.of(
+                        new Procedure.Argument("schema_name", VARCHAR),
+                        new Procedure.Argument("table_name", VARCHAR),
+                        new Procedure.Argument("partition_columns", new ArrayType(VARCHAR)),
+                        new Procedure.Argument("partition_values", new ArrayType(VARCHAR)),
+                        new Procedure.Argument("location", VARCHAR)),
+                REGISTER_PARTITION.bindTo(this));
+    }
+
+    public void registerPartition(ConnectorSession session, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues, String location)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doRegisterPartition(session, schemaName, tableName, partitionColumn, partitionValues, location);
+        }
+    }
+
+    private void doRegisterPartition(ConnectorSession session, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues, String location)
+    {
+        HiveIdentity identity = new HiveIdentity(session);
+        HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+
+        Path partitionLocation = new Path(location);
+
+        Table table = metastore.getTable(identity, schemaName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+
+        checkIsPartitionedTable(table);
+        checkPartitionColumns(table, partitionColumn);
+
+        Optional<Partition> partition = metastore.getPartition(new HiveIdentity(session), schemaName, tableName, partitionValues);
+        if (partition.isPresent()) {
+            String partitionName = FileUtils.makePartName(partitionColumn, partitionValues);
+            throw new PrestoException(ALREADY_EXISTS, format("Partition [%s] is already registered with location %s", partitionName, partition.get().getStorage().getLocation()));
+        }
+
+        if (!HiveWriteUtils.pathExists(hdfsContext, hdfsEnvironment, partitionLocation)) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Partition location does not exist: " + partitionLocation);
+        }
+
+        SemiTransactionalHiveMetastore metastore = ((HiveMetadata) hiveMetadataFactory.get()).getMetastore();
+
+        metastore.addPartition(
+                session,
+                table.getDatabaseName(),
+                table.getTableName(),
+                buildPartitionObject(session, table, partitionValues, partitionLocation),
+                partitionLocation,
+                PartitionStatistics.empty());
+
+        metastore.commit();
+    }
+
+    private static Partition buildPartitionObject(ConnectorSession session, Table table, List<String> partitionValues, Path location)
+    {
+        return Partition.builder()
+                .setDatabaseName(table.getDatabaseName())
+                .setTableName(table.getTableName())
+                .setColumns(table.getDataColumns())
+                .setValues(partitionValues)
+                .setParameters(ImmutableMap.of(PRESTO_QUERY_ID_NAME, session.getQueryId()))
+                .withStorage(storage -> storage
+                        .setStorageFormat(table.getStorage().getStorageFormat())
+                        .setLocation(location.toString())
+                        .setBucketProperty(table.getStorage().getBucketProperty())
+                        .setSerdeParameters(table.getStorage().getSerdeParameters()))
+                .build();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/SyncPartitionMetadataProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/SyncPartitionMetadataProcedure.java
@@ -216,7 +216,8 @@ public class SyncPartitionMetadataProcedure
                     session,
                     table.getDatabaseName(),
                     table.getTableName(),
-                    extractPartitionValues(name));
+                    extractPartitionValues(name),
+                    false);
         }
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/UnregisterPartitionProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/UnregisterPartitionProcedure.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.Partition;
+import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
+import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.procedure.Procedure;
+import io.prestosql.spi.type.ArrayType;
+import org.apache.hadoop.hive.common.FileUtils;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.prestosql.plugin.hive.ProceduresUtil.checkIsPartitionedTable;
+import static io.prestosql.plugin.hive.ProceduresUtil.checkPartitionColumns;
+import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
+import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UnregisterPartitionProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle UNREGISTER_PARTITION = methodHandle(
+            UnregisterPartitionProcedure.class,
+            "unregisterPartition",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            List.class,
+            List.class);
+
+    private final Supplier<TransactionalMetadata> hiveMetadataFactory;
+    private final HiveMetastoreClosure metastore;
+
+    @Inject
+    public UnregisterPartitionProcedure(Supplier<TransactionalMetadata> hiveMetadataFactory, HiveMetastore metastore)
+    {
+        this.hiveMetadataFactory = requireNonNull(hiveMetadataFactory, "hiveMetadataFactory is null");
+        this.metastore = new HiveMetastoreClosure(requireNonNull(metastore, "metastore is null"));
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "unregister_partition",
+                ImmutableList.of(
+                        new Procedure.Argument("schema_name", VARCHAR),
+                        new Procedure.Argument("table_name", VARCHAR),
+                        new Procedure.Argument("partition_columns", new ArrayType(VARCHAR)),
+                        new Procedure.Argument("partition_values", new ArrayType(VARCHAR))),
+                UNREGISTER_PARTITION.bindTo(this));
+    }
+
+    public void unregisterPartition(ConnectorSession session, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doUnregisterPartition(session, schemaName, tableName, partitionColumn, partitionValues);
+        }
+    }
+
+    private void doUnregisterPartition(ConnectorSession session, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues)
+    {
+        HiveIdentity identity = new HiveIdentity(session);
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+
+        Table table = metastore.getTable(identity, schemaName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+
+        checkIsPartitionedTable(table);
+        checkPartitionColumns(table, partitionColumn);
+
+        String partitionName = FileUtils.makePartName(partitionColumn, partitionValues);
+
+        Partition partition = metastore.getPartition(new HiveIdentity(session), schemaName, tableName, partitionValues)
+                .orElseThrow(() -> new PrestoException(NOT_FOUND, format("Partition %s does not exist", partitionName)));
+
+        SemiTransactionalHiveMetastore metastore = ((HiveMetadata) hiveMetadataFactory.get()).getMetastore();
+
+        metastore.dropPartition(
+                session,
+                table.getDatabaseName(),
+                table.getTableName(),
+                partition.getValues(),
+                false);
+
+        metastore.commit();
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -883,9 +883,20 @@ public class FileHiveMetastore
 
         List<String> partitionNames = partitions.stream()
                 .map(partitionValues -> makePartitionName(table.getPartitionColumns(), ImmutableList.copyOf(partitionValues)))
+                .filter(partitionName -> isValidPartition(table, partitionName))
                 .collect(toList());
 
         return Optional.of(ImmutableList.copyOf(partitionNames));
+    }
+
+    private boolean isValidPartition(Table table, String partitionName)
+    {
+        try {
+            return metadataFileSystem.exists(new Path(getPartitionMetadataDirectory(table, partitionName), PRESTO_SCHEMA_FILE_NAME));
+        }
+        catch (IOException e) {
+            return false;
+        }
     }
 
     private List<ArrayDeque<String>> listPartitions(Path director, List<Column> partitionColumns)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -1176,6 +1176,40 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testUnregisterRegisterPartition()
+    {
+        String tableName = "test_register_partition_for_table";
+        assertUpdate("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  dummy_col bigint," +
+                "  part varchar)" +
+                "WITH (" +
+                "  partitioned_by = ARRAY['part'] " +
+                ")");
+
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 0");
+
+        assertUpdate(format("INSERT INTO %s (dummy_col, part) VALUES (1, 'first'), (2, 'second'), (3, 'third')", tableName), 3);
+        List<MaterializedRow> paths = getQueryRunner().execute(getSession(), "SELECT \"$path\" FROM " + tableName + " ORDER BY \"$path\" ASC").toTestTypes().getMaterializedRows();
+        assertEquals(paths.size(), 3);
+
+        String firstPartition = new Path((String) paths.get(0).getField(0)).getParent().toString();
+
+        assertQueryFails(format("CALL system.unregister_partition('%s', '%s', ARRAY['part'], ARRAY['empty'])", TPCH_SCHEMA, tableName), "Partition part=empty does not exist");
+        assertUpdate(format("CALL system.unregister_partition('%s', '%s', ARRAY['part'], ARRAY['first'])", TPCH_SCHEMA, tableName));
+
+        assertQuery(getSession(), format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 2");
+        assertQuery(getSession(), "SELECT count(*) FROM " + tableName, "SELECT 2");
+
+        assertUpdate(format("CALL system.register_partition('%s', '%s', ARRAY['part'], ARRAY['first'], '%s')", TPCH_SCHEMA, tableName, firstPartition));
+
+        assertQuery(getSession(), format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 3");
+        assertQuery(getSession(), "SELECT count(*) FROM " + tableName, "SELECT 3");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testCreateEmptyBucketedPartition()
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
@@ -47,7 +47,8 @@ public class TestSemiTransactionalHiveMetastore
             IntStream.range(0, partitionsToDrop).forEach(i -> semiTransactionalHiveMetastore.dropPartition(SESSION,
                     "test",
                     "test",
-                    ImmutableList.of(String.valueOf(i))));
+                    ImmutableList.of(String.valueOf(i)),
+                    true));
             semiTransactionalHiveMetastore.commit();
         });
     }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHivePartitionProcedures.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHivePartitionProcedures.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import com.google.inject.Inject;
+import io.prestosql.tempto.ProductTest;
+import io.prestosql.tempto.assertions.QueryAssert;
+import io.prestosql.tempto.fulfillment.table.hive.HiveDataSource;
+import io.prestosql.tempto.hadoop.hdfs.HdfsClient;
+import io.prestosql.tempto.internal.hadoop.hdfs.HdfsDataSourceWriter;
+import io.prestosql.tempto.query.QueryResult;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
+import static io.prestosql.tempto.query.QueryExecutor.query;
+import static io.prestosql.tests.TestGroups.HIVE_PARTITIONING;
+import static io.prestosql.tests.TestGroups.SMOKE;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHivePartitionProcedures
+        extends ProductTest
+{
+    private static final String HDFS_DIRECTORY_PATH = "/user/hive/warehouse/";
+    private static final String OUTSIDE_TABLES_DIRECTORY_PATH = "/user/hive/dangling";
+    private static final String FIRST_TABLE = "first_table";
+    private static final String SECOND_TABLE = "second_table";
+    private static final String VIEW_TABLE = "view_table";
+
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @Inject
+    private HdfsDataSourceWriter hdfsDataSourceWriter;
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterPartition()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        assertThat(getTableCount(FIRST_TABLE)).isEqualTo(3L);
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c");
+
+        dropPartition(FIRST_TABLE, "col", "a");
+
+        assertThat(getTableCount(FIRST_TABLE)).isEqualTo(2L);
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("b", "c");
+
+        // should not drop data
+        assertThat(hdfsClient.exist(HDFS_DIRECTORY_PATH + FIRST_TABLE + "/col=a/")).isTrue();
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterViewTableShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+        createView(VIEW_TABLE, FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> dropPartition(VIEW_TABLE, "col", "a"))
+                .failsWithMessage("Table is a view: default." + VIEW_TABLE);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterMissingTableShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> dropPartition("missing_table", "col", "f"))
+                .failsWithMessage("Table 'default.missing_table' not found");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterUnpartitionedTableShouldFail()
+    {
+        createUnpartitionedTable(SECOND_TABLE);
+
+        QueryAssert.assertThat(() -> dropPartition(SECOND_TABLE, "col", "a"))
+                .failsWithMessage("Table is not partitioned: default." + SECOND_TABLE);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterInvalidPartitionColumnsShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> dropPartition(FIRST_TABLE, "not_existing_partition_col", "a"))
+                .failsWithMessage("Provided partition column names do not match actual partition column names: [col]");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testUnregisterMissingPartitionShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> dropPartition(FIRST_TABLE, "col", "f"))
+                .failsWithMessage("Partition col=f does not exist");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartitionMissingTableShouldFail()
+    {
+        QueryAssert.assertThat(() -> addPartition("missing_table", "col", "f", "/"))
+                .failsWithMessage("Table 'default.missing_table' not found");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterUnpartitionedTableShouldFail()
+    {
+        createUnpartitionedTable(SECOND_TABLE);
+
+        QueryAssert.assertThat(() -> addPartition(SECOND_TABLE, "col", "a", "/"))
+                .failsWithMessage("Table is not partitioned: default." + SECOND_TABLE);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterViewTableShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+        createView(VIEW_TABLE, FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> addPartition(VIEW_TABLE, "col", "a", "/"))
+                .failsWithMessage("Table is a view: default." + VIEW_TABLE);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartitionCollisionShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "col", "a", "/"))
+                .failsWithMessage("Partition [col=a] is already registered");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartitionInvalidPartitionColumnsShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "not_existing_partition_col", "a", "/"))
+                .failsWithMessage("Provided partition column names do not match actual partition column names: [col]");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartitionInvalidLocationShouldFail()
+    {
+        createPartitionedTable(FIRST_TABLE);
+
+        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "col", "f", "/some/non/existing/path"))
+                .failsWithMessage("Partition location does not exist: /some/non/existing/path");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartition()
+    {
+        createPartitionedTable(FIRST_TABLE);
+        createPartitionedTable(SECOND_TABLE);
+
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c");
+
+        query(format("INSERT INTO %s (val, col) VALUES (10, 'f')", SECOND_TABLE));
+        assertThat(getPartitionValues(SECOND_TABLE)).containsOnly("a", "b", "c", "f");
+
+        // Move partition f from SECOND_TABLE to FIRST_TABLE
+        addPartition(FIRST_TABLE, "col", "f", HDFS_DIRECTORY_PATH + SECOND_TABLE + "/col=f");
+        dropPartition(SECOND_TABLE, "col", "f");
+
+        assertThat(getPartitionValues(SECOND_TABLE)).containsOnly("a", "b", "c");
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c", "f");
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testRegisterPartitionFromAnyLocation()
+    {
+        createPartitionedTable(FIRST_TABLE);
+        createDanglingLocationWithData(OUTSIDE_TABLES_DIRECTORY_PATH, "dangling");
+
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c");
+        addPartition(FIRST_TABLE, "col", "f", OUTSIDE_TABLES_DIRECTORY_PATH);
+
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c", "f");
+        assertThat(getValues(FIRST_TABLE)).containsOnly(1, 2, 3, 42);
+
+        dropPartition(FIRST_TABLE, "col", "f");
+
+        assertThat(getPartitionValues(FIRST_TABLE)).containsOnly("a", "b", "c");
+        assertThat(getValues(FIRST_TABLE)).containsOnly(1, 2, 3);
+    }
+
+    private QueryResult dropPartition(String tableName, String partitionCol, String partition)
+    {
+        return query(format("CALL system.unregister_partition(\n" +
+                        "    schema_name => '%s',\n" +
+                        "    table_name => '%s',\n" +
+                        "    partition_columns => ARRAY['%s'],\n" +
+                        "    partition_values => ARRAY['%s'])",
+                "default", tableName, partitionCol, partition));
+    }
+
+    private QueryResult addPartition(String tableName, String partitionCol, String partition, String location)
+    {
+        return query(format("CALL system.register_partition(\n" +
+                        "    schema_name => '%s',\n" +
+                        "    table_name => '%s',\n" +
+                        "    partition_columns => ARRAY['%s'],\n" +
+                        "    partition_values => ARRAY['%s'],\n" +
+                        "    location => '%s')",
+                "default", tableName, partitionCol, partition, location));
+    }
+
+    private void createDanglingLocationWithData(String path, String tableName)
+    {
+        hdfsClient.createDirectory(path);
+        HiveDataSource dataSource = createResourceDataSource(tableName, "io/prestosql/tests/hive/data/single_int_column/data.textfile");
+        hdfsDataSourceWriter.ensureDataOnHdfs(path, dataSource);
+    }
+
+    private static void createPartitionedTable(String tableName)
+    {
+        query("DROP TABLE IF EXISTS " + tableName);
+
+        query("CREATE TABLE " + tableName + " (val int, col varchar) WITH (format = 'TEXTFILE', partitioned_by = ARRAY['col'])");
+        query("INSERT INTO " + tableName + " VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    }
+
+    private static void createView(String viewName, String tableName)
+    {
+        query("DROP VIEW IF EXISTS " + viewName);
+        query(format("CREATE VIEW %s AS SELECT val, col FROM %s", viewName, tableName));
+    }
+
+    private static void createUnpartitionedTable(String tableName)
+    {
+        query("DROP TABLE IF EXISTS " + tableName);
+
+        query("CREATE TABLE " + tableName + " (val int, col varchar) WITH (format = 'TEXTFILE')");
+        query("INSERT INTO " + tableName + " VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    }
+
+    private Long getTableCount(String tableName)
+    {
+        QueryResult countResult = query("SELECT count(*) FROM " + tableName);
+        return (Long) countResult.row(0).get(0);
+    }
+
+    private Set<String> getPartitionValues(String tableName)
+    {
+        return query("SELECT col FROM " + tableName).rows().stream().map(row -> row.get(0)).map(String.class::cast).collect(Collectors.toSet());
+    }
+
+    private Set<Integer> getValues(String tableName)
+    {
+        return query("SELECT val FROM " + tableName).column(1).stream()
+                .map(Integer.class::cast)
+                .collect(toImmutableSet());
+    }
+}


### PR DESCRIPTION
Hive: Add partition manipulation procedures:

* ``system.register_partition(schema_name, table_name, location, partition_columns, partition_values)``

    Registers existing location as a partition in metastore for specified table.

* ``system.unregister_partition(schema_name, table_name, partition_columns, partition_values)``

    Unregisters given, existing partition in metastore for specified table.
    The referenced partition data location is not deleted.