### PR TITLE
Fix query failure when DF allows join to become INNER

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -498,6 +498,13 @@ public class PredicatePushDown
                 }
             }
 
+            if (node.getDistributionType().isPresent()
+                    && JoinNode.requiresEquiJoinClauses(node.getDistributionType().get(), node.getType())
+                    && equiJoinClauses.isEmpty()) {
+                verify(!node.getCriteria().isEmpty(), "Original criteria was empty");
+                equiJoinClauses.add(node.getCriteria().get(0));
+            }
+
             DynamicFiltersResult dynamicFiltersResult = createDynamicFilters(node, equiJoinClauses, session, idAllocator);
             Map<String, Symbol> dynamicFilters = dynamicFiltersResult.getDynamicFilters();
             leftPredicate = combineConjuncts(metadata, leftPredicate, combineConjuncts(metadata, dynamicFiltersResult.getPredicates()));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
@@ -132,7 +132,7 @@ public class JoinNode
                     distributionType.get());
             // It does not make sense to PARTITION when there is nothing to partition on
             checkArgument(
-                    !(distributionType.get() == PARTITIONED && criteria.isEmpty() && type != RIGHT && type != FULL),
+                    !criteria.isEmpty() || !requiresEquiJoinClauses(distributionType.get(), type),
                     "Equi criteria are empty, so %s join should not have %s distribution type",
                     type,
                     distributionType.get());
@@ -141,6 +141,11 @@ public class JoinNode
         for (Symbol symbol : dynamicFilters.values()) {
             checkArgument(rightSymbols.contains(symbol), "Right join input doesn't contain symbol for dynamic filter: %s", symbol);
         }
+    }
+
+    public static boolean requiresEquiJoinClauses(DistributionType distributionType, Type type)
+    {
+        return distributionType == PARTITIONED && type != RIGHT && type != FULL;
     }
 
     public JoinNode flipChildren()

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
@@ -2275,6 +2275,28 @@ public abstract class AbstractTestJoinQueries
                 "WHERE id3 = 10");
     }
 
+    @Test
+    public void testMultiJoinWithEligibleForDynamicFiltering()
+    {
+        assertQuery("" +
+                        "SELECT customer.name, lineitem.partkey " +
+                        "FROM lineitem " +
+                        "LEFT JOIN orders ON lineitem.orderkey = orders.orderkey " + // with dynamic filters enabled, gets converted to INNER CROSS JOIN
+                        "LEFT JOIN customer ON orders.custkey = customer.custkey " + // gets converted to INNER join
+                        "WHERE lineitem.orderkey = 31718 " +
+                        "AND customer.name >= 'Customer#000001463' ",
+                "VALUES ('Customer#000001471', 474), ('Customer#000001471', 1969), ('Customer#000001471', 32)");
+
+        assertQuery("" +
+                        "SELECT count(*) " +
+                        "FROM lineitem " +
+                        "LEFT JOIN orders ON lineitem.orderkey = orders.orderkey " + // with dynamic filters enabled, gets converted to INNER CROSS JOIN
+                        "LEFT JOIN customer ON orders.custkey = customer.custkey " + // gets converted to INNER join
+                        "WHERE lineitem.orderkey = 31718 " +
+                        "AND customer.name >= 'Customer#000001463' ",
+                "VALUES 3");
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(getSession())


### PR DESCRIPTION
`PredicatePushDown` may determine a join needs to be inner because of
dynamic filter function call. Since dynamic filters pushdown is delayed
after join reordering, when this happens the distribution type may be
fixed already. For INNER joins we are able to completely remove join
condition.

Fixes https://github.com/prestosql/presto/issues/3149