### PR TITLE
Upgrade Elastic connector to 7.6.x

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.9.1</dep.log4j.version>
-        <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.log4j.version>2.11.1</dep.log4j.version>
+        <dep.elasticsearch.version>7.6.2</dep.elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -141,10 +141,10 @@
                     <groupId>org.apache.lucene</groupId>
                     <artifactId>lucene-highlighter</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.lucene</groupId>
-                    <artifactId>lucene-join</artifactId>
-                </exclusion>
+<!--                <exclusion>-->
+<!--                    <groupId>org.apache.lucene</groupId>-->
+<!--                    <artifactId>lucene-join</artifactId>-->
+<!--                </exclusion>-->
                 <exclusion>
                     <groupId>org.apache.lucene</groupId>
                     <artifactId>lucene-memory</artifactId>
@@ -181,6 +181,24 @@
         </dependency>
 
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-core</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-x-content</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
             <version>${dep.elasticsearch.version}</version>
@@ -200,14 +218,8 @@
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore-nio</artifactId>
-            <version>4.4.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.12</version>
 
             <exclusions>
                 <!-- elasticsearch-rest-high-level-client 6.0.0 brings in httpcore 4.4.5 vs (4.4.4) -->
@@ -232,13 +244,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <version>4.4.12</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.4</version>
 
             <exclusions>
                 <exclusion>

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
@@ -24,6 +24,7 @@ import io.prestosql.testing.ResultsSession;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -109,7 +110,7 @@ public class ElasticsearchLoader
 
             request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             try {
-                client.bulk(request);
+                client.bulk(request, RequestOptions.DEFAULT);
             }
             catch (IOException e) {
                 throw new RuntimeException(e);

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchServer.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchServer.java
@@ -22,7 +22,7 @@ public class ElasticsearchServer
 
     public ElasticsearchServer()
     {
-        container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0");
+        container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:7.6.2");
         container.start();
     }
 


### PR DESCRIPTION
Update Elastic connector to last version of elastic


I test this changes against a 6.8.8 docker image and dont work because of breaking changes on 7
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html


should I create a presto-elasticseach7 ??

and maybe rename actual connector to presto-elasticsearch6, 
and create a presto-elasticsearch-base for common classes?
