### PR TITLE
Fix predicate push-down accuracy

### DIFF
--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientSession.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientSession.java
@@ -528,7 +528,7 @@ public class KuduClientSession
                             }
                             Marker high = span.getHigh();
                             if (!high.isUpperUnbounded()) {
-                                KuduPredicate.ComparisonOp op = (low.getBound() == BELOW) ? LESS : LESS_EQUAL;
+                                KuduPredicate.ComparisonOp op = (high.getBound() == BELOW) ? LESS : LESS_EQUAL;
                                 KuduPredicate predicate = createComparisonPredicate(columnSchema, op, high.getValue());
                                 builder.addPredicate(predicate);
                             }


### PR DESCRIPTION
I think this is a coding error which will not affect the final result.
I think it's unreasonable for lower bound to have a BELOW bound type.
When the query condition is < 3, then it will change to <= 3 according to this code:
`KuduPredicate.ComparisonOp op = (low.getBound() == BELOW) ? LESS : LESS_EQUAL;`

With this error code, the predicate push-down will get more data returned.
