### PR TITLE
Add access-control.properties file placeholder

### DIFF
--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/access-control.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/access-control.properties
@@ -1,0 +1,1 @@
+access-control.name=allow-all


### PR DESCRIPTION
Since configuration directory (etc) is binded in read-only mode
binding a completely new file in an environment extender is imposible
which is why this placeholder is neeeded.