### PR TITLE
Change the way mongo connector infers schema for nested bson docs

### DIFF
--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
@@ -550,13 +550,13 @@ public class MongoSession
 
             for (String key : ((Document) value).keySet()) {
                 Optional<TypeSignature> fieldType = guessFieldType(((Document) value).get(key));
-                if (!fieldType.isPresent()) {
-                    return Optional.empty();
+                if (fieldType.isPresent()) {
+                    parameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(key)), fieldType.get())));
                 }
-
-                parameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(key)), fieldType.get())));
             }
-            typeSignature = new TypeSignature(StandardTypes.ROW, parameters);
+            if (!parameters.isEmpty()) {
+                typeSignature = new TypeSignature(StandardTypes.ROW, parameters);
+            }
         }
 
         return Optional.ofNullable(typeSignature);

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
@@ -181,6 +181,19 @@ public class TestMongoIntegrationSmokeTest
     }
 
     @Test
+    public void testSkipUnknownTypes()
+    {
+        Document document1 = new Document("col", Document.parse("{\"key1\": \"value1\", \"key2\": null}"));
+        client.getDatabase("test").getCollection("tmp_guess_schema1").insertOne(document1);
+        assertQuery("SHOW COLUMNS FROM test.tmp_guess_schema1", "SELECT 'col', 'row(key1 varchar)', '', ''");
+        assertQuery("SELECT col.key1 FROM test.tmp_guess_schema1", "SELECT 'value1'");
+
+        Document document2 = new Document("col", new Document("key1", null));
+        client.getDatabase("test").getCollection("tmp_guess_schema2").insertOne(document2);
+        assertQueryReturnsEmptyResult("SHOW COLUMNS FROM test.tmp_guess_schema2");
+    }
+
+    @Test
     public void testMaps()
     {
         assertUpdate("CREATE TABLE tmp_map1 AS SELECT MAP(ARRAY[0,1], ARRAY[2,NULL]) AS col", 1);


### PR DESCRIPTION
Fixes #2934

Instead of omitting the whole column in presence of unknown type, only a given json field is ignored.