### PR TITLE
Elasticsearch name clash: omit conflicting keys.

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -129,9 +130,13 @@ public class ElasticsearchMetadata
         result.add(BuiltinColumns.SOURCE.getMetadata());
         result.add(BuiltinColumns.SCORE.getMetadata());
 
+        Map<String, Long> counts = metadata.getSchema()
+                .getFields().stream()
+                .collect(Collectors.groupingBy(f -> f.getName().toLowerCase(ENGLISH), Collectors.counting()));
+
         for (IndexMetadata.Field field : metadata.getSchema().getFields()) {
             Type type = toPrestoType(field);
-            if (type == null) {
+            if (type == null || counts.get(field.getName().toLowerCase(ENGLISH)) > 1) {
                 continue;
             }
 

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -127,6 +127,22 @@ public class TestElasticsearchIntegrationSmokeTest
     }
 
     @Test
+    public void testNameConflict()
+            throws IOException
+    {
+        String indexName = "name_conflict";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("field", "value")
+                .put("Conflict", "conflict1")
+                .put("conflict", "conflict2")
+                .build());
+
+        assertQuery(
+                "SELECT * FROM name_conflict",
+                "VALUES ('value')");
+    }
+
+    @Test
     public void testArrayFields()
             throws IOException
     {


### PR DESCRIPTION
Fixes #2965