### PR TITLE
Fix CBO broadcast join reordering

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
@@ -4,13 +4,12 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["d_year", "i_brand", "i_brand_id"])
                     partial aggregation over (d_year, i_brand, i_brand_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan item
+                        join (INNER, REPLICATED):
+                            join (INNER, REPLICATED):
+                                scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_date_sk"])
+                                remote exchange (REPLICATE, BROADCAST, [])
                                     scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
@@ -27,11 +27,10 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                    scan customer_demographics
+                                            join (INNER, REPLICATED):
+                                                scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
                                                         join (INNER, PARTITIONED):
                                                             final aggregation over (ss_customer_sk)
                                                                 local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
@@ -15,16 +15,15 @@ local exchange (GATHER, SINGLE, [])
                                                 scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, PARTITIONED):
-                                                        remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan item
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
+                                                            scan store_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                                                scan date_dim
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
@@ -4,17 +4,16 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_current_price", "i_item_desc", "i_item_id"])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                scan catalog_sales
+                        join (INNER, REPLICATED):
+                            scan catalog_sales
                             local exchange (GATHER, SINGLE, [])
-                                join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["inv_item_sk"])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                            scan item
+                                                    scan item
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
@@ -4,13 +4,12 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["d_year", "i_category", "i_category_id"])
                     partial aggregation over (d_year, i_category, i_category_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan item
+                        join (INNER, REPLICATED):
+                            join (INNER, REPLICATED):
+                                scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_date_sk"])
+                                remote exchange (REPLICATE, BROADCAST, [])
                                     scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
@@ -9,19 +9,18 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_moy", "d_year", "i_brand", "i_category", "s_company_name", "s_store_name"])
                                     partial aggregation over (d_moy, d_year, i_brand, i_category, s_company_name, s_store_name)
                                         join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                            join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                        scan item
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan item
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_brand_73", "i_category_77", "s_company_name_155", "s_store_name_143"])
                         final aggregation over (d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143)
@@ -29,19 +28,18 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_moy_118", "d_year_116", "i_brand_73", "i_category_77", "s_company_name_155", "s_store_name_143"])
                                     partial aggregation over (d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143)
                                         join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_item_sk_89"])
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                            join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["i_item_sk_65"])
-                                                        scan item
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                    scan item
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_brand_250", "i_category_254", "s_company_name_332", "s_store_name_320"])
                     final aggregation over (d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320)
