### PR TITLE
Refactor blackhole connector

### DIFF
--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
@@ -256,7 +256,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
     {
         BlackHoleTableHandle handle = (BlackHoleTableHandle) tableHandle;
         return new BlackHoleInsertTableHandle(handle.getPageProcessingDelay());

--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHolePageSink.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHolePageSink.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.ConnectorPageSink;
 
 import java.util.Collection;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
@@ -52,7 +53,7 @@ class BlackHolePageSink
     private CompletableFuture<Collection<Slice>> scheduleAppend()
     {
         if (pageProcessingDelayMillis > 0) {
-            return toCompletableFuture(executorService.schedule(() -> ImmutableList.of(), pageProcessingDelayMillis, MILLISECONDS));
+            return toCompletableFuture(executorService.schedule((Callable<Collection<Slice>>) ImmutableList::of, pageProcessingDelayMillis, MILLISECONDS));
         }
         return NON_BLOCKED;
     }

--- a/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleMetadata.java
@@ -30,7 +30,6 @@ import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestBlackHoleMetadata
@@ -68,8 +67,8 @@ public class TestBlackHoleMetadata
         metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
 
         List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.empty());
-        assertTrue(tables.size() == 1, "Expected only one table.");
-        assertTrue(tables.get(0).getTableName().equals("temp_table"), "Expected table with name 'temp_table'");
+        assertEquals(tables.size(), 1, "Expected only one table.");
+        assertEquals(tables.get(0).getTableName(), "temp_table", "Expected table with name 'temp_table'");
     }
 
     @Test
@@ -82,7 +81,7 @@ public class TestBlackHoleMetadata
         }
         catch (PrestoException ex) {
             assertEquals(ex.getErrorCode(), NOT_FOUND.toErrorCode());
-            assertTrue(ex.getMessage().equals("Schema schema1 not found"));
+            assertEquals(ex.getMessage(), "Schema schema1 not found");
         }
     }
 

--- a/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleSmoke.java
@@ -43,7 +43,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
@@ -90,7 +89,7 @@ public class TestBlackHoleSmoke
             fail("Expected exception to be thrown here!");
         }
         catch (RuntimeException ex) { // it has to RuntimeException as FailureInfo$FailureException is private
-            assertTrue(ex.getMessage().equals("line 1:1: Destination table 'blackhole.default.nation' already exists"));
+            assertEquals(ex.getMessage(), "line 1:1: Destination table 'blackhole.default.nation' already exists");
         }
         finally {
             assertThatQueryReturnsValue("DROP TABLE nation", true);
@@ -103,8 +102,8 @@ public class TestBlackHoleSmoke
         assertThatQueryReturnsValue("CREATE TABLE nation as SELECT * FROM tpch.tiny.nation", 25L);
 
         List<QualifiedObjectName> tableNames = listBlackHoleTables();
-        assertTrue(tableNames.size() == 1, "Expected only one table.");
-        assertTrue(tableNames.get(0).getObjectName().equals("nation"), "Expected 'nation' table.");
+        assertEquals(tableNames.size(), 1, "Expected only one table.");
+        assertEquals(tableNames.get(0).getObjectName(), "nation", "Expected 'nation' table.");
 
         assertThatQueryReturnsValue("INSERT INTO nation SELECT * FROM tpch.tiny.nation", 25L);
 
@@ -157,7 +156,7 @@ public class TestBlackHoleSmoke
             fail("Expected exception to be thrown here!");
         }
         catch (RuntimeException ex) {
-            assertTrue(ex.getMessage().equals("Schema schema1 not found"));
+            assertEquals(ex.getMessage(), "Schema schema1 not found");
         }
 
         int tablesAfterCreate = listBlackHoleTables().size();
@@ -346,7 +345,7 @@ public class TestBlackHoleSmoke
 
     private void assertThatNoBlackHoleTableIsCreated()
     {
-        assertTrue(listBlackHoleTables().size() == 0, "No blackhole tables expected");
+        assertEquals(listBlackHoleTables().size(), 0, "No blackhole tables expected");
     }
 
     private List<QualifiedObjectName> listBlackHoleTables()
@@ -364,9 +363,9 @@ public class TestBlackHoleSmoke
         MaterializedResult rows = session == null ? queryRunner.execute(sql) : queryRunner.execute(session, sql);
         MaterializedRow materializedRow = Iterables.getOnlyElement(rows);
         int fieldCount = materializedRow.getFieldCount();
-        assertTrue(fieldCount == 1, format("Expected only one column, but got '%d'", fieldCount));
+        assertEquals(fieldCount, 1, format("Expected only one column, but got '%d'", fieldCount));
         Object value = materializedRow.getField(0);
         assertEquals(value, expected);
-        assertTrue(Iterables.getOnlyElement(rows).getFieldCount() == 1);
+        assertEquals(Iterables.getOnlyElement(rows).getFieldCount(), 1);
     }
 }


### PR DESCRIPTION
# Overview

- Remove deprecated `beginInsert` usage
- Use a method reference instead of lambda
- Use `assertEquals` if applicable