### PR TITLE
Support reading uniontype as struct from Avro/ORC Hive tables

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
@@ -656,7 +656,7 @@ public class BackgroundHiveSplitLoader
         for (int i = 0; i < keys.size(); i++) {
             String name = keys.get(i).getName();
             HiveType hiveType = keys.get(i).getType();
-            if (!hiveType.isSupportedType()) {
+            if (!hiveType.isSupportedType(table.getStorage().getStorageFormat())) {
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
             }
             String value = values.get(i);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.hive;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.metastore.StorageFormat;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.NamedTypeSignature;
 import io.prestosql.spi.type.RowFieldName;
@@ -31,6 +32,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 
 import java.util.List;
@@ -39,6 +41,8 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.HiveStorageFormat.AVRO;
+import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
@@ -148,26 +152,38 @@ public final class HiveType
         return hiveTypeName.toString();
     }
 
-    public boolean isSupportedType()
+    public boolean isSupportedType(StorageFormat storageFormat)
     {
-        return isSupportedType(getTypeInfo());
+        return isSupportedType(getTypeInfo(), storageFormat);
     }
 
-    public static boolean isSupportedType(TypeInfo typeInfo)
+    public static boolean isSupportedType(TypeInfo typeInfo, StorageFormat storageFormat)
     {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
                 return getPrimitiveType((PrimitiveTypeInfo) typeInfo) != null;
             case MAP:
                 MapTypeInfo mapTypeInfo = (MapTypeInfo) typeInfo;
-                return isSupportedType(mapTypeInfo.getMapKeyTypeInfo()) && isSupportedType(mapTypeInfo.getMapValueTypeInfo());
+                return isSupportedType(mapTypeInfo.getMapKeyTypeInfo(), storageFormat) && isSupportedType(mapTypeInfo.getMapValueTypeInfo(), storageFormat);
             case LIST:
                 ListTypeInfo listTypeInfo = (ListTypeInfo) typeInfo;
-                return isSupportedType(listTypeInfo.getListElementTypeInfo());
+                return isSupportedType(listTypeInfo.getListElementTypeInfo(), storageFormat);
             case STRUCT:
                 StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
                 return structTypeInfo.getAllStructFieldTypeInfos().stream()
-                        .allMatch(HiveType::isSupportedType);
+                        .allMatch(fieldTypeInfo -> isSupportedType(fieldTypeInfo, storageFormat));
+            case UNION:
+                // This feature (reading uniontypes as structs) has only been verified against Avro and ORC tables. Here's a discussion:
+                //   1. Avro tables are supported and verified.
+                //   2. ORC tables are supported and verified.
+                //   3. The Parquet format doesn't support uniontypes itself so there's no need to add support for it in Presto.
+                //   4. TODO: RCFile tables are not supported yet.
+                //   5. TODO: The support for Avro is done in SerDeUtils so it's possible that formats other than Avro are also supported. But verification is needed.
+                if (storageFormat.getSerDe().equalsIgnoreCase(AVRO.getSerDe()) || storageFormat.getSerDe().equalsIgnoreCase(ORC.getSerDe())) {
+                    UnionTypeInfo unionTypeInfo = (UnionTypeInfo) typeInfo;
+                    return unionTypeInfo.getAllUnionObjectTypeInfos().stream()
+                            .allMatch(fieldTypeInfo -> isSupportedType(fieldTypeInfo, storageFormat));
+                }
         }
         return false;
     }
@@ -240,6 +256,17 @@ public final class HiveType
                     typeSignatureBuilder.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(rowFieldName)), typeSignature)));
                 }
                 return new TypeSignature(StandardTypes.ROW, typeSignatureBuilder.build());
+            case UNION:
+                // Use a row type to represent a union type in Hive for reading
+                UnionTypeInfo unionTypeInfo = (UnionTypeInfo) typeInfo;
+                List<TypeInfo> unionObjectTypeInfos = unionTypeInfo.getAllUnionObjectTypeInfos();
+                ImmutableList.Builder<TypeSignatureParameter> typeSignatures = ImmutableList.builder();
+                typeSignatures.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("tag")), TINYINT.getTypeSignature())));
+                for (int i = 0; i < unionObjectTypeInfos.size(); i++) {
+                    TypeSignature typeSignature = getTypeSignature(unionObjectTypeInfos.get(i));
+                    typeSignatures.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("field" + i)), typeSignature)));
+                }
+                return new TypeSignature(StandardTypes.ROW, typeSignatures.build());
         }
         throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", typeInfo));
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -736,7 +736,7 @@ public final class HiveUtil
 
     public static boolean isStructuralType(HiveType hiveType)
     {
-        return hiveType.getCategory() == Category.LIST || hiveType.getCategory() == Category.MAP || hiveType.getCategory() == Category.STRUCT;
+        return hiveType.getCategory() == Category.LIST || hiveType.getCategory() == Category.MAP || hiveType.getCategory() == Category.STRUCT || hiveType.getCategory() == Category.UNION;
     }
 
     public static boolean booleanPartitionKey(String value, String name)
