### PR TITLE
Support case insensitive identifiers in MongoDB

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -34,24 +34,24 @@ Configuration Properties
 
 The following configuration properties are available:
 
-===================================== ==============================================================
-Property Name                         Description
-===================================== ==============================================================
-``mongodb.seeds``                     List of all MongoDB servers
-``mongodb.schema-collection``         A collection which contains schema information
-``mongodb.credentials``               List of credentials
-``mongodb.min-connections-per-host``  The minimum size of the connection pool per host
-``mongodb.connections-per-host``      The maximum size of the connection pool per host
-``mongodb.max-wait-time``             The maximum wait time
-``mongodb.connection-timeout``        The socket connect timeout
-``mongodb.socket-timeout``            The socket timeout
-``mongodb.socket-keep-alive``         Whether keep-alive is enabled on each socket
-``mongodb.ssl.enabled``               Use TLS/SSL for connections to mongod/mongos
-``mongodb.read-preference``           The read preference
-``mongodb.write-concern``             The write concern
-``mongodb.required-replica-set``      The required replica set name
-``mongodb.cursor-batch-size``         The number of elements to return in a batch
-===================================== ==============================================================
+========================================== ==============================================================
+Property Name                              Description
+========================================== ==============================================================
+``mongodb.seeds``                          List of all MongoDB servers
+``mongodb.schema-collection``              A collection which contains schema information
+``mongodb.credentials``                    List of credentials
+``mongodb.min-connections-per-host``       The minimum size of the connection pool per host
+``mongodb.connections-per-host``           The maximum size of the connection pool per host
+``mongodb.max-wait-time``                  The maximum wait time
+``mongodb.connection-timeout``             The socket connect timeout
+``mongodb.socket-timeout``                 The socket timeout
+``mongodb.socket-keep-alive``              Whether keep-alive is enabled on each socket
+``mongodb.ssl.enabled``                    Use TLS/SSL for connections to mongod/mongos
+``mongodb.read-preference``                The read preference
+``mongodb.write-concern``                  The write concern
+``mongodb.required-replica-set``           The required replica set name
+``mongodb.cursor-batch-size``              The number of elements to return in a batch
+========================================== ==============================================================
 
 ``mongodb.seeds``
 ^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -39,6 +39,7 @@ Property Name                              Description
 ========================================== ==============================================================
 ``mongodb.seeds``                          List of all MongoDB servers
 ``mongodb.schema-collection``              A collection which contains schema information
+``mongodb.case-insensitive-name-matching`` Match database and collection names case insensitively
 ``mongodb.credentials``                    List of credentials
 ``mongodb.min-connections-per-host``       The minimum size of the connection pool per host
 ``mongodb.connections-per-host``           The maximum size of the connection pool per host

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoClientConfig.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoClientConfig.java
@@ -37,6 +37,7 @@ public class MongoClientConfig
     private static final Splitter PORT_SPLITTER = Splitter.on(':').trimResults().omitEmptyStrings();
 
     private String schemaCollection = "_schema";
+    private boolean caseInsensitiveNameMatching;
     private List<ServerAddress> seeds = ImmutableList.of();
     private List<MongoCredential> credentials = ImmutableList.of();
 
@@ -66,6 +67,18 @@ public class MongoClientConfig
     public MongoClientConfig setSchemaCollection(String schemaCollection)
     {
         this.schemaCollection = schemaCollection;
+        return this;
+    }
+
+    public boolean isCaseInsensitiveNameMatching()
+    {
+        return caseInsensitiveNameMatching;
+    }
+
+    @Config("mongodb.case-insensitive-name-matching")
+    public MongoClientConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
+    {
+        this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
         return this;
     }
 

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoQueryRunner.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoQueryRunner.java
@@ -55,6 +55,7 @@ public final class MongoQueryRunner
             queryRunner.createCatalog("tpch", "tpch");
 
             Map<String, String> properties = ImmutableMap.of(
+                    "mongodb.case-insensitive-name-matching", "true",
                     "mongodb.seeds", server.getAddress().toString(),
                     "mongodb.socket-keep-alive", "true");
 

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoClientConfig.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoClientConfig.java
@@ -31,6 +31,7 @@ public class TestMongoClientConfig
     {
         assertRecordedDefaults(recordDefaults(MongoClientConfig.class)
                 .setSchemaCollection("_schema")
+                .setCaseInsensitiveNameMatching(false)
                 .setSeeds("")
                 .setCredentials("")
                 .setMinConnectionsPerHost(0)
@@ -52,6 +53,7 @@ public class TestMongoClientConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("mongodb.schema-collection", "_my_schema")
+                .put("mongodb.case-insensitive-name-matching", "true")
                 .put("mongodb.seeds", "host1,host2:27016")
                 .put("mongodb.credentials", "username:password@collection")
                 .put("mongodb.min-connections-per-host", "1")
@@ -70,6 +72,7 @@ public class TestMongoClientConfig
 
         MongoClientConfig expected = new MongoClientConfig()
                 .setSchemaCollection("_my_schema")
+                .setCaseInsensitiveNameMatching(true)
                 .setSeeds("host1", "host2:27016")
                 .setCredentials("username:password@collection")
                 .setMinConnectionsPerHost(1)


### PR DESCRIPTION
Supersedes #1915 and fixes #1102

Recently, we've received this request several times. 