### PR TITLE
Add Project-off rule for AssignUniqueId

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -62,6 +62,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneAggregationColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneApplyColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneApplySourceColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneAssignUniqueIdColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import io.prestosql.sql.planner.iterative.rule.PruneCrossJoinColumns;
@@ -236,6 +237,7 @@ public class PlanOptimizers
                 new PruneAggregationSourceColumns(),
                 new PruneApplyColumns(),
                 new PruneApplySourceColumns(),
+                new PruneAssignUniqueIdColumns(),
                 new PruneCorrelatedJoinColumns(),
                 new PruneCrossJoinColumns(),
                 new PruneFilterColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneAssignUniqueIdColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneAssignUniqueIdColumns.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.PlanNode;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.prestosql.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static io.prestosql.sql.planner.plan.Patterns.assignUniqueId;
+
+public class PruneAssignUniqueIdColumns
+        extends ProjectOffPushDownRule<AssignUniqueId>
+{
+    public PruneAssignUniqueIdColumns()
+    {
+        super(assignUniqueId());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(
+            Context context,
+            AssignUniqueId assignUniqueId,
+            Set<Symbol> referencedOutputs)
+    {
+        // remove unused AssignUniqueId node
+        if (!referencedOutputs.contains(assignUniqueId.getIdColumn())) {
+            return Optional.of(assignUniqueId.getSource());
+        }
+
+        return restrictChildOutputs(context.getIdAllocator(), assignUniqueId, referencedOutputs);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneAssignUniqueIdColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneAssignUniqueIdColumns.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.assertions.PlanMatchPattern;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneAssignUniqueIdColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testRemoveUnusedAssignUniqueId()
+    {
+        tester().assertThat(new PruneAssignUniqueIdColumns())
+                .on(p -> {
+                    Symbol uniqueId = p.symbol("unique_id");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a),
+                            p.assignUniqueId(
+                                    uniqueId,
+                                    p.values(a, b)));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("a", PlanMatchPattern.expression("a")),
+                                values("a", "b")));
+    }
+
+    @Test
+    public void testNotAllInputsReferenced()
+    {
+        tester().assertThat(new PruneAssignUniqueIdColumns())
+                .on(p -> {
+                    Symbol uniqueId = p.symbol("unique_id");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(a, uniqueId),
+                            p.assignUniqueId(
+                                    uniqueId,
+                                    p.values(a, b)));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("a", PlanMatchPattern.expression("a"), "unique_id", PlanMatchPattern.expression("unique_id")),
+                                assignUniqueId(
+                                        "unique_id",
+                                        strictProject(
+                                                ImmutableMap.of("a", PlanMatchPattern.expression("a")),
+                                                values("a", "b")))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneAssignUniqueIdColumns())
+                .on(p -> {
+                    Symbol uniqueId = p.symbol("unique_id");
+                    Symbol a = p.symbol("a");
+                    return p.project(
+                            Assignments.identity(a, uniqueId),
+                            p.assignUniqueId(
+                                    uniqueId,
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
this change is part of the effort to completely migrate `PruneUnreferencedOutputs` optimizer into a set of iterative rules.