### PR TITLE
Allow public access to ParquetPageSourceFactory#createParquetPageSource

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -144,7 +144,7 @@ public class ParquetPageSourceFactory
                 stats));
     }
 
-    private static ParquetPageSource createParquetPageSource(
+    public static ParquetPageSource createParquetPageSource(
             HdfsEnvironment hdfsEnvironment,
             String user,
             Configuration configuration,


### PR DESCRIPTION
Allows for better reuse in connectors reading Parquet, such as the IcebergPageSourceProvider.