### PR TITLE
Allow blocking page source until dynamic filters are ready

### DIFF
--- a/presto-benchmark/src/main/java/io/prestosql/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/io/prestosql/benchmark/AbstractOperatorBenchmark.java
@@ -45,8 +45,8 @@ import io.prestosql.security.AllowAllAccessControl;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.memory.MemoryPoolId;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spiller.SpillSpaceTracker;
 import io.prestosql.split.SplitSource;
@@ -181,7 +181,7 @@ public abstract class AbstractOperatorBenchmark
             public Operator createOperator(DriverContext driverContext)
             {
                 OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, "BenchmarkSource");
-                ConnectorPageSource pageSource = localQueryRunner.getPageSourceManager().createPageSource(session, split, tableHandle, columnHandles, TupleDomain::all);
+                ConnectorPageSource pageSource = localQueryRunner.getPageSourceManager().createPageSource(session, split, tableHandle, columnHandles, DynamicFilter.EMPTY);
                 return new PageSourceOperator(pageSource, operatorContext);
             }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -41,6 +41,7 @@ import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.ExpressionCompiler;
@@ -515,7 +516,7 @@ public class TestOrcPageSourceMemoryTracking
                     (session, split, table, columnHandles, dynamicFilter) -> pageSource,
                     TEST_TABLE_HANDLE,
                     columns.stream().map(columnHandle -> (ColumnHandle) columnHandle).collect(toImmutableList()),
-                    TupleDomain::all);
+                    DynamicFilter.EMPTY);
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(new CatalogName("test"), TestingSplit.createLocalSplit(), Lifespan.taskWide()));
             return operator;
@@ -539,7 +540,7 @@ public class TestOrcPageSourceMemoryTracking
                     pageProcessor,
                     TEST_TABLE_HANDLE,
                     columns.stream().map(columnHandle -> (ColumnHandle) columnHandle).collect(toList()),
-                    TupleDomain::all,
+                    DynamicFilter.EMPTY,
                     types,
                     DataSize.ofBytes(0),
                     0);

--- a/presto-main/src/main/java/io/prestosql/operator/TaskContext.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TaskContext.java
@@ -382,7 +382,7 @@ public class TaskContext
         return toIntExact(max(0, endFullGcCount - startFullGcCount));
     }
 
