### PR TITLE
Add catalog session property details

### DIFF
--- a/presto-docs/src/main/sphinx/sql/set-session.rst
+++ b/presto-docs/src/main/sphinx/sql/set-session.rst
@@ -13,15 +13,30 @@ Synopsis
 Description
 -----------
 
-Set a session property value.
+Set a session property value or a catalog session property.
+
+
+Connectors can provide session properties. They are set separately for each
+catalog by prefixing them with the catalog name. There is no sharing of
+properties across catalogs, even if the catalogs use the same connector.
 
 Examples
 --------
 
-.. code-block:: sql
+The following example sets a system session property to enable optimized hash
+generation::
 
     SET SESSION optimize_hash_generation = true;
-    SET SESSION hive.optimized_reader_enabled = true;
+
+An example of the usage of catalog session properties is the :doc:`Accumulo
+connector </connector/accumulo>`, which supports a property named
+``optimize_locality_enabled``. If your Accumulo catalog is named ``data``, you
+would use the following to set the catalog session property::
+
+    SET SESSION data.optimize_locality_enabled = false;
+
+This catalog session property does not apply to any other catalog, even if it
+also uses the Accumulo connector.
 
 See Also
 --------


### PR DESCRIPTION
We can either do this approach of using the term "catalog session property" as discussed with @martint on slack or we change terminology to use "system session property"  for global ones and some other terms (not sure what) as suggested by @electrum 

If we do not want to use catalog session property we have to fix a number of release note documents. I can rejig this PR either way .. just let me know what you prefer to use as term.

Personally I think using "system session property" and "catalog session property" is most logic and self-explanatory.