### PR TITLE
Use JAXB for Base64 encoding in aws sdk with Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -986,6 +986,12 @@
             </dependency>
 
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>testing-mysql-server</artifactId>
                 <version>8.0.12-2</version>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -129,6 +129,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>


### PR DESCRIPTION
Right now running a query with hive connector which writes results to S3 generates the below warning from aws sdk with Java 9+
```
2020-02-22T02:48:09.263+0530	WARN	s3-transfer-manager-worker-1	com.amazonaws.util.Base64	JAXB is unavailable. Will fallback to SDK implementation which may be less performant.If you are using Java 9+, you will need to include javax.xml.bind:jaxb-api as a dependency.
```