### PR TITLE
Pass RemoteTable to createTableSql

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -38,6 +38,8 @@ import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
 
+import javax.annotation.Nullable;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -467,7 +469,7 @@ public abstract class BaseJdbcClient
         }
     }
 
-    protected String createTableSql(String catalog, String remoteSchema, String tableName, List<String> columns)
+    protected String createTableSql(@Nullable String catalog, @Nullable String remoteSchema, String tableName, List<String> columns)
     {
         return format("CREATE TABLE %s (%s)", quoted(catalog, remoteSchema, tableName), join(", ", columns));
     }
@@ -919,7 +921,7 @@ public abstract class BaseJdbcClient
         return identifierQuote + name + identifierQuote;
     }
 
-    protected String quoted(String catalog, String schema, String table)
+    protected String quoted(@Nullable String catalog, @Nullable String schema, String table)
     {
         StringBuilder sb = new StringBuilder();
         if (!isNullOrEmpty(catalog)) {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -123,9 +123,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 newDomain,
                 Optional.empty(), // groupBy
                 handle.getLimit(),
@@ -154,9 +152,7 @@ public class JdbcMetadata
         return Optional.of(new ProjectionApplicationResult<>(
                 new JdbcTableHandle(
                         handle.getSchemaTableName(),
-                        handle.getCatalogName(),
-                        handle.getSchemaName(),
-                        handle.getTableName(),
+                        handle.getRemoteTableName(),
                         handle.getConstraint(),
                         handle.getGroupingSets(),
                         handle.getLimit(),
@@ -236,9 +232,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 handle.getConstraint(),
                 Optional.of(groupingSets.stream()
                         .map(groupingSet -> groupingSet.stream()
@@ -266,9 +260,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 handle.getConstraint(),
                 handle.getGroupingSets(),
                 OptionalLong.of(limit),

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableName.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableName.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Qualified table name reported by the remote database.
+ */
+public final class RemoteTableName
+{
+    private final Optional<String> catalogName;
+    private final Optional<String> schemaName;
+    private final String tableName;
+
+    @JsonCreator
+    public RemoteTableName(Optional<String> catalogName, Optional<String> schemaName, String tableName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    @JsonProperty
+    public Optional<String> getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @JsonProperty
+    public Optional<String> getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RemoteTableName that = (RemoteTableName) o;
+        return catalogName.equals(that.catalogName) &&
+                schemaName.equals(that.schemaName) &&
+                tableName.equals(that.tableName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(catalogName, schemaName, tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return Joiner.on(".").skipNulls().join(catalogName.orElse(null), schemaName.orElse(null), tableName);
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -180,9 +180,7 @@ public class TestJdbcRecordSetProvider
     {
         jdbcTableHandle = new JdbcTableHandle(
                 jdbcTableHandle.getSchemaTableName(),
-                jdbcTableHandle.getCatalogName(),
-                jdbcTableHandle.getSchemaName(),
-                jdbcTableHandle.getTableName(),
+                jdbcTableHandle.getRemoteTableName(),
                 domain,
                 Optional.empty(),
                 OptionalLong.empty(),

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRemoteTableName.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRemoteTableName.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestRemoteTableName
+{
+    @Test
+    public void testJsonRoundTrip()
+    {
+        JsonCodec<RemoteTableName> codec = JsonCodec.jsonCodec(RemoteTableName.class);
+        RemoteTableName table = new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table");
+        RemoteTableName roundTrip = codec.fromJson(codec.toJson(table));
+        assertEquals(table.getCatalogName(), roundTrip.getCatalogName());
+        assertEquals(table.getSchemaName(), roundTrip.getSchemaName());
+        assertEquals(table.getTableName(), roundTrip.getTableName());
+    }
+}


### PR DESCRIPTION
Pass RemoteTable to createTableSql

Passing RemoteTable is much less error prone that passing a triple of
Strings. Especially, where some of them are nullable.
