### PR TITLE
Bump aws-sdk to 1.11.697

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dep.antlr.version>4.7.1</dep.antlr.version>
         <dep.airlift.version>0.192</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.11.602</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.11.697</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/2614 and https://github.com/prestosql/presto/issues/1132