### PR TITLE
Ignore asList(expression) warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Enable the following inspections:
 
 Disable the following inspections:
 
+- ``Java | Performance | Call to 'Arrays.asList()' with too few arguments``,
 - ``Java | Abstraction issues | 'Optional' used as field or parameter type``.
 
 ### Building the Web UI


### PR DESCRIPTION
`asList` is usually used to construct nullable test data (we prefer
`ImmutableList.of` in general). As such, it's common that `asList()` or
`asList(expression)` call is next to `asList(expr1, expr2, ...)`.