### PR TITLE
Use fixed pattern in a rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -117,6 +117,7 @@ import io.prestosql.sql.planner.iterative.rule.RemoveEmptyDelete;
 import io.prestosql.sql.planner.iterative.rule.RemoveFullSample;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantCrossJoin;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
+import io.prestosql.sql.planner.iterative.rule.RemoveRedundantEnforceSingleRowNode;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantJoin;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantLimit;
@@ -350,6 +351,7 @@ public class PlanOptimizers
                                         new RemoveRedundantDistinctLimit(),
                                         new RemoveRedundantCrossJoin(),
                                         new RemoveRedundantJoin(),
+                                        new RemoveRedundantEnforceSingleRowNode(),
                                         new ImplementFilteredAggregations(metadata),
                                         new SingleDistinctAggregationToGroupBy(),
                                         new MultipleDistinctAggregationToMarkDistinct(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -401,12 +401,15 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(
-                                new RemoveUnreferencedScalarSubqueries(),
-                                new TransformUncorrelatedSubqueryToJoin(),
-                                new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
-                                new TransformCorrelatedScalarAggregationToJoin(metadata),
-                                new TransformCorrelatedJoinToJoin(metadata))),
+                        ImmutableSet.<Rule<?>>builder()
+                                .add(
+                                        new RemoveRedundantEnforceSingleRowNode(),
+                                        new RemoveUnreferencedScalarSubqueries(),
+                                        new TransformUncorrelatedSubqueryToJoin(),
+                                        new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
+                                        new TransformCorrelatedJoinToJoin(metadata))
+                                .addAll(new TransformCorrelatedScalarAggregationToJoin(metadata).rules())
+                                .build()),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveRedundantEnforceSingleRowNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveRedundantEnforceSingleRowNode.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
+
+import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
+import static io.prestosql.sql.planner.plan.Patterns.enforceSingleRow;
+
+public class RemoveRedundantEnforceSingleRowNode
+        implements Rule<EnforceSingleRowNode>
+{
+    private static final Pattern<EnforceSingleRowNode> PATTERN = enforceSingleRow();
+
+    @Override
+    public Pattern<EnforceSingleRowNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(EnforceSingleRowNode node, Captures captures, Context context)
+    {
+        if (isScalar(node.getSource(), context.getLookup())) {
+            return Result.ofPlanNode(node.getSource());
+        }
+        return Result.empty();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -30,22 +30,17 @@ import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
 import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
-import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.QualifiedName;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
-import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.prestosql.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static java.util.Objects.requireNonNull;
@@ -122,43 +117,10 @@ public class ScalarAggregationToJoinRewriter
                 ImmutableMap.of(),
                 Optional.empty());
 
-        AggregationNode aggregationNode = createAggregationNode(
+        return createAggregationNode(
                 scalarAggregation,
                 leftOuterJoin,
                 nonNull);
-
-        Optional<ProjectNode> subqueryProjection = searchFrom(correlatedJoinNode.getSubquery(), lookup)
-                .where(ProjectNode.class::isInstance)
-                .recurseOnlyWhen(EnforceSingleRowNode.class::isInstance)
-                .findFirst();
-
-        List<Symbol> aggregationOutputSymbols = getTruncatedAggregationSymbols(correlatedJoinNode, aggregationNode);
-
-        if (subqueryProjection.isPresent()) {
-            Assignments assignments = Assignments.builder()
-                    .putIdentities(aggregationOutputSymbols)
-                    .putAll(subqueryProjection.get().getAssignments())
-                    .build();
-
-            return new ProjectNode(
-                    idAllocator.getNextId(),
-                    aggregationNode,
-                    assignments);
-        }
-        else {
-            return new ProjectNode(
-                    idAllocator.getNextId(),
-                    aggregationNode,
-                    Assignments.identity(aggregationOutputSymbols));
-        }
-    }
-
-    private static List<Symbol> getTruncatedAggregationSymbols(CorrelatedJoinNode correlatedJoinNode, AggregationNode aggregationNode)
-    {
-        Set<Symbol> applySymbols = new HashSet<>(correlatedJoinNode.getOutputSymbols());
-        return aggregationNode.getOutputSymbols().stream()
-                .filter(applySymbols::contains)
-                .collect(toImmutableList());
     }
 
     private AggregationNode createAggregationNode(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
@@ -250,7 +250,7 @@ public final class Patterns
 
         public static Property<CorrelatedJoinNode, Lookup, PlanNode> subquery()
         {
-            return property("subquery", CorrelatedJoinNode::getSubquery);
+            return property("subquery", (node, context) -> context.resolve(node.getSubquery()));
         }
 
         public static Property<CorrelatedJoinNode, Lookup, Expression> filter()

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -1133,7 +1133,7 @@ public class PlanPrinter
         public Void visitCorrelatedJoin(CorrelatedJoinNode node, Void context)
         {
             addNode(node,
-                    "Lateral",
+                    "CorrelatedJoin",
                     format("[%s%s]",
                             node.getCorrelation(),
                             node.getFilter().equals(TRUE_LITERAL) ? "" : " " + node.getFilter()));

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
@@ -74,7 +74,6 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.apply;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.constrainedTableScan;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.constrainedTableScanWithTableLayout;
-import static io.prestosql.sql.planner.assertions.PlanMatchPattern.enforceSingleRow;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
@@ -178,7 +177,6 @@ public class TestLogicalPlanner
                                 ImmutableMap.of(
                                         "output_1", expression("CAST(\"row\" AS ROW(f0 bigint,f1 varchar(25))).f0"),
                                         "output_2", expression("CAST(\"row\" AS ROW(f0 bigint,f1 varchar(25))).f1")),
-                                enforceSingleRow(
                                         project(
                                                 ImmutableMap.of("row", expression("ROW(min, max)")),
                                                 aggregation(
@@ -192,7 +190,7 @@ public class TestLogicalPlanner
                                                                                 "min_regionkey", functionCall("min", ImmutableList.of("REGIONKEY")),
                                                                                 "max_name", functionCall("max", ImmutableList.of("NAME"))),
                                                                         PARTIAL,
-                                                                        tableScan("nation", ImmutableMap.of("NAME", "name", "REGIONKEY", "regionkey"))))))))));
+                                                                        tableScan("nation", ImmutableMap.of("NAME", "name", "REGIONKEY", "regionkey")))))))));
     }
 
     @Test
