### PR TITLE
Extend SortExpressionExtractor for BETWEEN predicate

### DIFF
--- a/presto-benchmark/src/test/java/io/prestosql/benchmark/BenchmarkInequalityJoin.java
+++ b/presto-benchmark/src/test/java/io/prestosql/benchmark/BenchmarkInequalityJoin.java
@@ -136,6 +136,13 @@ public class BenchmarkInequalityJoin
                 .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 + 1 < t2.val2 AND t2.val2 < t1.val1 + 5 ");
     }
 
+    @Benchmark
+    public List<Page> benchmarkBetweenPredicateJoin(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t2.val2 BETWEEN t1.val1 + 1 AND t1.val1 + 5");
+    }
+
     public static void main(String[] args)
             throws RunnerException
     {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SortExpressionExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SortExpressionExtractor.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.sql.ExpressionUtils;
 import io.prestosql.sql.tree.AstVisitor;
+import io.prestosql.sql.tree.BetweenPredicate;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.Node;
@@ -29,6 +30,8 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
@@ -126,6 +129,16 @@ public final class SortExpressionExtractor
                 default:
                     return Optional.empty();
             }
+        }
+
+        @Override
+        protected Optional<SortExpressionContext> visitBetweenPredicate(BetweenPredicate node, Void context)
+        {
+            Optional<SortExpressionContext> result = visitComparisonExpression(new ComparisonExpression(GREATER_THAN_OR_EQUAL, node.getValue(), node.getMin()), context);
+            if (result.isPresent()) {
+                return result;
+            }
+            return visitComparisonExpression(new ComparisonExpression(LESS_THAN_OR_EQUAL, node.getValue(), node.getMax()), context);
         }
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestSortExpressionExtractor.java
@@ -81,6 +81,14 @@ public class TestSortExpressionExtractor
         assertGetSortExpression("b1 > p1 AND b1 <= p1 AND b2 > p1", "b1", "b1 > p1", "b1 <= p1");
 
         assertGetSortExpression("b1 > p1 AND b1 <= p1 AND b2 > p1 AND b2 < p1 + 10 AND b2 > p2", "b2", "b2 > p1", "b2 < p1 + 10", "b2 > p2");
+
+        assertGetSortExpression("p1 BETWEEN b1 AND b2", "b1", "p1 >= b1");
+
+        assertGetSortExpression("p1 BETWEEN p2 AND b1", "b1", "p1 <= b1");
+
+        assertGetSortExpression("b1 BETWEEN p1 AND p2", "b1", "b1 >= p1");
+
+        assertGetSortExpression("b1 > p1 AND p1 BETWEEN b1 AND b2", "b1", "b1 > p1", "p1 >= b1");
     }
 
     private Expression expression(String sql)


### PR DESCRIPTION
This allows use of fast inequality join optimization when the range predicate is written as a BETWEEN clause.

```
Benchmark                                              (buckets)  (fastInequalityJoins)  (filterOutCoefficient)  Mode  Cnt     Score    Error  Units
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin        100                   true                      10  avgt   30    92.654 ± 13.636  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin        100                  false                      10  avgt   30  1120.703 ± 32.170  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin       1000                   true                      10  avgt   30    77.637 ±  6.043  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin       1000                  false                      10  avgt   30   172.802 ±  4.488  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin      10000                   true                      10  avgt   30    75.608 ±  7.518  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin      10000                  false                      10  avgt   30    85.164 ±  7.538  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin      60000                   true                      10  avgt   30    79.120 ± 13.802  ms/op
BenchmarkInequalityJoin.benchmarkBetweenPredicateJoin      60000                  false                      10  avgt   30    59.516 ±  5.242  ms/op
```