### PR TITLE
Allow queries containing backticks in identifiers (ie around alias/column names) only BUT buggy if used backticks are elsewhere

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/DispatchManager.java
@@ -156,10 +156,11 @@ public class DispatchManager
      *  Creates and registers a dispatch query with the query tracker.  This method will never fail to register a query with the query
      *  tracker.  If an error occurs while creating a dispatch query, a failed dispatch will be created and registered.
      */
-    private <C> void createQueryInternal(QueryId queryId, Slug slug, SessionContext sessionContext, String query, ResourceGroupManager<C> resourceGroupManager)
+    private <C> void createQueryInternal(QueryId queryId, Slug slug, SessionContext sessionContext, String rawQuery, ResourceGroupManager<C> resourceGroupManager)
     {
         Session session = null;
         PreparedQuery preparedQuery = null;
+        String query = rawQuery.replaceAll("`", "\"");
         try {
             if (query.length() > maxQueryLength) {
                 int queryLength = query.length();


### PR DESCRIPTION
Dataiku generates invalid queries against presto (it uses backticks for subquery alias name). While I know its not ANSI sql and Dataiku should really fix it, this patch will replace all backticks in any incoming query with double quotes.

example bad query:
```select * from (select * from tbl) `get` limit 1```

Below currently blocks backtick identifiers:
https://github.com/prestosql/presto/blob/332/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java#L200

Similarly mentioned on https://github.com/prestosql-rocks/presto-query-formatter/issues/7

Fix is done where coordinator receives raw sql from the client and then does simple  .replaceAll("`", "\"") on the entire sql before sending it to the parser. _Handy to know that DispatchManager.createQueryInternal is where queries can be intercepted and rewritten_

This is **NOT PROD READY** as would get incorrect results for queries like:
```select * from query_log where sql like '`tacos`'```

Proper fix would not be a blanket replaceAll (which leads to bad query results if backticks are within a search expression for example) but instead change the sql parser. ie  SqlBase.g4 and AstBuilder.visitQuotedIdentifier()

