### PR TITLE
Refactor memory connector

### DIFF
--- a/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryMetadata.java
@@ -211,11 +211,9 @@ public class MemoryMetadata
     {
         checkSchemaExists(tableMetadata.getTable().getSchemaName());
         checkTableNotExists(tableMetadata.getTable());
-        long nextId = nextTableId.getAndIncrement();
+        long tableId = nextTableId.getAndIncrement();
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
         checkState(!nodes.isEmpty(), "No Memory nodes available");
-
-        long tableId = nextId;
 
         ImmutableList.Builder<ColumnInfo> columns = ImmutableList.builder();
         for (int i = 0; i < tableMetadata.getColumns().size(); i++) {
@@ -262,7 +260,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized MemoryInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public synchronized MemoryInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
     {
         MemoryTableHandle memoryTableHandle = (MemoryTableHandle) tableHandle;
         return new MemoryInsertTableHandle(memoryTableHandle.getId(), ImmutableSet.copyOf(tableIds.values()));


### PR DESCRIPTION
I did several refacotoring works for the memory connector.
- Remove redundant variable usage
- Prefer `assertEquals` if possible
- Prefer `assertNull` if possible
- Avoid raw type usage
- Remove deprecated `beginInsert` usage