### PR TITLE
Limit pushdown for Elasticsearch connector

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,6 +32,7 @@ public final class ElasticsearchTableHandle
     private final String index;
     private final TupleDomain<ColumnHandle> constraint;
     private final Optional<String> query;
+    private final OptionalLong limit;
 
     public ElasticsearchTableHandle(String schema, String index, Optional<String> query)
     {
@@ -39,6 +41,7 @@ public final class ElasticsearchTableHandle
         this.query = requireNonNull(query, "query is null");
 
         constraint = TupleDomain.all();
+        limit = OptionalLong.empty();
     }
 
     @JsonCreator
@@ -46,12 +49,14 @@ public final class ElasticsearchTableHandle
             @JsonProperty("schema") String schema,
             @JsonProperty("index") String index,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
-            @JsonProperty("query") Optional<String> query)
+            @JsonProperty("query") Optional<String> query,
+            @JsonProperty("limit") OptionalLong limit)
     {
         this.schema = requireNonNull(schema, "schema is null");
         this.index = requireNonNull(index, "index is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.query = requireNonNull(query, "query is null");
+        this.limit = requireNonNull(limit, "limit is null");
     }
 
     @JsonProperty
@@ -76,6 +81,12 @@ public final class ElasticsearchTableHandle
     public Optional<String> getQuery()
     {
         return query;
+    }
+
+    @JsonProperty
+    public OptionalLong getLimit()
+    {
+        return limit;
     }
 
     @Override

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -479,6 +479,20 @@ public class TestElasticsearchIntegrationSmokeTest
     }
 
     @Test
+    public void testLimitPushdown()
+            throws IOException
+    {
+        String indexName = "limit_pushdown";
+
+        index(indexName, ImmutableMap.of("c1", "v1"));
+        index(indexName, ImmutableMap.of("c1", "v2"));
+        index(indexName, ImmutableMap.of("c1", "v3"));
+        assertEquals(computeActual("SELECT * FROM limit_pushdown").getRowCount(), 3);
+        assertEquals(computeActual("SELECT * FROM limit_pushdown LIMIT 1").getRowCount(), 1);
+        assertEquals(computeActual("SELECT * FROM limit_pushdown LIMIT 2").getRowCount(), 2);
+    }
+
+    @Test
     public void testDataTypesNested()
             throws IOException
     {


### PR DESCRIPTION
# Summary
Implement limit pushdown to Elasticsearch connector

See: https://github.com/prestosql/presto/issues/2624

# Overview
- Extend ElasticsearchTableHandle to store limit information
- Change iterator to stop reading records when it exceeds the limit
- Override scroll size with the given limit