### PR TITLE
Remove parquet.fail-on-corrupted-statistics configuration option

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -71,7 +71,7 @@ public final class HiveSessionProperties
     private static final String RESPECT_TABLE_FORMAT = "respect_table_format";
     private static final String CREATE_EMPTY_BUCKET_FILES = "create_empty_bucket_files";
     private static final String PARQUET_USE_COLUMN_NAME = "parquet_use_column_names";
-    private static final String PARQUET_FAIL_WITH_CORRUPTED_STATISTICS = "parquet_fail_with_corrupted_statistics";
+    private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
@@ -275,9 +275,9 @@ public final class HiveSessionProperties
                         hiveConfig.isUseParquetColumnNames(),
                         false),
                 booleanProperty(
-                        PARQUET_FAIL_WITH_CORRUPTED_STATISTICS,
-                        "Parquet: Fail when scanning Parquet files with corrupted statistics",
-                        parquetReaderConfig.isFailOnCorruptedStatistics(),
+                        PARQUET_IGNORE_STATISTICS,
+                        "Ignore statistics from Parquet to allow querying files with corrupted or incorrect statistics",
+                        parquetReaderConfig.isIgnoreStatistics(),
                         false),
                 dataSizeProperty(
                         PARQUET_MAX_READ_BLOCK_SIZE,
@@ -542,14 +542,9 @@ public final class HiveSessionProperties
         return useParquetColumnNames;
     }
 
-    /**
-     * @deprecated this can mask correctness issues
-     */
-    // TODO remove
-    @Deprecated
-    public static boolean isFailOnCorruptedParquetStatistics(ConnectorSession session)
+    public static boolean isParquetIgnoreStatistics(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_FAIL_WITH_CORRUPTED_STATISTICS, Boolean.class);
+        return session.getProperty(PARQUET_IGNORE_STATISTICS, Boolean.class);
     }
 
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetReaderConfig.java
@@ -26,19 +26,28 @@ public class ParquetReaderConfig
     private ParquetReaderOptions options = new ParquetReaderOptions();
 
     @Deprecated
-    public boolean isFailOnCorruptedStatistics()
+    public boolean isIgnoreStatistics()
     {
-        return options.isFailOnCorruptedStatistics();
+        return options.isIgnoreStatistics();
     }
 
     @Deprecated
-    @Config("parquet.fail-on-corrupted-statistics")
-    @LegacyConfig("hive.parquet.fail-on-corrupted-statistics")
-    @ConfigDescription("Fail when scanning Parquet files with corrupted statistics")
+    @Config("parquet.ignore-statistics")
+    @ConfigDescription("Ignore statistics from Parquet to allow querying files with corrupted or incorrect statistics")
+    public ParquetReaderConfig setIgnoreStatistics(boolean ignoreStatistics)
+    {
+        options = options.withIgnoreStatistics(ignoreStatistics);
+        return this;
+    }
+
+    /**
+     * @deprecated Use {@link #setIgnoreStatistics} instead.
+     */
+    @Deprecated
+    @LegacyConfig(value = {"hive.parquet.fail-on-corrupted-statistics", "parquet.fail-on-corrupted-statistics"}, replacedBy = "parquet.ignore-statistics")
     public ParquetReaderConfig setFailOnCorruptedStatistics(boolean failOnCorruptedStatistics)
     {
-        options = options.withFailOnCorruptedStatistics(failOnCorruptedStatistics);
-        return this;
+        return setIgnoreStatistics(!failOnCorruptedStatistics);
     }
 
     @NotNull

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -31,7 +31,7 @@ public class TestParquetReaderConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ParquetReaderConfig.class)
-                .setFailOnCorruptedStatistics(true)
+                .setIgnoreStatistics(false)
                 .setMaxReadBlockSize(DataSize.of(16, MEGABYTE))
                 .setMaxMergeDistance(DataSize.of(1, MEGABYTE))
                 .setMaxBufferSize(DataSize.of(8, MEGABYTE)));
@@ -41,14 +41,14 @@ public class TestParquetReaderConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("parquet.fail-on-corrupted-statistics", "false")
+                .put("parquet.ignore-statistics", "true")
                 .put("parquet.max-read-block-size", "66kB")
                 .put("parquet.max-buffer-size", "1431kB")
                 .put("parquet.max-merge-distance", "342kB")
                 .build();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
