### PR TITLE
Support filter push down in Big Query

### DIFF
--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryFilterQueryBuilder.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryFilterQueryBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+class BigQueryFilterQueryBuilder
+{
+    private static final String QUOTE = "`";
+    private static final String ESCAPED_QUOTE = "``";
+    private final TupleDomain<ColumnHandle> tupleDomain;
+
+    public static Optional<String> buildFilter(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return new BigQueryFilterQueryBuilder(tupleDomain).buildFilter();
+    }
+
+    private BigQueryFilterQueryBuilder(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        this.tupleDomain = tupleDomain;
+    }
+
+    private Optional<String> buildFilter()
+    {
+        Optional<Map<ColumnHandle, Domain>> domains = tupleDomain.getDomains();
+        return domains.map(this::toConjuncts)
+                .map(this::concat);
+    }
+
+    private String concat(List<String> clauses)
+    {
+        return clauses.isEmpty() ? null : clauses.stream().collect(joining(" AND "));
+    }
+
+    private List<String> toConjuncts(Map<ColumnHandle, Domain> domains)
+    {
+        List<BigQueryColumnHandle> columns = domains.keySet().stream().map(BigQueryColumnHandle.class::cast).collect(toList());
+        return toConjuncts(columns);
+    }
+
+    private List<String> toConjuncts(List<BigQueryColumnHandle> columns)
+    {
+        if (tupleDomain.isNone()) {
+            return ImmutableList.of("FALSE");
+        }
+        ImmutableList.Builder<String> clauses = ImmutableList.builder();
+        for (BigQueryColumnHandle column : columns) {
+            Domain domain = tupleDomain.getDomains().get().get(column);
+            if (domain != null) {
+                clauses.add(toPredicate(column.getName(), domain, column));
+            }
+        }
+        return clauses.build();
+    }
+
+    private String toPredicate(String columnName, Domain domain, BigQueryColumnHandle column)
+    {
+        if (domain.getValues().isNone()) {
+            return domain.isNullAllowed() ? quote(columnName) + " IS NULL" : "FALSE";
+        }
+
+        if (domain.getValues().isAll()) {
+            return domain.isNullAllowed() ? "TRUE" : quote(columnName) + " IS NOT NULL";
+        }
+
+        List<String> disjuncts = new ArrayList<>();
+        List<Object> singleValues = new ArrayList<>();
+        for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
+            checkState(!range.isAll()); // Already checked
+            if (range.isSingleValue()) {
+                singleValues.add(range.getLow().getValue());
+            }
+            else {
+                List<String> rangeConjuncts = new ArrayList<>();
+                if (!range.getLow().isLowerUnbounded()) {
+                    switch (range.getLow().getBound()) {
+                        case ABOVE:
+                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), column));
+                            break;
+                        case EXACTLY:
+                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), column));
+                            break;
+                        case BELOW:
+                            throw new IllegalArgumentException("Low marker should never use BELOW bound");
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                    }
+                }
+                if (!range.getHigh().isUpperUnbounded()) {
+                    switch (range.getHigh().getBound()) {
+                        case ABOVE:
+                            throw new IllegalArgumentException("High marker should never use ABOVE bound");
+                        case EXACTLY:
+                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), column));
+                            break;
+                        case BELOW:
+                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), column));
+                            break;
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                    }
+                }
+                // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+                checkState(!rangeConjuncts.isEmpty());
+                disjuncts.add("(" + concat(rangeConjuncts) + ")");
+            }
+        }
+
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues), column));
+        }
+        else if (singleValues.size() > 1) {
+            String values = singleValues.stream()
+                    .map(column.getBigQueryType()::convertToString)
+                    .collect(joining(","));
+            disjuncts.add(quote(columnName) + " IN (" + values + ")");
+        }
+
+        // Add nullability disjuncts
+        checkState(!disjuncts.isEmpty());
+        if (domain.isNullAllowed()) {
+            disjuncts.add(quote(columnName) + " IS NULL");
+        }
+
+        return "(" + String.join(" OR ", disjuncts) + ")";
+    }
+
+    private String toPredicate(String columnName, String operator, Object value, BigQueryColumnHandle column)
+    {
+        String valueAsString = column.getBigQueryType().convertToString(value);
+        return quote(columnName) + " " + operator + " " + valueAsString;
+    }
+
+    private String quote(String name)
+    {
+        return QUOTE + name.replace(QUOTE, ESCAPED_QUOTE) + QUOTE;
+    }
+}

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQuerySplitManager.java
@@ -28,6 +28,7 @@ import io.prestosql.spi.connector.ConnectorSplitSource;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.connector.FixedSplitSource;
+import io.prestosql.spi.predicate.TupleDomain;
 
 import javax.inject.Inject;
 
