### PR TITLE
Use generated (random) node.id when not set

### DIFF
--- a/docker/bin/run-presto
+++ b/docker/bin/run-presto
@@ -10,14 +10,4 @@ if [[ ! -d /usr/lib/presto/etc ]]; then
     fi
 fi
 
-set +e
-grep -s -q 'node.id' /usr/lib/presto/etc/node.properties
-NODE_ID_EXISTS=$?
-set -e
-
-NODE_ID=""
-if [[ ${NODE_ID_EXISTS} != 0 ]] ; then
-    NODE_ID="-Dnode.id=${HOSTNAME}"
-fi
-
-exec /usr/lib/presto/bin/launcher run ${NODE_ID} "$@"
+exec /usr/lib/presto/bin/launcher run "$@"


### PR DESCRIPTION
There is no benefit from using node.id derived from host name, so let's
remove unnecessary complexity.