-    public synchronized void collectDynamicTupleDomain(Map<DynamicFilterId, Domain> dynamicFilterDomains)
+    public synchronized void collectDynamicFilterDomains(Map<DynamicFilterId, Domain> dynamicFilterDomains)
     {
         for (Map.Entry<DynamicFilterId, Domain> entry : dynamicFilterDomains.entrySet()) {
             dynamicTupleDomains.merge(entry.getKey(), entry.getValue(), Domain::intersect);

--- a/presto-main/src/main/java/io/prestosql/split/PageSourceProvider.java
+++ b/presto-main/src/main/java/io/prestosql/split/PageSourceProvider.java
@@ -18,10 +18,9 @@ import io.prestosql.metadata.Split;
 import io.prestosql.metadata.TableHandle;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.connector.DynamicFilter;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 public interface PageSourceProvider
 {
@@ -30,5 +29,5 @@ public interface PageSourceProvider
             Split split,
             TableHandle table,
             List<ColumnHandle> columns,
-            Supplier<TupleDomain<ColumnHandle>> dynamicFilter);
+            DynamicFilter dynamicFilter);
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalDynamicFiltersCollector.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalDynamicFiltersCollector.java
@@ -13,40 +13,151 @@
  */
 package io.prestosql.sql.planner;
 
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.plan.DynamicFilterId;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static io.prestosql.sql.DynamicFilters.Descriptor;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 class LocalDynamicFiltersCollector
 {
-    /**
-     * May contains domains for dynamic filters for different table scans
-     * (e.g. in case of co-located joins).
-     */
-    @GuardedBy("this")
-    private final Map<Symbol, Domain> dynamicFilterDomainsResult = new HashMap<>();
+    // Each future blocks until its dynamic filter is collected.
+    private final Map<DynamicFilterId, SettableFuture<Domain>> futures = new HashMap<>();
 
-    public synchronized TupleDomain<Symbol> getDynamicFilter(Set<Symbol> probeSymbols)
+    public LocalDynamicFiltersCollector()
     {
-        Map<Symbol, Domain> probeSymbolDomains = dynamicFilterDomainsResult.entrySet().stream()
-                .filter(entry -> probeSymbols.contains(entry.getKey()))
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-        return TupleDomain.withColumnDomains(probeSymbolDomains);
     }
 
-    public synchronized void addDynamicFilter(Map<Symbol, Domain> dynamicFilterDomains)
+    // Called during JoinNode planning (no need to be synchronized as local planning is single threaded)
+    public void register(Set<DynamicFilterId> filterIds)
     {
-        for (Map.Entry<Symbol, Domain> entry : dynamicFilterDomains.entrySet()) {
-            dynamicFilterDomainsResult.merge(entry.getKey(), entry.getValue(), Domain::intersect);
+        filterIds.forEach(filterId -> verify(
+                futures.put(filterId, SettableFuture.create()) == null,
+                "LocalDynamicFiltersCollector: duplicate filter %s", filterId));
+    }
+
+    // Used during execution (after build-side dynamic filter collection is over).
+    // No need to be synchronized as the futures map doesn't change.
+    public void collectDynamicFilterDomains(Map<DynamicFilterId, Domain> dynamicFilterDomains)
+    {
+        dynamicFilterDomains
+                .entrySet()
+                .stream()
+                .forEach(entry -> {
+                    SettableFuture<Domain> future = futures.get(entry.getKey());
+                    // Skip dynamic filters that are not applied locally.
+                    if (future != null) {
+                        verify(future.set(entry.getValue()), "Dynamic filter %s already collected", entry.getKey());
+                    }
+                });
+    }
+
+    // Called during TableScan planning (no need to be synchronized as local planning is single threaded)
+    public DynamicFilter createDynamicFilter(List<Descriptor> descriptors, Map<Symbol, ColumnHandle> columnsMap)
+    {
+        Multimap<DynamicFilterId, Symbol> symbolsMap = descriptors.stream()
+                .collect(toImmutableSetMultimap(Descriptor::getId, descriptor -> Symbol.from(descriptor.getInput())));
+
+        // Iterate over dynamic filters that are collected (correspond to one of the futures), and required for filtering (correspond to one of the descriptors).
+        // It is possible that some dynamic filters are collected in a different stage - and will not available here.
+        // It is also possible that not all local dynamic filters are needed for this specific table scan.
+        List<ListenableFuture<TupleDomain<ColumnHandle>>> predicateFutures = symbolsMap.keySet().stream()
+                .filter(futures.keySet()::contains)
+                .map(filterId -> {
+                    // Probe-side columns that can be filtered with this dynamic filter resulting domain.
+                    List<ColumnHandle> probeColumns = symbolsMap.get(filterId).stream()
+                            .map(probeSymbol -> requireNonNull(columnsMap.get(probeSymbol), () -> format("Missing probe column for %s", probeSymbol)))
+                            .collect(toImmutableList());
+                    return Futures.transform(
+                            requireNonNull(futures.get(filterId), () -> format("Missing dynamic filter %s", filterId)),
+                            // Construct a probe-side predicate by duplicating the resulting domain over the corresponding columns.
+                            domain -> TupleDomain.withColumnDomains(
+                                    probeColumns.stream()
+                                            .collect(toImmutableMap(
+                                                    column -> column,
+                                                    column -> domain))),
+                            directExecutor());
+                })
+                .collect(toImmutableList());
+        return new TableSpecificDynamicFilter(predicateFutures);
+    }
+
+    // Table-specific dynamic filter (collects all domains for a specific table scan)
+    private static class TableSpecificDynamicFilter
+            implements DynamicFilter
+    {
+        @GuardedBy("this")
+        private CompletableFuture<?> isBlocked;
+
+        @GuardedBy("this")
+        private TupleDomain<ColumnHandle> currentPredicate;
+
+        @GuardedBy("this")
+        private int futuresLeft;
+
+        private TableSpecificDynamicFilter(List<ListenableFuture<TupleDomain<ColumnHandle>>> predicateFutures)
+        {
+            this.futuresLeft = predicateFutures.size();
+            this.isBlocked = predicateFutures.isEmpty() ? NOT_BLOCKED : new CompletableFuture();
+            this.currentPredicate = TupleDomain.all();
+            predicateFutures.stream().forEach(future -> addSuccessCallback(future, this::update, directExecutor()));
+        }
+
+        private void update(TupleDomain<ColumnHandle> predicate)
+        {
+            CompletableFuture<?> currentFuture;
+            synchronized (this) {
+                futuresLeft -= 1;
+                verify(futuresLeft >= 0);
+                currentPredicate = currentPredicate.intersect(predicate);
+                currentFuture = isBlocked;
+                // create next blocking future (if needed)
+                isBlocked = isComplete() ? NOT_BLOCKED : new CompletableFuture();
+            }
+            // notify readers outside of lock since this may result in a callback
+            verify(currentFuture.complete(null));
+        }
+
+        @Override
+        public synchronized CompletableFuture<?> isBlocked()
+        {
+            return isBlocked;
+        }
+
+        @Override
+        public synchronized boolean isComplete()
+        {
+            return futuresLeft == 0;
+        }
+
+        @Override
+        public synchronized TupleDomain<ColumnHandle> getCurrentPredicate()
+        {
+            return currentPredicate;
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -34,7 +34,7 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
@@ -472,7 +472,7 @@ public class ExtractSpatialJoins
                 List<Split> splits = splitBatch.getSplits();
 
                 for (Split split : splits) {
-                    try (ConnectorPageSource pageSource = pageSourceManager.createPageSource(session, split, tableHandle, ImmutableList.of(kdbTreeColumn), TupleDomain::all)) {
+                    try (ConnectorPageSource pageSource = pageSourceManager.createPageSource(session, split, tableHandle, ImmutableList.of(kdbTreeColumn), DynamicFilter.EMPTY)) {
                         do {
                             getFutureValue(pageSource.isBlocked());
                             Page page = pageSource.getNextPage();

--- a/presto-main/src/test/java/io/prestosql/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/io/prestosql/memory/TestSystemMemoryBlocking.java
@@ -30,8 +30,8 @@ import io.prestosql.operator.TaskContext;
 import io.prestosql.spi.HostAddress;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.connector.ConnectorSplit;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.FixedPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 import io.prestosql.testing.MaterializedResult;
@@ -107,7 +107,7 @@ public class TestSystemMemoryBlocking
                         .build()),
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all);
+                DynamicFilter.EMPTY);
         PageConsumerOperator sink = createSinkOperator(types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
         assertSame(driver.getDriverContext(), driverContext);

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -27,8 +27,8 @@ import io.prestosql.operator.project.CursorProcessor;
 import io.prestosql.operator.project.PageProcessor;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.FixedPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.ExpressionCompiler;
 import io.prestosql.sql.gen.PageFunctionCompiler;
@@ -175,7 +175,7 @@ public class BenchmarkScanFilterAndProjectOperator
                     () -> pageProcessor,
                     TEST_TABLE_HANDLE,
                     columnHandles,
-                    TupleDomain::all,
+                    DynamicFilter.EMPTY,
                     types,
                     FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
                     FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT);

--- a/presto-main/src/test/java/io/prestosql/operator/TestDriver.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestDriver.java
@@ -31,8 +31,8 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorSplit;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.FixedPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
 import io.prestosql.split.PageSourceProvider;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -173,7 +173,7 @@ public class TestDriver
                         .build()),
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all);
+                DynamicFilter.EMPTY);
 
         PageConsumerOperator sink = createSinkOperator(types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
@@ -448,7 +448,7 @@ public class TestDriver
                 TableHandle table,
                 Iterable<ColumnHandle> columns)
         {
-            super(operatorContext, planNodeId, pageSourceProvider, table, columns, TupleDomain::all);
+            super(operatorContext, planNodeId, pageSourceProvider, table, columns, DynamicFilter.EMPTY);
         }
 
         @Override
@@ -473,7 +473,7 @@ public class TestDriver
                 TableHandle table,
                 Iterable<ColumnHandle> columns)
         {
-            super(operatorContext, planNodeId, pageSourceProvider, table, columns, TupleDomain::all);
+            super(operatorContext, planNodeId, pageSourceProvider, table, columns, DynamicFilter.EMPTY);
         }
 
         @Override

--- a/presto-main/src/test/java/io/prestosql/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestScanFilterAndProjectOperator.java
@@ -32,9 +32,9 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.LazyBlock;
 import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.FixedPageSource;
 import io.prestosql.spi.connector.RecordPageSource;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.sql.gen.ExpressionCompiler;
 import io.prestosql.sql.gen.PageFunctionCompiler;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -109,7 +109,7 @@ public class TestScanFilterAndProjectOperator
                 pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
                 0);
@@ -152,7 +152,7 @@ public class TestScanFilterAndProjectOperator
                 pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.of(64, KILOBYTE),
                 2);
