### PR TITLE
Cache .m2/repository dependencies to speed up builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -33,6 +39,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -23,6 +23,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Install Hive Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -50,6 +56,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Install Kudu Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -68,6 +80,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -111,6 +129,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/product-tests.yml
+++ b/.github/workflows/product-tests.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION
I don't know if there is some reason why maven dependencies aren't cached so I've made this PR to enable .m2/repository caching to speed up builds.

/ cc @electrum @findepi 