### PR TITLE
Correction to parent project id property name in BigQuery documentation.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -129,7 +129,7 @@ All configuration properties are optional.
 Property                                  Description                                                    Default
 ========================================= ============================================================== ==============================================
 ``bigquery.project-id``                   The Google Cloud Project ID where the data reside              Taken from the service account
-``bigquery.parent-project``               The project ID Google Cloud Project to bill for the export     Taken from the service account
+``bigquery.parent-project-id``            The project ID Google Cloud Project to bill for the export     Taken from the service account
 ``bigquery.parallelism``                  The number of partitions to split the data into                The number of executors
 ``bigquery.views-enabled``                Enables the connector to read from views and not only tables.  ``false``
                                           Please read `this section <#reading-from-views>`_ before


### PR DESCRIPTION
I noticed that the BigQuery configuration looks for `parent-project-id` instead of `project-id`.

What I am unsure if is a bug or not, but line 73 of BigQueryConnectorModule.java sets the project id to  the parent project id:

```.setProjectId(config.getParentProjectId()```

BigQueryConfig attempts to provide a parent project id if one wasn't specified, but in my case it had returned null, leading to factory to fail.