### PR TITLE
Use reentrant executor in CachingHiveMetastoreModule

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.hive.metastore.cache;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import io.airlift.concurrent.BoundedExecutor;
 import io.prestosql.plugin.hive.HiveCatalogName;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 
@@ -53,7 +52,7 @@ public class CachingHiveMetastoreModule
     @ForCachingHiveMetastore
     public Executor createCachingHiveMetastoreExecutor(HiveCatalogName catalogName, CachingHiveMetastoreConfig hiveConfig)
     {
-        return new BoundedExecutor(
+        return new ReentrantBoundedExecutor(
                 newCachedThreadPool(daemonThreadsNamed("hive-metastore-" + catalogName + "-%s")),
                 hiveConfig.getMaxMetastoreRefreshThreads());
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/ReentrantBoundedExecutor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/ReentrantBoundedExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.cache;
+
+import io.airlift.concurrent.BoundedExecutor;
+
+import java.util.concurrent.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Extension of {@link BoundedExecutor} that will skip task queue when recursive tasks are scheduled
+ * from within currently executed task.
+ */
+public class ReentrantBoundedExecutor
+        implements Executor
+{
+    private final ThreadLocal<Boolean> executorThreadMarkers = ThreadLocal.withInitial(() -> false);
+    private final Executor boundedExecutor;
+    private final Executor coreExecutor;
+
+    ReentrantBoundedExecutor(Executor coreExecutor, int maxThreads)
+    {
+        this.boundedExecutor = new BoundedExecutor(requireNonNull(coreExecutor, "coreExecutor is null"), maxThreads);
+        this.coreExecutor = coreExecutor;
+    }
+
+    @Override
+    public void execute(Runnable task)
+    {
+        if (executorThreadMarkers.get()) {
+            // schedule recursive task immediately as it's being scheduled from currently executed task
+            coreExecutor.execute(task);
+            return;
+        }
+
+        boundedExecutor.execute(() -> {
+            executorThreadMarkers.set(true);
+            try {
+                task.run();
+            }
+            finally {
+                executorThreadMarkers.remove();
+            }
+        });
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestReentrantBoundedExecutor.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestReentrantBoundedExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.cache;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestReentrantBoundedExecutor
+{
+    @Test
+    public void testReentrantBoundedExecutor()
+            throws ExecutionException, InterruptedException
+    {
+        AtomicInteger callCounter = new AtomicInteger();
+        SettableFuture<Object> future = SettableFuture.create();
+        Executor reentrantExecutor = new ReentrantBoundedExecutor(newCachedThreadPool(), 1);
+        reentrantExecutor.execute(() -> {
+            callCounter.incrementAndGet();
+            reentrantExecutor.execute(() -> {
+                callCounter.incrementAndGet();
+                future.set(null);
+            });
+            try {
+                future.get();
+            }
+            catch (Exception ignored) {
+            }
+        });
+        future.get();
+
+        SettableFuture<Object> secondFuture = SettableFuture.create();
+        reentrantExecutor.execute(() -> secondFuture.set(null));
+        secondFuture.get();
+
+        assertEquals(callCounter.get(), 2);
+    }
+}


### PR DESCRIPTION
Loading of cache entry in CachingHiveMetastoreModule
might trigger loading of another cache entry for different
object type. In case there are no empty executor slots,
such operation would deadlock. Therefore, a reentrant
executor needs to be used that would trigger loading
action directly if it is triggered from executor thread
context.

Fixes: https://github.com/prestosql/presto/issues/2962