### PR TITLE
Add approx_most_frequent aggregation function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1218,6 +1218,12 @@
                 <artifactId>rubix-presto-shaded</artifactId>
                 <version>${rubix.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.clearspring.analytics</groupId>
+                <artifactId>stream</artifactId>
+                <version>2.9.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -327,6 +327,25 @@ Approximate Aggregate Functions
     for all ``value``\ s. This function is equivalent to the variant of
     :func:`numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
 
+.. function:: approx_most_frequent(buckets, value, capacity) -> map<[same as value], bigint>
+
+    Computes the top frequent values up to ``buckets`` elements approximately.
+    Approximate estimation of the function enables us to pick up the frequent
+    values with less memory. Larger ``capacity`` improves the accuracy of
+    underlying algorithm with sacrificing the memory capacity. The returned
+    value is a map containing the top elements with corresponding estimated
+    frequency.
+
+    The error of the function depends on the permutation of the values and its
+    cardinality. We can set the capacity same as the cardinality of the
+    underlying data to achieve the least error.
+
+    ``buckets`` and ``capacity`` must be ``bigint``. ``value`` can be numeric
+    or string type.
+
+    The function uses the stream summary data structure proposed in the paper
+    `Efficient computation of frequent and top-k elements in data streams <https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFrequentAndTop-kElementsInDataStreams.pdf>`_ by A.Metwalley, D.Agrawl and A.Abbadi.
+
 Statistical Aggregate Functions
 -------------------------------
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -308,6 +308,11 @@
             <artifactId>jjwt</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.clearspring.analytics</groupId>
+            <artifactId>stream</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -26,6 +26,7 @@ import io.prestosql.operator.aggregation.ApproximateDoublePercentileAggregations
 import io.prestosql.operator.aggregation.ApproximateDoublePercentileArrayAggregations;
 import io.prestosql.operator.aggregation.ApproximateLongPercentileAggregations;
 import io.prestosql.operator.aggregation.ApproximateLongPercentileArrayAggregations;
+import io.prestosql.operator.aggregation.ApproximateMostFrequentFunction;
 import io.prestosql.operator.aggregation.ApproximateRealPercentileAggregations;
 import io.prestosql.operator.aggregation.ApproximateRealPercentileArrayAggregations;
 import io.prestosql.operator.aggregation.ApproximateSetAggregation;
@@ -638,7 +639,8 @@ public class FunctionRegistry
                 .aggregate(BuildSetDigestAggregation.class)
                 .scalars(SetDigestFunctions.class)
                 .scalars(SetDigestOperators.class)
-                .scalars(WilsonInterval.class);
+                .scalars(WilsonInterval.class)
+                .aggregate(ApproximateMostFrequentFunction.class);
 
         // timestamp operators and functions
         builder

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketDeserializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketDeserializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.SliceInput;
+
+public interface ApproximateMostFrequentBucketDeserializer<K>
+{
+    void deserialize(SliceInput input, ApproximateMostFrequentHistogram<K> histogram);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketSerializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+
+public interface ApproximateMostFrequentBucketSerializer<K>
+{
+    public void serialize(K key, long count, DynamicSliceOutput output);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentFunction.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.Slice;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateMetadata;
+import io.prestosql.spi.function.AggregationFunction;
+import io.prestosql.spi.function.AggregationState;
+import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.InputFunction;
+import io.prestosql.spi.function.OutputFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.function.TypeParameter;
+import io.prestosql.spi.type.BigintType;
+import io.prestosql.spi.type.VarcharType;
+
+import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.prestosql.spi.type.StandardTypes.BIGINT;
+import static io.prestosql.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
+
+/**
+ *  <p>
+ *  Aggregation function that approximates the frequency of the top-K elements.
+ *  This function keeps counts for a "frequent" subset of elements and assumes all other elements
+ *  once fewer than the least-frequent "frequent" element.
+ *  </p>
+ *
+ * <p>
+ * The algorithm is based loosely on:
+ * <a href="https://dl.acm.org/doi/10.1007/978-3-540-30570-5_27">Efficient Computation of Frequent and Top-*k* Elements in Data Streams</a>
+ * by Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi
+ * </p>
+ */
+@AggregationFunction("approx_most_frequent")
+public final class ApproximateMostFrequentFunction
+{
+    private ApproximateMostFrequentFunction() {}
+
+    public interface State<K>
+            extends AccumulatorState
+    {
+        ApproximateMostFrequentHistogram<K> get();
+
+        void set(ApproximateMostFrequentHistogram<K> value);
+    }
+
+    @AccumulatorStateMetadata(stateSerializerClass = LongApproximateMostFrequentStateSerializer.class, stateFactoryClass = LongApproximateMostFrequentStateFactory.class)
+    public interface LongState
+            extends State<Long>
+    {}
+
+    @AccumulatorStateMetadata(stateSerializerClass = StringApproximateMostFrequentStateSerializer.class, stateFactoryClass = StringApproximateMostFrequentStateFactory.class)
+    public interface StringState
+            extends State<Slice>
+    {}
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState LongState state, @SqlType(BIGINT) long buckets, @SqlType("T") long value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<Long>(
+                    toIntExact(buckets),
+                    toIntExact(capacity),
+                    LongApproximateMostFrequentStateSerializer::serializeBucket,
+                    LongApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState StringState state, @SqlType(BIGINT) long buckets, @SqlType("T") Slice value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<Slice> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<Slice>(
+                    toIntExact(buckets),
+                    toIntExact(capacity),
+                    StringApproximateMostFrequentStateSerializer::serializeBucket,
+                    StringApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState LongState state, @AggregationState LongState otherState)
+    {
+        ApproximateMostFrequentHistogram<Long> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState StringState state, @AggregationState StringState otherState)
+    {
+        ApproximateMostFrequentHistogram<Slice> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<Slice> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @OutputFunction("map(T,bigint)")
+    public static void output(@AggregationState LongState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            state.get().forEachBucket((key, value) -> {
+                BigintType.BIGINT.writeLong(entryBuilder, key);
+                BigintType.BIGINT.writeLong(entryBuilder, value);
+            });
+            out.closeEntry();
+        }
+    }
+
+    @OutputFunction("map(T,bigint)")
+    public static void output(@AggregationState StringState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            state.get().forEachBucket((key, value) -> {
+                VarcharType.VARCHAR.writeSlice(entryBuilder, key);
+                BigintType.BIGINT.writeLong(entryBuilder, value);
+            });
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentHistogram.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentHistogram.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import com.clearspring.analytics.stream.Counter;
+import com.clearspring.analytics.stream.StreamSummary;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ *  Calculate the histogram approximately for topk elements based on the
+ *  <i>Space-Saving</i> algorithm and the <i>Stream-Summary</i> data structure
+ *  as described in:
+ *  <i>Efficient Computation of Frequent and Top-k Elements in Data Streams</i>
+ *  by Metwally, Agrawal, and Abbadi
+ * @param <K>
+ */
+public class ApproximateMostFrequentHistogram<K>
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ApproximateMostFrequentHistogram.class).instanceSize();
+
+    private final StreamSummary<K> streamSummary;
+    private final int maxBuckets;
+    private final int capacity;
+    private final ApproximateMostFrequentBucketSerializer<K> serializer;
+    private final ApproximateMostFrequentBucketDeserializer<K> deserializer;
+
+    /**
+     * @param maxBuckets The maximum number of elements stored in the bucket.
+     * @param capacity The maximum capacity of the stream summary data structure.
+     * @param serializer It serializes a bucket into varbinary slice.
+     * @param deserializer It appends a bucket into the histogram.
+     */
+    public ApproximateMostFrequentHistogram(
+            int maxBuckets,
+            int capacity,
+            ApproximateMostFrequentBucketSerializer<K> serializer,
+            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        requireNonNull(serializer, "serializer is null");
+        requireNonNull(deserializer, "deserializer is null");
+        streamSummary = new StreamSummary<>(capacity);
+        this.maxBuckets = maxBuckets;
+        this.capacity = capacity;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
+
+    public ApproximateMostFrequentHistogram(
+            Slice serialized,
+            ApproximateMostFrequentBucketSerializer<K> serializer,
+            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        SliceInput input = serialized.getInput();
+
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+
+        this.maxBuckets = input.readInt();
+        this.capacity = input.readInt();
+        int bucketSize = input.readInt();
+        this.streamSummary = new StreamSummary<>(capacity);
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+
+        for (int i = 0; i < bucketSize; i++) {
+            this.deserializer.deserialize(input, this);
+        }
+    }
+
+    public void add(K value)
+    {
+        streamSummary.offer(value);
+    }
+
+    public void add(K value, long incrementCount)
+    {
+        streamSummary.offer(value, toIntExact(incrementCount));
+    }
+
+    public Slice serialize()
+    {
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        int estimatedSliceSize = Byte.BYTES + // FORMAT_TAG
+                Integer.BYTES + // maxBuckets
+                Integer.BYTES + // capacity
+                Integer.BYTES + // Counters size
+                counters.size() * Long.BYTES * 2; // Bytes allocated for item and count. Although the estimation is not correct for variable length slices, it should work.
+        DynamicSliceOutput output = new DynamicSliceOutput(estimatedSliceSize);
+        output.appendByte(FORMAT_TAG);
+        output.appendInt(maxBuckets);
+        output.appendInt(capacity);
+        output.appendInt(counters.size());
+        // Serialize key and counts.
+        for (Counter<K> counter : counters) {
+            serializer.serialize(counter.getItem(), counter.getCount(), output);
+        }
+
+        return output.slice();
+    }
+
+    public void merge(ApproximateMostFrequentHistogram<K> other)
+    {
+        List<Counter<K>> counters = other.streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            add(counter.getItem(), counter.getCount());
+        }
+    }
+
+    public void forEachBucket(BucketConsumer<K> consumer)
+    {
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            consumer.process(counter.getItem(), counter.getCount());
+        }
+    }
+
+    @VisibleForTesting
+    public Map<K, Long> getBuckets()
+    {
+        ImmutableMap.Builder<K, Long> buckets = new ImmutableMap.Builder<>();
+        forEachBucket(buckets::put);
+
+        return buckets.build();
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/BucketConsumer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/BucketConsumer.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+@FunctionalInterface
+public interface BucketConsumer<K>
+{
+    void process(K key, long value);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.prestosql.array.ObjectBigArray;
+import io.prestosql.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateFactory;
+
+public class LongApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<ApproximateMostFrequentFunction.LongState>
+{
+    @Override
+    public ApproximateMostFrequentFunction.LongState createSingleState()
+    {
+        return new SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.LongState> getSingleStateClass()
+    {
+        return SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public ApproximateMostFrequentFunction.LongState createGroupedState()
+    {
+        return new GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.LongState> getGroupedStateClass()
+    {
+        return GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements ApproximateMostFrequentFunction.LongState
+    {
+        private ApproximateMostFrequentHistogram<Long> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            this.histogram = histogram;
+            size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements ApproximateMostFrequentFunction.LongState
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<Long>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            ApproximateMostFrequentHistogram<Long> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            size += histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorStateSerializer;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+
+public class LongApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<ApproximateMostFrequentFunction.LongState>
+{
+    public static void serializeBucket(long key, long count, DynamicSliceOutput output)
+    {
+        output.appendLong(key);
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<Long> histogram)
+    {
+        long key = input.readLong();
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(ApproximateMostFrequentFunction.LongState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ApproximateMostFrequentFunction.LongState state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<Long>(
+                VARBINARY.getSlice(block, index),
+                LongApproximateMostFrequentStateSerializer::serializeBucket,
+                LongApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.Slice;
+import io.prestosql.array.ObjectBigArray;
+import io.prestosql.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateFactory;
+
+public class StringApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<ApproximateMostFrequentFunction.StringState>
+{
+    @Override
+    public ApproximateMostFrequentFunction.StringState createSingleState()
+    {
+        return new StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.StringState> getSingleStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public ApproximateMostFrequentFunction.StringState createGroupedState()
+    {
+        return new StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.StringState> getGroupedStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements ApproximateMostFrequentFunction.StringState
+    {
+        private ApproximateMostFrequentHistogram<Slice> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Slice> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Slice> histogram)
+        {
+            this.histogram = histogram;
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements ApproximateMostFrequentFunction.StringState
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<Slice>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Slice> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Slice> histogram)
+        {
+            ApproximateMostFrequentHistogram<Slice> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorStateSerializer;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+
+public class StringApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<ApproximateMostFrequentFunction.StringState>
+{
+    public static void serializeBucket(Slice key, Long count, DynamicSliceOutput output)
+    {
+        output.appendInt(key.length());
+        output.appendBytes(key);
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<Slice> histogram)
+    {
+        int keySize = input.readInt();
+        Slice key = input.readSlice(keySize);
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(ApproximateMostFrequentFunction.StringState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ApproximateMostFrequentFunction.StringState state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<Slice>(
+                VARBINARY.getSlice(block, index),
+                StringApproximateMostFrequentStateSerializer::serializeBucket,
+                StringApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximateMostFrequentHistogram.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximateMostFrequentHistogram.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestApproximateMostFrequentHistogram
+{
+    @Test
+    public void testLongHistogram()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add(1L);
+        histogram.add(1L);
+        histogram.add(2L);
+        histogram.add(3L);
+        histogram.add(4L);
+
+        Map<Long, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testLongRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<Long> original = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add(1L);
+        original.add(1L);
+        original.add(2L);
+        original.add(3L);
+        original.add(4L);
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<Long> deserialized = new ApproximateMostFrequentHistogram<Long>(serialized, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+
+    @Test
+    public void testMerge()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram1 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram1.add(1L);
+        histogram1.add(1L);
+        histogram1.add(2L);
+
+        ApproximateMostFrequentHistogram<Long> histogram2 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+        histogram2.add(3L);
+        histogram2.add(4L);
+
+        histogram1.merge(histogram2);
+        Map<Long, Long> buckets = histogram1.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testStringHistogram()
+    {
+        ApproximateMostFrequentHistogram<Slice> histogram = new ApproximateMostFrequentHistogram<Slice>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add(Slices.utf8Slice("A"));
+        histogram.add(Slices.utf8Slice("A"));
+        histogram.add(Slices.utf8Slice("B"));
+        histogram.add(Slices.utf8Slice("C"));
+        histogram.add(Slices.utf8Slice("D"));
+
+        Map<Slice, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(Slices.utf8Slice("A"), 2L, Slices.utf8Slice("B"), 1L, Slices.utf8Slice("C"), 1L));
+    }
+
+    @Test
+    public void testStringRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<Slice> original = new ApproximateMostFrequentHistogram<Slice>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add(Slices.utf8Slice("A"));
+        original.add(Slices.utf8Slice("A"));
+        original.add(Slices.utf8Slice("B"));
+        original.add(Slices.utf8Slice("C"));
+        original.add(Slices.utf8Slice("D"));
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<Slice> deserialized = new ApproximateMostFrequentHistogram<Slice>(serialized, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+}

--- a/presto-phoenix/pom.xml
+++ b/presto-phoenix/pom.xml
@@ -311,6 +311,12 @@
                         <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
                         <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
                     </ignoredResourcePatterns>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>com.clearspring.analytics</groupId>
+                            <artifactId>stream</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.testing;
 
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -1314,5 +1315,55 @@ public abstract class AbstractTestAggregations
         assertQuery(
                 "SELECT orderkey, COUNT(DISTINCT k) FROM (SELECT orderkey, 1 k FROM orders) GROUP BY GROUPING SETS ((), orderkey) HAVING orderkey IS NULL",
                 "VALUES (null, 1)");
+    }
+
+    @Test
+    public void testApproxMostFrequentWithLong()
+    {
+        MaterializedResult actual1 = computeActual("SELECT approx_most_frequent(3, cast(x as bigint), 15) FROM (values 1, 2, 1, 3, 1, 2, 3, 4, 5) t(x)");
+        assertEquals(actual1.getRowCount(), 1);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of(1L, 3L, 2L, 2L, 3L, 2L));
+
+        MaterializedResult actual2 = computeActual("SELECT approx_most_frequent(2, cast(x as bigint), 15) FROM (values 1, 2, 1, 3, 1, 2, 3, 4, 5) t(x)");
+        assertEquals(actual2.getRowCount(), 1);
+        assertEquals(actual2.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of(1L, 3L, 2L, 2L));
+    }
+
+    @Test
+    public void testApproxMostFrequentWithVarchar()
+    {
+        MaterializedResult actual1 = computeActual("SELECT approx_most_frequent(3, x, 15) FROM (values 'A', 'B', 'A', 'C', 'A', 'B', 'C', 'D', 'E') t(x)");
+        assertEquals(actual1.getRowCount(), 1);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of("A", 3L, "B", 2L, "C", 2L));
+
+        MaterializedResult actual2 = computeActual("SELECT approx_most_frequent(2, x, 15) FROM (values 'A', 'B', 'A', 'C', 'A', 'B', 'C', 'D', 'E') t(x)");
+        assertEquals(actual2.getRowCount(), 1);
+        assertEquals(actual2.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of("A", 3L, "B", 2L));
+    }
+
+    @Test
+    public void testApproxMostFrequentWithLongGroupBy()
+    {
+        MaterializedResult actual1 = computeActual("SELECT k, approx_most_frequent(3, cast(v as bigint), 15) FROM (values ('a', 1), ('b', 2), ('a', 1), ('c', 3), ('a', 1), ('b', 2), ('c', 3), ('a', 4), ('b', 5)) t(k, v) GROUP BY 1 ORDER BY 1");
+        assertEquals(actual1.getRowCount(), 3);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), "a");
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(1), ImmutableMap.of(1L, 3L, 4L, 1L));
+        assertEquals(actual1.getMaterializedRows().get(1).getFields().get(0), "b");
+        assertEquals(actual1.getMaterializedRows().get(1).getFields().get(1), ImmutableMap.of(2L, 2L, 5L, 1L));
+        assertEquals(actual1.getMaterializedRows().get(2).getFields().get(0), "c");
+        assertEquals(actual1.getMaterializedRows().get(2).getFields().get(1), ImmutableMap.of(3L, 2L));
+    }
+
+    @Test
+    public void testApproxMostFrequentWithStringGroupBy()
+    {
+        MaterializedResult actual1 = computeActual("SELECT k, approx_most_frequent(3, v, 15) FROM (values ('a', 'A'), ('b', 'B'), ('a', 'A'), ('c', 'C'), ('a', 'A'), ('b', 'B'), ('c', 'C'), ('a', 'D'), ('b', 'E')) t(k, v) GROUP BY 1 ORDER BY 1");
+        assertEquals(actual1.getRowCount(), 3);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), "a");
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(1), ImmutableMap.of("A", 3L, "D", 1L));
+        assertEquals(actual1.getMaterializedRows().get(1).getFields().get(0), "b");
+        assertEquals(actual1.getMaterializedRows().get(1).getFields().get(1), ImmutableMap.of("B", 2L, "E", 1L));
+        assertEquals(actual1.getMaterializedRows().get(2).getFields().get(0), "c");
+        assertEquals(actual1.getMaterializedRows().get(2).getFields().get(1), ImmutableMap.of("C", 2L));
     }
 }


### PR DESCRIPTION
# Purpose
In our experience, we need to get the samples from the underlying table which can contain millions of records and its cardinality is significantly skewed. (e.g. suggesting the selection items in UI) We can get the frequent values by using group by count for now.

But since the grouping by the high cardinality column (e.g. user ID, email) from a huge table causes out of memory error, we put the limitation on the number of original records by the `LIMIT`. For example, the following query fetches the top 3 sample values but column v has large cardinality, it is necessary to limit the number of records for the stable execution.
 
```sql
SELECT
  v, COUNT(1)
FROM (
  SELECT v FROM huge_table LIMIT 10000
)
GROUP BY 1
ORDER BY 2 DESC
LIMIT 3
```

 It sometimes provides us non-intuitive samples. (e.g. lack the frequent items). We want to ensure to keep the high-frequency values while omitting the unimportant values efficiently.

The space-saving algorithm with a stream summary suggested in [1] will mitigate this type of problem by counting the frequency and truncate low-frequency data in an online manner. The `approx_most_frequent` returns the map value containing the high-frequency element calculated approximately. It gets 3 arguments:

* **max buckets**: The number of top K elements in the stream summary
* **values**: Values stored in the stream summary
* **capacity**: The maximum capacity of the stream summary. Larger value improves the accuracy of space-saving algorithm.

The previous example can be rewritten as follows. The third argument is used to control the accuracy of the approximation.

```sql
SELECT
  approx_most_frequent(3, v, 1000) 
FROM
  huge_table
```

# Experiment

With my skewed table (1=60%, 2=20%, 3=10%, 4=3%,5=3%,6=3%), `approx_most_frequent` returns the correct count while the group by count query fails due to memory overflow. This experiment uses 3 node docker based cluster.

```
presto:default> select approx_most_frequent(2, cast(v as bigint), 10) from skew_table;
         _col0
------------------------
 {1=4014080, 2=2408448}
(1 row)

Query 20200414_044201_00086_r2sgg, FINISHED, 2 nodes
Splits: 25 total, 25 done (100.00%)
0:05 [8.83M rows, 75.8MB] [1.62M rows/s, 13.9MB/s]
```

```
presto:default> select v,count(1) from skew_table group by 1 order by 2 limit 2;
...
```

Additionally, I run the function on the high cardinality table having (e.g. `query_id`) as follows. The number of unique values of `query_id` is over 3.5 million.

```sql
select 
  query_id,
  count(1) 
from queries 
group by 1 order by 2 desc limit 5;
```

```sql
select 
  items,
  freq 
from (
  select approx_most_frequent(5, query_id, 1000) as frequent_items 
  from queries 
  cross join unnest(frequent_items) as t(items, freq)
);
```

The first one consumes over 60 times peak total memory usage than the second one.  `approx_most_frequent` can significantly reduce the memory pressure on the system without losing the performance. Here is a detailed comparison between these two approaches.

||GROUP BY COUNT|APPROX_MOST_FREQUENT|
|:---|:---|:---|
|Elapsed Time|16.54s|16.30s|
|CPU Time|6.15s|2.65s|
|Internal Network Data|160.18MB|6.06KB|
|Peak User Memory|294.00MB|32B|
|Peak Total Memory|316.43MB|5.03MB|

Of course, the returned value is an approximation which is not exactly the high frequent items in strict means. But we can have a good balance between the accuracy and the stability in terms of the memory usage by controlling the capacity of the stream summary structure. 

The original implementation was in [2] but it does use the stream summary data structure accurately. Therefore I rewrote the implementation to use stream-lib [3] and fit the latest interface.

# Reference

[1]: A.Metwalley, D.Agrawl, A.Abbadi, "Efficient computation of frequent and top-k elements in data streams"  https://dl.acm.org/doi/10.1007/978-3-540-30570-5_27
[2]: https://github.com/prestodb/presto/pull/6036
[3]: https://github.com/addthis/stream-lib