### PR TITLE
Change SQL tree identifier name value to lowerCase

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/query/TestGrouping.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestGrouping.java
@@ -61,4 +61,14 @@ public class TestGrouping
                         "HAVING grouping(a, b) = 0",
                 "VALUES ('x0', 'y0', 0), ('x1', 'y1', 0)");
     }
+
+    @Test
+    public void testCastDifferentCase()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(x AS bigint) " +
+                    "FROM (VALUES 42) t(x) " +
+                    "GROUP BY CAST(x AS BIGINT)",
+                "VALUES CAST(42 AS BIGINT)");
+    }
 }

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/Identifier.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class Identifier
@@ -33,23 +34,23 @@ public class Identifier
 
     public Identifier(NodeLocation location, String value, boolean delimited)
     {
-        this(Optional.of(location), value, delimited);
+        this(Optional.of(location), value.toLowerCase(ENGLISH), delimited);
     }
 
     public Identifier(String value, boolean delimited)
     {
-        this(Optional.empty(), value, delimited);
+        this(Optional.empty(), value.toLowerCase(ENGLISH), delimited);
     }
 
     public Identifier(String value)
     {
-        this(Optional.empty(), value, !NAME_PATTERN.matcher(value).matches());
+        this(Optional.empty(), value.toLowerCase(ENGLISH), !NAME_PATTERN.matcher(value).matches());
     }
 
     private Identifier(Optional<NodeLocation> location, String value, boolean delimited)
     {
         super(location);
-        this.value = requireNonNull(value, "value is null");
+        this.value = requireNonNull(value.toLowerCase(ENGLISH), "value is null");
         this.delimited = delimited;
 
         checkArgument(!value.isEmpty(), "value is empty");


### PR DESCRIPTION
As #2960 mentioned, `equals` method in `io.prestosql.sql.tree.Cast` compares type and the type is `Identifier`. `Identifier` should be lowercase.
[PrestoDB Change](https://github.com/prestodb/presto/commit/4e51ec2ef2692466be178bc8f49c4bf2692cb984#diff-81bd6f494f63d8fc515407faa8fd6db6)