### PR TITLE
Add Hive 3 metastore config for CSV support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -40,6 +40,18 @@ The following file types are supported for the Hive connector:
 * CSV (using ``org.apache.hadoop.hive.serde2.OpenCSVSerde``)
 * TextFile
 
+In order to enable first-class support for Avro tables and CSV files when using
+Hive 3.x, you need to add the following property definition to the Hive
+metastore configuration file ``hive-site.xml``:
+
+.. code-block:: xml
+
+   <property>
+        <!-- https://community.hortonworks.com/content/supportkb/247055/errorjavalangunsupportedoperationexception-storage.html -->
+        <name>metastore.storage.schema.reader.impl</name>
+        <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
+    </property>
+
 Configuration
 -------------
 


### PR DESCRIPTION
Aimed to fix https://github.com/prestosql/presto/issues/2678

To be honest I am not sure if this is the correct place or if we need to create a separate section about the Hive metastore configuration beyond the properties and add it there. Or link both sections.

Also is the content I wrote correct or am I missing a bunch of things? 