### PR TITLE
Allow SqlExecutor to throw SQLException

### DIFF
--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.function.Function;
@@ -224,6 +225,7 @@ public class TestMySqlTypeMapping
 
     @Test
     public void testDecimalExceedingPrecisionMax()
+            throws SQLException
     {
         testUnsupportedDataType("decimal(50,0)");
     }
@@ -465,6 +467,7 @@ public class TestMySqlTypeMapping
     }
 
     private void testUnsupportedDataType(String databaseDataType)
+            throws SQLException
     {
         SqlExecutor jdbcSqlExecutor = mysqlServer::execute;
         jdbcSqlExecutor.execute(format("CREATE TABLE tpch.test_unsupported_data_type(supported_column varchar(5), unsupported_column %s)", databaseDataType));

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestingMySqlServer.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestingMySqlServer.java
@@ -35,7 +35,12 @@ public class TestingMySqlServer
         super(dockerImageName);
         withDatabaseName("tpch");
         start();
-        execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", getUsername()), "root", getPassword());
+        try {
+            execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", getUsername()), "root", getPassword());
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -45,18 +50,16 @@ public class TestingMySqlServer
     }
 
     public void execute(String sql)
+            throws SQLException
     {
         execute(sql, getUsername(), getPassword());
     }
 
     public void execute(String sql, String user, String password)
+            throws SQLException
     {
-        try (Connection connection = DriverManager.getConnection(getJdbcUrl(), user, password);
-                Statement statement = connection.createStatement()) {
-            statement.execute(sql);
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        Connection connection = DriverManager.getConnection(getJdbcUrl(), user, password);
+        Statement statement = connection.createStatement();
+        statement.execute(sql);
     }
 }

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.SQLException;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -157,6 +158,7 @@ public class TestPostgreSqlTypeMapping
 
     @BeforeClass
     public void setUp()
+            throws SQLException
     {
         checkIsGap(jvmZone, timeGapInJvmZone1);
         checkIsGap(jvmZone, timeGapInJvmZone2);
@@ -314,6 +316,7 @@ public class TestPostgreSqlTypeMapping
 
     @Test
     public void testForcedMappingToVarchar()
+            throws SQLException
     {
         JdbcSqlExecutor jdbcSqlExecutor = new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl());
         jdbcSqlExecutor.execute("CREATE TABLE tpch.test_forced_varchar_mapping(tsrange_col tsrange, inet_col inet, tsrange_arr_col tsrange[], unsupported_nonforced_column tstzrange)");
@@ -915,6 +918,7 @@ public class TestPostgreSqlTypeMapping
 
     @Test
     public void testEnum()
+            throws SQLException
     {
         JdbcSqlExecutor jdbcSqlExecutor = new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl());
         jdbcSqlExecutor.execute("CREATE TYPE enum_t AS ENUM ('a','b','c')");

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndInsertDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndInsertDataSetup.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import io.prestosql.testing.sql.SqlExecutor;
 import io.prestosql.testing.sql.TestTable;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -45,7 +46,7 @@ public class CreateAndInsertDataSetup
         }
         catch (Exception e) {
             closeQuietly(testTable);
-            throw e;
+            throw new RuntimeException(e);
         }
         return testTable;
     }
@@ -61,6 +62,7 @@ public class CreateAndInsertDataSetup
     }
 
     private void insertRows(TestTable testTable, List<DataTypeTest.Input<?>> inputs)
+            throws SQLException
     {
         Stream<String> literals = inputs.stream()
                 .map(DataTypeTest.Input::toLiteral);

--- a/presto-testing/src/main/java/io/prestosql/testing/sql/JdbcSqlExecutor.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/sql/JdbcSqlExecutor.java
@@ -41,13 +41,10 @@ public class JdbcSqlExecutor
 
     @Override
     public void execute(String sql)
+            throws SQLException
     {
-        try (Connection connection = DriverManager.getConnection(jdbcUrl, jdbcProperties);
-                Statement statement = connection.createStatement()) {
-            statement.execute(sql);
-        }
-        catch (SQLException e) {
-            throw new RuntimeException("Error executing sql:\n" + sql, e);
-        }
+        Connection connection = DriverManager.getConnection(jdbcUrl, jdbcProperties);
+        Statement statement = connection.createStatement();
+        statement.execute(sql);
     }
 }

--- a/presto-testing/src/main/java/io/prestosql/testing/sql/SqlExecutor.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/sql/SqlExecutor.java
@@ -13,7 +13,9 @@
  */
 package io.prestosql.testing.sql;
 
+import java.sql.SQLException;
+
 public interface SqlExecutor
 {
-    void execute(String sql);
+    void execute(String sql) throws SQLException;
 }


### PR DESCRIPTION
Suggestion from @findepi to add a checked SQLException to `SqlExecutor#execute`.