### PR TITLE
Move special modules to the end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,9 @@ jobs:
             !presto-redis,
             !presto-sqlserver,!presto-postgresql,!presto-mysql,
             !presto-oracle,
+            !presto-kudu,
             !presto-phoenix,!presto-iceberg,
-            !presto-docs,!presto-server,!presto-server-rpm,
-            !presto-kudu'
+            !presto-docs,!presto-server,!presto-server-rpm'
 
   test:
     runs-on: ubuntu-latest
@@ -158,9 +158,9 @@ jobs:
           - "presto-mongodb,presto-kafka,presto-elasticsearch"
           - "presto-redis"
           - "presto-sqlserver,presto-postgresql,presto-mysql"
-          - "presto-phoenix,presto-iceberg"
-          - "presto-kudu"
           - "presto-oracle"
+          - "presto-kudu"
+          - "presto-phoenix,presto-iceberg"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1


### PR DESCRIPTION
The main list of modules should be consistent between the
test-other-modules and test jobs, as the purpose of the former is to
test everything that is not tested explicitly by the latter.