### PR TITLE
Add ping endpoint handler

### DIFF
--- a/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/io/prestosql/failuredetector/HeartbeatFailureDetector.java
@@ -66,6 +66,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareHead;
 import static io.prestosql.failuredetector.FailureDetector.State.ALIVE;
 import static io.prestosql.failuredetector.FailureDetector.State.GONE;
@@ -257,7 +258,7 @@ public class HeartbeatFailureDetector
                 URI uri = getHttpUri(service);
 
                 if (uri != null) {
-                    tasks.put(service.getId(), new MonitoringTask(service, uri));
+                    tasks.put(service.getId(), new MonitoringTask(service, uriBuilderFrom(uri).appendPath("/v1/status").build()));
                 }
             }
 

--- a/presto-main/src/main/java/io/prestosql/server/StatusResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/StatusResource.java
@@ -20,8 +20,10 @@ import io.prestosql.memory.LocalMemoryManager;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -59,6 +61,13 @@ public class StatusResource
             // we want the com.sun.management sub-interface of java.lang.management.OperatingSystemMXBean
             this.operatingSystemMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         }
+    }
+
+    @HEAD
+    @Produces(APPLICATION_JSON) // to match the GET route
+    public Response statusPing()
+    {
+        return Response.ok().build();
     }
 
     @GET

--- a/presto-main/src/test/java/io/prestosql/server/TestServer.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServer.java
@@ -45,11 +45,13 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.prepareHead;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
@@ -72,6 +74,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_USER;
 import static io.prestosql.spi.StandardErrorCode.INCOMPATIBLE_CLIENT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SEE_OTHER;
 import static org.testng.Assert.assertEquals;
@@ -227,6 +230,18 @@ public class TestServer
                 {"SELECT 1 / 0"}, // fails during optimization
                 {"select 1 / a from (values 0) t(a)"}, // fails during execution
         };
+    }
+
+    @Test
+    public void testStatusPing()
+    {
+        Request request = prepareHead()
+                .setUri(uriFor("/v1/status"))
+                .setFollowRedirects(false)
+                .build();
+        StatusResponse response = client.execute(request, createStatusResponseHandler());
+        assertEquals(response.getStatusCode(), OK.getStatusCode(), "Status code");
+        assertEquals(response.getHeader(CONTENT_TYPE), APPLICATION_JSON, "Content Type");
     }
 
     @Test


### PR DESCRIPTION
Previously, node pings in `HeartbeatFailureDetector` would return a 404 to pings because no endpoint was configured to handle HEAD requests to the root path. Now they return empty HTTP OK responses.