@@ -49,16 +47,15 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["d_moy_295", "d_year_293", "i_brand_250", "i_category_254", "s_company_name_332", "s_store_name_320"])
                                 partial aggregation over (d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320)
                                     join (INNER, REPLICATED):
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["ss_item_sk_266"])
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                        join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["i_item_sk_242"])
-                                                    scan item
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan store
+                                                scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
@@ -4,13 +4,12 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["d_year", "i_brand", "i_brand_id"])
                     partial aggregation over (d_year, i_brand, i_brand_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan item
+                        join (INNER, REPLICATED):
+                            join (INNER, REPLICATED):
+                                scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                    scan date_dim
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
@@ -7,16 +7,15 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_qoy", "i_manufact_id"])
                             partial aggregation over (d_qoy, i_manufact_id)
                                 join (INNER, REPLICATED):
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                    join (INNER, REPLICATED):
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                scan item
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
@@ -6,60 +6,60 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (expr_134)
                         final aggregation over (c_customer_sk)
                             local exchange (GATHER, SINGLE, [])
-                                partial aggregation over (c_customer_sk)
-                                    cross join:
+                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                    partial aggregation over (c_customer_sk)
                                         cross join:
-                                            join (INNER, REPLICATED):
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                            cross join:
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
                                                         scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                            join (INNER, REPLICATED):
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan customer_address
+                                                                    join (INNER, REPLICATED):
+                                                                        scan customer_address
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk", "c_customer_sk"])
+                                                                                            partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                                join (INNER, REPLICATED):
+                                                                                                    scan customer
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            join (INNER, REPLICATED):
+                                                                                                                join (INNER, REPLICATED):
+                                                                                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                                        scan catalog_sales
+                                                                                                                        scan web_sales
+                                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                            scan item
+                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                        scan date_dim
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                                             scan store
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                    join (INNER, PARTITIONED):
-                                                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                                            scan customer
-                                                                                        local exchange (GATHER, SINGLE, [])
-                                                                                            remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk_13"])
-                                                                                                join (INNER, REPLICATED):
-                                                                                                    join (INNER, REPLICATED):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                            scan catalog_sales
-                                                                                                            scan web_sales
-                                                                                                        local exchange (GATHER, SINGLE, [])
-                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                scan item
-                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                            scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                final aggregation over (expr_86)
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPARTITION, HASH, ["expr_86"])
+                                                                            partial aggregation over (expr_86)
+                                                                                scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
-                                                            final aggregation over (expr_86)
+                                                            final aggregation over (expr_118)
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, ["expr_86"])
-                                                                        partial aggregation over (expr_86)
+                                                                    remote exchange (REPARTITION, HASH, ["expr_118"])
+                                                                        partial aggregation over (expr_118)
                                                                             scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        final aggregation over (expr_118)
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["expr_118"])
-                                                                    partial aggregation over (expr_118)
-                                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
@@ -4,13 +4,12 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_brand", "i_brand_id"])
                     partial aggregation over (i_brand, i_brand_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan item
+                        join (INNER, REPLICATED):
+                            join (INNER, REPLICATED):
+                                scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                    scan date_dim
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
@@ -9,15 +9,14 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cc_name", "d_moy", "d_year", "i_brand", "i_category"])
                                     partial aggregation over (cc_name, d_moy, d_year, i_brand, i_category)
                                         join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                            join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
                                                         scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -29,15 +28,14 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cc_name_147", "d_moy_121", "d_year_119", "i_brand_65", "i_category_69"])
                                     partial aggregation over (cc_name_147, d_moy_121, d_year_119, i_brand_65, i_category_69)
                                         join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cs_item_sk_94"])
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                            join (INNER, REPLICATED):
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["i_item_sk_57"])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
                                                         scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -49,15 +47,14 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["cc_name_328", "d_moy_302", "d_year_300", "i_brand_246", "i_category_250"])
                                 partial aggregation over (cc_name_328, d_moy_302, d_year_300, i_brand_246, i_category_250)
                                     join (INNER, REPLICATED):
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["cs_item_sk_275"])
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                        join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["i_item_sk_238"])
+                                                remote exchange (REPLICATE, BROADCAST, [])
                                                     scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
@@ -7,16 +7,15 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_moy", "i_manager_id"])
                             partial aggregation over (d_moy, i_manager_id)
                                 join (INNER, REPLICATED):
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                    join (INNER, REPLICATED):
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                scan item
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
@@ -1,34 +1,34 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, REPLICATED):
-            join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["ss_store_sk_31"])
-                    final aggregation over (ss_item_sk_26, ss_store_sk_31)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ss_item_sk_26", "ss_store_sk_31"])
-                                partial aggregation over (ss_item_sk_26, ss_store_sk_31)
-                                    join (INNER, REPLICATED):
-                                        scan store_sales
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+            join (INNER, REPLICATED):
+                final aggregation over (ss_item_sk_26, ss_store_sk_31)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, ["ss_item_sk_26", "ss_store_sk_31"])
+                            partial aggregation over (ss_item_sk_26, ss_store_sk_31)
+                                join (INNER, REPLICATED):
+                                    scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan date_dim
                 local exchange (GATHER, SINGLE, [])
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, ["s_store_sk"])
-                            scan store
-                        final aggregation over (ss_store_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_store_sk"])
-                                    partial aggregation over (ss_store_sk)
-                                        final aggregation over (ss_item_sk, ss_store_sk)
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_store_sk"])
-                                                    partial aggregation over (ss_item_sk, ss_store_sk)
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                    remote exchange (REPLICATE, BROADCAST, [])
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, ["s_store_sk"])
+                                scan store
+                            final aggregation over (ss_store_sk)
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["ss_store_sk"])
+                                        partial aggregation over (ss_store_sk)
+                                            final aggregation over (ss_item_sk, ss_store_sk)
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_store_sk"])
+                                                        partial aggregation over (ss_item_sk, ss_store_sk)
+                                                            join (INNER, REPLICATED):
+                                                                scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
@@ -6,28 +6,25 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_brand", "i_brand_id", "t_hour", "t_minute"])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
-                                join (INNER, PARTITIONED):
-                                    local exchange (REPARTITION, ROUND_ROBIN, [])
-                                        remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan catalog_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                join (INNER, REPLICATED):
+                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                        join (INNER, REPLICATED):
+                                            scan web_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                        join (INNER, REPLICATED):
+                                            scan catalog_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                        remote exchange (REPLICATE, BROADCAST, [])
                                             scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