@@ -197,7 +197,7 @@ public class TestScanFilterAndProjectOperator
                 () -> pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
                 0);
@@ -232,7 +232,7 @@ public class TestScanFilterAndProjectOperator
                 pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
                 0);
@@ -285,7 +285,7 @@ public class TestScanFilterAndProjectOperator
                 pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
                 0);
@@ -350,7 +350,7 @@ public class TestScanFilterAndProjectOperator
                 pageProcessor,
                 TEST_TABLE_HANDLE,
                 ImmutableList.of(),
-                TupleDomain::all,
+                DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
                 0);

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/FunctionAssertions.java
@@ -47,11 +47,11 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSplit;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.FixedPageSource;
 import io.prestosql.spi.connector.InMemoryRecordSet;
 import io.prestosql.spi.connector.RecordPageSource;
 import io.prestosql.spi.connector.RecordSet;
-import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.predicate.Utils;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.RowType;
@@ -784,7 +784,7 @@ public final class FunctionAssertions
                     pageProcessor,
                     TEST_TABLE_HANDLE,
                     ImmutableList.of(),
-                    TupleDomain::all,
+                    DynamicFilter.EMPTY,
                     ImmutableList.of(projection.getType()),
                     DataSize.ofBytes(0),
                     0);
@@ -859,7 +859,7 @@ public final class FunctionAssertions
             implements PageSourceProvider
     {
         @Override
-        public ConnectorPageSource createPageSource(Session session, Split split, TableHandle table, List<ColumnHandle> columns, Supplier<TupleDomain<ColumnHandle>> dynamicFilter)
+        public ConnectorPageSource createPageSource(Session session, Split split, TableHandle table, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
         {
             assertInstanceOf(split.getConnectorSplit(), FunctionAssertions.TestSplit.class);
             FunctionAssertions.TestSplit testSplit = (FunctionAssertions.TestSplit) split.getConnectorSplit();

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFilterConsumer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFilterConsumer.java
@@ -16,7 +16,6 @@ package io.prestosql.sql.planner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.prestosql.Session;
 import io.prestosql.spi.predicate.Domain;
@@ -62,19 +61,18 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0));
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
+        ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
         assertFalse(result.isDone());
 
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 new DynamicFilterId("123"), Domain.singleValue(INTEGER, 7L))));
         assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a"), Domain.singleValue(INTEGER, 7L)));
+                new DynamicFilterId("123"), Domain.singleValue(INTEGER, 7L)));
     }
 
     @Test
@@ -82,47 +80,22 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER),
                 2);
 
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> localResult = filter.getNodeLocalDynamicFilterForSymbols();
         ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
-        assertFalse(localResult.isDone());
         assertFalse(result.isDone());
 
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 new DynamicFilterId("123"), Domain.all(INTEGER))));
-        assertEquals(localResult.get(), ImmutableMap.of());
         assertEquals(result.get(), ImmutableMap.of(new DynamicFilterId("123"), Domain.all(INTEGER)));
 
         // adding another partition domain won't change final domain
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 new DynamicFilterId("123"), Domain.singleValue(INTEGER, 1L))));
-        assertEquals(localResult.get(), ImmutableMap.of());
-    }
-
-    @Test
-    public void testMultipleProbeSymbols()
-            throws Exception
-    {
-        LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a1"), new DynamicFilterId("123"), new Symbol("a2")),
-                ImmutableMap.of(new DynamicFilterId("123"), 0),
-                ImmutableMap.of(new DynamicFilterId("123"), INTEGER),
-                1);
-        assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0));
-        Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
-        assertFalse(result.isDone());
-
-        consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
-                new DynamicFilterId("123"), Domain.singleValue(INTEGER, 7L))));
-        assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a1"), Domain.singleValue(INTEGER, 7L),
-                new Symbol("a2"), Domain.singleValue(INTEGER, 7L)));
+        assertEquals(result.get(), ImmutableMap.of(new DynamicFilterId("123"), Domain.all(INTEGER)));
     }
 
     @Test
@@ -130,13 +103,12 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER),
                 2);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0));
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
+        ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
 
         assertFalse(result.isDone());
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
@@ -147,7 +119,7 @@ public class TestLocalDynamicFilterConsumer
                 new DynamicFilterId("123"), Domain.singleValue(INTEGER, 20L))));
 
         assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a"), Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L))));
+                new DynamicFilterId("123"), Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L))));
     }
 
     @Test
