### PR TITLE
Add session property for hive projection pushdown

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -129,6 +129,8 @@ public class HiveConfig
     private boolean queryPartitionFilterRequired;
     private boolean partitionUseColumnNames;
 
+    private boolean projectionPushdownEnabled = true;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -920,6 +922,19 @@ public class HiveConfig
     public HiveConfig setPartitionUseColumnNames(boolean partitionUseColumnNames)
     {
         this.partitionUseColumnNames = partitionUseColumnNames;
+        return this;
+    }
+
+    public boolean isProjectionPushdownEnabled()
+    {
+        return projectionPushdownEnabled;
+    }
+
+    @Config("hive.projection-pushdown-enabled")
+    @ConfigDescription("Projection pushdown into hive is enabled through applyProjection")
+    public HiveConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
+    {
+        this.projectionPushdownEnabled = projectionPushdownEnabled;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -163,6 +163,7 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.isBucketExecutionEn
 import static io.prestosql.plugin.hive.HiveSessionProperties.isCollectColumnStatisticsOnWrite;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isCreateEmptyBucketFiles;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOptimizedMismatchedBucketCount;
+import static io.prestosql.plugin.hive.HiveSessionProperties.isProjectionPushdownEnabled;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isRespectTableFormat;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isSortedWritingEnabled;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isStatisticsEnabled;
@@ -1968,6 +1969,10 @@ public class HiveMetadata
             List<ConnectorExpression> projections,
             Map<String, ColumnHandle> assignments)
     {
+        if (!isProjectionPushdownEnabled(session)) {
+            return Optional.empty();
+        }
+
         // Create projected column representations for supported sub expressions. Simple column references and chain of
         // dereferences on a variable are supported right now.
         Set<ConnectorExpression> projectedExpressions = projections.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -89,6 +89,7 @@ public final class HiveSessionProperties
     private static final String TEMPORARY_STAGING_DIRECTORY_PATH = "temporary_staging_directory_path";
     private static final String IGNORE_ABSENT_PARTITIONS = "ignore_absent_partitions";
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
+    private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -357,6 +358,11 @@ public final class HiveSessionProperties
                         QUERY_PARTITION_FILTER_REQUIRED,
                         "Require filter on partition column",
                         hiveConfig.isQueryPartitionFilterRequired(),
+                        false),
+                booleanProperty(
+                        PROJECTION_PUSHDOWN_ENABLED,
+                        "Projection push down enabled for hive",
+                        hiveConfig.isProjectionPushdownEnabled(),
                         false));
     }
 
@@ -612,5 +618,10 @@ public final class HiveSessionProperties
     public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
     {
         return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
+    }
+
+    public static boolean isProjectionPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -93,7 +93,8 @@ public class TestHiveConfig
                 .setHiveTransactionHeartbeatThreads(5)
                 .setAllowRegisterPartition(false)
                 .setQueryPartitionFilterRequired(false)
-                .setPartitionUseColumnNames(false));
+                .setPartitionUseColumnNames(false)
+                .setProjectionPushdownEnabled(true));
     }
 
     @Test
@@ -160,6 +161,7 @@ public class TestHiveConfig
                 .put("hive.allow-register-partition-procedure", "true")
                 .put("hive.query-partition-filter-required", "true")
                 .put("hive.partition-use-column-names", "true")
+                .put("hive.projection-pushdown-enabled", "false")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -222,7 +224,8 @@ public class TestHiveConfig
                 .setHiveTransactionHeartbeatThreads(10)
                 .setAllowRegisterPartition(true)
                 .setQueryPartitionFilterRequired(true)
-                .setPartitionUseColumnNames(true);
+                .setPartitionUseColumnNames(true)
+                .setProjectionPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -155,7 +155,6 @@ public class TestConnectorPushdownRulesWithHive
                                     table,
                                     ImmutableList.of(p.symbol("struct_of_int", baseType)),
                                     ImmutableMap.of(p.symbol("struct_of_int", baseType), fullColumn))))
-                .withSession(HIVE_SESSION)
                 .doesNotFire();
 
         // Test Dereference pushdown
@@ -168,7 +167,6 @@ public class TestConnectorPushdownRulesWithHive
                                         table,
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
                                         ImmutableMap.of(p.symbol("struct_of_int", baseType), fullColumn))))
-                .withSession(HIVE_SESSION)
                 .matches(project(
                         ImmutableMap.of("expr_deref", expression(new SymbolReference("struct_of_int#a"))),
                         tableScan(


### PR DESCRIPTION
Adding a session property for controlling the projection pushdown in hive. It'll be enabled by default, but will make it easy to revert this feature. cc @martint 