### PR TITLE
Fix SQL formatting for nested alias or sample

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/SqlFormatter.java
@@ -475,7 +475,7 @@ public final class SqlFormatter
         @Override
         protected Void visitAliasedRelation(AliasedRelation node, Integer indent)
         {
-            process(node.getRelation(), indent);
+            processRelationSuffix(node.getRelation(), indent);
 
             builder.append(' ')
                     .append(formatExpression(node.getAlias()));
@@ -487,7 +487,7 @@ public final class SqlFormatter
         @Override
         protected Void visitSampledRelation(SampledRelation node, Integer indent)
         {
-            process(node.getRelation(), indent);
+            processRelationSuffix(node.getRelation(), indent);
 
             builder.append(" TABLESAMPLE ")
                     .append(node.getType())
@@ -496,6 +496,18 @@ public final class SqlFormatter
                     .append(')');
 
             return null;
+        }
+
+        private void processRelationSuffix(Relation relation, Integer indent)
+        {
+            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation)) {
+                builder.append("( ");
+                process(relation, indent + 1);
+                append(indent, ")");
+            }
+            else {
+                process(relation, indent);
+            }
         }
 
         @Override

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
@@ -61,6 +61,19 @@ public class TestStatementBuilder
         printStatement("select x[1][2] from my_table");
         printStatement("select x[cast(10 * sin(x) as bigint)] from my_table");
 
+        printStatement("select * from (select * from (select * from t) x) y");
+        printStatement("select * from (select * from (table t) x) y");
+
+        printStatement("select * from t x tablesample system (10)");
+        printStatement("select * from (t x tablesample system (10)) y");
+        printStatement("select * from (t tablesample system (10)) tablesample system (10)");
+        printStatement("select * from (t x tablesample system (10)) y tablesample system (10)");
+
+        printStatement("select * from (((select q)))");
+        printStatement("select * from (select q) x");
+        printStatement("select * from ((select q) x) y");
+        printStatement("select * from (((select q) x) y) z");
+
         printStatement("select * from unnest(t.my_array)");
         printStatement("select * from unnest(array[1, 2, 3])");
         printStatement("select x from unnest(array[1, 2, 3]) t(x)");


### PR DESCRIPTION
Nested aliases or table samples are formatted without parentheses.  For example, `select * from ((select q) x) y` would format as `select * from (select q) x y`.