### PR TITLE
Avoid S3 eventual consistency race condition

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/SortingFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/SortingFileWriter.java
@@ -223,8 +223,7 @@ public class SortingFileWriter
 
             for (TempFile tempFile : files) {
                 Path file = tempFile.getPath();
-                fileSystem.delete(file, false);
-                if (fileSystem.exists(file)) {
+                if (!fileSystem.delete(file, false)) {
                     throw new IOException("Failed to delete temporary file: " + file);
                 }
             }
@@ -252,8 +251,7 @@ public class SortingFileWriter
     private void cleanupFile(Path file)
     {
         try {
-            fileSystem.delete(file, false);
-            if (fileSystem.exists(file)) {
+            if (!fileSystem.delete(file, false)) {
                 throw new IOException("Delete failed");
             }
         }


### PR DESCRIPTION
Depend on results of Hive tempfile deletion rather than checking for file existence.

Fixes https://github.com/prestosql/presto/issues/2296