@@ -406,13 +404,13 @@ public class TestLogicalPlanner
         assertEquals(
                 countOfMatchingNodes(
                         plan("SELECT * FROM orders WHERE CAST(orderkey AS INTEGER) = (SELECT 1) AND custkey = (SELECT 2) AND CAST(custkey as REAL) != (SELECT 1)"),
-                        EnforceSingleRowNode.class::isInstance),
+                        ValuesNode.class::isInstance),
                 2);
         // same query used for left, right and complex join condition
         assertEquals(
                 countOfMatchingNodes(
-                        plan("SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = (SELECT 1) AND o2.orderkey = (SELECT 1) AND o1.orderkey + o2.orderkey = (SELECT 1)"),
-                        EnforceSingleRowNode.class::isInstance),
+                        plan("SELECT * FROM orders o1 JOIN orders o2 ON o1.orderkey = (SELECT 1) AND o2.orderkey = (SELECT 1) AND o1.orderkey + o2.orderkey > (SELECT 1)"),
+                        ValuesNode.class::isInstance),
                 1);
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveRedundantEnforceSingleRowNode.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveRedundantEnforceSingleRowNode.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.node;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestRemoveRedundantEnforceSingleRowNode
+        extends BaseRuleTest
+{
+    @Test
+    public void testRemoveEnforceWhenSourceScalar()
+    {
+        tester().assertThat(new RemoveRedundantEnforceSingleRowNode())
+                .on(p -> p.enforceSingleRow(p.aggregation(builder -> builder
+                        .addAggregation(p.symbol("c"), expression("count(a)"), ImmutableList.of(BIGINT))
+                        .globalGrouping()
+                        .source(p.values(p.symbol("a"))))))
+                .matches(node(AggregationNode.class, values("a")));
+    }
+
+    @Test
+    public void testDoNotFireWhenSourceNotScalar()
+    {
+        tester().assertThat(new RemoveRedundantEnforceSingleRowNode())
+                .on(p -> p.enforceSingleRow(p.values(10, p.symbol("a"))))
+                .doesNotFire();
+
+        tester().assertThat(new RemoveRedundantEnforceSingleRowNode())
+                .on(p -> p.enforceSingleRow(p.values(p.symbol("a"))))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationWithoutProjection.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationWithoutProjection.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedScalarAggregationToJoin.TransformCorrelatedScalarAggregationWithoutProjection;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.iterative.rule.test.PlanBuilder;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.JoinNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestTransformCorrelatedScalarAggregationWithoutProjection
+        extends BaseRuleTest
+{
+    @Test
+    public void doesNotFireOnPlanWithoutCorrelatedJoinNode()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.values(p.symbol("a")))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnCorrelatedWithoutAggregation()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.values(p.symbol("a"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnUncorrelated()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(),
+                        p.values(p.symbol("a")),
+                        p.values(p.symbol("b"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnCorrelatedWithNonScalarAggregation()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("sum"), PlanBuilder.expression("sum(a)"), ImmutableList.of(BIGINT))
+                                .singleGroupingSet(p.symbol("b")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnMultipleProjections()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.project(
+                                Assignments.of(p.symbol("expr_2"), p.expression("expr - 1")),
+                                p.project(
+                                        Assignments.of(p.symbol("expr"), p.expression("sum + 1")),
+                                        p.aggregation(ab -> ab
+                                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                                .addAggregation(p.symbol("sum"), PlanBuilder.expression("sum(a)"), ImmutableList.of(BIGINT))
+                                                .globalGrouping())))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithoutProjection()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("sum"), PlanBuilder.expression("sum(a)"), ImmutableList.of(BIGINT))
+                                .globalGrouping())))
+                .matches(
+                        project(ImmutableMap.of("sum_1", expression("sum_1"), "corr", expression("corr")),
+                                aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
+                                        join(JoinNode.Type.LEFT,
+                                                ImmutableList.of(),
+                                                assignUniqueId("unique",
+                                                        values(ImmutableMap.of("corr", 0))),
+                                                project(ImmutableMap.of("non_null", expression("true")),
+                                                        values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithProjection()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.project(Assignments.of(p.symbol("expr"), p.expression("sum + 1")),
+                                p.aggregation(ab -> ab
+                                        .source(p.values(p.symbol("a"), p.symbol("b")))
+                                        .addAggregation(p.symbol("sum"), PlanBuilder.expression("sum(a)"), ImmutableList.of(BIGINT))
+                                        .globalGrouping()))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSubqueryWithCount()
+    {
+        tester().assertThat(new TransformCorrelatedScalarAggregationWithoutProjection(tester().getMetadata()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("count_rows"), PlanBuilder.expression("count(*)"), ImmutableList.of())
+                                .addAggregation(p.symbol("count_non_null_values"), PlanBuilder.expression("count(a)"), ImmutableList.of(BIGINT))
+                                .globalGrouping())))
+                .matches(
+                        project(
+                                aggregation(ImmutableMap.of(
+                                        "count_rows", functionCall("count", ImmutableList.of("non_null")),
+                                        "count_non_null_values", functionCall("count", ImmutableList.of("a"))),
+                                        join(JoinNode.Type.LEFT,
+                                                ImmutableList.of(),
+                                                assignUniqueId("unique",
+                                                        values(ImmutableMap.of("corr", 0))),
+                                                project(ImmutableMap.of("non_null", expression("true")),
+                                                        values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+}


### PR DESCRIPTION
Splits the TransformCorrelatedScalarAggregationToJoin Optimizer rule
into a set of two rules with fixed patterns instead of using
PlanNodeSearcher inside the rule.
After this change, the only patterns supported by the rules are:

- CorrelatedJoin
    - Input
    - global Aggregation

and

- CorrelatedJoin
    - Input
    - Project
	    - global Aggregation

Previously, the rule supported also cases were
1. there were multiple Projections above the Aggregation.
   This case was handled incorrectly.
2. there were EnforceSingleRowNodes in the subquery
   above the Aggregation. This functionality is restored
   by adding a rule to remove redundant EnforceSingleRowNodes.