@@ -157,9 +129,6 @@ public class TestLocalDynamicFilterConsumer
         DynamicFilterId filter1 = new DynamicFilterId("123");
         DynamicFilterId filter2 = new DynamicFilterId("124");
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(
-                        filter1, new Symbol("a"),
-                        filter2, new Symbol("b")),
                 ImmutableMap.of(
                         filter1, 0,
                         filter2, 1),
@@ -183,19 +152,18 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0));
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
+        ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
 
         assertFalse(result.isDone());
         consumer.accept(TupleDomain.none());
 
         assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a"), Domain.none(INTEGER)));
+                new DynamicFilterId("123"), Domain.none(INTEGER)));
     }
 
     @Test
@@ -203,21 +171,20 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a"), new DynamicFilterId("456"), new Symbol("b")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0, new DynamicFilterId("456"), 1),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER, new DynamicFilterId("456"), INTEGER),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0, new DynamicFilterId("456"), 1));
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
+        ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
         assertFalse(result.isDone());
 
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 new DynamicFilterId("123"), Domain.singleValue(INTEGER, 10L),
                 new DynamicFilterId("456"), Domain.singleValue(INTEGER, 20L))));
         assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a"), Domain.singleValue(INTEGER, 10L),
-                new Symbol("b"), Domain.singleValue(INTEGER, 20L)));
+                new DynamicFilterId("123"), Domain.singleValue(INTEGER, 10L),
+                new DynamicFilterId("456"), Domain.singleValue(INTEGER, 20L)));
     }
 
     @Test
@@ -225,13 +192,12 @@ public class TestLocalDynamicFilterConsumer
             throws Exception
     {
         LocalDynamicFilterConsumer filter = new LocalDynamicFilterConsumer(
-                ImmutableMultimap.of(new DynamicFilterId("123"), new Symbol("a"), new DynamicFilterId("456"), new Symbol("b")),
                 ImmutableMap.of(new DynamicFilterId("123"), 0, new DynamicFilterId("456"), 1),
                 ImmutableMap.of(new DynamicFilterId("123"), INTEGER, new DynamicFilterId("456"), BIGINT),
                 2);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of(new DynamicFilterId("123"), 0, new DynamicFilterId("456"), 1));
         Consumer<TupleDomain<DynamicFilterId>> consumer = filter.getTupleDomainConsumer();
-        ListenableFuture<Map<Symbol, Domain>> result = filter.getNodeLocalDynamicFilterForSymbols();
+        ListenableFuture<Map<DynamicFilterId, Domain>> result = filter.getDynamicFilterDomains();
 
         assertFalse(result.isDone());
         consumer.accept(TupleDomain.withColumnDomains(ImmutableMap.of(
@@ -244,8 +210,8 @@ public class TestLocalDynamicFilterConsumer
                 new DynamicFilterId("456"), Domain.singleValue(BIGINT, 200L))));
 
         assertEquals(result.get(), ImmutableMap.of(
-                new Symbol("a"), Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L)),
-                new Symbol("b"), Domain.multipleValues(BIGINT, ImmutableList.of(100L, 200L))));
+                new DynamicFilterId("123"), Domain.multipleValues(INTEGER, ImmutableList.of(10L, 20L)),
+                new DynamicFilterId("456"), Domain.multipleValues(BIGINT, ImmutableList.of(100L, 200L))));
     }
 
     @Test
@@ -260,12 +226,11 @@ public class TestLocalDynamicFilterConsumer
         JoinNode joinNode = searchJoins(subplan.getChildren().get(0).getFragment()).findOnlyElement();
         LocalDynamicFilterConsumer filter = LocalDynamicFilterConsumer.create(joinNode, ImmutableList.copyOf(subplan.getFragment().getSymbols().values()), 1);
         DynamicFilterId filterId = getOnlyElement(filter.getBuildChannels().keySet());
-        Symbol probeSymbol = getOnlyElement(joinNode.getCriteria()).getLeft();
 
         filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 filterId, Domain.singleValue(BIGINT, 3L))));
-        assertEquals(filter.getNodeLocalDynamicFilterForSymbols().get(), ImmutableMap.of(
-                probeSymbol, Domain.singleValue(BIGINT, 3L)));
+        assertEquals(filter.getDynamicFilterDomains().get(), ImmutableMap.of(
+                filterId, Domain.singleValue(BIGINT, 3L)));
     }
 
     @Test
@@ -288,7 +253,6 @@ public class TestLocalDynamicFilterConsumer
 
         filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 filterId, Domain.singleValue(BIGINT, 3L))));
-        assertEquals(filter.getNodeLocalDynamicFilterForSymbols().get(), ImmutableMap.of());
         assertEquals(filter.getDynamicFilterDomains().get(), ImmutableMap.of(
                 filterId, Domain.singleValue(BIGINT, 3L)));
     }
@@ -313,13 +277,13 @@ public class TestLocalDynamicFilterConsumer
                 .sorted(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
                 .collect(toImmutableList());
-        filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(
-                filterIds.get(0), Domain.singleValue(BIGINT, 4L),
-                filterIds.get(1), Domain.singleValue(BIGINT, 5L))));
 
-        assertEquals(filter.getNodeLocalDynamicFilterForSymbols().get(), ImmutableMap.of(
-                new Symbol("partkey"), Domain.singleValue(BIGINT, 4L),
-                new Symbol("suppkey"), Domain.singleValue(BIGINT, 5L)));
+        Map<DynamicFilterId, Domain> domainMap = ImmutableMap.of(
+                filterIds.get(0), Domain.singleValue(BIGINT, 4L),
+                filterIds.get(1), Domain.singleValue(BIGINT, 5L));
+        filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(domainMap));
+
+        assertEquals(filter.getDynamicFilterDomains().get(), domainMap);
     }
 
     @Test
