### PR TITLE
Remove launcher help output from documentation

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -264,44 +264,17 @@ if using a supervision system like daemontools:
     bin/launcher run
 
 Run the launcher with ``--help`` to see the supported commands and
-command line options:
+command line options. In particular, the ``--verbose`` option is
+very useful for debugging the installation.
 
-.. code-block:: none
-
-    bin/launcher --help
-    Usage: launcher [options] command
-
-    Commands: run, start, stop, restart, kill, status
-
-    Options:
-    -h, --help               show this help message and exit
-    -v, --verbose            Run verbosely
-    --etc-dir=DIR            Defaults to INSTALL_PATH/etc
-    --launcher-config=FILE   Defaults to INSTALL_PATH/bin/launcher.properties
-    --node-config=FILE       Defaults to ETC_DIR/node.properties
-    --jvm-config=FILE        Defaults to ETC_DIR/jvm.config
-    --config=FILE            Defaults to ETC_DIR/config.properties
-    --log-levels-file=FILE   Defaults to ETC_DIR/log.properties
-    --data-dir=DIR           Defaults to INSTALL_PATH
-    --pid-file=FILE          Defaults to DATA_DIR/var/run/launcher.pid
-    --launcher-log-file=FILE Defaults to DATA_DIR/var/log/launcher.log (only in
-                             daemon mode)
-    --server-log-file=FILE   Defaults to DATA_DIR/var/log/server.log (only in
-                             daemon mode)
-    -D NAME=VALUE            Set a Java system property
-
-In particular, the ``--verbose`` option is very useful for debugging the
-installation and any problems starting Presto.
-
-As you can see, the launcher script configures default values for the
-configuration directory ``etc``, configuration files, the data directory ``var``
-and log files in the data directory.
-
-You can use these options to adjust your Presto usage to any requirements, such
-as using a directory outside the installation directory, specific mount points
-or locations and even using other file names. For example, the Presto RPM
-package adjusts the used directories to better follow the Linux Filesystem
-Hierarchy Standard.
+The launcher configures default values for the configuration
+directory ``etc``, configuration files, the data directory ``var``,
+and log files in the data directory. You can change these values
+to adjust your Presto usage to any requirements, such as using a
+directory outside the installation directory, specific mount points
+or locations, and even using other file names. For example, the Presto
+RPM adjusts the used directories to better follow the Linux Filesystem
+Hierarchy Standard (FHS).
 
 After starting Presto, you can find log files in the ``log`` directory inside
 the data directory ``var``:


### PR DESCRIPTION
This will become out of date and is not needed in the documentation,
as anyone that needs to adjust it can run help on their own.