### PR TITLE
Add initializer hook for SqlParser

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -52,6 +53,7 @@ public class SqlParser
             throw new ParsingException(message, e, line, charPositionInLine);
         }
     };
+    private static final BiConsumer<SqlBaseLexer, SqlBaseParser> DEFAULT_BASE_PARSER_INITIALIZER = (SqlBaseLexer lexer, SqlBaseParser parser) -> {};
 
     private static final ErrorHandler PARSER_ERROR_HANDLER = ErrorHandler.builder()
             .specialRule(SqlBaseParser.RULE_expression, "<expression>")
@@ -67,6 +69,7 @@ public class SqlParser
             .ignoredRule(SqlBaseParser.RULE_nonReserved)
             .build();
 
+    private final BiConsumer<SqlBaseLexer, SqlBaseParser> sqlBaseParserInitializer;
     private boolean enhancedErrorHandlerEnabled;
 
     public SqlParser()
@@ -77,6 +80,12 @@ public class SqlParser
     @Inject
     public SqlParser(SqlParserOptions options)
     {
+        this(options, DEFAULT_BASE_PARSER_INITIALIZER);
+    }
+
+    public SqlParser(SqlParserOptions options, BiConsumer<SqlBaseLexer, SqlBaseParser> sqlBaseParserInitializer)
+    {
+        this.sqlBaseParserInitializer = requireNonNull(sqlBaseParserInitializer, "sqlBaseParserInitializer is null");
         requireNonNull(options, "options is null");
         enhancedErrorHandlerEnabled = options.isEnhancedErrorHandlerEnabled();
     }
@@ -107,6 +116,7 @@ public class SqlParser
             SqlBaseLexer lexer = new SqlBaseLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
             SqlBaseParser parser = new SqlBaseParser(tokenStream);
+            sqlBaseParserInitializer.accept(lexer, parser);
 
             // Override the default error strategy to not attempt inserting or deleting a token.
             // Otherwise, it messes up error reporting


### PR DESCRIPTION
Allows external management of SqlBaseLexer and SqlBaseParser initialization which can be used to avoid unbounded growth the the default internal parser shared caches.