### PR TITLE
Add support for dereference pushdown to parquet reader

### DIFF
--- a/presto-parquet/src/main/java/io/prestosql/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/ParquetTypeUtils.java
@@ -22,6 +22,7 @@ import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.PrimitiveColumnIO;
 import org.apache.parquet.schema.DecimalMetadata;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 
 import java.util.Arrays;
@@ -165,14 +166,14 @@ public final class ParquetTypeUtils
         }
     }
 
-    public static org.apache.parquet.schema.Type getParquetTypeByName(String columnName, MessageType messageType)
+    public static org.apache.parquet.schema.Type getParquetTypeByName(String columnName, GroupType groupType)
     {
-        if (messageType.containsField(columnName)) {
-            return messageType.getType(columnName);
+        if (groupType.containsField(columnName)) {
+            return groupType.getType(columnName);
         }
         // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
         // check for direct match above but if no match found, try case-insensitive match
-        for (org.apache.parquet.schema.Type type : messageType.getFields()) {
+        for (org.apache.parquet.schema.Type type : groupType.getFields()) {
             if (type.getName().equalsIgnoreCase(columnName)) {
                 return type;
             }

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
@@ -99,14 +99,14 @@ public class ParquetReader
             throws IOException
     {
         this.fileCreatedBy = requireNonNull(fileCreatedBy, "fileCreatedBy is null");
-        this.blocks = blocks;
+        this.columns = requireNonNull(messageColumnIO, "messageColumnIO is null").getLeaves();
+        this.blocks = requireNonNull(blocks, "blocks is null");
         this.dataSource = requireNonNull(dataSource, "dataSource is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.currentRowGroupMemoryContext = systemMemoryContext.newAggregatedMemoryContext();
-        columns = messageColumnIO.getLeaves();
         this.options = requireNonNull(options, "options is null");
-        columnReaders = new PrimitiveColumnReader[columns.size()];
-        maxBytesPerCell = new long[columns.size()];
+        this.columnReaders = new PrimitiveColumnReader[columns.size()];
+        this.maxBytesPerCell = new long[columns.size()];
 
         Map<ChunkKey, DiskRange> ranges = new HashMap<>();
         for (int rowGroup = 0; rowGroup < blocks.size(); rowGroup++) {
@@ -119,7 +119,7 @@ public class ParquetReader
             }
         }
 
-        chunkReaders = dataSource.planRead(ranges);
+        this.chunkReaders = dataSource.planRead(ranges);
     }
 
     @Override


### PR DESCRIPTION
Prunes requestedSchema of ParquetReader to only included referenced nested columns. See https://github.com/prestosql/presto/issues/3116 for more detail. Note that this patch also requires https://github.com/prestosql/presto/pull/2672 to see the performance gain.