### PR TITLE
Allow JDBC connectors to customize generated SQL

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DefaultSqlCustomization.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DefaultSqlCustomization.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import static java.util.Objects.requireNonNull;
+
+public class DefaultSqlCustomization
+        implements SqlCustomization
+{
+    private final String quoteValue;
+
+    public DefaultSqlCustomization(String quoteValue)
+    {
+        this.quoteValue = requireNonNull(quoteValue, "quoteValue was null");
+    }
+
+    @Override
+    public String quote(String name)
+    {
+        return quoteValue + name.replace(quoteValue, quoteValue + quoteValue) + quoteValue;
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -52,35 +52,6 @@ public class QueryBuilder
 
     private final String identifierQuote;
 
-    private static class TypeAndValue
-    {
-        private final Type type;
-        private final JdbcTypeHandle typeHandle;
-        private final Object value;
-
-        public TypeAndValue(Type type, JdbcTypeHandle typeHandle, Object value)
-        {
-            this.type = requireNonNull(type, "type is null");
-            this.typeHandle = requireNonNull(typeHandle, "typeHandle is null");
-            this.value = requireNonNull(value, "value is null");
-        }
-
-        public Type getType()
-        {
-            return type;
-        }
-
-        public JdbcTypeHandle getTypeHandle()
-        {
-            return typeHandle;
-        }
-
-        public Object getValue()
-        {
-            return value;
-        }
-    }
-
     public QueryBuilder(String identifierQuote)
     {
         this.identifierQuote = requireNonNull(identifierQuote, "identifierQuote is null");
@@ -289,5 +260,34 @@ public class QueryBuilder
     {
         Type type = column.getColumnType();
         accumulator.add(new TypeAndValue(type, column.getJdbcTypeHandle(), value));
+    }
+
+    private static class TypeAndValue
+    {
+        private final Type type;
+        private final JdbcTypeHandle typeHandle;
+        private final Object value;
+
+        public TypeAndValue(Type type, JdbcTypeHandle typeHandle, Object value)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.typeHandle = requireNonNull(typeHandle, "typeHandle is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public JdbcTypeHandle getTypeHandle()
+        {
+            return typeHandle;
+        }
+
+        public Object getValue()
+        {
+            return value;
+        }
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SqlCustomization.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SqlCustomization.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.util.List;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * Encapsulates strategies to use for various parts of SQL generation in {@link QueryBuilder}.
+ */
+public interface SqlCustomization
+{
+    String quote(String name);
+
+    default List<String> columnNames(List<JdbcColumnHandle> handles)
+    {
+        return handles.stream()
+                .map(JdbcColumnHandle::getColumnName)
+                .map(this::quote)
+                .collect(toImmutableList());
+    }
+
+    default String fromRelation(String catalog, String schema, String table)
+    {
+        StringBuilder sql = new StringBuilder();
+
+        if (!isNullOrEmpty(catalog)) {
+            sql.append(quote(catalog)).append('.');
+        }
+
+        if (!isNullOrEmpty(schema)) {
+            sql.append(quote(schema)).append('.');
+        }
+
+        return sql.append(quote(table)).toString();
+    }
+}


### PR DESCRIPTION
Some connectors need better control over various parts of the query.