### PR TITLE
Include filtered columns in EXPLAIN (TYPE IO)

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -142,58 +142,111 @@ IO:
 .. code-block:: none
 
 
-    presto:hive> EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_nation SELECT * FROM nation WHERE regionkey = 2;
+    presto:hive> EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_lineitem SELECT * FROM lineitem WHERE shipdate = '2020-02-01' AND quantity > 10;
                 Query Plan
     -----------------------------------
-     {
-       "inputTableColumnInfos" : [ {
-         "table" : {
-           "catalog" : "hive",
-           "schemaTable" : {
-             "schema" : "tpch",
-             "table" : "nation"
-           }
-         },
-         "columns" : [ {
-           "columnName" : "regionkey",
-           "type" : "bigint",
-           "domain" : {
-             "nullsAllowed" : false,
-             "ranges" : [ {
-               "low" : {
-                 "value" : "2",
-                 "bound" : "EXACTLY"
-               },
-               "high" : {
-                 "value" : "2",
-                 "bound" : "EXACTLY"
-               }
-             } ]
-           }
-         } ],
-         "estimate" : {
-           "outputRowCount" : 15000.0,
-           "outputSizeInBytes" : 1597294.0,
-           "cpuCost" : 1597294.0,
-           "maxMemory" : 0.0,
-           "networkCost" : 0.0
-         },
-       } ],
-       "outputTable" : {
-         "catalog" : "hive",
-         "schemaTable" : {
-           "schema" : "tpch",
-           "table" : "test_nation"
-         }
+    {
+       inputTableColumnInfos: [
+          {
+             table: {
+                catalog: "hive",
+                schemaTable: {
+                   schema: "tpch",
+                   table: "test_orders"
+                }
+             },
+             columnConstraints: [
+                {
+                   columnName: "orderkey",
+                   type: "bigint",
+                   domain: {
+                      nullsAllowed: false,
+                      ranges: [
+                         {
+                            low: {
+                               value: "1",
+                               bound: "EXACTLY"
+                            },
+                            high: {
+                               value: "1",
+                               bound: "EXACTLY"
+                            }
+                         },
+                         {
+                            low: {
+                               value: "2",
+                               bound: "EXACTLY"
+                            },
+                            high: {
+                               value: "2",
+                               bound: "EXACTLY"
+                            }
+                         }
+                      ]
+                   }
+                },
+                {
+                   columnName: "processing",
+                   type: "boolean",
+                   domain: {
+                      nullsAllowed: false,
+                      ranges: [
+                         {
+                            low: {
+                               value: "false",
+                               bound: "EXACTLY"
+                            },
+                            high: {
+                               value: "false",
+                               bound: "EXACTLY"
+                            }
+                         }
+                      ]
+                   }
+                },
+                {
+                   columnName: "custkey",
+                   type: "bigint",
+                   domain: {
+                      nullsAllowed: false,
+                      ranges: [
+                         {
+                            low: {
+                               bound: "ABOVE"
+                            },
+                            high: {
+                               value: "10",
+                               bound: "EXACTLY"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ],
+             estimate: {
+                outputRowCount: 2,
+                outputSizeInBytes: 40,
+                cpuCost: 40,
+                maxMemory: 0,
+                networkCost: 0
+             }
+          }
+       ],
+       outputTable: {
+          catalog: "hive",
+          schemaTable: {
+             schema: "tpch",
+             table: "test_orders"
+          }
        },
-       "estimate" : {
-         "outputRowCount" : 15000.0,
-         "outputSizeInBytes" : 1597294.0,
-         "cpuCost" : 1597294.0,
-         "maxMemory" : 0.0,
-         "networkCost" : 1597294.0
+       estimate: {
+          outputRowCount: "NaN",
+          outputSizeInBytes: "NaN",
+          cpuCost: "NaN",
+          maxMemory: "NaN",
+          networkCost: "NaN"
        }
-     }
+    }
 
 
 See Also

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -36,6 +36,7 @@ import io.prestosql.spi.security.SelectedRole;
 import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.plan.ExchangeNode;
 import io.prestosql.sql.planner.planprinter.IoPlanPrinter.ColumnConstraint;
@@ -99,6 +100,7 @@ import static io.prestosql.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPER
 import static io.prestosql.plugin.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.util.HiveUtil.columnExtraInfo;
+import static io.prestosql.spi.predicate.Marker.Bound.ABOVE;
 import static io.prestosql.spi.predicate.Marker.Bound.EXACTLY;
 import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -221,7 +223,16 @@ public class TestHiveIntegrationSmokeTest
                                                                 ImmutableSet.of(
                                                                         new FormattedRange(
                                                                                 new FormattedMarker(Optional.of("false"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("false"), EXACTLY)))))),
+                                                                                new FormattedMarker(Optional.of("false"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "custkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
                                         estimate)),
                         Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_orders")),
                         estimate));
@@ -248,12 +259,281 @@ public class TestHiveIntegrationSmokeTest
                                                                 ImmutableSet.of(
                                                                         new FormattedRange(
                                                                                 new FormattedMarker(Optional.of("1"), EXACTLY),
-                                                                                new FormattedMarker(Optional.of("199"), EXACTLY)))))),
+                                                                                new FormattedMarker(Optional.of("199"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "custkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
                                         estimate)),
                         Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_orders")),
                         estimate));
 