@@ -81,7 +82,8 @@ public class BigQuerySplitManager
 
         TableId tableId = bigQueryTableHandle.getTableId();
         int actualParallelism = parallelism.orElse(nodeManager.getRequiredWorkerNodes().size());
-        Optional<String> filter = Optional.empty();
+        TupleDomain<ColumnHandle> constraint = bigQueryTableHandle.getConstraint();
+        Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(constraint);
         List<BigQuerySplit> splits = emptyProjectionIsRequired(bigQueryTableHandle.getProjectedColumns()) ?
                 createEmptyProjection(tableId, actualParallelism, filter) :
                 readFromBigQuery(tableId, bigQueryTableHandle.getProjectedColumns(), actualParallelism, filter);

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryTableHandle.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryTableHandle.java
@@ -63,7 +63,7 @@ public class BigQueryTableHandle
     {
         TableId tableId = tableInfo.getTableId();
         String type = tableInfo.getDefinition().getType().toString();
-        return new BigQueryTableHandle(tableId.getProject(), tableId.getDataset(), tableId.getTable(), type, TupleDomain.none(), Optional.empty(), OptionalLong.empty());
+        return new BigQueryTableHandle(tableId.getProject(), tableId.getDataset(), tableId.getTable(), type, TupleDomain.all(), Optional.empty(), OptionalLong.empty());
     }
 
     @JsonProperty

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryUtil.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryUtil.java
@@ -19,15 +19,19 @@ import com.google.common.collect.ImmutableSet;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
+import java.util.Set;
+
 import static com.google.cloud.http.BaseHttpServiceException.UNKNOWN_CODE;
 import static com.google.common.base.Throwables.getCausalChain;
 
 class BigQueryUtil
 {
-    static final ImmutableSet<String> INTERNAL_ERROR_MESSAGES = ImmutableSet.of(
+    private static final Set<String> INTERNAL_ERROR_MESSAGES = ImmutableSet.of(
             "HTTP/2 error code: INTERNAL_ERROR",
             "Connection closed with unknown cause",
             "Received unexpected EOS on DATA frame from server");
+
+    private static final Set<String> INVALID_COLUMN_NAMES = ImmutableSet.of("_partitiondate", "_PARTITIONDATE", "_partitiontime", "_PARTITIONTIME");
 
     private BigQueryUtil() {}
 
@@ -50,5 +54,10 @@ class BigQueryUtil
     static BigQueryException convertToBigQueryException(BigQueryError error)
     {
         return new BigQueryException(UNKNOWN_CODE, error.getMessage(), error);
+    }
+
+    public static boolean validColumnName(String columnName)
+    {
+        return !INVALID_COLUMN_NAMES.contains(columnName);
     }
 }

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/Conversions.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/Conversions.java
@@ -43,7 +43,8 @@ class Conversions
                 BigQueryType.valueOf(field.getType().name()),
                 getMode(field),
                 subColumns,
-                field.getDescription());
+                field.getDescription(),
+                false);
     }
 
     static ColumnMetadata toColumnMetadata(Field field)

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadRowsHelper.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/ReadRowsHelper.java
@@ -14,12 +14,12 @@
 package io.prestosql.plugin.bigquery;
 
 import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient;
