### PR TITLE
Add default value of Glue GetPartitions MaxResults

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -147,6 +147,7 @@ public class GlueHiveMetastore
     private static final String WILDCARD_EXPRESSION = "";
     private static final int BATCH_GET_PARTITION_MAX_PAGE_SIZE = 1000;
     private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
+    private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 128;
     private static final Comparator<Partition> PARTITION_COMPARATOR =
             comparing(Partition::getValues, lexicographical(String.CASE_INSENSITIVE_ORDER));
 
@@ -747,7 +748,8 @@ public class GlueHiveMetastore
                             .withTableName(table.getTableName())
                             .withExpression(expression)
                             .withSegment(segment)
-                            .withNextToken(nextToken));
+                            .withNextToken(nextToken)
+                            .withMaxResults(AWS_GLUE_GET_PARTITIONS_MAX_RESULTS));
                     result.getPartitions()
                             .forEach(partition -> partitions.add(GlueToPrestoConverter.convertPartition(partition, table.getParameters())));
                     nextToken = result.getNextToken();


### PR DESCRIPTION
Fixes #2996

As per our discussion with @findepi and @ebyhr here is the fix for using batched requests with AWS Glue.