### PR TITLE
Add column-pruning rules for set operation nodes

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -67,8 +67,10 @@ import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import io.prestosql.sql.planner.iterative.rule.PruneDeleteSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneEnforceSingleRowColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneExceptSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneFilterColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneIndexSourceColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneIntersectSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneLimitColumns;
@@ -81,6 +83,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneTopNColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneUnionSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneValuesColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneWindowColumns;
 import io.prestosql.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
@@ -242,8 +245,10 @@ public class PlanOptimizers
                 new PruneCorrelatedJoinColumns(),
                 new PruneDeleteSourceColumns(),
                 new PruneEnforceSingleRowColumns(),
+                new PruneExceptSourceColumns(),
                 new PruneFilterColumns(),
                 new PruneIndexSourceColumns(),
+                new PruneIntersectSourceColumns(),
                 new PruneJoinChildrenColumns(),
                 new PruneJoinColumns(),
                 new PruneMarkDistinctColumns(),
@@ -252,6 +257,7 @@ public class PlanOptimizers
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneTopNColumns(),
+                new PruneUnionSourceColumns(),
                 new PruneValuesColumns(),
                 new PruneWindowColumns(),
                 new PruneOffsetColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -83,6 +83,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneTopNColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneUnionColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneUnionSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneValuesColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneWindowColumns;
@@ -257,6 +258,7 @@ public class PlanOptimizers
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneTopNColumns(),
+                new PruneUnionColumns(),
                 new PruneUnionSourceColumns(),
                 new PruneValuesColumns(),
                 new PruneWindowColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneExceptSourceColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneExceptSourceColumns.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.ExceptNode;