@@ -338,12 +302,11 @@ public class TestLocalDynamicFilterConsumer
         for (JoinNode joinNode : joinNodes) {
             LocalDynamicFilterConsumer filter = LocalDynamicFilterConsumer.create(joinNode, ImmutableList.copyOf(subplan.getFragment().getSymbols().values()), 1);
             DynamicFilterId filterId = getOnlyElement(filter.getBuildChannels().keySet());
-            Symbol probeSymbol = getOnlyElement(joinNode.getCriteria()).getLeft();
 
             filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                     filterId, Domain.singleValue(BIGINT, 6L))));
-            assertEquals(filter.getNodeLocalDynamicFilterForSymbols().get(), ImmutableMap.of(
-                    probeSymbol, Domain.singleValue(BIGINT, 6L)));
+            assertEquals(filter.getDynamicFilterDomains().get(), ImmutableMap.of(
+                    filterId, Domain.singleValue(BIGINT, 6L)));
         }
     }
 
@@ -365,11 +328,8 @@ public class TestLocalDynamicFilterConsumer
 
         filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(
                 filterId, Domain.singleValue(BIGINT, 7L))));
-
-        // TODO: hard-coding symbol names makes tests brittle
-        assertEquals(filter.getNodeLocalDynamicFilterForSymbols().get(), ImmutableMap.of(
-                new Symbol("partkey_0"), Domain.singleValue(BIGINT, 7L),
-                new Symbol("suppkey"), Domain.singleValue(BIGINT, 7L)));
+        assertEquals(filter.getDynamicFilterDomains().get(), ImmutableMap.of(
+                filterId, Domain.singleValue(BIGINT, 7L)));
     }
 
     private PlanNodeSearcher searchJoins(PlanFragment fragment)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFiltersCollector.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFiltersCollector.java
@@ -17,101 +17,200 @@ package io.prestosql.sql.planner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.DynamicFilter;
+import io.prestosql.spi.connector.TestingColumnHandle;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.DynamicFilters;
+import io.prestosql.sql.planner.plan.DynamicFilterId;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestLocalDynamicFiltersCollector
 {
     @Test
-    public void testCollector()
+    public void testSingle()
     {
+        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
+        DynamicFilterId filterId = new DynamicFilterId("filter");
+        collector.register(ImmutableSet.of(filterId));
+
         Symbol symbol = new Symbol("symbol");
-        Set<Symbol> probeSymbols = ImmutableSet.of(symbol);
+        ColumnHandle column = new TestingColumnHandle("column");
+        DynamicFilter filter = collector.createDynamicFilter(
+                ImmutableList.of(new DynamicFilters.Descriptor(filterId, symbol.toSymbolReference())),
+                ImmutableMap.of(symbol, column));
 
-        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
-        assertEquals(collector.getDynamicFilter(probeSymbols), TupleDomain.all());
+        // Filter is blocked and not completed.
+        CompletableFuture<?> isBlocked = filter.isBlocked();
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
 
-        collector.addDynamicFilter(ImmutableMap.of());
-        assertEquals(collector.getDynamicFilter(probeSymbols), TupleDomain.all());
+        Domain domain = Domain.singleValue(BIGINT, 7L);
+        collector.collectDynamicFilterDomains(ImmutableMap.of(filterId, domain));
 
-        collector.addDynamicFilter(toDomainMap(symbol, 1L, 2L));
-        assertEquals(collector.getDynamicFilter(probeSymbols), tupleDomain(symbol, 1L, 2L));
-
-        collector.addDynamicFilter(toDomainMap(symbol, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(probeSymbols), tupleDomain(symbol, 2L));
-
-        collector.addDynamicFilter(toDomainMap(symbol, 0L));
-        assertEquals(collector.getDynamicFilter(probeSymbols), TupleDomain.none());
+        // Unblocked and completed.
+        assertTrue(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
     }
 
     @Test
-    public void testCollectorMultipleScans()
+    public void testMultipleProbeColumns()
     {
+        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
+        DynamicFilterId filterId = new DynamicFilterId("filter");
+        collector.register(ImmutableSet.of(filterId));
+
+        // Same build-side column being matched to multiple probe-side columns.
         Symbol symbol1 = new Symbol("symbol1");
         Symbol symbol2 = new Symbol("symbol2");
-        Set<Symbol> probeSymbols1 = ImmutableSet.of(symbol1);
-        Set<Symbol> probeSymbols2 = ImmutableSet.of(symbol2);
+        ColumnHandle column1 = new TestingColumnHandle("column1");
+        ColumnHandle column2 = new TestingColumnHandle("column2");
+        DynamicFilter filter = collector.createDynamicFilter(
+                ImmutableList.of(
+                        new DynamicFilters.Descriptor(filterId, symbol1.toSymbolReference()),
+                        new DynamicFilters.Descriptor(filterId, symbol2.toSymbolReference())),
+                ImmutableMap.of(symbol1, column1, symbol2, column2));
 
-        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
-        assertEquals(collector.getDynamicFilter(probeSymbols1), TupleDomain.all());
-        assertEquals(collector.getDynamicFilter(probeSymbols2), TupleDomain.all());
+        // Filter is blocked and not completed.
+        CompletableFuture<?> isBlocked = filter.isBlocked();
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
 
-        collector.addDynamicFilter(toDomainMap(symbol1, 1L, 2L));
-        collector.addDynamicFilter(toDomainMap(symbol2, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(probeSymbols1), tupleDomain(symbol1, 1L, 2L));
-        assertEquals(collector.getDynamicFilter(probeSymbols2), tupleDomain(symbol2, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(
-                ImmutableSet.of(symbol1, symbol2)),
-                TupleDomain.withColumnDomains(ImmutableMap.of(
-                        symbol1, Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L)),
-                        symbol2, Domain.multipleValues(BIGINT, ImmutableList.of(2L, 3L)))));
+        Domain domain = Domain.singleValue(BIGINT, 7L);
+        collector.collectDynamicFilterDomains(ImmutableMap.of(filterId, domain));
 
-        collector.addDynamicFilter(toDomainMap(symbol1, 0L));
-        assertEquals(collector.getDynamicFilter(probeSymbols1), TupleDomain.none());
-        assertEquals(collector.getDynamicFilter(probeSymbols2), tupleDomain(symbol2, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(ImmutableSet.of(symbol1, symbol2)), TupleDomain.none());
+        // Unblocked and completed.
+        assertTrue(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(ImmutableMap.of(column1, domain, column2, domain)));
     }
 
     @Test
-    public void testCollectorMultipleScansNone()
+    public void testMultipleBuildColumnsSingleProbeColumn()
     {
-        Symbol symbol1 = new Symbol("symbol1");
-        Symbol symbol2 = new Symbol("symbol2");
-        Set<Symbol> probeSymbols1 = ImmutableSet.of(symbol1);
-        Set<Symbol> probeSymbols2 = ImmutableSet.of(symbol2);
-
         LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
-        assertEquals(collector.getDynamicFilter(probeSymbols1), TupleDomain.all());
-        assertEquals(collector.getDynamicFilter(probeSymbols2), TupleDomain.all());
+        DynamicFilterId filter1 = new DynamicFilterId("filter1");
+        DynamicFilterId filter2 = new DynamicFilterId("filter2");
+        collector.register(ImmutableSet.of(filter1));
+        collector.register(ImmutableSet.of(filter2));
 
-        collector.addDynamicFilter(toDomainMap(symbol1, 1L, 2L));
-        collector.addDynamicFilter(toDomainMap(symbol2, 2L, 3L));
+        // Multiple build-side columns matching the same probe-side column.
+        Symbol symbol = new Symbol("symbol");
+        ColumnHandle column = new TestingColumnHandle("column");
+        DynamicFilter filter = collector.createDynamicFilter(
+                ImmutableList.of(
+                        new DynamicFilters.Descriptor(filter1, symbol.toSymbolReference()),
+                        new DynamicFilters.Descriptor(filter2, symbol.toSymbolReference())),
+                ImmutableMap.of(symbol, column));
 
-        collector.addDynamicFilter(ImmutableMap.of(symbol1, Domain.none(BIGINT)));
-        assertEquals(collector.getDynamicFilter(probeSymbols1), TupleDomain.none());
-        assertEquals(collector.getDynamicFilter(probeSymbols2), tupleDomain(symbol2, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(ImmutableSet.of(symbol1, symbol2)), TupleDomain.none());
+        // Filter is blocking and not completed.
+        CompletableFuture<?> isBlocked = filter.isBlocked();
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
 
-        collector.addDynamicFilter(toDomainMap(symbol1, 1L, 2L));
-        assertEquals(collector.getDynamicFilter(probeSymbols1), TupleDomain.none());
-        assertEquals(collector.getDynamicFilter(probeSymbols2), tupleDomain(symbol2, 2L, 3L));
-        assertEquals(collector.getDynamicFilter(ImmutableSet.of(symbol1, symbol2)), TupleDomain.none());
+        collector.collectDynamicFilterDomains(
+                ImmutableMap.of(filter1, Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L, 3L))));
+
+        // Unblocked, but not completed.
+        assertFalse(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.multipleValues(BIGINT, ImmutableList.of(1L, 2L, 3L)))));
+
+        // Create a new blocking future, waiting for next completion.
+        isBlocked = filter.isBlocked();
+        assertFalse(isBlocked.isDone());
+        assertFalse(filter.isComplete());
+
+        collector.collectDynamicFilterDomains(
+                ImmutableMap.of(filter2, Domain.multipleValues(BIGINT, ImmutableList.of(2L, 3L, 4L))));
+
+        // Unblocked and completed.
+        assertTrue(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.multipleValues(BIGINT, ImmutableList.of(2L, 3L)))));
     }
 
