### PR TITLE
Embed version once

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlQueryManager.java
@@ -29,7 +29,6 @@ import io.prestosql.server.protocol.Slug;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.QueryId;
 import io.prestosql.sql.planner.Plan;
-import io.prestosql.version.EmbedVersion;
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -67,7 +66,6 @@ public class SqlQueryManager
 
     private final ClusterMemoryManager memoryManager;
     private final QueryMonitor queryMonitor;
-    private final EmbedVersion embedVersion;
     private final QueryTracker<QueryExecution> queryTracker;
 
     private final Duration maxQueryCpuTime;
@@ -81,11 +79,10 @@ public class SqlQueryManager
     private final QueryManagerStats stats = new QueryManagerStats();
 
     @Inject
-    public SqlQueryManager(ClusterMemoryManager memoryManager, QueryMonitor queryMonitor, EmbedVersion embedVersion, QueryManagerConfig queryManagerConfig)
+    public SqlQueryManager(ClusterMemoryManager memoryManager, QueryMonitor queryMonitor, QueryManagerConfig queryManagerConfig)
     {
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
-        this.embedVersion = requireNonNull(embedVersion, "embedVersion is null");
 
         this.maxQueryCpuTime = queryManagerConfig.getQueryMaxCpuTime();
 
@@ -237,7 +234,7 @@ public class SqlQueryManager
 
         stats.trackQueryStats(queryExecution);
 
-        embedVersion.embedVersion(queryExecution::start).run();
+        queryExecution.start();
     }
 
     @Override


### PR DESCRIPTION
For certain queries, embedded version would show up in stacktrace twice.

For example:

    presto> SELECT 1 / 0;
    Query 20200322_223738_00000_q5z3r failed: Division by zero
    io.prestosql.spi.PrestoException: Division by zero
            at io.prestosql.type.IntegerOperators.divide(IntegerOperators.java:106)
    ...
            at io.prestosql.sql.planner.iterative.rule.ExpressionRewriteRuleSet$ProjectExpressionRewrite.apply(ExpressionRewriteRuleSet.java:125)
            at io.prestosql.sql.planner.iterative.rule.ExpressionRewriteRuleSet$ProjectExpressionRewrite.apply(ExpressionRewriteRuleSet.java:106)
            at io.prestosql.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:165)
    ...
            at io.prestosql.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:180)
            at io.prestosql.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:395)
            at io.prestosql.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:383)
            at io.prestosql.execution.SqlQueryExecution.start(SqlQueryExecution.java:338)
            at io.prestosql.$gen.Presto_null__testversion____20200322_223351_2.run(Unknown Source)
            at io.prestosql.execution.SqlQueryManager.createQuery(SqlQueryManager.java:241)
            at io.prestosql.dispatcher.LocalDispatchQuery.lambda$startExecution$7(LocalDispatchQuery.java:132)
            at io.prestosql.$gen.Presto_null__testversion____20200322_223351_2.run(Unknown Source)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at java.base/java.lang.Thread.run(Thread.java:834)
    Caused by: java.lang.ArithmeticException: / by zero
            at io.prestosql.type.IntegerOperators.divide(IntegerOperators.java:103)
            ... 48 more