### PR TITLE
Fix flaky TestJdbcIntegrationSmokeTest tests

### DIFF
--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -62,7 +62,7 @@ public class TestJdbcIntegrationSmokeTest
     {
         try (TestTable table = new TestTable(
                 getSqlExecutor(),
-                "tpch.test_failure_on_unknown_type",
+                "tpch.test_failure_on_unknown_type_as_ignored",
                 "(int_column int, geometry_column GEOMETRY)",
                 ImmutableList.of(
                         "1, NULL",
@@ -72,7 +72,7 @@ public class TestJdbcIntegrationSmokeTest
             assertQuery(ignoreUnsupportedType, "SELECT * FROM " + table.getName(), "VALUES 1, 2");
             assertQuery(
                     ignoreUnsupportedType,
-                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name LIKE '%_unknown_%'",
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name LIKE 'test_failure_on_unknown_type_as_ignored%'",
                     "VALUES ('int_column', 'integer')");
             assertQuery(
                     ignoreUnsupportedType,
@@ -89,7 +89,7 @@ public class TestJdbcIntegrationSmokeTest
     {
         try (TestTable table = new TestTable(
                 getSqlExecutor(),
-                "tpch.test_failure_on_unknown_type",
+                "tpch.test_failure_on_unknown_type_as_varchar",
                 "(int_column int, geometry_column GEOMETRY)",
                 ImmutableList.of(
                         "1, NULL",
@@ -110,7 +110,7 @@ public class TestJdbcIntegrationSmokeTest
 
             assertQuery(
                     convertToVarcharUnsupportedTypes,
-                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name LIKE '%_unknown_%'",
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name LIKE 'test_failure_on_unknown_type_as_varchar%'",
                     "VALUES ('int_column', 'integer'), ('geometry_column', 'varchar')");
             assertQuery(
                     convertToVarcharUnsupportedTypes,


### PR DESCRIPTION
Fix flaky TestJdbcIntegrationSmokeTest tests

When testUnknownTypeAsIgnored and testUnknownTypeAsVarchar are run in
parallel there is small chance that they can break each other due not
very selective predicate on information_schema.tables that could match
to tables from both tests at once.
