### PR TITLE
Increase default HTTP request/response header size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.192</dep.airlift.version>
+        <dep.airlift.version>0.193</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.11.602</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcPreparedStatement.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcPreparedStatement.java
@@ -285,6 +285,20 @@ public class TestJdbcPreparedStatement
     }
 
     @Test
+    public void testPrepareLarge()
+            throws Exception
+    {
+        String sql = format("SELECT '%s' = '%s'", repeat("x", 100_000), repeat("y", 100_000));
+        try (Connection connection = createConnection();
+                PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet rs = statement.executeQuery()) {
+            assertTrue(rs.next());
+            assertFalse(rs.getBoolean(1));
+            assertFalse(rs.next());
+        }
+    }
+
+    @Test
     public void testSetNull()
             throws Exception
     {


### PR DESCRIPTION
This allows large prepared statements.

Depends on https://github.com/airlift/airlift/pull/820