### PR TITLE
Bump Apache Avro to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>98</version>
+        <version>99</version>
     </parent>
 
     <groupId>io.prestosql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -825,7 +825,7 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.9.1</version>
+                <version>1.9.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This minor version bump fixes regression issues:
https://github.com/apache/avro/releases/tag/release-1.9.2