### PR TITLE
Optimizations to avoid Slice data copies

### DIFF
--- a/presto-main/src/main/java/io/prestosql/block/BlockJsonSerde.java
+++ b/presto-main/src/main/java/io/prestosql/block/BlockJsonSerde.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.block;
 
+import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -20,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.prestosql.spi.block.Block;
@@ -28,10 +30,10 @@ import io.prestosql.spi.block.BlockEncodingSerde;
 import javax.inject.Inject;
 
 import java.io.IOException;
-import java.util.Base64;
 
 import static io.prestosql.block.BlockSerdeUtil.readBlock;
 import static io.prestosql.block.BlockSerdeUtil.writeBlock;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public final class BlockJsonSerde
@@ -53,10 +55,11 @@ public final class BlockJsonSerde
         public void serialize(Block block, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
                 throws IOException
         {
-            SliceOutput output = new DynamicSliceOutput(64);
+            //  Encoding name is length prefixed as are many block encodings
+            SliceOutput output = new DynamicSliceOutput(toIntExact(block.getSizeInBytes() + block.getEncodingName().length() + (2 * Integer.BYTES)));
             writeBlock(blockEncodingSerde, output, block);
-            String encoded = Base64.getEncoder().encodeToString(output.slice().getBytes());
-            jsonGenerator.writeString(encoded);
+            Slice slice = output.slice();
+            jsonGenerator.writeBinary(Base64Variants.MIME_NO_LINEFEEDS, slice.byteArray(), slice.byteArrayOffset(), slice.length());
         }
     }
 
@@ -75,7 +78,7 @@ public final class BlockJsonSerde
         public Block deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException
         {
-            byte[] decoded = Base64.getDecoder().decode(jsonParser.readValueAs(String.class));
+            byte[] decoded = jsonParser.getBinaryValue(Base64Variants.MIME_NO_LINEFEEDS);
             return readBlock(blockEncodingSerde, Slices.wrappedBuffer(decoded));
         }
     }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/HmacFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/HmacFunctions.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.operator.scalar;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.airlift.slice.Slice;
 import io.prestosql.spi.function.Description;
@@ -31,7 +33,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacMd5(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacMd5(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacMd5(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA1")
@@ -39,7 +41,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha1(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha1(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha1(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA256")
@@ -47,7 +49,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha256(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha256(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha256(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA512")
@@ -55,6 +57,18 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha512(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha512(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha512(key.getBytes()), slice);
+    }
+
+    static Slice computeHash(HashFunction hash, Slice data)
+    {
+        HashCode result;
+        if (data.hasByteArray()) {
+            result = hash.hashBytes(data.byteArray(), data.byteArrayOffset(), data.length());
+        }
+        else {
+            result = hash.hashBytes(data.getBytes());
+        }
+        return wrappedBuffer(result.asBytes());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/JoniRegexpFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/JoniRegexpFunctions.java
@@ -54,9 +54,17 @@ public final class JoniRegexpFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean regexpLike(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern)
     {
-        Matcher m = pattern.matcher(source.getBytes());
-        int offset = m.search(0, source.length(), Option.DEFAULT);
-        return offset != -1;
+        Matcher matcher;
+        int offset;
+        if (source.hasByteArray()) {
+            offset = source.byteArrayOffset();
+            matcher = pattern.regex().matcher(source.byteArray(), offset, offset + source.length());
+        }
+        else {
+            offset = 0;
+            matcher = pattern.matcher(source.getBytes());
+        }
+        return matcher.search(offset, offset + source.length(), Option.DEFAULT) != -1;
     }
 
     private static int getNextStart(Slice source, Matcher matcher)

--- a/presto-main/src/test/java/io/prestosql/sql/TestLikeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestLikeFunctions.java
@@ -36,11 +36,20 @@ import static org.testng.Assert.assertTrue;
 public class TestLikeFunctions
         extends AbstractTestFunctions
 {
+    private static Slice offsetHeapSlice(String value)
+    {
+        Slice source = Slices.utf8Slice(value);
+        Slice result = Slices.allocate(source.length() + 5);
+        result.setBytes(2, source);
+        return result.slice(2, source.length());
+    }
+
     @Test
     public void testLikeBasic()
     {
         JoniRegexp regex = LikeFunctions.compileLikePattern(utf8Slice("f%b__"));
         assertTrue(likeVarchar(utf8Slice("foobar"), regex));
+        assertTrue(likeVarchar(offsetHeapSlice("foobar"), regex));
 
         assertFunction("'foob' LIKE 'f%b__'", BOOLEAN, false);
         assertFunction("'foob' LIKE 'f%b'", BOOLEAN, true);
@@ -51,8 +60,11 @@ public class TestLikeFunctions
     {
         JoniRegexp regex = LikeFunctions.compileLikePattern(utf8Slice("f%b__"));
         assertTrue(likeChar(6L, utf8Slice("foobar"), regex));
+        assertTrue(likeChar(6L, offsetHeapSlice("foobar"), regex));
         assertTrue(likeChar(6L, utf8Slice("foob"), regex));
+        assertTrue(likeChar(6L, offsetHeapSlice("foob"), regex));
         assertFalse(likeChar(7L, utf8Slice("foob"), regex));
+        assertFalse(likeChar(7L, offsetHeapSlice("foob"), regex));
 
         assertFunction("cast('foob' as char(6)) LIKE 'f%b__'", BOOLEAN, true);
         assertFunction("cast('foob' as char(7)) LIKE 'f%b__'", BOOLEAN, false);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/dictionary/BinaryDictionary.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/dictionary/BinaryDictionary.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.parquet.dictionary;
 
+import io.airlift.slice.Slice;
 import io.prestosql.parquet.DictionaryPage;
 import org.apache.parquet.io.api.Binary;
 
@@ -37,9 +38,10 @@ public class BinaryDictionary
             throws IOException
     {
         super(dictionaryPage.getEncoding());
-        byte[] dictionaryBytes = dictionaryPage.getSlice().getBytes();
         content = new Binary[dictionaryPage.getDictionarySize()];
-        int offset = 0;
+        Slice dictionarySlice = dictionaryPage.getSlice();
+        byte[] dictionaryBytes = dictionarySlice.byteArray();
+        int offset = dictionarySlice.byteArrayOffset();
         if (length == null) {
             for (int i = 0; i < content.length; i++) {
                 int len = readIntLittleEndian(dictionaryBytes, offset);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
@@ -35,7 +35,6 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.OriginalType;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -286,7 +285,7 @@ public abstract class PrimitiveColumnReader
         if (maxLevel == 0) {
             return new LevelNullReader();
         }
-        return new LevelRLEReader(new RunLengthBitPackingHybridDecoder(BytesUtils.getWidthFromMaxInt(maxLevel), new ByteArrayInputStream(slice.getBytes())));
+        return new LevelRLEReader(new RunLengthBitPackingHybridDecoder(BytesUtils.getWidthFromMaxInt(maxLevel), slice.getInput()));
     }
 
     private ValuesReader initDataReader(ParquetEncoding dataEncoding, int valueCount, ByteBufferInputStream in)

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
@@ -295,7 +295,7 @@ public class InMemoryRecordSet
                 completedBytes += ((Block) value).getSizeInBytes();
             }
             else if (value instanceof Slice) {
-                completedBytes += ((Slice) value).getBytes().length;
+                completedBytes += ((Slice) value).length();
             }
             else {
                 throw new IllegalArgumentException("Unknown type: " + value.getClass());


### PR DESCRIPTION
Split into individual commits to make this easier to review. The general theme is replacing usages of `Slice#getBytes()` when a suitable alternative exists.