### PR TITLE
Add documentation of the new GC options for JVM version > 9

### DIFF
--- a/presto-docs/src/main/sphinx/admin/tuning.rst
+++ b/presto-docs/src/main/sphinx/admin/tuning.rst
@@ -30,3 +30,8 @@ The following can be helpful for diagnosing garbage collection (GC) issues:
     -XX:+PrintAdaptiveSizePolicy
     -XX:+PrintSafepointStatistics
     -XX:PrintSafepointStatisticsCount=1
+
+If Java JMV Version > 9:
+
+.. code-block:: none
+    -Xlog:gc*,safepoint::time,level,tags,tid

--- a/presto-docs/src/main/sphinx/admin/tuning.rst
+++ b/presto-docs/src/main/sphinx/admin/tuning.rst
@@ -31,7 +31,7 @@ The following can be helpful for diagnosing garbage collection (GC) issues:
     -XX:+PrintSafepointStatistics
     -XX:PrintSafepointStatisticsCount=1
 
-If Java JMV Version > 9:
+If running on Java 9 or later:
 
 .. code-block:: none
     -Xlog:gc*,safepoint::time,level,tags,tid


### PR DESCRIPTION
All the documented options are deprecated in the latest version of the JVM.