### PR TITLE
Export kafka ports for running tests locally

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKafka.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKafka.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import javax.inject.Inject;
 
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
+import static io.prestosql.tests.product.launcher.testcontainers.TestcontainersUtil.exposePort;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
 
@@ -61,17 +62,21 @@ public final class SinglenodeKafka
     @SuppressWarnings("resource")
     private DockerContainer createZookeeper()
     {
-        return new DockerContainer("confluentinc/cp-zookeeper:" + CONFLUENT_VERSION)
+        DockerContainer container = new DockerContainer("confluentinc/cp-zookeeper:" + CONFLUENT_VERSION)
                 .withEnv("ZOOKEEPER_CLIENT_PORT", "2181")
                 .withEnv("ZOOKEEPER_TICK_TIME", "2000")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(new SelectedPortWaitStrategy(2181));
+
+        exposePort(container, 2181);
+
+        return container;
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createKafka()
     {
-        return new DockerContainer("confluentinc/cp-kafka:" + CONFLUENT_VERSION)
+        DockerContainer container = new DockerContainer("confluentinc/cp-kafka:" + CONFLUENT_VERSION)
                 .withEnv("KAFKA_BROKER_ID", "1")
                 .withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181")
                 .withEnv("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://kafka:9092")
@@ -79,5 +84,9 @@ public final class SinglenodeKafka
                 .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(new SelectedPortWaitStrategy(9092));
+
+        exposePort(container, 9092);
+
+        return container;
     }
 }


### PR DESCRIPTION
Like with hadoop, this still requires adding `zookeeper` and `kafka` to
`/etc/hosts`.