-                .setFailOnCorruptedStatistics(false)
+                .setIgnoreStatistics(true)
                 .setMaxReadBlockSize(DataSize.of(66, KILOBYTE))
                 .setMaxBufferSize(DataSize.of(1431, KILOBYTE))
                 .setMaxMergeDistance(DataSize.of(342, KILOBYTE));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
@@ -103,7 +103,6 @@ import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcMaxRead
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcStreamBufferSize;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getOrcTinyStripeThreshold;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.getParquetMaxReadBlockSize;
-import static io.prestosql.plugin.iceberg.IcebergSessionProperties.isFailOnCorruptedParquetStatistics;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static io.prestosql.plugin.iceberg.IcebergSessionProperties.isOrcNestedLazy;
 import static io.prestosql.plugin.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
@@ -223,7 +222,6 @@ public class IcebergPageSourceProvider
                         length,
                         dataColumns,
                         parquetReaderOptions
-                                .withFailOnCorruptedStatistics(isFailOnCorruptedParquetStatistics(session))
                                 .withMaxReadBlockSize(getParquetMaxReadBlockSize(session)),
                         predicate,
                         fileFormatDataSourceStats);
@@ -391,7 +389,7 @@ public class IcebergPageSourceProvider
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
                 if ((firstDataPage >= start) && (firstDataPage < (start + length)) &&
-                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, options.isFailOnCorruptedStatistics())) {
+                        predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain)) {
                     blocks.add(block);
                 }
             }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -57,7 +57,6 @@ public final class IcebergSessionProperties
     private static final String ORC_WRITER_MAX_STRIPE_SIZE = "orc_writer_max_stripe_size";
     private static final String ORC_WRITER_MAX_STRIPE_ROWS = "orc_writer_max_stripe_rows";
     private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
-    private static final String PARQUET_FAIL_WITH_CORRUPTED_STATISTICS = "parquet_fail_with_corrupted_statistics";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
@@ -161,11 +160,6 @@ public final class IcebergSessionProperties
                         ORC_WRITER_MAX_DICTIONARY_MEMORY,
                         "ORC: Max dictionary memory",
                         orcWriterConfig.getDictionaryMaxMemory(),
-                        false))
-                .add(booleanProperty(
-                        PARQUET_FAIL_WITH_CORRUPTED_STATISTICS,
-                        "Parquet: Fail when scanning Parquet files with corrupted statistics",
-                        parquetReaderConfig.isFailOnCorruptedStatistics(),
                         false))
                 .add(dataSizeProperty(
                         PARQUET_MAX_READ_BLOCK_SIZE,
@@ -275,11 +269,6 @@ public final class IcebergSessionProperties
     public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)
     {
         return session.getProperty(COMPRESSION_CODEC, HiveCompressionCodec.class);
-    }
-
-    public static boolean isFailOnCorruptedParquetStatistics(ConnectorSession session)
-    {
-        return session.getProperty(PARQUET_FAIL_WITH_CORRUPTED_STATISTICS, Boolean.class);
     }
 
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)

--- a/presto-parquet/src/main/java/io/prestosql/parquet/ParquetReaderOptions.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/ParquetReaderOptions.java
@@ -24,35 +24,34 @@ public class ParquetReaderOptions
     private static final DataSize DEFAULT_MAX_MERGE_DISTANCE = DataSize.of(1, MEGABYTE);
     private static final DataSize DEFAULT_MAX_BUFFER_SIZE = DataSize.of(8, MEGABYTE);
 
-    private final boolean failOnCorruptedStatistics; // TODO remove, this can mask correctness issues
+    private final boolean ignoreStatistics;
     private final DataSize maxReadBlockSize;
     private final DataSize maxMergeDistance;
     private final DataSize maxBufferSize;
 
     public ParquetReaderOptions()
     {
-        failOnCorruptedStatistics = true;
+        ignoreStatistics = false;
         maxReadBlockSize = DEFAULT_MAX_READ_BLOCK_SIZE;
         maxMergeDistance = DEFAULT_MAX_MERGE_DISTANCE;
         maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
     }
 
     private ParquetReaderOptions(
-            boolean failOnCorruptedStatistics,
+            boolean ignoreStatistics,
             DataSize maxReadBlockSize,
             DataSize maxMergeDistance,
             DataSize maxBufferSize)
     {
-        this.failOnCorruptedStatistics = failOnCorruptedStatistics;
+        this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxMergeDistance is null");
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
     }
 
