### PR TITLE
Add latency statistics accumulation to GlueHiveMetastore

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreApiStats.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.glue;
+
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@ThreadSafe
+public class GlueMetastoreApiStats
+{
+    private final TimeStat time = new TimeStat(MILLISECONDS);
+    private final CounterStat totalFailures = new CounterStat();
+
+    public <V, E extends Exception> V call(ThrowingCallable<V, E> callable)
+            throws E
+    {
+        try (TimeStat.BlockTimer ignored = time.time()) {
+            return callable.call();
+        }
+        catch (Exception e) {
+            totalFailures.update(1);
+            throw e;
+        }
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getTime()
+    {
+        return time;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getTotalFailures()
+    {
+        return totalFailures;
+    }
+
+    public interface ThrowingCallable<V, E extends Exception>
+    {
+        V call() throws E;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreStats.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueMetastoreStats.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.glue;
+
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+public class GlueMetastoreStats
+{
+    private final GlueMetastoreApiStats getAllDatabases = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getAllTables = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getAllViews = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats createDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats dropDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats renameDatabase = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats createTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats dropTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats replaceTable = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getPartitionNames = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getPartitions = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getPartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats getPartitionByName = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats addPartitions = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats dropPartition = new GlueMetastoreApiStats();
+    private final GlueMetastoreApiStats alterPartition = new GlueMetastoreApiStats();
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetAllDatabases()
+    {
+        return getAllDatabases;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetDatabase()
+    {
+        return getDatabase;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetAllTables()
+    {
+        return getAllTables;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetTable()
+    {
+        return getTable;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetAllViews()
+    {
+        return getAllViews;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getCreateDatabase()
+    {
+        return createDatabase;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getDropDatabase()
+    {
+        return dropDatabase;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getRenameDatabase()
+    {
+        return renameDatabase;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getCreateTable()
+    {
+        return createTable;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getDropTable()
+    {
+        return dropTable;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getReplaceTable()
+    {
+        return replaceTable;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetPartitionNames()
+    {
+        return getPartitionNames;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetPartitions()
+    {
+        return getPartitions;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetPartition()
+    {
+        return getPartition;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getGetPartitionByName()
+    {
+        return getPartitionByName;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getAddPartitions()
+    {
+        return addPartitions;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getDropPartition()
+    {
+        return dropPartition;
+    }
+
+    @Managed
+    @Nested
+    public GlueMetastoreApiStats getAlterPartition()
+    {
+        return alterPartition;
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -18,6 +18,7 @@ import io.airlift.concurrent.BoundedExecutor;
 import io.prestosql.plugin.hive.AbstractTestHiveLocal;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.List;
@@ -29,6 +30,7 @@ import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Locale.ENGLISH;
 import static java.util.UUID.randomUUID;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 /*
@@ -36,6 +38,7 @@ import static org.testng.Assert.assertTrue;
  * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
  * on ways to set your AWS credentials which will be needed to run this test.
  */
+@Test(singleThreaded = true)
 public class TestHiveGlueMetastore
         extends AbstractTestHiveLocal
 {
@@ -112,5 +115,28 @@ public class TestHiveGlueMetastore
         finally {
             dropTable(tablePartitionFormat);
         }
+    }
+
+    @Test
+    public void testGetDatabasesLogsStats()
+    {
+        GlueHiveMetastore metastore = (GlueHiveMetastore) getMetastoreClient();
+        GlueMetastoreStats stats = metastore.getStats();
+        double initialCallCount = stats.getGetAllDatabases().getTime().getAllTime().getCount();
+        long initialFailureCount = stats.getGetAllDatabases().getTotalFailures().getTotalCount();
+        getMetastoreClient().getAllDatabases();
+        assertEquals(stats.getGetAllDatabases().getTime().getAllTime().getCount(), initialCallCount + 1.0);
+        assertTrue(stats.getGetAllDatabases().getTime().getAllTime().getAvg() > 0.0);
+        assertEquals(stats.getGetAllDatabases().getTotalFailures().getTotalCount(), initialFailureCount);
+    }
+
+    @Test
+    public void testGetDatabaseFailureLogsStats()
+    {
+        GlueHiveMetastore metastore = (GlueHiveMetastore) getMetastoreClient();
+        GlueMetastoreStats stats = metastore.getStats();
+        long initialFailureCount = stats.getGetDatabase().getTotalFailures().getTotalCount();
+        assertThrows(() -> getMetastoreClient().getDatabase(null));
+        assertEquals(stats.getGetDatabase().getTotalFailures().getTotalCount(), initialFailureCount + 1);
     }
 }


### PR DESCRIPTION
These are used by the JMX connector to present stats similar to the ThriftMetastoreStats: https://github.com/prestosql/presto/blob/master/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreStats.java

Issue: https://github.com/prestosql/presto/issues/1294

~~There were a few calls I didn't add stats to because they do async api calls so the stats didn't seem to make as much sense. Those were~~
- ~~getPartitionsByNames~~
- ~~addPartitions~~