### PR TITLE
Make default target result size configurable in ExecutingStatementResource

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -198,6 +198,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(SelectedRole.class);
         configBinder(binder).bindConfig(DispatcherConfig.class);
         jaxrsBinder(binder).bind(QueuedStatementResource.class);
+        configBinder(binder).bindConfig(ExecutingStatementResourceConfig.class);
         jaxrsBinder(binder).bind(ExecutingStatementResource.class);
         binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();

--- a/presto-main/src/main/java/io/prestosql/server/ExecutingStatementResourceConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/ExecutingStatementResourceConfig.java
@@ -32,7 +32,7 @@ public class ExecutingStatementResourceConfig
     }
 
     @Config("query.target-result-size")
-    @ConfigDescription("Chunk size for query results in JSON responses sent to client")
+    @ConfigDescription("Chunk size for query results in JSON responses to client")
     public ExecutingStatementResourceConfig setServerTargetResultSize(DataSize targetResultSize)
     {
         if (targetResultSize != null) {

--- a/presto-main/src/main/java/io/prestosql/server/ExecutingStatementResourceConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/ExecutingStatementResourceConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class ExecutingStatementResourceConfig
+{
+    private DataSize serverTargetResultSize = DataSize.of(1, MEGABYTE);
+    private static final DataSize MIN_TARGET_RESULT_SIZE = DataSize.of(1, MEGABYTE);
+    private static final DataSize MAX_TARGET_RESULT_SIZE = DataSize.of(128, MEGABYTE);
+
+    public DataSize getServerTargetResultSize()
+    {
+        return serverTargetResultSize;
+    }
+
+    @Config("query.target-result-size")
+    @ConfigDescription("Chunk size for query results in JSON responses sent to client")
+    public ExecutingStatementResourceConfig setServerTargetResultSize(DataSize targetResultSize)
+    {
+        if (targetResultSize != null) {
+            checkArgument(targetResultSize.compareTo(MIN_TARGET_RESULT_SIZE) >= 0, "targetResultSize must be greater than or equal to %s", MIN_TARGET_RESULT_SIZE.toString());
+            checkArgument(targetResultSize.compareTo(MAX_TARGET_RESULT_SIZE) <= 0, "targetResultSize must be less than or equal to %s", MAX_TARGET_RESULT_SIZE.toString());
+        }
+        this.serverTargetResultSize = targetResultSize;
+        return this;
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/server/TestExecutingStatementResourceConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestExecutingStatementResourceConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class TestExecutingStatementResourceConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ExecutingStatementResourceConfig.class)
+                .setServerTargetResultSize(DataSize.of(1, MEGABYTE)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("query.target-result-size", "4MB")
+                .build();
+
+        ExecutingStatementResourceConfig expected = new ExecutingStatementResourceConfig()
+                .setServerTargetResultSize(DataSize.of(4, MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/2210

This effectively controls the presto fetch size (ie client getting query results from the presto coordinator, but defined in terms of storage size rather than number of rows). Without this PR, JDBC is always going to have a 1MB fetch size.
With this PR (allowing higher fetch size) you will see benefits in 2 places:
1. Cross-region users connecting to single region cluster - for example, presto server hosted in Singapore but users running queries from New York and London. Changing the fetch from 1MB to 4MB will mean 4x less network round trips (if latency is 100ms on each roundtrip then pulling back a total of 40MB of data will now be 10 round trips instead of 40 round trips, potentially saving 300ms*10 so 3 seconds)
2. Queries pulling back huge volumes of data (ie >1GB) - since there are 1000s of round trips now, the saved network latency from reduced round trips will surely add up

Make default target result size configurable in ExecutingStatementResource.
https://github.com/prestodb/presto/issues/11908