-    private TupleDomain<Symbol> tupleDomain(Symbol symbol, Long... values)
+    @Test
+    public void testUnusedDynamicFilter()
     {
-        return TupleDomain.withColumnDomains(ImmutableMap.of(symbol, Domain.multipleValues(BIGINT, ImmutableList.copyOf(values))));
+        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
+        DynamicFilterId unusedFilterId = new DynamicFilterId("unused");
+        DynamicFilterId usedFilterId = new DynamicFilterId("used");
+        collector.register(ImmutableSet.of(unusedFilterId));
+        collector.register(ImmutableSet.of(usedFilterId));
+
+        // One of the dynamic filters is not used for the the table scan.
+        Symbol usedSymbol = new Symbol("used");
+        ColumnHandle usedColumn = new TestingColumnHandle("used");
+        DynamicFilter filter = collector.createDynamicFilter(
+                ImmutableList.of(new DynamicFilters.Descriptor(usedFilterId, usedSymbol.toSymbolReference())),
+                ImmutableMap.of(usedSymbol, usedColumn));
+
+        // Filter is blocking and not completed.
+        CompletableFuture<?> isBlocked = filter.isBlocked();
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
+
+        collector.collectDynamicFilterDomains(ImmutableMap.of(unusedFilterId, Domain.singleValue(BIGINT, 1L)));
+
+        // This dynamic filter is unused here - has no effect on blocking/completion of the above future.
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
+
+        collector.collectDynamicFilterDomains(ImmutableMap.of(usedFilterId, Domain.singleValue(BIGINT, 2L)));
+
+        // Unblocked and completed.
+        assertTrue(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(ImmutableMap.of(usedColumn, Domain.singleValue(BIGINT, 2L))));
     }
 
