### PR TITLE
Add support for CREATE SCHEMA name AUTHORIZATION

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -35,6 +35,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
 import io.prestosql.spi.statistics.TableStatistics;
 
@@ -304,7 +305,7 @@ public class JdbcMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         jdbcClient.createSchema(JdbcIdentity.from(session), schemaName);
     }

--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHoleMetadata.java
@@ -34,6 +34,7 @@ import io.prestosql.spi.connector.Constraint;
 import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
+import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ColumnStatistics;
 import io.prestosql.spi.statistics.ComputedStatistics;
 import io.prestosql.spi.statistics.DoubleRange;
@@ -82,7 +83,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public synchronized void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public synchronized void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         if (schemas.contains(schemaName)) {
             throw new PrestoException(ALREADY_EXISTS, format("Schema [%s] already exists", schemaName));

--- a/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/io/prestosql/plugin/blackhole/TestBlackHoleMetadata.java
@@ -20,6 +20,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorOutputTableHandle;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.security.PrestoPrincipal;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
+import static io.prestosql.spi.security.PrincipalType.USER;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -46,7 +48,7 @@ public class TestBlackHoleMetadata
     public void testCreateSchema()
     {
         assertEquals(metadata.listSchemaNames(SESSION), ImmutableList.of("default"));
-        metadata.createSchema(SESSION, "test", ImmutableMap.of());
+        metadata.createSchema(SESSION, "test", ImmutableMap.of(), new PrestoPrincipal(USER, SESSION.getUser()));
         assertEquals(metadata.listSchemaNames(SESSION), ImmutableList.of("default", "test"));
     }
 

--- a/presto-docs/src/main/sphinx/sql/create-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/create-schema.rst
@@ -8,6 +8,7 @@ Synopsis
 .. code-block:: none
 
     CREATE SCHEMA [ IF NOT EXISTS ] schema_name
+    [ AUTHORIZATION ( user | USER user | ROLE role ) ]
     [ WITH ( property_name = expression [, ...] ) ]
 
 Description
@@ -18,6 +19,9 @@ holds tables, views and other database objects.
 
 The optional ``IF NOT EXISTS`` clause causes the error to be
 suppressed if the schema already exists.
+
+The optional ``AUTHORIZATION`` clause can be used to set the
+owner of the newly created schema to a user or role.
 
 The optional ``WITH`` clause can be used to set properties
 on the newly created schema.  To list all available schema
@@ -39,6 +43,25 @@ Create a new schema ``sales`` in the ``hive`` catalog::
 Create the schema ``traffic`` if it does not already exist::
 
     CREATE SCHEMA IF NOT EXISTS traffic
+
+Create a new schema ``web`` and set the owner to user ``alice``::
+
+    CREATE SCHEMA web AUTHORIZATION alice
+
+Create a new schema ``web``, set the ``LOCATION`` property to ``/hive/data/web``
+and set the owner to user ``alice``::
+
+    CREATE SCHEMA web AUTHORIZATION alice WITH ( LOCATION = '/hive/data/web' )
+
+Create a new schema ``web`` and allow everyone to drop schema and create tables
+in schema ``web``::
+
+    CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC
+
+Create a new schema ``web``, set the ``LOCATION`` property to ``/hive/data/web``
+and allow everyone to drop schema and create tables in schema ``web``::
+
+    CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC WITH ( LOCATION = '/hive/data/web' )
 
 See Also
 --------

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -224,7 +224,6 @@ import static io.prestosql.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.prestosql.spi.predicate.TupleDomain.withColumnDomains;
-import static io.prestosql.spi.security.PrincipalType.USER;
 import static io.prestosql.spi.statistics.TableStatisticType.ROW_COUNT;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
@@ -737,7 +736,7 @@ public class HiveMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         Optional<String> location = HiveSchemaProperties.getLocation(properties).map(locationUri -> {
             try {
@@ -752,8 +751,8 @@ public class HiveMetadata
         Database database = Database.builder()
                 .setDatabaseName(schemaName)
                 .setLocation(location)
-                .setOwnerType(USER)
-                .setOwnerName(session.getUser())
+                .setOwnerType(owner.getType())
+                .setOwnerName(owner.getName())
                 .build();
 
         metastore.createDatabase(new HiveIdentity(session), database);

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -102,7 +102,6 @@ import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
-import static io.prestosql.spi.security.PrincipalType.USER;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -252,7 +251,7 @@ public class IcebergMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         Optional<String> location = getLocation(properties).map(uri -> {
             try {
@@ -267,8 +266,8 @@ public class IcebergMetadata
         Database database = Database.builder()
                 .setDatabaseName(schemaName)
                 .setLocation(location)
-                .setOwnerType(USER)
-                .setOwnerName(session.getUser())
+                .setOwnerType(owner.getType())
+                .setOwnerName(owner.getName())
                 .build();
 
         metastore.createDatabase(new HiveIdentity(session), database);

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduMetadata.java
@@ -38,6 +38,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
@@ -207,7 +208,7 @@ public class KuduMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         clientSession.createSchema(schemaName);
     }

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -141,8 +141,9 @@ public interface Metadata
 
     /**
      * Creates a schema.
+     * @param principal TODO
      */
-    void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties);
+    void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties, PrestoPrincipal principal);
 
     /**
      * Drops the specified schema.

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -591,12 +591,12 @@ public final class MetadataManager
     }
 
     @Override
-    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties)
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties, PrestoPrincipal principal)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, schema.getCatalogName());
         CatalogName catalogName = catalogMetadata.getCatalogName();
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
-        metadata.createSchema(session.toConnectorSession(catalogName), schema.getSchemaName(), properties);
+        metadata.createSchema(session.toConnectorSession(catalogName), schema.getSchemaName(), properties, principal);
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -184,7 +184,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties)
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties, PrestoPrincipal principal)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
@@ -40,6 +40,7 @@ import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.ViewNotFoundException;
+import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -94,7 +95,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public synchronized void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         if (schemas.contains(schemaName)) {
             throw new PrestoException(ALREADY_EXISTS, format("Schema [%s] already exists", schemaName));

--- a/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/io/prestosql/sql/parser/SqlBase.g4
@@ -39,6 +39,7 @@ statement
     | USE schema=identifier                                            #use
     | USE catalog=identifier '.' schema=identifier                     #use
     | CREATE SCHEMA (IF NOT EXISTS)? qualifiedName
+        (AUTHORIZATION principal)?
         (WITH properties)?                                             #createSchema
     | DROP SCHEMA (IF EXISTS)? qualifiedName (CASCADE | RESTRICT)?     #dropSchema
     | ALTER SCHEMA qualifiedName RENAME TO identifier                  #renameSchema

--- a/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
@@ -810,6 +810,10 @@ public final class SqlFormatter
                 builder.append("IF NOT EXISTS ");
             }
             builder.append(formatName(node.getSchemaName()));
+            if (node.getPrincipal().isPresent()) {
+                builder.append(" AUTHORIZATION ")
+                        .append(formatPrincipal(node.getPrincipal().get()));
+            }
             builder.append(formatPropertiesMultiLine(node.getProperties()));
 
             return null;

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/AstBuilder.java
@@ -253,6 +253,11 @@ class AstBuilder
     @Override
     public Node visitCreateSchema(SqlBaseParser.CreateSchemaContext context)
     {
+        Optional<PrincipalSpecification> principal = Optional.empty();
+        if (context.AUTHORIZATION() != null) {
+            principal = Optional.of(getPrincipalSpecification(context.principal()));
+        }
+
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
             properties = visit(context.properties().property(), Property.class);
@@ -262,7 +267,8 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 context.EXISTS() != null,
-                properties);
+                properties,
+                principal);
     }
 
     @Override

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/CreateSchema.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/CreateSchema.java
@@ -28,23 +28,25 @@ public class CreateSchema
     private final QualifiedName schemaName;
     private final boolean notExists;
     private final List<Property> properties;
+    private final Optional<PrincipalSpecification> principal;
 
     public CreateSchema(QualifiedName schemaName, boolean notExists, List<Property> properties)
     {
-        this(Optional.empty(), schemaName, notExists, properties);
+        this(Optional.empty(), schemaName, notExists, properties, Optional.empty());
     }
 
-    public CreateSchema(NodeLocation location, QualifiedName schemaName, boolean notExists, List<Property> properties)
+    public CreateSchema(NodeLocation location, QualifiedName schemaName, boolean notExists, List<Property> properties, Optional<PrincipalSpecification> principal)
     {
-        this(Optional.of(location), schemaName, notExists, properties);
+        this(Optional.of(location), schemaName, notExists, properties, principal);
     }
 
-    private CreateSchema(Optional<NodeLocation> location, QualifiedName schemaName, boolean notExists, List<Property> properties)
+    private CreateSchema(Optional<NodeLocation> location, QualifiedName schemaName, boolean notExists, List<Property> properties, Optional<PrincipalSpecification> principal)
     {
         super(location);
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.notExists = notExists;
         this.properties = ImmutableList.copyOf(requireNonNull(properties, "properties is null"));
+        this.principal = principal;
     }
 
     public QualifiedName getSchemaName()
@@ -55,6 +57,11 @@ public class CreateSchema
     public boolean isNotExists()
     {
         return notExists;
+    }
+
+    public Optional<PrincipalSpecification> getPrincipal()
+    {
+        return principal;
     }
 
     public List<Property> getProperties()

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
@@ -193,6 +193,12 @@ public class TestStatementBuilder
         printStatement("alter table a.b.c drop column x");
 
         printStatement("create schema test");
+        printStatement("create schema test authorization alice");
+        printStatement("create schema test authorization alice with ( location = 'xyz' )");
+        printStatement("create schema test authorization user alice");
+        printStatement("create schema test authorization user alice with ( location = 'xyz' )");
+        printStatement("create schema test authorization role public");
+        printStatement("create schema test authorization role public with ( location = 'xyz' )");
         printStatement("create schema if not exists test");
         printStatement("create schema test with (a = 'apple', b = 123)");
 

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
@@ -39,6 +39,7 @@ import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -217,7 +218,7 @@ public class PhoenixMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
         if (DEFAULT_SCHEMA.equalsIgnoreCase(schemaName)) {

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -279,10 +279,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createSchema(session, schemaName, properties);
+            delegate.createSchema(session, schemaName, properties, owner);
         }
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -232,7 +232,7 @@ public interface ConnectorMetadata
     /**
      * Creates a schema.
      */
-    default void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    default void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support creating schemas");
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -5127,6 +5127,8 @@ public abstract class AbstractTestQueries
         assertDescribeOutputEmpty("GRANT INSERT ON foo TO bar");
         assertDescribeOutputEmpty("REVOKE INSERT ON foo FROM bar");
         assertDescribeOutputEmpty("CREATE SCHEMA foo");
+        assertDescribeOutputEmpty("CREATE SCHEMA foo AUTHORIZATION bar");
+        assertDescribeOutputEmpty("CREATE SCHEMA foo AUTHORIZATION bar WITH ( x = 'y' )");
         assertDescribeOutputEmpty("ALTER SCHEMA foo RENAME TO bar");
         assertDescribeOutputEmpty("ALTER SCHEMA foo SET AUTHORIZATION bar");
         assertDescribeOutputEmpty("DROP SCHEMA foo");


### PR DESCRIPTION
This adds support for setting a different owner (user or role) when a schema is created.

See also #2974 

In a followup PR I will add SHOW CREATE SCHEMA to show the current owner.