+
+import java.util.Set;
+
+import static io.prestosql.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static io.prestosql.sql.planner.plan.Patterns.except;
+
+public class PruneExceptSourceColumns
+        implements Rule<ExceptNode>
+{
+    @Override
+    public Pattern<ExceptNode> getPattern()
+    {
+        return except();
+    }
+
+    @Override
+    public Result apply(ExceptNode node, Captures captures, Context context)
+    {
+        @SuppressWarnings("unchecked")
+        Set<Symbol>[] referencedInputs = new Set[node.getSources().size()];
+        for (int i = 0; i < node.getSources().size(); i++) {
+            referencedInputs[i] = ImmutableSet.copyOf(node.sourceOutputLayout(i));
+        }
+        return restrictChildOutputs(context.getIdAllocator(), node, referencedInputs)
+                .map(Rule.Result::ofPlanNode)
+                .orElse(Rule.Result.empty());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneIntersectSourceColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneIntersectSourceColumns.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.IntersectNode;
+
+import java.util.Set;
+
+import static io.prestosql.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static io.prestosql.sql.planner.plan.Patterns.intersect;
+
+public class PruneIntersectSourceColumns
+        implements Rule<IntersectNode>
+{
+    @Override
+    public Pattern<IntersectNode> getPattern()
+    {
+        return intersect();
+    }
+
+    @Override
+    public Result apply(IntersectNode node, Captures captures, Context context)
+    {
+        @SuppressWarnings("unchecked")
+        Set<Symbol>[] referencedInputs = new Set[node.getSources().size()];
+        for (int i = 0; i < node.getSources().size(); i++) {
+            referencedInputs[i] = ImmutableSet.copyOf(node.sourceOutputLayout(i));
+        }
+        return restrictChildOutputs(context.getIdAllocator(), node, referencedInputs)
+                .map(Rule.Result::ofPlanNode)
+                .orElse(Rule.Result.empty());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnionColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnionColumns.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.UnionNode;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+import static io.prestosql.sql.planner.plan.Patterns.union;
+
+/**
+ * Transforms
+ * <pre>
+ * - Project (a)
+ *      - Union
+ *        output mappings: {a->c, a->e, b->d, b->f}
+ *          - Source (c, d)
+ *          - Source (e, f)
+ * </pre>
+ * into:
+ * <pre>
+ * - Project (a)
+ *      - Union
+ *        output mappings: {a->c, a->e}
+ *          - Source (c, d)
+ *          - Source (e, f)
+ * </pre>
+ * Note: as a result of this rule, the UnionNode's sources
+ * are eligible for pruning outputs. This is accomplished
+ * by PruneUnionSourceColumns rule.
+ */
+public class PruneUnionColumns
+        extends ProjectOffPushDownRule<UnionNode>
+{
+    public PruneUnionColumns()
+    {
+        super(union());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(Context context, UnionNode unionNode, Set<Symbol> referencedOutputs)
+    {
+        ImmutableListMultimap<Symbol, Symbol> prunedOutputMappings = unionNode.getSymbolMapping().entries().stream()
+                .filter(entry -> referencedOutputs.contains(entry.getKey()))
+                .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return Optional.of(
+                new UnionNode(
+                        unionNode.getId(),
+                        unionNode.getSources(),
+                        prunedOutputMappings,
+                        ImmutableList.copyOf(prunedOutputMappings.keySet())));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnionSourceColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnionSourceColumns.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.UnionNode;
+
+import java.util.Set;
+
+import static io.prestosql.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static io.prestosql.sql.planner.plan.Patterns.union;
+
+public class PruneUnionSourceColumns
+        implements Rule<UnionNode>
+{
+    @Override
+    public Pattern<UnionNode> getPattern()
+    {
+        return union();
+    }
+
+    @Override
+    public Result apply(UnionNode node, Captures captures, Context context)
+    {
+        @SuppressWarnings("unchecked")
+        Set<Symbol>[] referencedInputs = new Set[node.getSources().size()];
+        for (int i = 0; i < node.getSources().size(); i++) {
+            referencedInputs[i] = ImmutableSet.copyOf(node.sourceOutputLayout(i));
+        }
+        return restrictChildOutputs(context.getIdAllocator(), node, referencedInputs)
+                .map(Rule.Result::ofPlanNode)
+                .orElse(Rule.Result.empty());
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneExceptSourceColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneExceptSourceColumns.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.except;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneExceptSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneOneChild()
+    {
+        tester().assertThat(new PruneExceptSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.except(
+                            ImmutableListMultimap.of(output, a, output, c),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c)));
+                })
+                .matches(except(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        values("c")));
+    }
+
+    @Test
+    public void testPruneAllChildren()
+    {
+        tester().assertThat(new PruneExceptSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    return p.except(
+                            ImmutableListMultimap.of(output, a, output, c),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c, d)));
+                })
+                .matches(except(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        strictProject(
+                                ImmutableMap.of("c", expression("c")),
+                                values("c", "d"))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneExceptSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.except(
+                            ImmutableListMultimap.of(output, a, output, b),
+                            ImmutableList.of(
+                                    p.values(a),
+                                    p.values(b)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneIntersectSourceColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneIntersectSourceColumns.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.intersect;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneIntersectSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneOneChild()
+    {
+        tester().assertThat(new PruneIntersectSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    return p.intersect(
+                            ImmutableListMultimap.of(output, a, output, c, output, d),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c),
+                                    p.values(d)));
+                })
+                .matches(intersect(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        values("c"),
+                        values("d")));
+    }
+
+    @Test
+    public void testPruneAllChildren()
+    {
+        tester().assertThat(new PruneIntersectSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    Symbol f = p.symbol("f");
+                    return p.intersect(
+                            ImmutableListMultimap.of(output, a, output, c, output, e),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c, d),
+                                    p.values(e, f)));
+                })
+                .matches(intersect(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        strictProject(
+                                ImmutableMap.of("c", expression("c")),
+                                values("c", "d")),
+                        strictProject(
+                                ImmutableMap.of("e", expression("e")),
+                                values("e", "f"))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneIntersectSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.intersect(
+                            ImmutableListMultimap.of(output, a, output, b, output, c),
+                            ImmutableList.of(
+                                    p.values(a),
+                                    p.values(b),
+                                    p.values(c)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnionColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnionColumns.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.union;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneUnionColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneInputColumns()
+    {
+        tester().assertThat(new PruneUnionColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.project(
+                            Assignments.of(),
+                            p.union(
+                                    ImmutableListMultimap.of(a, b, a, c),
+                                    ImmutableList.of(
+                                            p.values(b),
+                                            p.values(c))));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of(),
+                                union(
+                                        values("b"),
+                                        values("c"))
+                                        .withExactOutputs()));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+    {
+        tester().assertThat(new PruneUnionColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.project(
+                            Assignments.identity(a),
+                            p.enforceSingleRow(p.values(a)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnionSourceColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnionSourceColumns.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.union;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneUnionSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneOneChild()
+    {
+        tester().assertThat(new PruneUnionSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    return p.union(
+                            ImmutableListMultimap.of(output, a, output, c, output, d),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c),
+                                    p.values(d)));
+                })
+                .matches(union(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        values("c"),
+                        values("d")));
+    }
+
+    @Test
+    public void testPruneAllChildren()
+    {
+        tester().assertThat(new PruneUnionSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    Symbol d = p.symbol("d");
+                    Symbol e = p.symbol("e");
+                    Symbol f = p.symbol("f");
+                    return p.union(
+                            ImmutableListMultimap.of(output, a, output, c, output, e),
+                            ImmutableList.of(
+                                    p.values(a, b),
+                                    p.values(c, d),
+                                    p.values(e, f)));
+                })
+                .matches(union(
+                        strictProject(
+                                ImmutableMap.of("a", expression("a")),
+                                values("a", "b")),
+                        strictProject(
+                                ImmutableMap.of("c", expression("c")),
+                                values("c", "d")),
+                        strictProject(
+                                ImmutableMap.of("e", expression("e")),
+                                values("e", "f"))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+    {
+        tester().assertThat(new PruneUnionSourceColumns())
+                .on(p -> {
+                    Symbol output = p.symbol("output");
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    Symbol c = p.symbol("c");
+                    return p.union(
+                            ImmutableListMultimap.of(output, a, output, b, output, c),
+                            ImmutableList.of(
+                                    p.values(a),
+                                    p.values(b),
+                                    p.values(c)));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Adds a set of iterative rules for pruning ExceptNode's, IntersectNode's
and UnionNode's children's columns not referenced in the node's
mapping.