### PR TITLE
Allow web-ui without authentication

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -843,13 +843,15 @@ Web UI Properties
 
 The following properties can be used to configure the :doc:`./web-interface`.
 
-``web-ui.enabled``
+``web-ui``
 ^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``boolean``
-    * **Default value:** ``true``
+    * **Type:** ``string``
+    * **Allowed values:** ``JWT``, ``NOAUTH``, ``DISABLED``
+    * **Default value:** ``JWT``
 
-    This property controls whether or not the Web UI is available.
+    This property controls whether or not the Web UI is available and whether or
+    not the authorization is enable.
 
 ``web-ui.shared-secret``
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-main/src/main/java/io/prestosql/server/ui/DisabledWebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/DisabledWebUiAuthenticationManager.java
@@ -73,6 +73,6 @@ public class DisabledWebUiAuthenticationManager
 
     private static String getRedirectLocation(HttpServletRequest request, String path)
     {
-        return FormWebUiAuthenticationManager.getRedirectLocation(request, path, null);
+        return WebUiUtil.getRedirectLocation(request, path, null);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/NoAuthWebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/NoAuthWebUiAuthenticationManager.java
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.prestosql.server.ui;
 
 import javax.servlet.FilterChain;

--- a/presto-main/src/main/java/io/prestosql/server/ui/NoAuthWebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/NoAuthWebUiAuthenticationManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.server.ui;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static io.prestosql.server.ui.WebUiUtil.getUiLocation;
+import static io.prestosql.server.ui.WebUiUtil.sendRedirect;
+
+public class NoAuthWebUiAuthenticationManager
+        implements WebUiAuthenticationManager
+{
+    @Override
+    public void handleUiRequest(HttpServletRequest request, HttpServletResponse response, FilterChain nextFilter)
+            throws IOException, ServletException
+    {
+        if (request.getPathInfo() == null
+                || request.getPathInfo().equals("/")
+                || request.getPathInfo().equals("/ui/logout")) {
+            sendRedirect(response, getUiLocation(request));
+            return;
+        }
+
+        nextFilter.doFilter(request, response);
+        return;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiConfig.java
@@ -24,19 +24,19 @@ import static java.util.concurrent.TimeUnit.DAYS;
 
 public class WebUiConfig
 {
-    private boolean enabled = true;
+    private WebUiType type = WebUiType.JWT;
     private Optional<String> sharedSecret = Optional.empty();
     private Duration sessionTimeout = new Duration(1, DAYS);
 
-    public boolean isEnabled()
+    public WebUiType getType()
     {
-        return enabled;
+        return type;
     }
 
-    @Config("web-ui.enabled")
-    public WebUiConfig setEnabled(boolean enabled)
+    @Config("web-ui")
+    public WebUiConfig setType(WebUiType type)
     {
-        this.enabled = enabled;
+        this.type = type;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiType.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiType.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+public enum WebUiType
+{
+    DISABLED,
+    JWT,
+    NOAUTH
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiType.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiType.java
@@ -11,20 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.prestosql.server.ui;
 
 public enum WebUiType

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiUtil.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.server.ui;
+
+import com.google.common.net.HostAndPort;
+import com.google.common.primitives.Ints;
+import io.airlift.http.client.HttpUriBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.emptyToNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.HOST;
+import static com.google.common.net.HttpHeaders.LOCATION;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilder;
+import static javax.servlet.http.HttpServletResponse.SC_SEE_OTHER;
+
+public class WebUiUtil
+{
+    public static final String UI_LOCATION = "/ui/";
+    public static final String LOGIN_FORM = "/ui/login.html";
+
+    private WebUiUtil()
+    {
+    }
+
+    public static void sendRedirect(HttpServletResponse response, String location)
+    {
+        response.setHeader(LOCATION, location);
+        response.setStatus(SC_SEE_OTHER);
+    }
+
+    public static String getLoginFormLocation(HttpServletRequest request)
+    {
+        return getRedirectLocation(request, LOGIN_FORM);
+    }
+
+    public static String getUiLocation(HttpServletRequest request)
+    {
+        return getRedirectLocation(request, UI_LOCATION);
+    }
+
+    public static String getRedirectLocation(HttpServletRequest request, String path)
+    {
+        return getRedirectLocation(request, path, null);
+    }
+
+    public static String getRedirectLocation(HttpServletRequest request, String path, String queryParameter)
+    {
+        HttpUriBuilder builder = toUriBuilderWithForwarding(request);
+        builder.replacePath(path);
+        if (queryParameter != null) {
+            builder.addParameter(queryParameter);
+        }
+        return builder.toString();
+    }
+
+    public static HttpUriBuilder toUriBuilderWithForwarding(HttpServletRequest request)
+    {
+        HttpUriBuilder builder;
+        if (isNullOrEmpty(request.getHeader(X_FORWARDED_PROTO)) && isNullOrEmpty(request.getHeader(X_FORWARDED_HOST))) {
+            // not forwarded
+            builder = uriBuilder()
+                    .scheme(request.getScheme())
+                    .hostAndPort(HostAndPort.fromString(request.getHeader(HOST)));
+        }
+        else {
+            // forwarded
+            builder = uriBuilder()
+                    .scheme(firstNonNull(emptyToNull(request.getHeader(X_FORWARDED_PROTO)), request.getScheme()))
+                    .hostAndPort(HostAndPort.fromString(firstNonNull(emptyToNull(request.getHeader(X_FORWARDED_HOST)), request.getHeader(HOST))));
+
+            Optional.ofNullable(emptyToNull(request.getHeader(X_FORWARDED_PORT)))
+                    .map(Ints::tryParse)
+                    .ifPresent(builder::port);
+        }
+        return builder;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiUtil.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiUtil.java
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.prestosql.server.ui;
 
 import com.google.common.net.HostAndPort;

--- a/presto-main/src/test/java/io/prestosql/server/ui/TestWebUi.java
+++ b/presto-main/src/test/java/io/prestosql/server/ui/TestWebUi.java
@@ -263,7 +263,7 @@ public class TestWebUi
         try (TestingPrestoServer server = TestingPrestoServer.builder()
                 .setProperties(ImmutableMap.<String, String>builder()
                         .putAll(SECURE_PROPERTIES)
-                        .put("web-ui.enabled", "false")
+                        .put("web-ui", String.valueOf(WebUiType.DISABLED))
                         .build())
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestWebUi::authenticate);

--- a/presto-main/src/test/java/io/prestosql/server/ui/TestWebUiConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/ui/TestWebUiConfig.java
@@ -30,7 +30,7 @@ public class TestWebUiConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(WebUiConfig.class)
-                .setEnabled(true)
+                .setType(WebUiType.JWT)
                 .setSessionTimeout(new Duration(1, TimeUnit.DAYS))
                 .setSharedSecret(null));
     }
@@ -39,13 +39,13 @@ public class TestWebUiConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("web-ui.enabled", "false")
+                .put("web-ui", String.valueOf(WebUiType.DISABLED))
                 .put("web-ui.session-timeout", "33s")
                 .put("web-ui.shared-secret", "test-secret")
                 .build();
 
         WebUiConfig expected = new WebUiConfig()
-                .setEnabled(false)
+                .setType(WebUiType.DISABLED)
                 .setSessionTimeout(new Duration(33, TimeUnit.SECONDS))
                 .setSharedSecret("test-secret");
 


### PR DESCRIPTION
We have our own presto-proxy terminating the authentication. For now we would like to have the web-ui without authentication. In the future we plan to modify the presto-proxy to generate a JWT cookie like io.prestosql.server.ui.FormWebUiAuthenticationManager does.