-    @Deprecated
-    public boolean isFailOnCorruptedStatistics()
+    public boolean isIgnoreStatistics()
     {
-        return failOnCorruptedStatistics;
+        return ignoreStatistics;
     }
 
     public DataSize getMaxReadBlockSize()
@@ -70,10 +69,10 @@ public class ParquetReaderOptions
         return maxBufferSize;
     }
 
-    public ParquetReaderOptions withFailOnCorruptedStatistics(boolean failOnCorruptedStatistics)
+    public ParquetReaderOptions withIgnoreStatistics(boolean ignoreStatistics)
     {
         return new ParquetReaderOptions(
-                failOnCorruptedStatistics,
+                ignoreStatistics,
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize);
@@ -82,7 +81,7 @@ public class ParquetReaderOptions
     public ParquetReaderOptions withMaxReadBlockSize(DataSize maxReadBlockSize)
     {
         return new ParquetReaderOptions(
-                failOnCorruptedStatistics,
+                ignoreStatistics,
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize);
@@ -91,7 +90,7 @@ public class ParquetReaderOptions
     public ParquetReaderOptions withMaxMergeDistance(DataSize maxMergeDistance)
     {
         return new ParquetReaderOptions(
-                failOnCorruptedStatistics,
+                ignoreStatistics,
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize);
@@ -100,7 +99,7 @@ public class ParquetReaderOptions
     public ParquetReaderOptions withMaxBufferSize(DataSize maxBufferSize)
     {
         return new ParquetReaderOptions(
-                failOnCorruptedStatistics,
+                ignoreStatistics,
                 maxReadBlockSize,
                 maxMergeDistance,
                 maxBufferSize);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/Predicate.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/Predicate.java
@@ -29,9 +29,8 @@ public interface Predicate
      * Statistics to determine if a column is only null
      * @param statistics column statistics
      * @param id Parquet file name
-     * @param failOnCorruptedParquetStatistics whether to fail query when scanning a Parquet file with corrupted statistics
      */
-    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id, boolean failOnCorruptedParquetStatistics)
+    boolean matches(long numberOfRows, Map<ColumnDescriptor, Statistics<?>> statistics, ParquetDataSourceId id)
             throws ParquetCorruptionException;
 
     /**

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/PredicateUtils.java
@@ -122,11 +122,11 @@ public final class PredicateUtils
         return new TupleDomainParquetPredicate(parquetTupleDomain, columnReferences.build(), timeZone);
     }
 
-    public static boolean predicateMatches(Predicate parquetPredicate, BlockMetaData block, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain, boolean failOnCorruptedParquetStatistics)
+    public static boolean predicateMatches(Predicate parquetPredicate, BlockMetaData block, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
             throws ParquetCorruptionException
     {
         Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, descriptorsByPath);
-        if (!parquetPredicate.matches(block.getRowCount(), columnStatistics, dataSource.getId(), failOnCorruptedParquetStatistics)) {
+        if (!parquetPredicate.matches(block.getRowCount(), columnStatistics, dataSource.getId())) {
             return false;
         }
 

--- a/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
@@ -106,12 +106,12 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "BooleanColumn";
-        assertEquals(getDomain(BOOLEAN, 0, null, ID, column, true, UTC), all(BOOLEAN));
+        assertEquals(getDomain(BOOLEAN, 0, null, ID, column, UTC), all(BOOLEAN));
 
-        assertEquals(getDomain(BOOLEAN, 10, booleanColumnStats(true, true), ID, column, true, UTC), singleValue(BOOLEAN, true));
-        assertEquals(getDomain(BOOLEAN, 10, booleanColumnStats(false, false), ID, column, true, UTC), singleValue(BOOLEAN, false));
+        assertEquals(getDomain(BOOLEAN, 10, booleanColumnStats(true, true), ID, column, UTC), singleValue(BOOLEAN, true));
+        assertEquals(getDomain(BOOLEAN, 10, booleanColumnStats(false, false), ID, column, UTC), singleValue(BOOLEAN, false));
 
-        assertEquals(getDomain(BOOLEAN, 20, booleanColumnStats(false, true), ID, column, true, UTC), all(BOOLEAN));
+        assertEquals(getDomain(BOOLEAN, 20, booleanColumnStats(false, true), ID, column, UTC), all(BOOLEAN));
     }
 
     private static BooleanStatistics booleanColumnStats(boolean minimum, boolean maximum)
@@ -126,18 +126,16 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "BigintColumn";
-        assertEquals(getDomain(BIGINT, 0, null, ID, column, true, UTC), all(BIGINT));
+        assertEquals(getDomain(BIGINT, 0, null, ID, column, UTC), all(BIGINT));
 
-        assertEquals(getDomain(BIGINT, 10, longColumnStats(100L, 100L), ID, column, true, UTC), singleValue(BIGINT, 100L));
+        assertEquals(getDomain(BIGINT, 10, longColumnStats(100L, 100L), ID, column, UTC), singleValue(BIGINT, 100L));
 
-        assertEquals(getDomain(BIGINT, 10, longColumnStats(0L, 100L), ID, column, true, UTC), create(ValueSet.ofRanges(range(BIGINT, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(BIGINT, 10, longColumnStats(0L, 100L), ID, column, UTC), create(ValueSet.ofRanges(range(BIGINT, 0L, true, 100L, true)), false));
 
-        assertEquals(getDomain(BIGINT, 20, longOnlyNullsStats(10), ID, column, true, UTC), create(ValueSet.all(BIGINT), true));
-        // ignore corrupted statistics
-        assertEquals(getDomain(BIGINT, 10, longColumnStats(100L, 0L), ID, column, false, UTC), create(ValueSet.all(BIGINT), false));
+        assertEquals(getDomain(BIGINT, 20, longOnlyNullsStats(10), ID, column, UTC), create(ValueSet.all(BIGINT), true));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(BIGINT, 10, longColumnStats(100L, 10L), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(BIGINT, 10, longColumnStats(100L, 10L), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"BigintColumn\" in Parquet file \"testFile\": [min: 100, max: 10, num_nulls: 0]");
     }
 
@@ -146,20 +144,18 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "IntegerColumn";
-        assertEquals(getDomain(INTEGER, 0, null, ID, column, true, UTC), all(INTEGER));
+        assertEquals(getDomain(INTEGER, 0, null, ID, column, UTC), all(INTEGER));
 
-        assertEquals(getDomain(INTEGER, 10, longColumnStats(100, 100), ID, column, true, UTC), singleValue(INTEGER, 100L));
+        assertEquals(getDomain(INTEGER, 10, longColumnStats(100, 100), ID, column, UTC), singleValue(INTEGER, 100L));
 
-        assertEquals(getDomain(INTEGER, 10, longColumnStats(0, 100), ID, column, true, UTC), create(ValueSet.ofRanges(range(INTEGER, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(INTEGER, 10, longColumnStats(0, 100), ID, column, UTC), create(ValueSet.ofRanges(range(INTEGER, 0L, true, 100L, true)), false));
 
-        assertEquals(getDomain(INTEGER, 20, longColumnStats(0, 2147483648L), ID, column, true, UTC), notNull(INTEGER));
+        assertEquals(getDomain(INTEGER, 20, longColumnStats(0, 2147483648L), ID, column, UTC), notNull(INTEGER));
 
-        assertEquals(getDomain(INTEGER, 20, longOnlyNullsStats(10), ID, column, true, UTC), create(ValueSet.all(INTEGER), true));
-        // ignore corrupted statistics
-        assertEquals(getDomain(INTEGER, 10, longColumnStats(2147483648L, 0), ID, column, false, UTC), create(ValueSet.all(INTEGER), false));
+        assertEquals(getDomain(INTEGER, 20, longOnlyNullsStats(10), ID, column, UTC), create(ValueSet.all(INTEGER), true));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(INTEGER, 10, longColumnStats(2147483648L, 10), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(INTEGER, 10, longColumnStats(2147483648L, 10), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"IntegerColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
     }
 
@@ -168,20 +164,18 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "SmallintColumn";
-        assertEquals(getDomain(SMALLINT, 0, null, ID, column, true, UTC), all(SMALLINT));
+        assertEquals(getDomain(SMALLINT, 0, null, ID, column, UTC), all(SMALLINT));
 
-        assertEquals(getDomain(SMALLINT, 10, longColumnStats(100, 100), ID, column, true, UTC), singleValue(SMALLINT, 100L));
+        assertEquals(getDomain(SMALLINT, 10, longColumnStats(100, 100), ID, column, UTC), singleValue(SMALLINT, 100L));
 
-        assertEquals(getDomain(SMALLINT, 10, longColumnStats(0, 100), ID, column, true, UTC), create(ValueSet.ofRanges(range(SMALLINT, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(SMALLINT, 10, longColumnStats(0, 100), ID, column, UTC), create(ValueSet.ofRanges(range(SMALLINT, 0L, true, 100L, true)), false));
 
-        assertEquals(getDomain(SMALLINT, 20, longColumnStats(0, 2147483648L), ID, column, true, UTC), notNull(SMALLINT));
+        assertEquals(getDomain(SMALLINT, 20, longColumnStats(0, 2147483648L), ID, column, UTC), notNull(SMALLINT));
 
-        assertEquals(getDomain(SMALLINT, 20, longOnlyNullsStats(10), ID, column, true, UTC), create(ValueSet.all(SMALLINT), true));
-        // ignore corrupted statistics
-        assertEquals(getDomain(SMALLINT, 10, longColumnStats(2147483648L, 0), ID, column, false, UTC), create(ValueSet.all(SMALLINT), false));
+        assertEquals(getDomain(SMALLINT, 20, longOnlyNullsStats(10), ID, column, UTC), create(ValueSet.all(SMALLINT), true));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(SMALLINT, 10, longColumnStats(2147483648L, 10), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(SMALLINT, 10, longColumnStats(2147483648L, 10), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"SmallintColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
     }
 
@@ -190,20 +184,18 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "TinyintColumn";
-        assertEquals(getDomain(TINYINT, 0, null, ID, column, true, UTC), all(TINYINT));
+        assertEquals(getDomain(TINYINT, 0, null, ID, column, UTC), all(TINYINT));
 
-        assertEquals(getDomain(TINYINT, 10, longColumnStats(100, 100), ID, column, true, UTC), singleValue(TINYINT, 100L));
+        assertEquals(getDomain(TINYINT, 10, longColumnStats(100, 100), ID, column, UTC), singleValue(TINYINT, 100L));
 
-        assertEquals(getDomain(TINYINT, 10, longColumnStats(0, 100), ID, column, true, UTC), create(ValueSet.ofRanges(range(TINYINT, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(TINYINT, 10, longColumnStats(0, 100), ID, column, UTC), create(ValueSet.ofRanges(range(TINYINT, 0L, true, 100L, true)), false));
 
-        assertEquals(getDomain(TINYINT, 20, longColumnStats(0, 2147483648L), ID, column, true, UTC), notNull(TINYINT));
+        assertEquals(getDomain(TINYINT, 20, longColumnStats(0, 2147483648L), ID, column, UTC), notNull(TINYINT));
 
-        assertEquals(getDomain(TINYINT, 20, longOnlyNullsStats(10), ID, column, true, UTC), create(ValueSet.all(TINYINT), true));
-        // ignore corrupted statistics
-        assertEquals(getDomain(TINYINT, 10, longColumnStats(2147483648L, 0), ID, column, false, UTC), create(ValueSet.all(TINYINT), false));
+        assertEquals(getDomain(TINYINT, 20, longOnlyNullsStats(10), ID, column, UTC), create(ValueSet.all(TINYINT), true));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(TINYINT, 10, longColumnStats(2147483648L, 10), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(TINYINT, 10, longColumnStats(2147483648L, 10), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"TinyintColumn\" in Parquet file \"testFile\": [min: 2147483648, max: 10, num_nulls: 0]");
     }
 
@@ -213,16 +205,14 @@ public class TestTupleDomainParquetPredicate
     {
         String column = "ShortDecimalColumn";
         Type type = createDecimalType(5, 0);
-        assertEquals(getDomain(type, 0, null, ID, column, true, UTC), all(type));
+        assertEquals(getDomain(type, 0, null, ID, column, UTC), all(type));
 
-        assertEquals(getDomain(type, 10, longColumnStats(100L, 100L), ID, column, true, UTC), singleValue(type, 100L));
+        assertEquals(getDomain(type, 10, longColumnStats(100L, 100L), ID, column, UTC), singleValue(type, 100L));
 
-        assertEquals(getDomain(type, 10, longColumnStats(0L, 100L), ID, column, true, UTC), create(ValueSet.ofRanges(range(type, 0L, true, 100L, true)), false));
-        // ignore corrupted statistics
-        assertEquals(getDomain(type, 10, longColumnStats(100L, 0L), ID, column, false, UTC), create(ValueSet.all(type), false));
+        assertEquals(getDomain(type, 10, longColumnStats(0L, 100L), ID, column, UTC), create(ValueSet.ofRanges(range(type, 0L, true, 100L, true)), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(type, 10, longColumnStats(100L, 10L), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(type, 10, longColumnStats(100L, 10L), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"ShortDecimalColumn\" in Parquet file \"testFile\": [min: 100, max: 10, num_nulls: 0]");
     }
 
@@ -234,16 +224,14 @@ public class TestTupleDomainParquetPredicate
         DecimalType type = createDecimalType(20, 0);
         Slice zero = encodeScaledValue(new BigDecimal("0"), type.getScale());
         Slice hundred = encodeScaledValue(new BigDecimal("100"), type.getScale());
-        assertEquals(getDomain(type, 0, null, ID, column, true, UTC), all(type));
+        assertEquals(getDomain(type, 0, null, ID, column, UTC), all(type));
 
-        assertEquals(getDomain(type, 10, longColumnStats(100L, 100L), ID, column, true, UTC), singleValue(type, hundred));
+        assertEquals(getDomain(type, 10, longColumnStats(100L, 100L), ID, column, UTC), singleValue(type, hundred));
 
-        assertEquals(getDomain(type, 10, longColumnStats(0L, 100L), ID, column, true, UTC), create(ValueSet.ofRanges(range(type, zero, true, hundred, true)), false));
-        // ignore corrupted statistics
-        assertEquals(getDomain(type, 10, longColumnStats(100L, 0L), ID, column, false, UTC), create(ValueSet.all(type), false));
+        assertEquals(getDomain(type, 10, longColumnStats(0L, 100L), ID, column, UTC), create(ValueSet.ofRanges(range(type, zero, true, hundred, true)), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(type, 10, longColumnStats(100L, 10L), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(type, 10, longColumnStats(100L, 10L), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"LongDecimalColumn\" in Parquet file \"testFile\": [min: 100, max: 10, num_nulls: 0]");
     }
 
@@ -252,29 +240,27 @@ public class TestTupleDomainParquetPredicate
             throws Exception
     {
         String column = "DoubleColumn";
-        assertEquals(getDomain(DOUBLE, 0, null, ID, column, true, UTC), all(DOUBLE));
+        assertEquals(getDomain(DOUBLE, 0, null, ID, column, UTC), all(DOUBLE));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(42.24, 42.24), ID, column, true, UTC), singleValue(DOUBLE, 42.24));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(42.24, 42.24), ID, column, UTC), singleValue(DOUBLE, 42.24));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, 42.24), ID, column, true, UTC), create(ValueSet.ofRanges(range(DOUBLE, 3.3, true, 42.24, true)), false));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, 42.24), ID, column, UTC), create(ValueSet.ofRanges(range(DOUBLE, 3.3, true, 42.24, true)), false));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(NaN, NaN), ID, column, true, UTC), Domain.notNull(DOUBLE));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(NaN, NaN), ID, column, UTC), Domain.notNull(DOUBLE));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(NaN, NaN, true), ID, column, true, UTC), Domain.all(DOUBLE));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(NaN, NaN, true), ID, column, UTC), Domain.all(DOUBLE));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, NaN), ID, column, true, UTC), Domain.notNull(DOUBLE));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, NaN), ID, column, UTC), Domain.notNull(DOUBLE));
 
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, NaN, true), ID, column, true, UTC), Domain.all(DOUBLE));
+        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(3.3, NaN, true), ID, column, UTC), Domain.all(DOUBLE));
 
         assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(NaN)), Domain.all(DOUBLE));
 
         assertEquals(getDomain(DOUBLE, doubleDictionaryDescriptor(3.3, NaN)), Domain.all(DOUBLE));
 
-        // ignore corrupted statistics
-        assertEquals(getDomain(DOUBLE, 10, doubleColumnStats(42.24, 3.3), ID, column, false, UTC), create(ValueSet.all(DOUBLE), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(DOUBLE, 10, doubleColumnStats(42.24, 3.3), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(DOUBLE, 10, doubleColumnStats(42.24, 3.3), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"DoubleColumn\" in Parquet file \"testFile\": [min: 42.24, max: 3.3, num_nulls: 0]");
     }
 
@@ -283,19 +269,17 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "StringColumn";
-        assertEquals(getDomain(createUnboundedVarcharType(), 0, null, ID, column, true, UTC), all(createUnboundedVarcharType()));
+        assertEquals(getDomain(createUnboundedVarcharType(), 0, null, ID, column, UTC), all(createUnboundedVarcharType()));
 
-        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("taco", "taco"), ID, column, true, UTC), singleValue(createUnboundedVarcharType(), utf8Slice("taco")));
+        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("taco", "taco"), ID, column, UTC), singleValue(createUnboundedVarcharType(), utf8Slice("taco")));
 
-        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("apple", "taco"), ID, column, true, UTC), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
+        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("apple", "taco"), ID, column, UTC), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
 
-        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("中国", "美利坚"), ID, column, true, UTC), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("中国"), true, utf8Slice("美利坚"), true)), false));
+        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("中国", "美利坚"), ID, column, UTC), create(ValueSet.ofRanges(range(createUnboundedVarcharType(), utf8Slice("中国"), true, utf8Slice("美利坚"), true)), false));
 
-        // ignore corrupted statistics
-        assertEquals(getDomain(createUnboundedVarcharType(), 10, stringColumnStats("taco", "apple"), ID, column, false, UTC), create(ValueSet.all(createUnboundedVarcharType()), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(createUnboundedVarcharType(), 10, stringColumnStats("taco", "apple"), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(createUnboundedVarcharType(), 10, stringColumnStats("taco", "apple"), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"StringColumn\" in Parquet file \"testFile\": [min: 0x7461636F, max: 0x6170706C65, num_nulls: 0]");
     }
 
@@ -311,34 +295,32 @@ public class TestTupleDomainParquetPredicate
             throws Exception
     {
         String column = "FloatColumn";
-        assertEquals(getDomain(REAL, 0, null, ID, column, true, UTC), all(REAL));
+        assertEquals(getDomain(REAL, 0, null, ID, column, UTC), all(REAL));
 
         float minimum = 4.3f;
         float maximum = 40.3f;
 
-        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, minimum), ID, column, true, UTC), singleValue(REAL, (long) floatToRawIntBits(minimum)));
+        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, minimum), ID, column, UTC), singleValue(REAL, (long) floatToRawIntBits(minimum)));
 
         assertEquals(
-                getDomain(REAL, 10, floatColumnStats(minimum, maximum), ID, column, true, UTC),
+                getDomain(REAL, 10, floatColumnStats(minimum, maximum), ID, column, UTC),
                 create(ValueSet.ofRanges(range(REAL, (long) floatToRawIntBits(minimum), true, (long) floatToRawIntBits(maximum), true)), false));
 
-        assertEquals(getDomain(REAL, 10, floatColumnStats(NaN, NaN), ID, column, true, UTC), Domain.notNull(REAL));
+        assertEquals(getDomain(REAL, 10, floatColumnStats(NaN, NaN), ID, column, UTC), Domain.notNull(REAL));
 
-        assertEquals(getDomain(REAL, 10, floatColumnStats(NaN, NaN, true), ID, column, true, UTC), Domain.all(REAL));
+        assertEquals(getDomain(REAL, 10, floatColumnStats(NaN, NaN, true), ID, column, UTC), Domain.all(REAL));
 
-        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, NaN), ID, column, true, UTC), Domain.notNull(REAL));
+        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, NaN), ID, column, UTC), Domain.notNull(REAL));
 
-        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, NaN, true), ID, column, true, UTC), Domain.all(REAL));
+        assertEquals(getDomain(REAL, 10, floatColumnStats(minimum, NaN, true), ID, column, UTC), Domain.all(REAL));
 
         assertEquals(getDomain(REAL, floatDictionaryDescriptor(NaN)), Domain.all(REAL));
 
         assertEquals(getDomain(REAL, floatDictionaryDescriptor(minimum, NaN)), Domain.all(REAL));
 
-        // ignore corrupted statistics
-        assertEquals(getDomain(REAL, 10, floatColumnStats(maximum, minimum), ID, column, false, UTC), create(ValueSet.all(REAL), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(REAL, 10, floatColumnStats(maximum, minimum), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(REAL, 10, floatColumnStats(maximum, minimum), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"FloatColumn\" in Parquet file \"testFile\": [min: 40.3, max: 4.3, num_nulls: 0]");
     }
 
@@ -347,15 +329,13 @@ public class TestTupleDomainParquetPredicate
             throws ParquetCorruptionException
     {
         String column = "DateColumn";
-        assertEquals(getDomain(DATE, 0, null, ID, column, true, UTC), all(DATE));
-        assertEquals(getDomain(DATE, 10, intColumnStats(100, 100), ID, column, true, UTC), singleValue(DATE, 100L));
-        assertEquals(getDomain(DATE, 10, intColumnStats(0, 100), ID, column, true, UTC), create(ValueSet.ofRanges(range(DATE, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(DATE, 0, null, ID, column, UTC), all(DATE));
+        assertEquals(getDomain(DATE, 10, intColumnStats(100, 100), ID, column, UTC), singleValue(DATE, 100L));
+        assertEquals(getDomain(DATE, 10, intColumnStats(0, 100), ID, column, UTC), create(ValueSet.ofRanges(range(DATE, 0L, true, 100L, true)), false));
 
-        // ignore corrupted statistics
-        assertEquals(getDomain(DATE, 10, intColumnStats(200, 100), ID, column, false, UTC), create(ValueSet.all(DATE), false));
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(DATE, 10, intColumnStats(200, 100), ID, column, true, UTC))
+                .isThrownBy(() -> getDomain(DATE, 10, intColumnStats(200, 100), ID, column, UTC))
                 .withMessage("Corrupted statistics for column \"DateColumn\" in Parquet file \"testFile\": [min: 200, max: 100, num_nulls: 0]");
     }
 
@@ -377,11 +357,11 @@ public class TestTupleDomainParquetPredicate
     {
         String column = "timestampColumn";
         TimestampType timestampType = createTimestampType(precision);
-        assertEquals(getDomain(timestampType, 0, null, ID, column, true, UTC), all(timestampType));
-        assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime, baseTime), ID, column, true, UTC), singleValue(timestampType, baseDomainValue));
+        assertEquals(getDomain(timestampType, 0, null, ID, column, UTC), all(timestampType));
+        assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime, baseTime), ID, column, UTC), singleValue(timestampType, baseDomainValue));
         // INT96 binary ranges ignored when min <> max
         assertEquals(
-                getDomain(timestampType, 10, timestampColumnStats(baseTime.minusSeconds(10), baseTime), ID, column, true, UTC),
+                getDomain(timestampType, 10, timestampColumnStats(baseTime.minusSeconds(10), baseTime), ID, column, UTC),
                 create(ValueSet.all(timestampType), false));
     }
 
@@ -420,7 +400,7 @@ public class TestTupleDomainParquetPredicate
         Statistics<?> stats = getStatsBasedOnType(column.getPrimitiveType().getPrimitiveTypeName());
         stats.setNumNulls(1L);
         stats.setMinMaxFromBytes(value.getBytes(UTF_8), value.getBytes(UTF_8));
-        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, stats), ID, true));
+        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, stats), ID));
     }
 
     @Test(dataProvider = "typeForParquetInt32")
@@ -435,9 +415,9 @@ public class TestTupleDomainParquetPredicate
                 Domain.create(ValueSet.of(typeForParquetInt32, 42L, 43L, 44L, 112L), false)));
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column), UTC);
 
-        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(32, 42)), ID, true));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(30, 40)), ID, true));
-        assertEquals(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(1024, 0x10000 + 42)), ID, true), (typeForParquetInt32 != INTEGER)); // stats invalid for smallint/tinyint
+        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(32, 42)), ID));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(30, 40)), ID));
+        assertEquals(parquetPredicate.matches(2, ImmutableMap.of(column, intColumnStats(1024, 0x10000 + 42)), ID), (typeForParquetInt32 != INTEGER)); // stats invalid for smallint/tinyint
     }
 
     @DataProvider
@@ -462,9 +442,9 @@ public class TestTupleDomainParquetPredicate
                 Domain.create(ValueSet.of(BIGINT, 42L, 43L, 44L, 404L), false)));
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column), UTC);
 
-        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(32, 42)), ID, true));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(30, 40)), ID, true));
-        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(1024, 0x10000 + 42)), ID, true));
+        assertTrue(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(32, 42)), ID));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(30, 40)), ID));
+        assertFalse(parquetPredicate.matches(2, ImmutableMap.of(column, longColumnStats(1024, 0x10000 + 42)), ID));
     }
 
     @Test


### PR DESCRIPTION
It could mask correctness issues.