### PR TITLE
Update statistics on insert to empty table in Hive connector

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
@@ -90,7 +90,8 @@ public class HiveMetastoreClosure
 
     public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        delegate.updateTableStatistics(identity, databaseName, tableName, update);
+        Table table = getExistingTable(identity, databaseName, tableName);
+        delegate.updateTableStatistics(identity, table, update);
     }
 
     public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -42,7 +42,7 @@ public interface HiveMetastore
 
     Map<String, PartitionStatistics> getPartitionStatistics(HiveIdentity identity, Table table, List<Partition> partitions);
 
-    void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update);
+    void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update);
 
     void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -241,10 +241,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
         verifyRecordingMode();
-        delegate.updateTableStatistics(identity, databaseName, tableName, update);
+        delegate.updateTableStatistics(identity, table, update);
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -367,14 +367,14 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
         identity = updateIdentity(identity);
         try {
-            delegate.updateTableStatistics(identity, databaseName, tableName, update);
+            delegate.updateTableStatistics(identity, table, update);
         }
         finally {
-            HiveTableName hiveTableName = hiveTableName(databaseName, tableName);
+            HiveTableName hiveTableName = hiveTableName(table.getDatabaseName(), table.getTableName());
             tableStatisticsCache.invalidate(new WithIdentity<>(identity, hiveTableName));
             // basic stats are stored as table properties
             tableCache.invalidate(new WithIdentity<>(identity, hiveTableName));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -356,14 +356,14 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public synchronized void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        PartitionStatistics originalStatistics = getTableStatistics(databaseName, tableName);
+        PartitionStatistics originalStatistics = getTableStatistics(table.getDatabaseName(), table.getTableName());
         PartitionStatistics updatedStatistics = update.apply(originalStatistics);
 
-        Path tableMetadataDirectory = getTableMetadataDirectory(databaseName, tableName);
+        Path tableMetadataDirectory = getTableMetadataDirectory(table.getDatabaseName(), table.getTableName());
         TableMetadata tableMetadata = readSchemaFile("table", tableMetadataDirectory, tableCodec)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
+                .orElseThrow(() -> new TableNotFoundException(table.getSchemaTableName()));
 
         TableMetadata updatedMetadata = tableMetadata
                 .withParameters(updateStatisticsParameters(tableMetadata.getParameters(), updatedStatistics.getBasicStatistics()))

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -327,9 +327,8 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        Table table = getExistingTable(identity, databaseName, tableName);
         PartitionStatistics currentStatistics = getTableStatistics(identity, table);
         PartitionStatistics updatedStatistics = update.apply(currentStatistics);
 
@@ -339,11 +338,11 @@ public class GlueHiveMetastore
             columnStatisticsProvider.updateTableColumnStatistics(tableInput, updatedStatistics.getColumnStatistics());
             glueClient.updateTable(new UpdateTableRequest()
                     .withCatalogId(catalogId)
-                    .withDatabaseName(databaseName)
+                    .withDatabaseName(table.getDatabaseName())
                     .withTableInput(tableInput));
         }
         catch (EntityNotFoundException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(table.getSchemaTableName());
         }
         catch (AmazonServiceException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -116,9 +116,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        delegate.updateTableStatistics(identity, databaseName, tableName, update);
+        delegate.updateTableStatistics(identity, toMetastoreApiTable(table), update);
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -486,7 +486,6 @@ public class ThriftHiveMetastore
 
         OptionalLong rowCount = basicStatistics.getRowCount();
         List<ColumnStatisticsObj> metastoreColumnStatistics = updatedStatistics.getColumnStatistics().entrySet().stream()
-                .filter(column -> table.getColumn(column.getKey()).isPresent())
                 .map(entry -> createMetastoreColumnStatistics(entry.getKey(), table.getColumn(entry.getKey()).get().getType(), entry.getValue(), rowCount))
                 .collect(toImmutableList());
         if (!metastoreColumnStatistics.isEmpty()) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -84,7 +84,7 @@ public interface ThriftMetastore
 
     Map<String, PartitionStatistics> getPartitionStatistics(HiveIdentity identity, Table table, List<Partition> partitions);
 
-    void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update);
+    void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update);
 
     void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
@@ -83,6 +83,10 @@ public final class Statistics
 
     public static PartitionStatistics merge(PartitionStatistics first, PartitionStatistics second)
     {
+        if (first.getBasicStatistics().getRowCount().orElse(0L) == 0) {
+            return second;
+        }
+
         return new PartitionStatistics(
                 reduce(first.getBasicStatistics(), second.getBasicStatistics(), ADD),
                 merge(first.getColumnStatistics(), second.getColumnStatistics()));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -3772,9 +3772,11 @@ public abstract class AbstractTestHive
     {
         HiveMetastore metastoreClient = getMetastoreClient();
         HiveIdentity identity = new HiveIdentity(SESSION);
-        metastoreClient.updateTableStatistics(identity, schemaTableName.getSchemaName(), schemaTableName.getTableName(), statistics -> new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of()));
         Table table = metastoreClient.getTable(identity, schemaTableName.getSchemaName(), schemaTableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+
+        metastoreClient.updateTableStatistics(identity, table, statistics -> new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of()));
+
         List<String> partitionColumns = table.getPartitionColumns().stream()
                 .map(Column::getName)
                 .collect(toImmutableList());

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -3744,8 +3744,8 @@ public abstract class AbstractTestHive
 
             for (String partitionName : partitionNames) {
                 HiveBasicStatistics statistics = getBasicStatisticsForPartition(session, transaction, tableName, partitionName);
-                assertThat(statistics.getRowCount()).isNotPresent();
-                assertThat(statistics.getInMemoryDataSizeInBytes()).isNotPresent();
+                assertThat(statistics.getRowCount()).isEqualTo(OptionalLong.of(1));
+                assertThat(statistics.getInMemoryDataSizeInBytes()).isPresent();
                 // fileCount and rawSize statistics are computed on the fly by the metastore, thus cannot be erased
             }
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -66,7 +66,7 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -470,9 +470,9 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public synchronized void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    public synchronized void updateTableStatistics(HiveIdentity identity, Table table, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        columnStatistics.put(new SchemaTableName(databaseName, tableName), update.apply(getTableStatistics(databaseName, tableName)));
+        columnStatistics.put(new SchemaTableName(table.getDbName(), table.getTableName()), update.apply(getTableStatistics(identity, table)));
     }
 
     @Override

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaEvolution.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSchemaEvolution.java
@@ -149,9 +149,14 @@ public class TestAvroSchemaEvolution
                 .containsExactly(row("string0", 0));
 
         executeHiveQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", TABLE_NAME));
+
+        // Metastore requires that table column statistics must much columns from schema when updating table.
+        // This has a side-effect of schema being overriden by schema taken from avro.schema.url.
+        // When we drop avro.schema.url property we are not able to rollback to previous (dummy) schema.
         assertThat(query(COLUMNS_IN_TABLE))
                 .containsExactly(
-                        row("dummy_col", "varchar", "", ""));
+                        row("string_col", "varchar", "", ""),
+                        row("int_col", "integer", "", ""));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/2469

This has uncovered side-effect behaviour in Metastore. If we are updating table column statistics in metastore it will synchronize schema from schema.avro.url avro schema to check if columns from stats match actual schema columns. When we unset this attribute in Hive, we are unable to restore previous (dummy) schema.