### PR TITLE
Ensure kafka splits do not overlap

### DIFF
--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
@@ -139,13 +139,18 @@ public class KafkaRecordSet
                 records = kafkaConsumer.poll(CONSUMER_POLL_TIMEOUT).iterator();
                 return advanceNextPosition();
             }
-            nextRow(records.next());
-            return true;
+
+            return nextRow(records.next());
         }
 
         private boolean nextRow(ConsumerRecord<byte[], byte[]> message)
         {
             requireNonNull(message, "message is null");
+
+            if (message.offset() >= split.getMessagesRange().getEnd()) {
+                return false;
+            }
+
             completedBytes += max(message.serializedKeySize(), 0) + max(message.serializedValueSize(), 0);
 
             byte[] keyData = EMPTY_BYTE_ARRAY;

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestMinimalFunctionality.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestMinimalFunctionality.java
@@ -46,6 +46,9 @@ public class TestMinimalFunctionality
                 .setExtraTopicDescription(ImmutableMap.<SchemaTableName, KafkaTopicDescription>builder()
                         .put(createEmptyTopicDescription(topicName, new SchemaTableName("default", topicName)))
                         .build())
+                .setExtraKafkaProperties(ImmutableMap.<String, String>builder()
+                        .put("kafka.messages-per-split", "100")
+                        .build())
                 .build();
         testingKafka.createTopics(topicName);
         return queryRunner;


### PR DESCRIPTION
If multiple splits process offsets for a partition then messages can be duplicated if the offset range is greater than the configured messages per split.