### PR TITLE
Use updatable page source when effectivePredicate is None due to dynamic filters

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -25,7 +25,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
-import io.prestosql.spi.connector.FixedPageSource;
+import io.prestosql.spi.connector.EmptyPageSource;
 import io.prestosql.spi.connector.RecordCursor;
 import io.prestosql.spi.connector.RecordPageSource;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -155,7 +155,7 @@ public class HivePageSourceProvider
             Optional<DeleteDeltaLocations> deleteDeltaLocations)
     {
         if (effectivePredicate.isNone()) {
-            return Optional.of(new FixedPageSource(ImmutableList.of()));
+            return Optional.of(new EmptyPageSource());
         }
 
         List<ColumnMapping> columnMappings = ColumnMapping.buildColumnMappings(

--- a/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/ScanFilterAndProjectOperator.java
@@ -32,13 +32,13 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.EmptyPageSource;
 import io.prestosql.spi.connector.RecordCursor;
 import io.prestosql.spi.connector.RecordPageSource;
 import io.prestosql.spi.connector.UpdatablePageSource;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.split.EmptySplit;
-import io.prestosql.split.EmptySplitPageSource;
 import io.prestosql.split.PageSourceProvider;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
@@ -237,7 +237,7 @@ public class ScanFilterAndProjectOperator
 
             ConnectorPageSource source;
             if (split.getConnectorSplit() instanceof EmptySplit) {
-                source = new EmptySplitPageSource();
+                source = new EmptyPageSource();
             }
             else {
                 source = pageSourceProvider.createPageSource(session, split, table, columns, dynamicFilter);

--- a/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
@@ -24,10 +24,10 @@ import io.prestosql.metadata.TableHandle;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.EmptyPageSource;
 import io.prestosql.spi.connector.UpdatablePageSource;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.split.EmptySplit;
-import io.prestosql.split.EmptySplitPageSource;
 import io.prestosql.split.PageSourceProvider;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
@@ -205,7 +205,7 @@ public class TableScanOperator
         blocked.set(null);
 
         if (split.getConnectorSplit() instanceof EmptySplit) {
-            source = new EmptySplitPageSource();
+            source = new EmptyPageSource();
         }
 
         return () -> {

--- a/presto-main/src/main/java/io/prestosql/split/PageSourceManager.java
+++ b/presto-main/src/main/java/io/prestosql/split/PageSourceManager.java
@@ -20,6 +20,7 @@ import io.prestosql.metadata.TableHandle;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
+import io.prestosql.spi.connector.EmptyPageSource;
 import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public class PageSourceManager
                     columns);
         }
         if (constraint.isNone()) {
-            return new EmptySplitPageSource();
+            return new EmptyPageSource();
         }
         return provider.createPageSource(
                 table.getTransaction(),

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/EmptyPageSource.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/EmptyPageSource.java
@@ -11,32 +11,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.split;
+package io.prestosql.spi.connector;
 
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
-import io.prestosql.spi.connector.UpdatablePageSource;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-public class EmptySplitPageSource
+public class EmptyPageSource
         implements UpdatablePageSource
 {
     @Override
     public void deleteRows(Block rowIds)
     {
-        throw new UnsupportedOperationException("deleteRows called on EmptySplitPageSource");
+        throw new UnsupportedOperationException("deleteRows called on EmptyPageSource");
     }
 
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        return completedFuture(ImmutableList.of());
+        return completedFuture(Collections.emptyList());
     }
 
     @Override


### PR DESCRIPTION
Addresses similar issue as https://github.com/prestosql/presto/commit/2fac2761904e169d97200912928284b0d56182bd