### PR TITLE
Informative message by limit matcher

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/LimitMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/LimitMatcher.java
@@ -24,6 +24,7 @@ import io.prestosql.sql.planner.plan.PlanNode;
 
 import java.util.List;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
 import static io.prestosql.sql.planner.assertions.MatchResult.match;
@@ -70,5 +71,15 @@ public class LimitMatcher
             return match();
         }
         return NO_MATCH;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("limit", limit)
+                .add("tiesResolvers", tiesResolvers)
+                .add("partial", partial)
+                .toString();
     }
 }


### PR DESCRIPTION
Since `LimitMatcher` does not have an elaborate `toString` method, the error message shown in the test failure is not informative. `LimitMatcher` should have and provide necessary information to let developers get to know the problem quickly in case of optimization test failures.

## Before
```
Plan does not match, expected [

- node(LimitNode)
    io.prestosql.sql.planner.assertions.LimitMatcher@464df7e8
...
```

## After
```
Plan does not match, expected [

- node(LimitNode)
    LimitMatcher{limit=10, tiesResolvers=[], partial=false}
...
```