### PR TITLE
Handle the case of multiple projections in a rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -382,6 +382,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
+                                new InlineProjections(),
                                 new RemoveUnreferencedScalarSubqueries(),
                                 new TransformUncorrelatedSubqueryToJoin(),
                                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -1133,7 +1133,7 @@ public class PlanPrinter
         public Void visitCorrelatedJoin(CorrelatedJoinNode node, Void context)
         {
             addNode(node,
-                    "Lateral",
+                    "CorrelatedJoin",
                     format("[%s%s]",
                             node.getCorrelation(),
                             node.getFilter().equals(TRUE_LITERAL) ? "" : " " + node.getFilter()));


### PR DESCRIPTION
In TransformCorrelatedScalarAggregationToJoin Optimizer rule
adds a check for the number of ProjectNodes in the subquery.
If there is more than one ProjectNode over AggregationNode,
the rule does not fire.
Previously, the rule fired regardless of the number of Projections.
However, only the first Projection was applied in the resulting plan.

To enable optimization in the case of multiple Projections,
the InlineProjections rule was added to the iterative optimizer
along with TransformCorrelatedScalarAggregationToJoin rule.