### PR TITLE
Update outdated comment

### DIFF
--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -606,7 +606,7 @@ public class PostgreSqlClient
                 return Slices.wrappedBuffer(SORTED_MAPPER.writeValueAsBytes(value));
             }
             catch (JsonProcessingException e) {
-                throw new PrestoException(JDBC_ERROR, "Cast to JSON failed for  " + type.getDisplayName(), e);
+                throw new PrestoException(JDBC_ERROR, "Conversion to JSON failed for  " + type.getDisplayName(), e);
             }
         };
     }


### PR DESCRIPTION
When the comment was added, indeed `CAST` logic was used, but it no
longer is. Update comment not to imply there is SQL CAST being
performed.