-    private Map<Symbol, Domain> toDomainMap(Symbol symbol, Long... values)
+    @Test
+    public void testUnregisteredDynamicFilter()
     {
-        return ImmutableMap.of(symbol, Domain.multipleValues(BIGINT, ImmutableList.copyOf(values)));
+        // One dynamic filter is not collected locally (e.g. due to a distributed join)
+        LocalDynamicFiltersCollector collector = new LocalDynamicFiltersCollector();
+        DynamicFilterId registeredFilterId = new DynamicFilterId("registered");
+        DynamicFilterId unregisteredFilterId = new DynamicFilterId("unregistered");
+        collector.register(ImmutableSet.of(registeredFilterId));
+
+        Symbol registeredSymbol = new Symbol("registered");
+        Symbol unregisteredSymbol = new Symbol("unregistered");
+        ColumnHandle registeredColumn = new TestingColumnHandle("registered");
+        ColumnHandle unregisteredColumn = new TestingColumnHandle("unregistered");
+        DynamicFilter filter = collector.createDynamicFilter(
+                ImmutableList.of(
+                        new DynamicFilters.Descriptor(registeredFilterId, registeredSymbol.toSymbolReference()),
+                        new DynamicFilters.Descriptor(unregisteredFilterId, unregisteredSymbol.toSymbolReference())),
+                ImmutableMap.of(registeredSymbol, registeredColumn, unregisteredSymbol, unregisteredColumn));
+
+        // Filter is blocked and not completed.
+        CompletableFuture<?> isBlocked = filter.isBlocked();
+        assertFalse(filter.isComplete());
+        assertFalse(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.all());
+
+        collector.collectDynamicFilterDomains(ImmutableMap.of(registeredFilterId, Domain.singleValue(BIGINT, 2L)));
+
+        // Unblocked and completed (don't wait for filter2)
+        assertTrue(filter.isComplete());
+        assertTrue(isBlocked.isDone());
+        assertEquals(filter.getCurrentPredicate(), TupleDomain.withColumnDomains(ImmutableMap.of(registeredColumn, Domain.singleValue(BIGINT, 2L))));
     }
 }

--- a/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryConfig.java
+++ b/presto-memory/src/main/java/io/prestosql/plugin/memory/MemoryConfig.java
@@ -22,6 +22,7 @@ public class MemoryConfig
 {
     private int splitsPerNode = Runtime.getRuntime().availableProcessors();
     private DataSize maxDataPerNode = DataSize.of(128, DataSize.Unit.MEGABYTE);
+    private boolean enableLazyDynamicFiltering = true;
 
     @NotNull
     public int getSplitsPerNode()
@@ -46,6 +47,18 @@ public class MemoryConfig
     public MemoryConfig setMaxDataPerNode(DataSize maxDataPerNode)
     {
         this.maxDataPerNode = maxDataPerNode;
+        return this;
+    }
+
+    public boolean isEnableLazyDynamicFiltering()
+    {
+        return enableLazyDynamicFiltering;
+    }
+
+    @Config("memory.enable-lazy-dynamic-filtering")
+    public MemoryConfig setEnableLazyDynamicFiltering(boolean enableLazyDynamicFiltering)
+    {
+        this.enableLazyDynamicFiltering = enableLazyDynamicFiltering;
         return this;
     }
 }

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.prestosql.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
@@ -91,7 +90,6 @@ public class TestMemorySmoke
         assertQueryResult("SELECT COUNT() FROM orders WHERE totalprice < 0", 0L);
 
         Session session = Session.builder(getSession())
-                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "true")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
                 .build();
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
@@ -120,7 +118,6 @@ public class TestMemorySmoke
         assertQueryResult("SELECT COUNT() FROM lineitem WHERE orderkey = 1", 6L);
 
         Session session = Session.builder(getSession())
-                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "true")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
                 .build();
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
@@ -150,7 +147,6 @@ public class TestMemorySmoke
 
         String query = "SELECT k0, k1, k2 FROM t0, t1, t2 WHERE (k0 = k1) AND (k0 = k2) AND (v0 + v1 = v2)";
         Session session = Session.builder(getSession())
-                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "true")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, FeaturesConfig.JoinReorderingStrategy.NONE.name())
                 .build();

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
@@ -18,6 +18,7 @@ import io.prestosql.Session;
 import io.prestosql.execution.QueryStats;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.operator.OperatorStats;
+import io.prestosql.spi.QueryId;
 import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.testing.AbstractTestQueryFramework;
 import io.prestosql.testing.DistributedQueryRunner;
