### PR TITLE
Compile also with Java 13 on CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,11 +10,19 @@ env:
 jobs:
   maven-checks:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [
+            1.8,
+            11,
+            13
+        ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION
This adds compilation and maven checks with Java 13 on CI.

This also restores running maven checks on Java 8 that were removed
in f5b8496e0ff8db55d593f5cb86b0e6989e436d8f. As long as we support Java
8 for development, it is better to run check on 8 too.