### PR TITLE
Fix incorrect pushdown in Kudu when value can be NULL.

### DIFF
--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientSession.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientSession.java
@@ -491,6 +491,9 @@ public class KuduClientSession
             else if (domain.isOnlyNull()) {
                 builder.addPredicate(KuduPredicate.newIsNullPredicate(columnSchema));
             }
+            else if (!domain.getValues().isNone() && domain.isNullAllowed()) {
+                // no restriction
+            }
             else if (domain.getValues().isAll() && !domain.isNullAllowed()) {
                 builder.addPredicate(KuduPredicate.newIsNotNullPredicate(columnSchema));
             }

--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
@@ -78,6 +78,22 @@ public class TestKuduDistributedQueries
     }
 
     @Override
+    public void testPredicatePushdown()
+    {
+        assertUpdate("CREATE TABLE IF NOT EXISTS test_is_null (" +
+                "id INT WITH (primary_key=true), " +
+                "col_nullable bigint with (nullable=true)" +
+                ") WITH (" +
+                " partition_by_hash_columns = ARRAY['id'], " +
+                " partition_by_hash_buckets = 2" +
+                ")");
+
+        assertUpdate("INSERT INTO test_is_null VALUES (1, 1)", 1);
+        assertUpdate("INSERT INTO test_is_null(id) VALUES (2)", 1);
+        assertQuery("SELECT id FROM test_is_null WHERE col_nullable = 1 OR col_nullable IS NULL", "VALUES (1), (2)");
+    }
+
+    @Override
     public void testAddColumn()
     {
         // TODO Support these test once kudu connector can create tables with default partitions


### PR DESCRIPTION
Fix incorrect pushdown in Kudu when value can be NULL..
![image](https://user-images.githubusercontent.com/33892550/78011805-acc2bc80-7376-11ea-8be2-4d147e957cf9.png)


Fixes #3274