### PR TITLE
Flush remaining output pages before requesting next input page

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestStreamingAggregationOperator.java
@@ -128,6 +128,22 @@ public class TestStreamingAggregationOperator
     }
 
     @Test
+    public void testLargeInputPage()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder
+                .addSequencePage(1_000_000, 0, 0, 1)
+                .build();
+
+        MaterializedResult.Builder expectedBuilder = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT);
+        for (int i = 0; i < 1_000_000; ++i) {
+            expectedBuilder.row(String.valueOf(i), 1L, i + 1L);
+        }
+
+        assertOperatorEquals(operatorFactory, driverContext, input, expectedBuilder.build());
+    }
+
+    @Test
     public void testEmptyInput()
     {
         RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);


### PR DESCRIPTION
All output pages (potentially lazy) should be returned in
StreamingAggregationOperator before next input page is requested.