+import com.google.cloud.bigquery.storage.v1beta1.Storage;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
+import java.util.NoSuchElementException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,32 +38,8 @@ public class ReadRowsHelper
 
     public Iterator<ReadRowsResponse> readRows()
     {
-        List<ReadRowsResponse> readRowResponses = new ArrayList<>();
-        long readRowsCount = 0;
-        int retries = 0;
         Iterator<ReadRowsResponse> serverResponses = fetchResponses(request);
-        while (serverResponses.hasNext()) {
-            try {
-                ReadRowsResponse response = serverResponses.next();
-                readRowsCount += response.getRowCount();
-                readRowResponses.add(response);
-            }
-            catch (RuntimeException e) {
-                // if relevant, retry the read, from the last read position
-                if (BigQueryUtil.isRetryable(e) && retries < maxReadRowsRetries) {
-                    request.getReadPositionBuilder().setOffset(readRowsCount);
-                    serverResponses = fetchResponses(request);
-                    retries++;
-                }
-                else {
-                    // to safely close the client
-                    try (BigQueryStorageClient ignored = client) {
-                        throw e;
-                    }
-                }
-            }
-        }
-        return readRowResponses.iterator();
+        return new ReadRowsIterator(this, request.getReadPositionBuilder(), serverResponses);
     }
 
     // In order to enable testing
@@ -72,5 +48,59 @@ public class ReadRowsHelper
         return client.readRowsCallable()
                 .call(readRowsRequest.build())
                 .iterator();
+    }
+
+    // Ported from https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/150
+    private static class ReadRowsIterator
+            implements Iterator<ReadRowsResponse>
+    {
+        private final ReadRowsHelper helper;
+        private final Storage.StreamPosition.Builder readPosition;
+        private Iterator<ReadRowsResponse> serverResponses;
+        private long readRowsCount;
+        private int retries;
+
+        public ReadRowsIterator(
+                ReadRowsHelper helper,
+                Storage.StreamPosition.Builder readPosition,
+                Iterator<ReadRowsResponse> serverResponses)
+        {
+            this.helper = helper;
+            this.readPosition = readPosition;
+            this.serverResponses = serverResponses;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return serverResponses.hasNext();
+        }
+
+        @Override
+        public ReadRowsResponse next()
+        {
+            do {
+                try {
+                    ReadRowsResponse response = serverResponses.next();
+                    readRowsCount += response.getRowCount();
+                    return response;
+                }
+                catch (Exception e) {
+                    // if relevant, retry the read, from the last read position
+                    if (BigQueryUtil.isRetryable(e) && retries < helper.maxReadRowsRetries) {
+                        serverResponses = helper.fetchResponses(helper.request.setReadPosition(
+                                readPosition.setOffset(readRowsCount)));
+                        retries++;
+                    }
+                    else {
+                        helper.client.close();
+                        throw e;
+                    }
+                }
+            }
+            while (serverResponses.hasNext());
+
+            throw new NoSuchElementException("No more server responses");
+        }
     }
 }

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryType.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryType.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.bigquery;
+
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.prestosql.spi.type.Decimals.encodeScaledValue;
+import static java.math.BigDecimal.ONE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test
+public class TestBigQueryType
+{
+    @Test
+    public void testTimeToStringConverter()
+    {
+        assertThat(BigQueryType.timeToStringConverter(
+                Long.valueOf(303497217825L)))
+                .isEqualTo("'12:34:56'");
+    }
+
+    @Test
+    public void testTimestampToStringConverter()
+    {
+        assertThat(BigQueryType.timestampToStringConverter(
+                Long.valueOf(6494958783649569L)))
+                .isEqualTo("'2020-03-31 12:34:56.789'");
+    }
+
+    @Test
+    public void testDateToStringConverter()
+    {
+        assertThat(BigQueryType.dateToStringConverter(
+                Long.valueOf(18352)))
+                .isEqualTo("'2020-03-31'");
+    }
+
+    @Test
+    public void testStringToStringConverter()
+    {
+        assertThat(BigQueryType.stringToStringConverter(
+                utf8Slice("test")))
+                .isEqualTo("'test'");
+    }
+
+    @Test
+    public void testNumericToStringConverter()
+    {
+        assertThat(BigQueryType.numericToStringConverter(
+                encodeScaledValue(ONE, 9)))
+                .isEqualTo("1.000000000");
+    }
+
+    @Test
+    public void testBytesToStringConverter()
+    {
+        assertThat(BigQueryType.bytesToStringConverter(
+                wrappedBuffer((byte) 1, (byte) 2, (byte) 3, (byte) 4)))
+                .isEqualTo("FROM_BASE64('AQIDBA==')");
+    }
+}


### PR DESCRIPTION
Added support for filter push down. This has two benefits of this are:

- Performance improvement, where row filtering is done on the BigQuery storage size where applicable
- Partitioned tables where filtering by the partition is mandatory are supported now. 

In addition, the BigQuery libraries were updated.