### PR TITLE
Use HiveCatalogName to export S3 statistics without name conflicts

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Module.java
@@ -14,9 +14,11 @@
 package io.prestosql.plugin.hive.s3;
 
 import com.google.inject.Binder;
+import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.prestosql.plugin.hive.ConfigurationInitializer;
+import io.prestosql.plugin.hive.HiveCatalogName;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.JavaUtils;
 
@@ -38,8 +40,9 @@ public class HiveS3Module
             configBinder(binder).bindConfig(HiveS3Config.class);
 
             binder.bind(PrestoS3FileSystemStats.class).toInstance(PrestoS3FileSystem.getFileSystemStats());
+            Provider<HiveCatalogName> catalogName = binder.getProvider(HiveCatalogName.class);
             newExporter(binder).export(PrestoS3FileSystemStats.class)
-                    .as(generator -> generator.generatedNameOf(PrestoS3FileSystem.class));
+                    .as(generator -> generator.generatedNameOf(PrestoS3FileSystem.class, catalogName.get().toString()));
         }
         else if (type == S3FileSystemType.EMRFS) {
             validateEmrFsClass();


### PR DESCRIPTION
This fixes the problem of conflicting JMX keys for S3 statistics
when Hive and Iceberg connectors are loaded.