@@ -4,17 +4,16 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_current_price", "i_item_desc", "i_item_id"])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                scan store_sales
+                        join (INNER, REPLICATED):
+                            scan store_sales
                             local exchange (GATHER, SINGLE, [])
-                                join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, ["inv_item_sk"])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                            scan item
+                                                    scan item
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
@@ -1,10 +1,9 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        join (INNER, PARTITIONED):
-            remote exchange (REPARTITION, HASH, ["sr_cdemo_sk"])
-                scan store_returns
+        join (INNER, REPLICATED):
+            scan store_returns
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
+                remote exchange (REPLICATE, BROADCAST, [])
                     join (INNER, REPLICATED):
                         scan customer_demographics
                         local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
@@ -7,16 +7,15 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_moy", "i_brand", "i_category", "i_class", "s_company_name", "s_store_name"])
                             partial aggregation over (d_moy, i_brand, i_category, i_class, s_company_name, s_store_name)
                                 join (INNER, REPLICATED):
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ss_item_sk"])
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                    join (INNER, REPLICATED):
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                scan item
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
@@ -7,11 +7,10 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (expr_24, name_15, name_19)
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["suppkey_0"])
-                                            scan lineitem
+                                    join (INNER, REPLICATED):
+                                        scan lineitem
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["suppkey"])
+                                            remote exchange (REPLICATE, BROADCAST, [])
                                                 join (INNER, REPLICATED):
                                                     scan supplier
                                                     local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
@@ -14,11 +14,10 @@ remote exchange (GATHER, SINGLE, [])
                                                     scan orders
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["orderkey"])
-                                                        join (INNER, PARTITIONED):
-                                                            remote exchange (REPARTITION, HASH, ["partkey_3"])
-                                                                scan lineitem
+                                                        join (INNER, REPLICATED):
+                                                            scan lineitem
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["partkey"])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
                                                                     scan part
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["custkey_10"])

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReorderJoins.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -424,9 +425,7 @@ public class ReorderJoins
                 case AUTOMATIC:
                     ImmutableList.Builder<JoinEnumerationResult> result = ImmutableList.builder();
                     result.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
-                    if (canReplicate(joinNode, context)) {
-                        result.addAll(getPossibleJoinNodes(joinNode, REPLICATED));
-                    }
+                    result.addAll(getPossibleJoinNodes(joinNode, REPLICATED, node -> canReplicate(node, context)));
                     return result.build();
                 default:
                     throw new IllegalArgumentException("unexpected join distribution type: " + distributionType);
@@ -435,9 +434,15 @@ public class ReorderJoins
 
         private List<JoinEnumerationResult> getPossibleJoinNodes(JoinNode joinNode, DistributionType distributionType)
         {
-            return ImmutableList.of(
-                    createJoinEnumerationResult(joinNode.withDistributionType(distributionType)),
-                    createJoinEnumerationResult(joinNode.flipChildren().withDistributionType(distributionType)));
+            return getPossibleJoinNodes(joinNode, distributionType, (node) -> true);
+        }
+
+        private List<JoinEnumerationResult> getPossibleJoinNodes(JoinNode joinNode, DistributionType distributionType, Predicate<JoinNode> isAllowed)
+        {
+            List<JoinNode> nodes = ImmutableList.of(
+                    joinNode.withDistributionType(distributionType),
+                    joinNode.flipChildren().withDistributionType(distributionType));
+            return nodes.stream().filter(isAllowed).map(this::createJoinEnumerationResult).collect(toImmutableList());
         }
 
         private JoinEnumerationResult createJoinEnumerationResult(PlanNode planNode)


### PR DESCRIPTION
Allows reordering (and broadcast join distribution) when the original build-side estimated size is above `JOIN_MAX_BROADCAST_TABLE_SIZE`.