### PR TITLE
Add link to book and paper pages

### DIFF
--- a/presto-docs/src/main/sphinx/overview/concepts.rst
+++ b/presto-docs/src/main/sphinx/overview/concepts.rst
@@ -24,6 +24,14 @@ This section provides a solid definition for the core concepts
 referenced throughout Presto, and these sections are sorted from most
 general to most specific.
 
+.. note::
+
+    The book `Presto: The Definitive Guide
+    <https://prestosql.io/presto-the-definitive-guide.html>`_ and the research
+    paper `Presto: SQL on Everything <https://prestosql.io/paper.html>`_ can
+    provide further information about Presto and the concepts in use.
+
+
 Server Types
 ------------
 


### PR DESCRIPTION
Absolute URLs are used so it works wherever the docs are hosted.