### PR TITLE
Restore development log level for com.ning.http.client

### DIFF
--- a/presto-main/etc/log.properties
+++ b/presto-main/etc/log.properties
@@ -8,3 +8,6 @@
 io.prestosql=INFO
 com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory=WARN
 io.prestosql.server.PluginManager=DEBUG
+
+# Maven plugin loading code
+com.ning.http.client=WARN


### PR DESCRIPTION
This logger is used by the Maven plugin loading code.