### PR TITLE
Retry more compilations

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Kudu Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-kudu
+          ./bin/retry ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-kudu
       - name: Run Kudu Tests -- disable InferSchema
         run: presto-kudu/bin/run_kudu_tests.sh "null"
       - name: Run Kudu Tests -- enable InferSchema, empty prefix
@@ -71,7 +71,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm'
+          ./bin/retry ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm'
       - name: Maven Tests
         run: |
           ./mvnw test -B -Dair.check.skip-all -pl '
@@ -114,6 +114,6 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
+          ./bin/retry ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
         run: ./mvnw test -B -Dair.check.skip-all -pl ${{ matrix.modules }}


### PR DESCRIPTION
When adding `retry`, some `mvn install` invocations where inadvertently
omitted from retrying.