### PR TITLE
Issue #3131: Taking the credentials project id if configured

### DIFF
--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConfig.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConfig.java
@@ -14,7 +14,6 @@
 package io.prestosql.plugin.bigquery;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.bigquery.BigQueryOptions;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 
@@ -98,9 +97,9 @@ public class BigQueryConfig
         return this;
     }
 
-    public String getParentProjectId()
+    public Optional<String> getParentProjectId()
     {
-        return parentProjectId.orElseGet(() -> BigQueryOptions.getDefaultInstance().getProjectId());
+        return parentProjectId;
     }
 
     @Config("bigquery.parent-project-id")
@@ -185,7 +184,6 @@ public class BigQueryConfig
     ReadSessionCreatorConfig createReadSessionCreatorConfig()
     {
         return new ReadSessionCreatorConfig(
-                getParentProjectId(),
                 isViewsEnabled(),
                 getViewMaterializationProject(),
                 getViewMaterializationProject(),

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnectorModule.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnectorModule.java
@@ -15,6 +15,8 @@ package io.prestosql.plugin.bigquery;
 
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -22,6 +24,8 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.prestosql.spi.NodeManager;
+
+import java.util.Optional;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -68,11 +72,28 @@ public class BigQueryConnectorModule
     @Singleton
     public BigQueryClient provideBigQueryClient(BigQueryConfig config, HeaderProvider headerProvider, BigQueryCredentialsSupplier bigQueryCredentialsSupplier)
     {
+        String billingProjectId = calculateBillingProjectId(config.getParentProjectId(), bigQueryCredentialsSupplier.getCredentials());
         BigQueryOptions.Builder options = BigQueryOptions.newBuilder()
                 .setHeaderProvider(headerProvider)
-                .setProjectId(config.getParentProjectId());
+                .setProjectId(billingProjectId);
         // set credentials of provided
         bigQueryCredentialsSupplier.getCredentials().ifPresent(options::setCredentials);
         return new BigQueryClient(options.build().getService(), config);
+    }
+
+    // Note that at this point the config has been validated, which means that option 2 or option 3 will always be valid
+    static String calculateBillingProjectId(Optional<String> configParentProjectId, Optional<Credentials> credentials)
+    {
+        // 1. Get from configuration
+        if (configParentProjectId.isPresent()) {
+            return configParentProjectId.get();
+        }
+        // 2. Get from the provided credentials, but only ServiceAccountCredentials contains the project id.
+        // All other credentials types (User, AppEngine, GCE, CloudShell, etc.) take it from the environment
+        if (credentials.isPresent() && credentials.get() instanceof ServiceAccountCredentials) {
+            return ((ServiceAccountCredentials) credentials.get()).getProjectId();
+        }
+        // 3. No configuration was provided, so get the default from the environment
+        return BigQueryOptions.getDefaultProjectId();
     }
 }

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadSessionCreator.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadSessionCreator.java
@@ -82,7 +82,7 @@ public class ReadSessionCreator
 
             Storage.ReadSession readSession = bigQueryStorageClient.createReadSession(
                     Storage.CreateReadSessionRequest.newBuilder()
-                            .setParent("projects/" + config.parentProjectId)
+                            .setParent("projects/" + bigQueryClient.getProjectId())
                             .setFormat(Storage.DataFormat.AVRO)
                             .setRequestedStreams(parallelism)
                             .setReadOptions(readOptions)

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadSessionCreatorConfig.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadSessionCreatorConfig.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 class ReadSessionCreatorConfig
 {
-    final String parentProjectId;
     final boolean viewsEnabled;
     final Optional<String> viewMaterializationProject;
     final Optional<String> viewMaterializationDataset;
@@ -25,14 +24,12 @@ class ReadSessionCreatorConfig
     final int maxReadRowsRetries;
 
     ReadSessionCreatorConfig(
-            String parentProjectId,
             boolean viewsEnabled,
             Optional<String> viewMaterializationProject,
             Optional<String> viewMaterializationDataset,
             int viewExpirationTimeInHours,
             int maxReadRowsRetries)
     {
-        this.parentProjectId = parentProjectId;
         this.viewsEnabled = viewsEnabled;
         this.viewMaterializationProject = viewMaterializationProject;
         this.viewMaterializationDataset = viewMaterializationDataset;

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryConfig.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryConfig.java
@@ -41,7 +41,7 @@ public class TestBigQueryConfig
         assertEquals(config.getCredentialsKey(), Optional.of("ckey"));
         assertEquals(config.getCredentialsFile(), Optional.of("cfile"));
         assertEquals(config.getProjectId(), Optional.of("pid"));
-        assertEquals(config.getParentProjectId(), "ppid");
+        assertEquals(config.getParentProjectId(), Optional.of("ppid"));
         assertEquals(config.getParallelism(), OptionalInt.of(20));
         assertEquals(config.getViewMaterializationProject(), Optional.of("vmproject"));
         assertEquals(config.getViewMaterializationDataset(), Optional.of("vmdataset"));
@@ -66,7 +66,7 @@ public class TestBigQueryConfig
 
         assertEquals(config.getCredentialsKey(), Optional.of("ckey"));
         assertEquals(config.getProjectId(), Optional.of("pid"));
-        assertEquals(config.getParentProjectId(), "ppid");
+        assertEquals(config.getParentProjectId(), Optional.of("ppid"));
         assertEquals(config.getParallelism(), OptionalInt.of(20));
         assertEquals(config.getViewMaterializationProject(), Optional.of("vmproject"));
         assertEquals(config.getViewMaterializationDataset(), Optional.of("vmdataset"));

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryConnectorModule.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryConnectorModule.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.bigquery;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test
+public class TestBigQueryConnectorModule
+{
+    @Test
+    public void testConfigurationOnly()
+            throws Exception
+    {
+        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.of("pid"), Optional.empty());
+        assertThat(projectId).isEqualTo("pid");
+    }
+
+    @Test
+    public void testCredentialsOnly()
+            throws Exception
+    {
+        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.empty(), credentials());
+        assertThat(projectId).isEqualTo("presto-bq-credentials-test");
+    }
+
+    @Test
+    public void testBothConfigurationAndCredentials()
+            throws Exception
+    {
+        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.of("pid"), credentials());
+        assertThat(projectId).isEqualTo("pid");
+    }
+
+    private Optional<Credentials> credentials()
+            throws IOException
+    {
+        return Optional.of(GoogleCredentials.fromStream(getClass().getResourceAsStream("/test-account.json")));
+    }
+}

--- a/presto-bigquery/src/test/resources/test-account.json
+++ b/presto-bigquery/src/test/resources/test-account.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "presto-bq-credentials-test",
+  "private_key_id": "ffffffffffffffffffffffffffffffffffffffff",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAq7BFUpkGp3+LQmlQ\nYx2eqzDV+xeG8kx/sQFV18S5JhzGeIJNA72wSeukEPojtqUyX2J0CciPBh7eqclQ\n2zpAswIDAQABAkAgisq4+zRdrzkwH1ITV1vpytnkO/NiHcnePQiOW0VUybPyHoGM\n/jf75C5xET7ZQpBe5kx5VHsPZj0CBb3b+wSRAiEA2mPWCBytosIU/ODRfq6EiV04\nlt6waE7I2uSPqIC20LcCIQDJQYIHQII+3YaPqyhGgqMexuuuGx+lDKD6/Fu/JwPb\n5QIhAKthiYcYKlL9h8bjDsQhZDUACPasjzdsDEdq8inDyLOFAiEAmCr/tZwA3qeA\nZoBzI10DGPIuoKXBd3nk/eBxPkaxlEECIQCNymjsoI7GldtujVnr1qT+3yedLfHK\nsrDVjIT3LsvTqw==\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-account@presto-bq-credentials-test.iam.gserviceaccount.com",
+  "client_id": "999999999999999999999",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-account%40presto-bq-credentials-test.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
There's a bug where if `bigquery.parent-project-id` is not configured, it will always be taken from the environment (env variable, metadata server, etc.) and not from the service account key file.

This PR fixes that by taking the parent project id from the service account (if provided) before looking at the environment.

A note regarding the test account key file - it is completely bogus: The project does not exist, the private key id and client id have been overridden,  and the private key has been taken from [Wikipedia](https://en.wikipedia.org/wiki/PKCS_8)

Fixes #3131