### PR TITLE
Add info about login page

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -836,4 +836,37 @@ Logging Properties
 
     The maximum file size for the log file of the HTTP server.
 
+.. _web-ui-properties:
 
+Web UI Properties
+-----------------
+
+The following properties can be used to configure the :doc:`./web-interface`.
+
+``web-ui.enabled``
+^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    This property controls whether or not the Web UI is available.
+
+``web-ui.shared-secret``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``string``
+    * **Default value:** randomly generated unless set
+
+    The shared secret is used to generate authentication cookies for users of
+    the Web UI. If not set to a static value, any coordinator restart generates
+    a new random value, which in turn invalidates the session of any currently
+    logged in Web UI user.
+
+web-ui.session-timeout
+^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``duration``
+    * **Default value:** ``1 day``
+
+    The duration how long a user can be logged into the Web UI, before the
+    session times out, which forces an automatic log-out.

--- a/presto-docs/src/main/sphinx/admin/web-interface.rst
+++ b/presto-docs/src/main/sphinx/admin/web-interface.rst
@@ -3,9 +3,20 @@ Web UI
 ======
 
 Presto provides a web-based user interface (UI) for monitoring a Presto cluster
-and managing queries. The web UI is accessible on the Presto coordinator via
+and managing queries. The Web UI is accessible on the coordinator via
 HTTP/HTTPS, using the corresponding port number specified in the coordinator
-:ref:`config_properties`.
+:ref:`config_properties`. It can be configured with :ref:`specific related
+properties <web-ui-properties>`.
+
+The Web UI requires users to log in. If Presto is not configured to require
+authentication, then any username can be used, and no password is required or
+allowed. Typically, users should login with the same username that they use for
+running queries.
+
+When the server is configured to use HTTPS, a :doc:`password authenticator
+</develop/password-authenticator>` such as :doc:`LDAP </security/ldap>` or
+:doc:`password file </security/password-file>` must be configured in order to
+use the Web UI.
 
 The main page has a list of queries along with information like unique query ID, query text,
 query state, percentage completed, username and source from which this query originated.


### PR DESCRIPTION
We might have to document more about the TLS requirement and what to do e.g. if the Presto cluster runs on HTTP but sits behind a loadbalancer or other proxy that deals with TLS