@@ -42,6 +43,10 @@ import static org.testng.Assert.assertTrue;
 public class TestMemorySmoke
         extends AbstractTestQueryFramework
 {
+    private static final long LINEITEM_COUNT = 60175;
+    private static final long ORDERS_COUNT = 15000;
+    private static final long PART_COUNT = 2000;
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -85,54 +90,110 @@ public class TestMemorySmoke
     @Test
     public void testJoinDynamicFilteringNone()
     {
-        final long buildSideRowsCount = 15_000L;
-        assertQueryResult("SELECT COUNT() FROM orders", buildSideRowsCount);
-        assertQueryResult("SELECT COUNT() FROM orders WHERE totalprice < 0", 0L);
-
         Session session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
                 .build();
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, "SELECT * FROM lineitem JOIN orders " +
-                "ON lineitem.orderkey = orders.orderkey AND orders.totalprice < 0");
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(
+                session,
+                "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice < 0");
         assertEquals(result.getResult().getRowCount(), 0);
 
         // Probe-side is not scanned at all, due to dynamic filtering:
-        QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(result.getQueryId()).getQueryStats();
-        Set<Long> rowsRead = stats.getOperatorSummaries()
-                .stream()
-                .filter(summary -> summary.getOperatorType().equals("ScanFilterAndProjectOperator"))
-                .map(OperatorStats::getInputPositions)
-                .collect(toImmutableSet());
-        assertEquals(rowsRead, ImmutableSet.of(0L, buildSideRowsCount));
+        Set<Long> rowsRead = getOperatorRowsRead(runner, result.getQueryId());
+        assertEquals(rowsRead, ImmutableSet.of(0L, ORDERS_COUNT));
+    }
+
+    @Test
+    public void testJoinLargeBuildSideNoDynamicFiltering()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
+                .build();
+        DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(
+                session,
+                "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey");
+        assertEquals(result.getResult().getRowCount(), LINEITEM_COUNT);
+
+        // Probe-side is fully scanned because the build-side is too large for dynamic filtering:
+        Set<Long> rowsRead = getOperatorRowsRead(runner, result.getQueryId());
+        assertEquals(rowsRead, ImmutableSet.of(LINEITEM_COUNT, ORDERS_COUNT));
+    }
+
+    @Test
+    public void testPartitionedJoinNoDynamicFiltering()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.PARTITIONED.name())
+                .build();
+        DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(
+                session,
+                "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.totalprice < 0");
+        assertEquals(result.getResult().getRowCount(), 0);
+
+        // Probe-side is fully scanned, because local dynamic filtering does not work for partitioned joins:
+        Set<Long> rowsRead = getOperatorRowsRead(runner, result.getQueryId());
+        assertEquals(rowsRead, ImmutableSet.of(LINEITEM_COUNT, ORDERS_COUNT));
     }
 
     @Test
     public void testJoinDynamicFilteringSingleValue()
     {
-        final long buildSideRowsCount = 15_000L;
-
-        assertQueryResult("SELECT COUNT() FROM orders", buildSideRowsCount);
-        assertQueryResult("SELECT COUNT() FROM orders WHERE comment = 'nstructions sleep furiously among '", 1L);
         assertQueryResult("SELECT orderkey FROM orders WHERE comment = 'nstructions sleep furiously among '", 1L);
         assertQueryResult("SELECT COUNT() FROM lineitem WHERE orderkey = 1", 6L);
+
+        assertQueryResult("SELECT partkey FROM part WHERE comment = 'onic deposits'", 1552L);
+        assertQueryResult("SELECT COUNT() FROM lineitem WHERE partkey = 1552", 39L);
 
         Session session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
                 .build();
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
-        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, "SELECT * FROM lineitem JOIN orders " +
-                "ON lineitem.orderkey = orders.orderkey AND orders.comment = 'nstructions sleep furiously among '");
-        assertEquals(result.getResult().getRowCount(), 6);
 
-        // Probe-side is dynamically filtered:
-        QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(result.getQueryId()).getQueryStats();
-        Set<Long> rowsRead = stats.getOperatorSummaries()
+        // Join lineitem with a single row of orders
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(
+                session,
+                "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.comment = 'nstructions sleep furiously among '");
+        assertEquals(result.getResult().getRowCount(), 6);
+        assertEquals(getOperatorRowsRead(runner, result.getQueryId()), ImmutableSet.of(6L, ORDERS_COUNT));
+
+        // Join lineitem with a single row of part
+        result = runner.executeWithQueryId(
+                session,
+                "SELECT l.comment FROM  lineitem l, part p WHERE p.partkey = l.partkey AND p.comment = 'onic deposits'");
+        assertEquals(result.getResult().getRowCount(), 39);
+        assertEquals(getOperatorRowsRead(runner, result.getQueryId()), ImmutableSet.of(39L, PART_COUNT));
+    }
+
+    @Test
+    public void testJoinDynamicFilteringBlockProbeSide()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, FeaturesConfig.JoinReorderingStrategy.NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.BROADCAST.name())
+                .build();
+        DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
+        // Wait for both build sides to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
+        ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(
+                session,
+                "SELECT l.comment" +
+                        " FROM  lineitem l, part p, orders o" +
+                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '" +
+                        " AND p.partkey = l.partkey AND p.comment = 'onic deposits'");
+        assertEquals(result.getResult().getRowCount(), 1);
+        assertEquals(getOperatorRowsRead(runner, result.getQueryId()), ImmutableSet.of(1L, ORDERS_COUNT, PART_COUNT));
+    }
+
+    private static Set<Long> getOperatorRowsRead(DistributedQueryRunner runner, QueryId queryId)
+    {
+        QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getQueryStats();
+        return stats.getOperatorSummaries()
                 .stream()
                 .filter(summary -> summary.getOperatorType().equals("ScanFilterAndProjectOperator"))
                 .map(OperatorStats::getInputPositions)
                 .collect(toImmutableSet());
-        assertEquals(rowsRead, ImmutableSet.of(6L, buildSideRowsCount));
     }
 
     @Test

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.predicate.TupleDomain;
 
 import javax.inject.Inject;
@@ -52,6 +53,14 @@ public class ClassLoaderSafeConnectorPageSourceProvider
 
     @Override
     public ConnectorPageSource createPageSource(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<ColumnHandle> columns, TupleDomain<ColumnHandle> dynamicFilter)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.createPageSource(transaction, session, split, table, columns, dynamicFilter);
+        }
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.createPageSource(transaction, session, split, table, columns, dynamicFilter);

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorPageSourceProvider.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorPageSourceProvider.java
@@ -49,4 +49,20 @@ public interface ConnectorPageSourceProvider
         // By default, ignore dynamic filter (as it is an optimization and doesn't affect correctness).
         return createPageSource(transaction, session, split, table, columns);
     }
+
+    /**
+     * @param columns columns that should show up in the output page, in this order
+     * @param dynamicFilter optionally remove rows that don't satisfy this predicate
+     */
+    default ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableHandle table,
+            List<ColumnHandle> columns,
+            DynamicFilter dynamicFilter)
+    {
+        // By default, poll dynamic filtering without blocking for collection to complete.
+        return createPageSource(transaction, session, split, table, columns, dynamicFilter.getCurrentPredicate());
+    }
 }


### PR DESCRIPTION
By default, we wait up to 1s for the build-side filters to be ready, to allow more efficient probe-side scan.
If the filters are not ready, we fallback to the previous behaviour (use current filters without blocking probe-side).

This feature can be configured using:

    SET SESSION dynamic_filtering_probe_side_blocking_timeout='10s';

To disable, use:

    SET SESSION dynamic_filtering_probe_side_blocking_timeout='0s';