### PR TITLE
Create group provider configuration for product tests

### DIFF
--- a/presto-noop/src/main/java/io/prestosql/plugin/noop/NoOpPlugin.java
+++ b/presto-noop/src/main/java/io/prestosql/plugin/noop/NoOpPlugin.java
@@ -21,8 +21,11 @@ import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.spi.connector.ConnectorHandleResolver;
 import io.prestosql.spi.connector.ConnectorMetadata;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.security.GroupProvider;
+import io.prestosql.spi.security.GroupProviderFactory;
 import io.prestosql.spi.transaction.IsolationLevel;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -34,6 +37,12 @@ public final class NoOpPlugin
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
         return singletonList(new NoOpConnectorFactory());
+    }
+
+    @Override
+    public Iterable<GroupProviderFactory> getGroupProviderFactories()
+    {
+        return singletonList(new NoOpGroupProviderFactory());
     }
 
     private static class NoOpConnectorFactory
@@ -98,4 +107,23 @@ public final class NoOpPlugin
 
     private static class NoOpMetadata
             implements ConnectorMetadata {}
+
+    private static class NoOpGroupProviderFactory
+            implements GroupProviderFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "noop";
+        }
+
+        @Override
+        public GroupProvider create(Map<String, String> config)
+        {
+            if (!config.isEmpty()) {
+                throw new IllegalArgumentException("this group provider accepts no configuration properties");
+            }
+            return user -> Collections.emptySet();
+        }
+    }
 }

--- a/presto-noop/src/test/java/io/prestosql/plugin/noop/TestNoOpPlugin.java
+++ b/presto-noop/src/test/java/io/prestosql/plugin/noop/TestNoOpPlugin.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.noop;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
+import io.prestosql.spi.security.GroupProviderFactory;
 import io.prestosql.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
 
@@ -29,5 +30,13 @@ public class TestNoOpPlugin
         Plugin plugin = new NoOpPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create("noop", ImmutableMap.of(), new TestingConnectorContext());
+    }
+
+    @Test
+    public void testCreateGroupProvider()
+    {
+        Plugin plugin = new NoOpPlugin();
+        GroupProviderFactory factory = getOnlyElement(plugin.getGroupProviderFactories());
+        factory.create(ImmutableMap.of());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/AbstractSinglenodeLdap.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/AbstractSinglenodeLdap.java
@@ -13,18 +13,17 @@
  */
 package io.prestosql.tests.product.launcher.env.environment;
 
-import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
-import io.prestosql.tests.product.launcher.env.common.Hadoop;
-import io.prestosql.tests.product.launcher.env.common.Standard;
+import io.prestosql.tests.product.launcher.env.common.EnvironmentExtender;
 import io.prestosql.tests.product.launcher.testcontainers.SelectedPortWaitStrategy;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 
 import java.time.Duration;
+import java.util.List;
 
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
@@ -42,9 +41,9 @@ public abstract class AbstractSinglenodeLdap
 
     private static final int LDAP_PORT = 636;
 
-    protected AbstractSinglenodeLdap(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentOptions environmentOptions)
+    protected AbstractSinglenodeLdap(List<EnvironmentExtender> bases, DockerFiles dockerFiles, EnvironmentOptions environmentOptions)
     {
-        super(ImmutableList.of(standard, hadoop));
+        super(bases);
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
     }
@@ -90,6 +89,16 @@ public abstract class AbstractSinglenodeLdap
     protected String getBaseImage()
     {
         return "centos6-oj8-openldap";
+    }
+
+    protected DockerFiles getDockerFiles()
+    {
+        return dockerFiles;
+    }
+
+    protected String getImagesVersion()
+    {
+        return imagesVersion;
     }
 
     protected abstract String getPasswordAuthenticatorConfigPath();

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdap.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdap.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.tests.product.launcher.env.environment;
 
+import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -26,9 +27,9 @@ public class SinglenodeLdap
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdap(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentOptions environmentOptions)
+    public SinglenodeLdap(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, EnvironmentOptions environmentOptions)
     {
-        super(dockerFiles, standard, hadoop, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, environmentOptions);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapBindDn.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapBindDn.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.tests.product.launcher.env.environment;
 
+import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -26,9 +27,9 @@ public class SinglenodeLdapBindDn
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdapBindDn(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentOptions environmentOptions)
+    public SinglenodeLdapBindDn(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, EnvironmentOptions environmentOptions)
     {
-        super(dockerFiles, standard, hadoop, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, environmentOptions);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapReferrals.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapReferrals.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.tests.product.launcher.env.environment;
 
+import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -26,9 +27,9 @@ public class SinglenodeLdapReferrals
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdapReferrals(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentOptions environmentOptions)
+    public SinglenodeLdapReferrals(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, EnvironmentOptions environmentOptions)
     {
-        super(dockerFiles, standard, hadoop, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, environmentOptions);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/access-control.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/access-control.properties
@@ -1,1 +1,3 @@
+# This file exists so that we can install different access control in tests requiring it.
+# Docker does not allow to re-bind a file inside a folder that is also a volume, unless the file already exists.
 access-control.name=allow-all

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/group-provider.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/group-provider.properties
@@ -1,0 +1,3 @@
+# This file exists so that we can install group providers only in tests using it.
+# Docker does not allow to re-bind a file inside a folder that is also a volume, unless the file already exists.
+group-provider.name=noop


### PR DESCRIPTION
It allows extending with new group providers by mounting different `group-provider.properties` files.