### PR TITLE
Optimize parquet gzip decompression

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -420,6 +420,19 @@ public class TestHiveFileFormats
     }
 
     @Test(dataProvider = "rowCount")
+    public void testParquetPageSourceGzip(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> testColumns = getTestColumnsSupportedByParquet();
+        assertThatFileFormat(PARQUET)
+                .withColumns(testColumns)
+                .withSession(PARQUET_SESSION)
+                .withCompressionCodec(HiveCompressionCodec.GZIP)
+                .withRowsCount(rowCount)
+                .isReadableByPageSource(new ParquetPageSourceFactory(HDFS_ENVIRONMENT, STATS, new ParquetReaderConfig()));
+    }
+
+    @Test(dataProvider = "rowCount")
     public void testParquetPageSourceSchemaEvolution(int rowCount)
             throws Exception
     {

--- a/presto-parquet/src/main/java/io/prestosql/parquet/ParquetCompressionUtils.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/ParquetCompressionUtils.java
@@ -13,17 +13,16 @@
  */
 package io.prestosql.parquet;
 
+import com.google.common.io.ByteStreams;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.lz4.Lz4Decompressor;
 import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.compress.zstd.ZstdDecompressor;
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -31,7 +30,9 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
@@ -89,14 +90,15 @@ public final class ParquetCompressionUtils
             return EMPTY_SLICE;
         }
 
-        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(uncompressedSize);
-        byte[] buffer = new byte[uncompressedSize];
-        try (InputStream gzipInputStream = new GZIPInputStream(input.getInput(), GZIP_BUFFER_SIZE)) {
-            int bytesRead;
-            while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
-                sliceOutput.write(buffer, 0, bytesRead);
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(input.getInput(), min(GZIP_BUFFER_SIZE, input.length()))) {
+            byte[] buffer = new byte[uncompressedSize];
+            int bytesRead = ByteStreams.read(gzipInputStream, buffer, 0, buffer.length);
+            if (bytesRead != uncompressedSize) {
+                throw new IllegalArgumentException(format("Invalid uncompressedSize for GZIP input. Expected %s, actual: %s", uncompressedSize, bytesRead));
             }
-            return sliceOutput.getUnderlyingSlice();
+            // Verify we're at EOF and aren't truncating the input
+            checkArgument(gzipInputStream.read() == -1, "Invalid uncompressedSize for GZIP input. Actual size exceeds %s bytes", uncompressedSize);
+            return wrappedBuffer(buffer, 0, bytesRead);
         }
     }
 


### PR DESCRIPTION
Avoids creating an intermediate buffer (with the full `uncompressedSize` capacity) and copy from buffer to `DynamicSliceOutput` in parquet gzip decompression. Also avoids allocating the full 8k gzip input buffer size when the slice input is smaller. Finally, a validation check is added to verify the `uncompressedSize` was correct whereas previously the resulting slice would contain garbage data at the end (likely zeroed memory).