@@ -912,7 +912,7 @@ public final class HiveUtil
         for (Column field : table.getDataColumns()) {
             // ignore unsupported types rather than failing
             HiveType hiveType = field.getType();
-            if (hiveType.isSupportedType()) {
+            if (hiveType.isSupportedType(table.getStorage().getStorageFormat())) {
                 columns.add(createBaseColumn(field.getName(), hiveColumnIndex, hiveType, hiveType.getType(typeManager), REGULAR, field.getComment()));
             }
             hiveColumnIndex++;
@@ -928,7 +928,7 @@ public final class HiveUtil
         List<Column> partitionKeys = table.getPartitionColumns();
         for (Column field : partitionKeys) {
             HiveType hiveType = field.getType();
-            if (!hiveType.isSupportedType()) {
+            if (!hiveType.isSupportedType(table.getStorage().getStorageFormat())) {
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
             }
             columns.add(createBaseColumn(field.getName(), -1, hiveType, hiveType.getType(typeManager), PARTITION_KEY, field.getComment()));

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcReader.java
@@ -354,6 +354,16 @@ public class OrcReader
                     createOrcColumn(path, "key", orcType.getFieldTypeIndex(0), types, orcDataSourceId),
                     createOrcColumn(path, "value", orcType.getFieldTypeIndex(1), types, orcDataSourceId));
         }
+        else if (orcType.getOrcTypeKind() == OrcTypeKind.UNION) {
+            nestedColumns = IntStream.range(0, orcType.getFieldCount())
+                    .mapToObj(fieldId -> createOrcColumn(
+                            path,
+                            "field" + fieldId,
+                            orcType.getFieldTypeIndex(fieldId),
+                            types,
+                            orcDataSourceId))
+                    .collect(toImmutableList());
+        }
         return new OrcColumn(path, columnId, fieldName, orcType.getOrcTypeKind(), orcDataSourceId, nestedColumns, orcType.getAttributes());
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/ColumnReaders.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/ColumnReaders.java
@@ -62,6 +62,7 @@ public final class ColumnReaders
             case DECIMAL:
                 return new DecimalColumnReader(type, column, systemMemoryContext.newLocalMemoryContext(ColumnReaders.class.getSimpleName()));
             case UNION:
+                return new UnionColumnReader(type, column, systemMemoryContext, blockFactory);
             default:
                 throw new IllegalArgumentException("Unsupported type: " + column.getColumnType());
         }

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/UnionColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/UnionColumnReader.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import io.prestosql.memory.context.AggregatedMemoryContext;
+import io.prestosql.orc.OrcBlockFactory;
+import io.prestosql.orc.OrcColumn;
+import io.prestosql.orc.OrcCorruptionException;
+import io.prestosql.orc.metadata.ColumnEncoding;
+import io.prestosql.orc.metadata.ColumnMetadata;
+import io.prestosql.orc.stream.BooleanInputStream;
+import io.prestosql.orc.stream.ByteInputStream;
+import io.prestosql.orc.stream.InputStreamSource;
+import io.prestosql.orc.stream.InputStreamSources;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.ByteArrayBlock;
+import io.prestosql.spi.block.LazyBlock;
+import io.prestosql.spi.block.LazyBlockLoader;
+import io.prestosql.spi.block.RowBlock;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.prestosql.orc.OrcReader.ProjectedLayout.fullyProjectedLayout;
+import static io.prestosql.orc.metadata.Stream.StreamKind.DATA;
+import static io.prestosql.orc.metadata.Stream.StreamKind.PRESENT;
+import static io.prestosql.orc.reader.ColumnReaders.createColumnReader;
+import static io.prestosql.orc.reader.ReaderUtils.verifyStreamType;
+import static io.prestosql.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static java.util.Objects.requireNonNull;
+
+// Use row blocks to represent union objects when reading
+public class UnionColumnReader
+        implements ColumnReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(UnionColumnReader.class).instanceSize();
+
+    private final OrcColumn column;
+    private final OrcBlockFactory blockFactory;
+
+    private final RowType type;
+    private final List<ColumnReader> fieldReaders;
+
+    private int readOffset;
+    private int nextBatchSize;
+
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    private InputStreamSource<ByteInputStream> dataStreamSource = missingStreamSource(ByteInputStream.class);
+    @Nullable
+    private BooleanInputStream presentStream;
+    @Nullable
+    private ByteInputStream dataStream;
+
+    private boolean rowGroupOpen;
+
+    UnionColumnReader(Type type, OrcColumn column, AggregatedMemoryContext systemMemoryContext, OrcBlockFactory blockFactory)
+            throws OrcCorruptionException
+    {
+        requireNonNull(type, "type is null");
+        verifyStreamType(column, type, RowType.class::isInstance);
+        this.type = (RowType) type;
+
+        this.column = requireNonNull(column, "column is null");
+        this.blockFactory = requireNonNull(blockFactory, "blockFactory is null");
+
+        ImmutableList.Builder<ColumnReader> fieldReadersBuilder = ImmutableList.builder();
+        List<OrcColumn> fields = column.getNestedColumns();
+        for (int i = 0; i < fields.size(); i++) {
+            fieldReadersBuilder.add(createColumnReader(type.getTypeParameters().get(i + 1), fields.get(i), fullyProjectedLayout(), systemMemoryContext, blockFactory));
+        }
+        fieldReaders = fieldReadersBuilder.build();
+    }
+
+    @Override
+    public void prepareNextRead(int batchSize)
+    {
+        readOffset += nextBatchSize;
+        nextBatchSize = batchSize;
+    }
+
+    @Override
+    public Block readBlock()
+            throws IOException
+    {
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        if (readOffset > 0) {
+            if (presentStream != null) {
+                readOffset = presentStream.countBitsSet(readOffset);
+            }
+            if (readOffset > 0) {
+                if (dataStream == null) {
+                    throw new OrcCorruptionException(column.getOrcDataSourceId(), "Value is not null but data stream is missing");
+                }
+                int[] readOffsets = new int[fieldReaders.size()];
+                for (byte tag : dataStream.next(readOffset)) {
+                    readOffsets[tag]++;
+                }
+                for (int i = 0; i < fieldReaders.size(); i++) {
+                    fieldReaders.get(i).prepareNextRead(readOffsets[i]);
+                }
+            }
+        }
+
+        boolean[] nullVector = null;
+        Block[] blocks;
+
+        if (presentStream == null) {
+            blocks = getBlocks(nextBatchSize);
+        }
+        else {
+            nullVector = new boolean[nextBatchSize];
+            int nullValues = presentStream.getUnsetBits(nextBatchSize, nullVector);
+            if (nullValues != nextBatchSize) {
+                blocks = getBlocks(nextBatchSize - nullValues);
+            }
+            else {
+                List<Type> typeParameters = type.getTypeParameters();
+                blocks = new Block[typeParameters.size() + 1];
+                blocks[0] = TINYINT.createBlockBuilder(null, 0).build();
+                for (int i = 0; i < typeParameters.size(); i++) {
+                    blocks[i + 1] = typeParameters.get(i).createBlockBuilder(null, 0).build();
+                }
+            }
+        }
+
+        verify(Arrays.stream(blocks)
+                .mapToInt(Block::getPositionCount)
+                .distinct()
+                .count() == 1);
+
+        Block rowBlock = RowBlock.fromFieldBlocks(nextBatchSize, Optional.ofNullable(nullVector), blocks);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+
+        return rowBlock;
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+        dataStream = dataStreamSource.openStream();
+
+        rowGroupOpen = true;
+    }
+
+    @Override
+    public void startStripe(ZoneId fileTimeZone, ZoneId storageTimeZone, InputStreamSources dictionaryStreamSources, ColumnMetadata<ColumnEncoding> encoding)
+            throws IOException
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+        dataStreamSource = missingStreamSource(ByteInputStream.class);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+
+        presentStream = null;
+        dataStream = null;
+
+        rowGroupOpen = false;
+
+        for (ColumnReader fieldReader : fieldReaders) {
+            fieldReader.startStripe(fileTimeZone, storageTimeZone, dictionaryStreamSources, encoding);
+        }
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+            throws IOException
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(column, PRESENT, BooleanInputStream.class);
+        dataStreamSource = dataStreamSources.getInputStreamSource(column, DATA, ByteInputStream.class);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+
+        presentStream = null;
+        dataStream = null;
+
+        rowGroupOpen = false;
+
+        for (ColumnReader fieldReader : fieldReaders) {
+            fieldReader.startRowGroup(dataStreamSources);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(column)
+                .toString();
+    }
+
+    private Block[] getBlocks(int positionCount)
+            throws IOException
+    {
+        if (dataStream == null) {
+            throw new OrcCorruptionException(column.getOrcDataSourceId(), "Value is not null but data stream is missing");
+        }
+
+        Block[] blocks = new Block[fieldReaders.size() + 1];
+
+        byte[] tags = dataStream.next(positionCount);
+        blocks[0] = new ByteArrayBlock(positionCount, Optional.empty(), tags);
+
+        boolean[][] valueIsNonNull = new boolean[fieldReaders.size()][positionCount];
+        int[] nonNullValueCount = new int[fieldReaders.size()];
+        for (int i = 0; i < positionCount; i++) {
+            valueIsNonNull[tags[i]][i] = true;
+            nonNullValueCount[tags[i]]++;
+        }
+
+        for (int i = 0; i < fieldReaders.size(); i++) {
+            Type fieldType = type.getTypeParameters().get(i + 1);
+            if (nonNullValueCount[i] > 0) {
+                ColumnReader reader = fieldReaders.get(i);
+                reader.prepareNextRead(nonNullValueCount[i]);
+                Block rawBlock = blockFactory.createBlock(nonNullValueCount[i], reader::readBlock, true);
+                blocks[i + 1] = new LazyBlock(positionCount, new UnpackLazyBlockLoader(rawBlock, fieldType, valueIsNonNull[i]));
+            }
+            else {
+                blocks[i + 1] = new RunLengthEncodedBlock(
+                        fieldType.createBlockBuilder(null, 1).appendNull().build(),
+                        positionCount);
+            }
+        }
+        return blocks;
+    }
+
+    @Override
+    public void close()
+    {
+        try (Closer closer = Closer.create()) {
+            for (ColumnReader structField : fieldReaders) {
+                closer.register(structField::close);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        long retainedSizeInBytes = INSTANCE_SIZE;
+        for (ColumnReader structField : fieldReaders) {
+            retainedSizeInBytes += structField.getRetainedSizeInBytes();
+        }
+        return retainedSizeInBytes;
+    }
+
+    private static final class UnpackLazyBlockLoader
+            implements LazyBlockLoader
+    {
+        private final Block denseBlock;
+        private final Type type;
+        private final boolean[] valueIsNonNull;
+
+        public UnpackLazyBlockLoader(Block denseBlock, Type type, boolean[] valueIsNonNull)
+        {
+            this.denseBlock = requireNonNull(denseBlock, "denseBlock is null");
+            this.type = requireNonNull(type, "type is null");
+            this.valueIsNonNull = requireNonNull(valueIsNonNull, "valueIsNonNull");
+        }
+
+        @Override
+        public Block load()
+        {
+            Block loadedDenseBlock = denseBlock.getLoadedBlock();
+            BlockBuilder unpackedBlock = type.createBlockBuilder(null, valueIsNonNull.length);
+
+            int denseBlockPosition = 0;
+            for (boolean isNonNull : valueIsNonNull) {
+                if (isNonNull) {
+                    type.appendTo(loadedDenseBlock, denseBlockPosition++, unpackedBlock);
+                }
+                else {
+                    unpackedBlock.appendNull();
+                }
+            }
+            checkState(denseBlockPosition == loadedDenseBlock.getPositionCount(), "inconsistency between denseBlock and valueIsNonNull");
+            return unpackedBlock.build();
+        }
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/stream/ValueStreams.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/stream/ValueStreams.java
@@ -73,6 +73,8 @@ public final class ValueStreams
                     return createLongStream(new OrcInputStream(chunkLoader), encoding, true);
                 case DECIMAL:
                     return new DecimalInputStream(chunkLoader);
+                case UNION:
+                    return new ByteInputStream(new OrcInputStream(chunkLoader));
             }
         }
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestReadUniontype.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestReadUniontype.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import io.prestosql.tempto.AfterTestWithContext;
+import io.prestosql.tempto.BeforeTestWithContext;
+import io.prestosql.tempto.query.QueryResult;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.prestosql.tests.TestGroups.SMOKE;
+import static io.prestosql.tests.utils.QueryExecutors.onHive;
+import static io.prestosql.tests.utils.QueryExecutors.onPresto;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestReadUniontype
+        extends HiveProductTest
+{
+    private static final String TABLE_NAME = "test_read_uniontype";
+
+    @BeforeTestWithContext
+    @AfterTestWithContext
+    public void cleanup()
+    {
+        onHive().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+    }
+
+    @DataProvider(name = "storage_formats")
+    public static Object[][] storageFormats()
+    {
+        return new String[][] {{"ORC"}, {"AVRO"}};
+    }
+
+    private void createTestTable(String storageFormat)
+    {
+        cleanup();
+        onHive().executeQuery(format(
+                "CREATE TABLE %s (id INT,foo UNIONTYPE<" +
+                        "INT," +
+                        "DOUBLE," +
+                        "ARRAY<STRING>>)" +
+                        "STORED AS %s",
+                TABLE_NAME,
+                storageFormat));
+    }
+
+    @Test(dataProvider = "storage_formats", groups = SMOKE)
+    public void testReadUniontype(String storageFormat)
+    {
+        // According to testing results, the Hive INSERT queries here only work in Hive 1.2
+        if (getHiveVersionMajor() != 1 || getHiveVersionMinor() != 2) {
+            throw new SkipException("This test can only be run with Hive 1.2 (default config)");
+        }
+        createTestTable(storageFormat);
+        // Generate a file with rows:
+        //   0, {0: 36}
+        //   1, {1: 7.2}
+        //   2, {2: ['foo', 'bar']}
+        //   3, {1: 10.8}
+        //   4, {0: 144}
+        //   5, {2: ['hello']
+        onHive().executeQuery(format(
+                "INSERT INTO TABLE %s " +
+                        "SELECT 0, create_union(0, CAST(36 AS INT), CAST(NULL AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 1, create_union(1, CAST(NULL AS INT), CAST(7.2 AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 2, create_union(2, CAST(NULL AS INT), CAST(NULL AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 3, create_union(1, CAST(NULL AS INT), CAST(10.8 AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 4, create_union(0, CAST(144 AS INT), CAST(NULL AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 5, create_union(2, CAST(NULL AS INT), CAST(NULL AS DOUBLE), ARRAY('hello', 'world'))",
+                TABLE_NAME));
+        // Generate a file with rows:
+        //    6, {0: 180}
+        //    7, {1: 21.6}
+        //    8, {0: 252}
+        onHive().executeQuery(format(
+                "INSERT INTO TABLE %s " +
+                        "SELECT 6, create_union(0, CAST(180 AS INT), CAST(NULL AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 7, create_union(1, CAST(NULL AS INT), CAST(21.6 AS DOUBLE), ARRAY('foo','bar')) " +
+                        "UNION ALL " +
+                        "SELECT 8, create_union(0, CAST(252 AS INT), CAST(NULL AS DOUBLE), ARRAY('foo','bar'))",
+                TABLE_NAME));
+        QueryResult selectAllResult = onPresto().executeQuery(format("SELECT * FROM %s", TABLE_NAME));
+        assertEquals(selectAllResult.rows().size(), 9);
+        for (List<?> row : selectAllResult.rows()) {
+            int id = (Integer) row.get(0);
+            switch (id) {
+                case 0:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 0, 36, null, null});
+                    break;
+                case 1:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 1, null, 7.2D, null});
+                    break;
+                case 2:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 2, null, null, Arrays.asList("foo", "bar")});
+                    break;
+                case 3:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 1, null, 10.8D, null});
+                    break;
+                case 4:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 0, 144, null, null});
+                    break;
+                case 5:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 2, null, null, Arrays.asList("hello", "world")});
+                    break;
+                case 6:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 0, 180, null, null});
+                    break;
+                case 7:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 1, null, 21.6, null});
+                    break;
+                case 8:
+                    assertStructEquals(row.get(1), new Object[] {(byte) 0, 252, null, null});
+                    break;
+            }
+        }
+    }
+
+    private static void assertStructEquals(Object actual, Object[] expected)
+    {
+        assertTrue(actual instanceof LinkedHashMap);
+        Map<String, Object> actualStruct = (LinkedHashMap<String, Object>) actual;
+        assertEquals(actualStruct.size(), expected.length);
+        int i = 0;
+        for (Object fieldValue : actualStruct.values()) {
+            assertEquals(fieldValue, expected[i++]);
+        }
+    }
+}


### PR DESCRIPTION
Reading uniontypes by converting them into structs. Take type
"uniontype<int, double>" as an example:
1. It will be regarded as "struct<tag int, field0 int, field1 string>"
2. Data {1: 'hello'}, {0: 312}, {1: 'world'} will be read as [1, NULL,
   'hello'], [0, 312, NULL], [1, NULL, 'world']

Writing into uniontypes remains unsupported.

(Note: support for Parquet is not added because Parquet itself doesn't support union types yet.)

Closes #1751 