### PR TITLE
Balance ArbitraryOutputBuffer distribution over clients

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/ArbitraryOutputBuffer.java
@@ -70,6 +70,9 @@ public class ArbitraryOutputBuffer
     @GuardedBy("this")
     private final ConcurrentMap<OutputBufferId, ClientBuffer> buffers = new ConcurrentHashMap<>();
 
+    //  The index of the first client buffer that should be polled
+    private final AtomicInteger nextClientBufferIndex = new AtomicInteger(0);
+
     private final StateMachine<BufferState> state;
     private final String taskInstanceId;
 
@@ -177,6 +180,8 @@ public class ArbitraryOutputBuffer
             for (OutputBufferId outputBufferId : outputBuffers.getBuffers().keySet()) {
                 getBuffer(outputBufferId);
             }
+            // Reset resume from position
+            nextClientBufferIndex.set(0);
 
             // update state if no more buffers is set
             if (outputBuffers.isNoMoreBufferIds()) {
@@ -228,11 +233,20 @@ public class ArbitraryOutputBuffer
         masterBuffer.addPages(serializedPageReferences);
 
         // process any pending reads from the client buffers
-        for (ClientBuffer clientBuffer : safeGetBuffersSnapshot()) {
+        List<ClientBuffer> buffers = safeGetBuffersSnapshot();
+        if (buffers.isEmpty()) {
+            return;
+        }
+        // handle potential for racy update of next index and client buffers present
+        int index = nextClientBufferIndex.get() % buffers.size();
+        for (int i = 0; i < buffers.size(); i++) {
+            buffers.get(index).loadPagesIfNecessary(masterBuffer);
+            index = (index + 1) % buffers.size();
             if (masterBuffer.isEmpty()) {
+                // Resume from the next client buffer on the next iteration
+                nextClientBufferIndex.set(index);
                 break;
             }
-            clientBuffer.loadPagesIfNecessary(masterBuffer);
         }
     }
 
@@ -357,7 +371,7 @@ public class ArbitraryOutputBuffer
         return buffer;
     }
 
-    private synchronized Collection<ClientBuffer> safeGetBuffersSnapshot()
+    private synchronized List<ClientBuffer> safeGetBuffersSnapshot()
     {
         return ImmutableList.copyOf(this.buffers.values());
     }

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
@@ -27,7 +27,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -51,6 +54,8 @@ import static io.prestosql.execution.buffer.OutputBuffers.createInitialEmptyOutp
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -421,6 +426,54 @@ public class TestArbitraryOutputBuffer
         addPage(buffer, createPage(33));
         assertTrue(future.isDone());
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(33)));
+    }
+
+    @Test
+    public void testResumeFromPreviousPosition()
+    {
+        OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(ARBITRARY);
+        OutputBufferId[] ids = new OutputBufferId[5];
+        for (int i = 0; i < ids.length; i++) {
+            ids[i] = new OutputBufferId(i);
+            outputBuffers = outputBuffers.withBuffer(ids[i], i);
+        }
+
+        ArbitraryOutputBuffer buffer = createArbitraryBuffer(outputBuffers, sizeOfPages(5));
+        assertFalse(buffer.isFinished());
+
+        Map<OutputBufferId, ListenableFuture<BufferResult>> firstReads = new HashMap<>();
+        for (OutputBufferId id : ids) {
+            firstReads.put(id, buffer.get(id, 0L, sizeOfPages(1)));
+        }
+        // All must be blocked initially
+        assertThat(firstReads.values()).noneMatch(Future::isDone);
+
+        List<ListenableFuture<BufferResult>> secondReads = new ArrayList<>();
+
+        for (int i = 0; i < ids.length; i++) {
+            // add one page
+            addPage(buffer, createPage(33));
+            assertThat(secondReads).allMatch(future -> !future.isDone(), "No secondary reads should complete until after all first reads");
+            List<OutputBufferId> completedIds = firstReads.entrySet().stream()
+                    .filter(entry -> entry.getValue().isDone())
+                    .map(Map.Entry::getKey)
+                    .collect(toList());
+            assertEquals(completedIds.size(), 1, "One completed buffer read per page addition");
+            OutputBufferId completed = completedIds.get(0);
+
+            BufferResult result = getFuture(firstReads.remove(completed), NO_WAIT);
+            // Store completion order of first for follow up sequence
+            secondReads.add(buffer.get(completed, result.getNextToken(), sizeOfPages(1)));
+        }
+        // Test sanity
+        assertEquals(secondReads.size(), ids.length);
+
+        // Completion order should be identical to the first iteration at this point
+        for (int i = 0; i < ids.length; i++) {
+            // add one page
+            addPage(buffer, createPage(33));
+            assertTrue(secondReads.get(i).isDone(), "Invalid second read completion order at index: " + i);
+        }
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No more buffers already set")


### PR DESCRIPTION
Previously, the order that client buffers were polled was always started with the first ClientBuffer, which could lead to data skew when the master buffer drained before all clients could be polled since the client buffer traversal order was stable (but arbitrary).

This change stores the stop index of client buffer iteration to ensure that subsequent polling loops don't overload the first client buffer.

This is an alternative, simpler solution to the problem described in https://github.com/prestosql/presto/pull/2225 which does a much better job of documenting the existing issue. Shuffling the order is certainly preferable to skewing data, but the extra allocations and shuffling work shouldn't be necessary to produce a more fair output distribution.