### PR TITLE
Pass ConnectorSession to JdbcClient.isLimitGuaranteed

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -885,7 +885,7 @@ public class BaseJdbcClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         throw new PrestoException(JDBC_ERROR, "limitFunction() is implemented without isLimitGuaranteed()");
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
@@ -160,9 +160,9 @@ public final class CachingJdbcClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
-        return delegate.isLimitGuaranteed();
+        return delegate.isLimitGuaranteed(session);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
@@ -190,9 +190,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
-        return delegate().isLimitGuaranteed();
+        return delegate().isLimitGuaranteed(session);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -66,7 +66,7 @@ public interface JdbcClient
 
     boolean supportsLimit();
 
-    boolean isLimitGuaranteed();
+    boolean isLimitGuaranteed(ConnectorSession session);
 
     void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column);
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -175,7 +175,7 @@ public class JdbcMetadata
                 handle.getConstraint(),
                 OptionalLong.of(limit));
 
-        return Optional.of(new LimitApplicationResult<>(handle, jdbcClient.isLimitGuaranteed()));
+        return Optional.of(new LimitApplicationResult<>(handle, jdbcClient.isLimitGuaranteed(session)));
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -235,9 +235,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
-        return delegate().isLimitGuaranteed();
+        return delegate().isLimitGuaranteed(session);
     }
 
     @Override

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import javax.inject.Inject;
 
@@ -85,7 +86,7 @@ public class MemSqlClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return true;
     }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -292,7 +292,7 @@ public class MySqlClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return true;
     }

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -434,7 +434,7 @@ public class PostgreSqlClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return true;
     }

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -18,6 +18,7 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
 
 import javax.inject.Inject;
@@ -71,7 +72,7 @@ public class RedshiftClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return true;
     }

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -170,7 +170,7 @@ public class SqlServerClient
     }
 
     @Override
-    public boolean isLimitGuaranteed()
+    public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return true;
     }


### PR DESCRIPTION
Sometimes we would like to change JDBC Client behaviour based on catalog session/configuration properties