+        EstimatedStatsAndCost finalEstimate = new EstimatedStatsAndCost(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        estimate = new EstimatedStatsAndCost(1.0, 18.0, 18, 0.0, 0.0);
+        result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_orders SELECT custkey, orderkey FROM test_orders WHERE orderkey = 100");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "test_orders"),
+                                        ImmutableSet.of(
+                                                new ColumnConstraint(
+                                                        "orderkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                 false,
+                                                                ImmutableSet.of(
+                                                                         new FormattedRange(
+                                                                                 new FormattedMarker(Optional.of("100"), EXACTLY),
+                                                                                 new FormattedMarker(Optional.of("100"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "orderkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                 ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("100"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("100"), EXACTLY)))))),
+                                estimate)),
+                        Optional.of(new CatalogSchemaTableName(catalog, "tpch", "test_orders")),
+                        finalEstimate));
+
         assertUpdate("DROP TABLE test_orders");
+    }
+
+    @Test
+    public void testIoExplainColumnFilters()
+    {
+        // Test IO explain with small number of discrete components.
+        computeActual("CREATE TABLE test_orders WITH (partitioned_by = ARRAY['orderkey']) AS SELECT custkey, orderstatus, orderkey FROM orders WHERE orderkey < 3");
+
+        EstimatedStatsAndCost estimate = new EstimatedStatsAndCost(2.0, 48.0, 48.0, 0.0, 0.0);
+        EstimatedStatsAndCost finalEstimate = new EstimatedStatsAndCost(0.0, 0.0, 96.0, 0.0, 0.0);
+        MaterializedResult result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT custkey, orderkey, orderstatus FROM test_orders WHERE custkey <= 10 and orderstatus='P'");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "test_orders"),
+                                        ImmutableSet.of(
+                                                new ColumnConstraint(
+                                                        "orderkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "custkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                new FormattedMarker(Optional.of("10"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "orderstatus",
+                                                        VarcharType.createVarcharType(1),
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("P"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("P"), EXACTLY)))))),
+                                        estimate)),
+                        Optional.empty(),
+                        finalEstimate));
+        result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT custkey, orderkey, orderstatus FROM test_orders WHERE custkey <= 10 and (orderstatus='P' or orderstatus='S')");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "test_orders"),
+                                        ImmutableSet.of(
+                                                new ColumnConstraint(
+                                                        "orderkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "orderstatus",
+                                                        VarcharType.createVarcharType(1),
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("P"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("P"), EXACTLY)),
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("S"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("S"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "custkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        estimate)),
+                        Optional.empty(),
+                        finalEstimate));
+        result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT custkey, orderkey, orderstatus FROM test_orders WHERE custkey <= 10 and cast(orderstatus as integer) = 5");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "test_orders"),
+                                        ImmutableSet.of(
+                                                new ColumnConstraint(
+                                                        "orderkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("1"), EXACTLY)),
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("2"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "custkey",
+                                                        BIGINT,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.empty(), ABOVE),
+                                                                                new FormattedMarker(Optional.of("10"), EXACTLY)))))),
+                                        estimate)),
+                        Optional.empty(),
+                        finalEstimate));
+
+        assertUpdate("DROP TABLE test_orders");
+    }
+
+    @Test
+    public void testIoExplainNoFilter()
+    {
+        Session admin = Session.builder(getQueryRunner().getDefaultSession())
+                .setIdentity(Identity.forUser("hive")
+                        .withRole("hive", new SelectedRole(ROLE, Optional.of("admin")))
+                        .build())
+                .build();
+
+        assertUpdate(
+                admin,
+                "create table io_explain_test(\n"
+                + "id integer,\n"
+                + "a varchar,\n"
+                + "b varchar,\n"
+                + "ds varchar)"
+                + "WITH (format='PARQUET', partitioned_by = ARRAY['ds'])");
+        assertUpdate(admin, "insert into io_explain_test(id,a,ds) values(1, 'a','a')", 1);
+
+        EstimatedStatsAndCost estimate = new EstimatedStatsAndCost(1.0, 22.0, 22.0, 0.0, 0.0);
+        EstimatedStatsAndCost finalEstimate = new EstimatedStatsAndCost(1.0, 22.0, 22.0, 0.0, 22.0);
+        MaterializedResult result =
+                computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT * FROM io_explain_test");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                            new TableColumnInfo(
+                                    new CatalogSchemaTableName(catalog, "tpch", "io_explain_test"),
+                                    ImmutableSet.of(
+                                            new ColumnConstraint(
+                                                    "ds",
+                                                    VARCHAR,
+                                                    new FormattedDomain(
+                                                            false,
+                                                            ImmutableSet.of(
+                                                                    new FormattedRange(
+                                                                            new FormattedMarker(Optional.of("a"), EXACTLY),
+                                                                            new FormattedMarker(Optional.of("a"), EXACTLY)))))),
+                        estimate)),
+                Optional.empty(),
+                finalEstimate));
+        assertUpdate("DROP TABLE io_explain_test");
+    }
+
+    @Test
+    public void testIoExplainFilterOnAgg()
+    {
+        Session admin = Session.builder(getQueryRunner().getDefaultSession())
+                .setIdentity(Identity.forUser("hive")
+                        .withRole("hive", new SelectedRole(ROLE, Optional.of("admin")))
+                        .build())
+                .build();
+
+        assertUpdate(
+                admin,
+                "create table io_explain_test(\n"
+                + "id integer,\n"
+                + "a varchar,\n"
+                + "b varchar,\n"
+                + "ds varchar)"
+                + "WITH (format='PARQUET', partitioned_by = ARRAY['ds'])");
+        assertUpdate(admin, "insert into io_explain_test(id,a,ds) values(1, 'a','a')", 1);
+
+        EstimatedStatsAndCost estimate = new EstimatedStatsAndCost(1.0, 5.0, 5.0, 0.0, 0.0);
+        EstimatedStatsAndCost finalEstimate = new EstimatedStatsAndCost(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        MaterializedResult result =
+                computeActual("EXPLAIN (TYPE IO, FORMAT JSON) SELECT * FROM (SELECT COUNT(*) cnt FROM io_explain_test WHERE b = 'b') WHERE cnt > 0");
+        assertEquals(
+                getIoPlanCodec().fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
+                new IoPlan(
+                        ImmutableSet.of(
+                                new TableColumnInfo(
+                                        new CatalogSchemaTableName(catalog, "tpch", "io_explain_test"),
+                                        ImmutableSet.of(
+                                                new ColumnConstraint(
+                                                        "ds",
+                                                        VARCHAR,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("a"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("a"), EXACTLY))))),
+                                                new ColumnConstraint(
+                                                        "b",
+                                                        VARCHAR,
+                                                        new FormattedDomain(
+                                                                false,
+                                                                ImmutableSet.of(
+                                                                        new FormattedRange(
+                                                                                new FormattedMarker(Optional.of("b"), EXACTLY),
+                                                                                new FormattedMarker(Optional.of("b"), EXACTLY)))))),
+                                        estimate)),
+                        Optional.empty(),
+                        finalEstimate));
+        assertUpdate("DROP TABLE io_explain_test");
     }
 
     @Test
@@ -5376,7 +5656,7 @@ public class TestHiveIntegrationSmokeTest
                 .findFirst().get()
                 .getColumnConstraints();
 
-        assertEquals(constraints, expected);
+        assertTrue(constraints.containsAll(expected));
     }
 
     private void verifyPartition(boolean hasPartition, TableMetadata tableMetadata, List<String> partitionKeys)


### PR DESCRIPTION
See issue here: https://github.com/prestosql/presto/issues/1120. This PR adds the columns that are filtered on taking the same approach as PlanPrinter.java. We use this information to track which columns are most frequently filtered to drive which columns should be clustered on. Who would be the right person to review, @martint? 