### PR TITLE
Refactor toCompactTupleDomain to reuse Domain#simplify

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/DiscreteValues.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/DiscreteValues.java
@@ -23,4 +23,6 @@ public interface DiscreteValues
     boolean isWhiteList();
 
     Collection<Object> getValues();
+
+    int getValuesCount();
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/Domain.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/Domain.java
@@ -276,15 +276,20 @@ public final class Domain
      */
     public Domain simplify()
     {
+        return simplify(32);
+    }
+
+    public Domain simplify(int threshold)
+    {
         ValueSet simplifiedValueSet = values.getValuesProcessor().<Optional<ValueSet>>transform(
                 ranges -> {
-                    if (ranges.getOrderedRanges().size() <= 32) {
+                    if (ranges.getRangeCount() <= threshold) {
                         return Optional.empty();
                     }
                     return Optional.of(ValueSet.ofRanges(ranges.getSpan()));
                 },
                 discreteValues -> {
-                    if (discreteValues.getValues().size() <= 32) {
+                    if (discreteValues.getValuesCount() <= threshold) {
                         return Optional.empty();
                     }
                     return Optional.of(ValueSet.all(values.getType()));

--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/EquatableValueSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/EquatableValueSet.java
@@ -125,6 +125,11 @@ public class EquatableValueSet
                 .collect(toList()));
     }
 
+    public int getValuesCount()
+    {
+        return entries.size();
+    }
+
     @Override
     public boolean isNone()
     {
@@ -190,6 +195,12 @@ public class EquatableValueSet
             public Collection<Object> getValues()
             {
                 return EquatableValueSet.this.getValues();
+            }
+
+            @Override
+            public int getValuesCount()
+            {
+                return EquatableValueSet.this.getValuesCount();
             }
         };
     }


### PR DESCRIPTION
Changed Domain#simplify to avoid constructing new objects to get size of Ranges or DiscreteValues