### PR TITLE
Delete MongoDB document if exists in schema collection

### DIFF
--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
@@ -494,7 +494,8 @@ public class MongoSession
         String tableName = schemaTableName.getTableName();
 
         MongoDatabase db = client.getDatabase(schemaName);
-        if (!collectionExists(db, tableName)) {
+        if (!collectionExists(db, tableName) &&
+                db.getCollection(schemaCollection).find(new Document(TABLE_NAME_KEY, tableName)).first().isEmpty()) {
             return false;
         }
 

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoIntegrationSmokeTest.java
@@ -296,6 +296,14 @@ public class TestMongoIntegrationSmokeTest
         assertUpdate("DROP TABLE test.view_base");
     }
 
+    @Test
+    public void testDropTable()
+    {
+        assertUpdate("CREATE TABLE test.drop_table(col bigint)");
+        assertUpdate("DROP TABLE test.drop_table");
+        assertQueryFails("SELECT * FROM test.drop_table", ".*Table 'mongodb.test.drop_table' does not exist");
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toTestTypes();


### PR DESCRIPTION
FIxes https://github.com/prestosql/presto/issues/3082

If table was created by Presto, it saves metadata in _schema, add '_schema' deleting code is necessary.