### PR TITLE
Presto Druid connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
             !presto-sqlserver,!presto-postgresql,!presto-mysql,
             !presto-oracle,
             !presto-kudu,
-            !presto-phoenix,!presto-iceberg,
+            !presto-phoenix,!presto-iceberg,!presto-druid,
             !presto-docs,!presto-server,!presto-server-rpm'
 
   test:
@@ -177,7 +177,7 @@ jobs:
           - "presto-sqlserver,presto-postgresql,presto-mysql"
           - "presto-oracle"
           - "presto-kudu"
-          - "presto-phoenix,presto-iceberg"
+          - "presto-phoenix,presto-iceberg,presto-druid"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <module>presto-bigquery</module>
         <module>presto-pinot</module>
         <module>presto-oracle</module>
+        <module>presto-druid</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -249,6 +250,12 @@ public class BaseJdbcClient
             int allColumns = 0;
             List<JdbcColumnHandle> columns = new ArrayList<>();
             while (resultSet.next()) {
+                // skip if table doesn't match expected
+                if (!(Objects.equals(tableHandle.getCatalogName(), resultSet.getString("TABLE_CAT"))
+                        && Objects.equals(tableHandle.getSchemaName(), resultSet.getString("TABLE_SCHEM"))
+                        && Objects.equals(tableHandle.getTableName(), resultSet.getString("TABLE_NAME")))) {
+                    continue;
+                }
                 allColumns++;
                 String columnName = resultSet.getString("COLUMN_NAME");
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
@@ -290,7 +297,7 @@ public class BaseJdbcClient
         }
     }
 
-    protected static ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
+    protected ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
             throws SQLException
     {
         return metadata.getColumns(

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -156,7 +156,7 @@ public class QueryBuilder
     protected String getProjection(List<JdbcColumnHandle> columns)
     {
         if (columns.isEmpty()) {
-            return "null";
+            return "1";
         }
         return columns.stream()
                 .map(JdbcColumnHandle::getColumnName)

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prestosql</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>337-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-druid</artifactId>
+    <description>Presto - Druid Jdbc Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Druid JDBC Connector -->
+        <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica-core</artifactId>
+            <version>1.16.0</version>
+            <!-- Excluded as they bring in duplicate classes -->
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <!-- SPI -->
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.14.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidErrorCode.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidErrorCode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import io.prestosql.spi.ErrorCode;
+import io.prestosql.spi.ErrorCodeSupplier;
+import io.prestosql.spi.ErrorType;
+
+import static io.prestosql.spi.ErrorType.EXTERNAL;
+
+public enum DruidErrorCode
+        implements ErrorCodeSupplier
+{
+    DRUID_DDL_NOT_SUPPORTED(0, EXTERNAL),
+    DRUID_DML_NOT_SUPPORTED(1, EXTERNAL);
+
+    private final ErrorCode errorCode;
+
+    DruidErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0510_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return null;
+    }
+}

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.jdbc.BaseJdbcClient;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ColumnMapping;
+import io.prestosql.plugin.jdbc.ConnectionFactory;
+import io.prestosql.plugin.jdbc.JdbcColumnHandle;
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
+import io.prestosql.plugin.jdbc.JdbcSplit;
+import io.prestosql.plugin.jdbc.JdbcTableHandle;
+import io.prestosql.plugin.jdbc.JdbcTypeHandle;
+import io.prestosql.plugin.jdbc.QueryBuilder;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.type.VarcharType;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
+import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.prestosql.spi.type.VarcharType.createVarcharType;
+
+public class DruidJdbcClient
+        extends BaseJdbcClient
+{
+    // Druid maintains its datasources related metadata by setting the catalog name as "druid"
+    // Note that while a user may name the catalog name as something else, metadata queries made
+    // to druid will always have the TABLE_CATALOG set to DRUID_CATALOG
+    private static final String DRUID_CATALOG = "druid";
+    // All the datasources in Druid are created under schema "druid"
+    public static final String DRUID_SCHEMA = "druid";
+
+    @Inject
+    public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
+            throws SQLException
+    {
+        super(config, "\"", connectionFactory);
+    }
+
+    @Override
+    protected Collection<String> listSchemas(Connection connection)
+    {
+        return ImmutableList.of(DRUID_SCHEMA);
+    }
+
+    //Overridden to filter out tables that don't match schemaTableName
+    @Override
+    public Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String jdbcSchemaName = schemaTableName.getSchemaName();
+            String jdbcTableName = schemaTableName.getTableName();
+            try (ResultSet resultSet = getTables(connection, Optional.of(jdbcSchemaName), Optional.of(jdbcTableName))) {
+                List<JdbcTableHandle> tableHandles = new ArrayList<>();
+                while (resultSet.next()) {
+                    tableHandles.add(new JdbcTableHandle(
+                            schemaTableName,
+                            DRUID_CATALOG,
+                            resultSet.getString("TABLE_SCHEM"),
+                            resultSet.getString("TABLE_NAME")));
+                }
+                if (tableHandles.isEmpty()) {
+                    return Optional.empty();
+                }
+                return Optional.of(
+                        getOnlyElement(
+                                tableHandles
+                                        .stream()
+                                        .filter(
+                                                jdbcTableHandle ->
+                                                        Objects.equals(jdbcTableHandle.getSchemaName(), schemaTableName.getSchemaName())
+                                                                && Objects.equals(jdbcTableHandle.getTableName(), schemaTableName.getTableName()))
+                                        .collect(Collectors.toList())));
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /*
+     * Overridden since the {@link BaseJdbcClient#getTables(Connection, Optional, Optional)}
+     * method uses character escaping that doesn't work well with Druid's Avatica handler.
+     * Unfortunately, because we can't escape search characters like '_' and '%", this call
+     * ends up retrieving metadata for all tables that match the search
+     * pattern. For ex - LIKE some_table matches somertable, somextable and some_table.
+     *
+     * See getTableHandle(JdbcIdentity, SchemaTableName)} to look at
+     * how tables are filtered.
+     */
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getTables(DRUID_CATALOG,
+                DRUID_SCHEMA,
+                tableName.orElse(null),
+                null);
+    }
+
+    @Override
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        switch (typeHandle.getJdbcType()) {
+            case Types.VARCHAR:
+                int columnSize = typeHandle.getColumnSize();
+                if (columnSize > VarcharType.MAX_LENGTH || columnSize == -1) {
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType()));
+                }
+                return Optional.of(varcharColumnMapping(createVarcharType(columnSize)));
+        }
+        return super.toPrestoType(session, connection, typeHandle);
+    }
+
+    // Druid doesn't like table names to be qualified with catalog names in the SQL query.
+    // Hence, overriding this method to pass catalog as null.
+    @Override
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+            throws SQLException
+    {
+        String schemaName = table.getSchemaName();
+        checkArgument("druid".equals(schemaName), "Only \"druid\" schema is supported");
+        return new QueryBuilder(identifierQuote)
+                .buildSql(
+                        this,
+                        session,
+                        connection,
+                        null,
+                        schemaName,
+                        table.getTableName(),
+                        columns,
+                        table.getConstraint(),
+                        split.getAdditionalPredicate(),
+                        tryApplyLimit(table.getLimit()));
+    }
+
+    /*
+     * Overridden since the {@link BaseJdbcClient#getColumns(JdbcTableHandle, DatabaseMetaData)}
+     * method uses character escaping that doesn't work well with Druid's Avatica handler.
+     * Unfortunately, because we can't escape search characters like '_' and '%",
+     * this call ends up retrieving columns for all tables that match the search
+     * pattern. For ex - LIKE some_table matches somertable, somextable and some_table.
+     *
+     * See getColumns(ConnectorSession, JdbcTableHandle)} to look at tables are filtered.
+     */
+    @Override
+    protected ResultSet getColumns(JdbcTableHandle tableHandle, DatabaseMetaData metadata)
+            throws SQLException
+    {
+        return metadata.getColumns(
+                tableHandle.getCatalogName(),
+                tableHandle.getSchemaName(),
+                tableHandle.getTableName(),
+                null);
+    }
+
+    @Override
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
+    {
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
+    }
+
+    @Override
+    public boolean isLimitGuaranteed(ConnectorSession session)
+    {
+        return true;
+    }
+
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public JdbcOutputTableHandle beginInsertTable(ConnectorSession session, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columns)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DML_NOT_SUPPORTED, "DML operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void dropTable(JdbcIdentity identity, JdbcTableHandle handle)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public String buildInsertSql(JdbcOutputTableHandle handle)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DML_NOT_SUPPORTED, "DML operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void createSchema(JdbcIdentity identity, String schemaName)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+
+    @Override
+    public void dropSchema(JdbcIdentity identity, String schemaName)
+    {
+        throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
+    }
+}

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClientModule.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClientModule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ConnectionFactory;
+import io.prestosql.plugin.jdbc.DriverConnectionFactory;
+import io.prestosql.plugin.jdbc.ForBaseJdbc;
+import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.credential.CredentialProvider;
+import org.apache.calcite.avatica.remote.Driver;
+
+import java.util.Properties;
+
+public class DruidJdbcClientModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(DruidJdbcClient.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider)
+    {
+        Properties connectionProperties = new Properties();
+        return new DriverConnectionFactory(
+                new Driver(),
+                config.getConnectionUrl(),
+                connectionProperties,
+                credentialProvider);
+    }
+}

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcPlugin.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcPlugin.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import io.prestosql.plugin.jdbc.JdbcPlugin;
+
+public class DruidJdbcPlugin
+        extends JdbcPlugin
+{
+    public DruidJdbcPlugin()
+    {
+        super("druid", new DruidJdbcClientModule());
+    }
+}

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/DruidQueryRunner.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/DruidQueryRunner.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import io.prestosql.Session;
+import io.prestosql.plugin.tpch.TpchPlugin;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.MaterializedRow;
+import io.prestosql.testing.QueryRunner;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class DruidQueryRunner
+{
+    private DruidQueryRunner() {}
+
+    public static QueryRunner createDruidQueryRunnerTpch(TestingDruidServer testingDruidServer)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(createSession()).setNodeCount(3).build();
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            Map<String, String> connectorProperties = new HashMap<>();
+            connectorProperties.putIfAbsent("connection-url", testingDruidServer.getJdbcUrl());
+            queryRunner.installPlugin(new DruidJdbcPlugin());
+            queryRunner.createCatalog("druid", "druid", connectorProperties);
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    public static void copyAndIngestTpchData(MaterializedResult rows, TestingDruidServer testingDruidServer, String druidDatasource)
+            throws IOException, InterruptedException
+    {
+        String tsvFileLocation = String.format("%s/%s.tsv", testingDruidServer.getHostWorkingDirectory(), druidDatasource);
+        writeDataAsTsv(rows, tsvFileLocation);
+        testingDruidServer.ingestData(druidDatasource, getIngestionSpecFileName(druidDatasource), tsvFileLocation);
+    }
+
+    private static String getIngestionSpecFileName(String datasource)
+    {
+        return String.format("druid-tpch-ingest-%s.json", datasource);
+    }
+
+    private static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("druid")
+                .setSchema("druid")
+                .build();
+    }
+
+    private static void writeDataAsTsv(MaterializedResult rows, String dataFile)
+            throws IOException
+    {
+        File file = new File(dataFile);
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+            for (MaterializedRow row : rows.getMaterializedRows()) {
+                bw.write(convertToTSV(row.getFields()));
+                bw.newLine();
+            }
+        }
+    }
+
+    private static String convertToTSV(List<Object> data)
+    {
+        return data.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining("\t"));
+    }
+}

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTest.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.plugin.jdbc.JdbcTableHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.assertions.Assert;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static io.prestosql.plugin.druid.DruidQueryRunner.copyAndIngestTpchData;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.tpch.TpchTable.ORDERS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test
+public class TestDruidIntegrationSmokeTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    private static final String SELECT_FROM_ORDERS = "SELECT " +
+            "orderdate, " +
+            "orderdate AS orderdate_druid_ts, " + // Druid stores the orderdate_druid_ts column as __time column.
+            "orderkey, " +
+            "custkey, " +
+            "orderstatus, " +
+            "totalprice, " +
+            "orderpriority, " +
+            "clerk, " +
+            "shippriority, " +
+            "comment " +
+            "FROM tpch.tiny.orders";
+    private TestingDruidServer druidServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.druidServer = new TestingDruidServer();
+        QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer);
+        copyAndIngestTpchData(runner.execute(SELECT_FROM_ORDERS), this.druidServer, ORDERS.getTableName());
+        return runner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        if (druidServer != null) {
+            druidServer.close();
+        }
+    }
+
+    @Test
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "varchar", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice", "double", "", "")
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE orders");
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Test
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo("CREATE TABLE druid.druid.orders (\n" +
+                        "   __time timestamp(3) NOT NULL,\n" +
+                        "   clerk varchar,\n" +
+                        "   comment varchar,\n" +
+                        "   custkey bigint NOT NULL,\n" +
+                        "   orderdate varchar,\n" +
+                        "   orderkey bigint NOT NULL,\n" +
+                        "   orderpriority varchar,\n" +
+                        "   orderstatus varchar,\n" +
+                        "   shippriority bigint NOT NULL,\n" +
+                        "   totalprice double NOT NULL\n" +
+                        ")");
+    }
+
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll(".$", "_");
+
+        @Language("SQL") String ordersTableWithColumns = "VALUES " +
+                "('orders', 'orderkey'), " +
+                "('orders', 'custkey'), " +
+                "('orders', 'orderstatus'), " +
+                "('orders', 'totalprice'), " +
+                "('orders', 'orderdate'), " +
+                "('orders', '__time'), " +
+                "('orders', 'orderpriority'), " +
+                "('orders', 'clerk'), " +
+                "('orders', 'shippriority'), " +
+                "('orders', 'comment')";
+
+        assertQuery("SELECT table_schema FROM information_schema.columns WHERE table_schema = '" + schema + "' GROUP BY table_schema", "VALUES '" + schema + "'");
+        assertQuery("SELECT table_name FROM information_schema.columns WHERE table_name = 'orders' GROUP BY table_name", "VALUES 'orders'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'orders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name LIKE '%rders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '_rder_'", ordersTableWithColumns);
+        assertQuery(
+                "SELECT table_name, column_name FROM information_schema.columns " +
+                        "WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '%orders%'",
+                ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+    }
+
+    @Test
+    @Override
+    public void testSelectAll()
+    {
+        // List columns explicitly, as Druid has an additional __time column
+        assertQuery("SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment  FROM orders");
+    }
+
+    @Test
+    @Override
+    // nation, region, customer tables don't have any date/time in the rows.
+    // For a table to be ingested into Druid, a date/time/timestamp column is required.
+    //TODO: This test needs to be adjusted to possibly join between lineitems and orders datasources
+    public void testJoin()
+    {
+        assertThatThrownBy(super::testJoin)
+                .hasRootCauseMessage("line 1:36: Table 'druid.druid.nation' does not exist");
+    }
+
+    /**
+     * This test verifies that the filtering we have in place to overcome Druid's limitation of
+     * not handling the escaping of search characters like % and _, works correctly.
+     * <p>
+     * See {@link DruidJdbcClient#getTableHandle(JdbcIdentity, SchemaTableName)} and
+     * {@link DruidJdbcClient#getColumns(ConnectorSession, JdbcTableHandle)}
+     */
+    @Test
+    public void testFilteringForTablesAndColumns()
+            throws Exception
+    {
+        String sql = SELECT_FROM_ORDERS + " LIMIT 10";
+        String datasourceA = "some_table";
+        MaterializedResult materializedRows = getQueryRunner().execute(sql);
+        copyAndIngestTpchData(materializedRows, druidServer, datasourceA);
+        String datasourceB = "somextable";
+        copyAndIngestTpchData(materializedRows, druidServer, datasourceB);
+
+        // Assert that only columns from datsourceA are returned
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "varchar", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice", "double", "", "")
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE " + datasourceA);
+        Assert.assertEquals(actualColumns, expectedColumns);
+
+        // Assert that only columns from datsourceB are returned
+        expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk_x", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment_x", "varchar", "", "")
+                .row("custkey_x", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate_x", "varchar", "", "")
+                .row("orderkey_x", "bigint", "", "")
+                .row("orderpriority_x", "varchar", "", "")
+                .row("orderstatus_x", "varchar", "", "")
+                .row("shippriority_x", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice_x", "double", "", "")
+                .build();
+        actualColumns = computeActual("DESCRIBE " + datasourceB);
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+}

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidJdbcPlugin.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidJdbcPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.Plugin;
+import io.prestosql.spi.connector.ConnectorFactory;
+import io.prestosql.testing.TestingConnectorContext;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestDruidJdbcPlugin
+{
+    @Test
+    public void testCreateConnector()
+    {
+        Plugin plugin = new DruidJdbcPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("connection-url", "test"), new TestingConnectorContext());
+    }
+}

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestingDruidServer.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestingDruidServer.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Closer;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.Resources;
+import io.prestosql.testing.assertions.Assert;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.shaded.okhttp3.OkHttpClient;
+import org.testcontainers.shaded.okhttp3.Request;
+import org.testcontainers.shaded.okhttp3.RequestBody;
+import org.testcontainers.shaded.okhttp3.Response;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.common.io.Resources.getResource;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+public class TestingDruidServer
+        implements Closeable
+{
+    private final String hostWorkingDirectory;
+    private final GenericContainer broker;
+    private final GenericContainer coordinator;
+    private final GenericContainer historical;
+    private final GenericContainer middleManager;
+    private final GenericContainer zookeeper;
+    private final OkHttpClient httpClient;
+
+    private static final int DRUID_COORDINATOR_PORT = 8081;
+    private static final int DRUID_BROKER_PORT = 8082;
+    private static final int DRUID_HISTORICAL_PORT = 8083;
+    private static final int DRUID_MIDDLE_MANAGER_PORT = 8091;
+
+    private static final String DRUID_DOCKER_IMAGE = "apache/druid:0.18.0";
+
+    public TestingDruidServer()
+    {
+        try {
+            // Cannot use Files.createTempDirectory() because on Mac by default it uses
+            // /var/folders/ which is not visible to Docker for Mac
+            hostWorkingDirectory = Files.createDirectory(
+                    Paths.get("/tmp/docker-tests-files-" + randomUUID().toString()))
+                    .toAbsolutePath().toString();
+            File f = new File(hostWorkingDirectory);
+            // Enable read/write/exec access for the services running in containers
+            f.setWritable(true, false);
+            f.setReadable(true, false);
+            f.setExecutable(true, false);
+            this.httpClient = new OkHttpClient();
+            Network network = Network.newNetwork();
+            this.zookeeper = new GenericContainer("zookeeper")
+                    .withNetwork(network)
+                    .withNetworkAliases("zookeeper")
+                    .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                    .waitingFor(Wait.forListeningPort());
+            zookeeper.start();
+
+            this.coordinator = new GenericContainer(DRUID_DOCKER_IMAGE)
+                    .withExposedPorts(DRUID_COORDINATOR_PORT)
+                    .withNetwork(network)
+                    .withCommand("coordinator")
+                    .withWorkingDirectory("/opt/druid")
+                    .withFileSystemBind(hostWorkingDirectory, "/opt/druid/var", BindMode.READ_WRITE)
+                    .dependsOn(zookeeper)
+                    .withCopyFileToContainer(
+                            forClasspathResource("common.runtime.properties"),
+                            "/opt/druid/conf/druid/cluster/_common/common.runtime.properties")
+                    .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                    .withCopyFileToContainer(
+                            forClasspathResource("druid-coordinator.config"),
+                            "/opt/druid/conf/druid/cluster/master/coordinator-overlord/runtime.properties")
+                    .withCopyFileToContainer(
+                            forClasspathResource("druid-coordinator-jvm.config"),
+                            "/opt/druid/conf/druid/cluster/master/coordinator-overlord/jvm.config")
+                    .waitingFor(Wait.forHttp("/status/selfDiscovered"));
+            coordinator.start();
+
+            this.broker = new GenericContainer(DRUID_DOCKER_IMAGE)
+                    .withExposedPorts(DRUID_BROKER_PORT)
+                    .withNetwork(network)
+                    .withCommand("broker")
+                    .withWorkingDirectory("/opt/druid")
+                    .dependsOn(zookeeper, coordinator)
+                    .withFileSystemBind(hostWorkingDirectory, "/opt/druid/var", BindMode.READ_WRITE)
+                    .withCopyFileToContainer(
+                            forClasspathResource("common.runtime.properties"),
+                            "/opt/druid/conf/druid/cluster/_common/common.runtime.properties")
+                    .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                    .withCopyFileToContainer(
+                            forClasspathResource("broker.config"),
+                            "/opt/druid/conf/druid/cluster/query/broker/runtime.properties")
+                    .withCopyFileToContainer(
+                            forClasspathResource("broker-jvm.config"),
+                            "/opt/druid/conf/druid/cluster/query/broker/jvm.config")
+                    .waitingFor(Wait.forHttp("/status/selfDiscovered"));
+            broker.start();
+
+            this.historical = new GenericContainer(DRUID_DOCKER_IMAGE)
+                    .withExposedPorts(DRUID_HISTORICAL_PORT)
+                    .withNetwork(network)
+                    .withCommand("historical")
+                    .withWorkingDirectory("/opt/druid")
+                    .dependsOn(zookeeper, coordinator)
+                    .withFileSystemBind(hostWorkingDirectory, "/opt/druid/var", BindMode.READ_WRITE)
+                    .withCopyFileToContainer(
+                            forClasspathResource("common.runtime.properties"),
+                            "/opt/druid/conf/druid/cluster/_common/common.runtime.properties")
+                    .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                    .withCopyFileToContainer(
+                            forClasspathResource("historical.config"),
+                            "/opt/druid/conf/druid/cluster/data/historical/runtime.properties")
+                    .withCopyFileToContainer(
+                            forClasspathResource("historical-jvm.config"),
+                            "/opt/druid/conf/druid/cluster/data/historical/jvm.config")
+                    .waitingFor(Wait.forHttp("/status/selfDiscovered"));
+            historical.start();
+
+            this.middleManager = new GenericContainer(DRUID_DOCKER_IMAGE)
+                    .withExposedPorts(DRUID_MIDDLE_MANAGER_PORT)
+                    .withNetwork(network)
+                    .withCommand("middleManager")
+                    .withWorkingDirectory("/opt/druid")
+                    .dependsOn(zookeeper, coordinator)
+                    .withFileSystemBind(hostWorkingDirectory, "/opt/druid/var", BindMode.READ_WRITE)
+                    .withCopyFileToContainer(
+                            forClasspathResource("common.runtime.properties"),
+                            "/opt/druid/conf/druid/cluster/_common/common.runtime.properties")
+                    .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                    .withCopyFileToContainer(
+                            forClasspathResource("middleManager.config"),
+                            "/opt/druid/conf/druid/cluster/data/middleManager/runtime.properties")
+                    .withCopyFileToContainer(
+                            forClasspathResource("middleManager-jvm.config"),
+                            "/opt/druid/conf/druid/cluster/data/middleManager/jvm.config")
+                    .waitingFor(Wait.forHttp("/status/selfDiscovered"));
+            middleManager.start();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getHostWorkingDirectory()
+    {
+        return hostWorkingDirectory;
+    }
+
+    @Override
+    public void close()
+    {
+        try (Closer closer = Closer.create()) {
+            closer.register(() -> MoreFiles.deleteRecursively(Paths.get(hostWorkingDirectory), ALLOW_INSECURE));
+            closer.register(broker::stop);
+            closer.register(historical::stop);
+            closer.register(middleManager::stop);
+            closer.register(coordinator::stop);
+            closer.register(zookeeper::stop);
+        }
+        catch (FileSystemException e) {
+            // Unfortunately, on CI environment, the user running file deletion runs into
+            // access issues. However, the MoreFiles.deleteRecursively procedure may run successfully
+            // on developer environments. So it makes sense to still have it so that cruft
+            // isn't left behind.
+            // TODO: Once access issues are resolved, remove this catch block.
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getJdbcUrl()
+    {
+        return getJdbcUrl(broker.getMappedPort(DRUID_BROKER_PORT));
+    }
+
+    public int getCoordinatorOverlordPort()
+    {
+        return coordinator.getMappedPort(DRUID_COORDINATOR_PORT);
+    }
+
+    private static String getJdbcUrl(int port)
+    {
+        return format("jdbc:avatica:remote:url=http://localhost:%s/druid/v2/sql/avatica/", port);
+    }
+
+    void ingestData(String datasource, String indexTaskFile, String dataFilePath)
+            throws IOException, InterruptedException
+    {
+        middleManager.withCopyFileToContainer(forHostPath(dataFilePath),
+                getMiddleManagerContainerPathForDataFile(dataFilePath));
+        String indexTask = Resources.toString(getResource(indexTaskFile), Charset.defaultCharset());
+
+        Request.Builder requestBuilder = new Request.Builder();
+        requestBuilder.addHeader("content-type", "application/json;charset=utf-8")
+                .url("http://localhost:" + getCoordinatorOverlordPort() + "/druid/indexer/v1/task")
+                .post(RequestBody.create(null, indexTask));
+        Request ingestionRequest = requestBuilder.build();
+        try (Response ignored = httpClient.newCall(ingestionRequest).execute()) {
+            Assert.assertTrue(checkDatasourceAvailable(datasource), "Datasource " + datasource + " not loaded");
+        }
+    }
+
+    private boolean checkDatasourceAvailable(String datasource)
+            throws IOException, InterruptedException
+    {
+        Map<String, Double> datasourceAvailabilityDetails;
+        boolean datasourceNotLoaded = true;
+        int attempts = 10;
+        while (datasourceNotLoaded && attempts > 0) {
+            Request.Builder requestBuilder = new Request.Builder();
+            requestBuilder.url("http://localhost:" + getCoordinatorOverlordPort() + "/druid/coordinator/v1/loadstatus")
+                    .get();
+            Request datasourceAvailabilityRequest = requestBuilder.build();
+            try (Response response = httpClient.newCall(datasourceAvailabilityRequest).execute()) {
+                ObjectMapper mapper = new ObjectMapper();
+                datasourceAvailabilityDetails = mapper.readValue(response.body().string(), Map.class);
+                datasourceNotLoaded = datasourceAvailabilityDetails.get(datasource) == null || Double.compare(datasourceAvailabilityDetails.get(datasource), 100.0) < 0;
+                if (datasourceNotLoaded) {
+                    attempts--;
+                    // Wait for some time since it can take a while for coordinator to load the ingested segments
+                    Thread.sleep(15000);
+                }
+            }
+        }
+        return !datasourceNotLoaded;
+    }
+
+    private static String getMiddleManagerContainerPathForDataFile(String dataFilePath)
+    {
+        return "/opt/druid/var/" + dataFilePath;
+    }
+}

--- a/presto-druid/src/test/resources/broker-jvm.config
+++ b/presto-druid/src/test/resources/broker-jvm.config
@@ -1,0 +1,10 @@
+-server
+-Xms128m
+-Xmx128m
+-XX:MaxDirectMemorySize=200m
+-XX:+ExitOnOutOfMemoryError
+-XX:+UseG1GC
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/presto-druid/src/test/resources/broker.config
+++ b/presto-druid/src/test/resources/broker.config
@@ -1,0 +1,20 @@
+druid.service=druid/broker
+druid.plaintextPort=8082
+
+# HTTP server settings
+druid.server.http.numThreads=6
+
+# HTTP client settings
+druid.broker.http.numConnections=5
+druid.broker.http.maxQueuedBytes=5000000
+
+# Processing threads and buffers
+druid.processing.buffer.sizeBytes=50000000
+druid.processing.numMergeBuffers=1
+druid.processing.numThreads=1
+
+# Query cache disabled -- push down caching and merging instead
+druid.broker.cache.useCache=false
+druid.broker.cache.populateCache=false
+
+

--- a/presto-druid/src/test/resources/common.runtime.properties
+++ b/presto-druid/src/test/resources/common.runtime.properties
@@ -1,0 +1,109 @@
+druid.extensions.loadList=["druid-hdfs-storage", "druid-kafka-indexing-service", "druid-datasketches"]
+
+#
+# Hostname
+#
+druid.host=localhost
+
+#
+# Logging
+#
+
+# Log all runtime properties on startup. Disable to avoid logging properties on startup:
+druid.startup.logging.logProperties=true
+
+#
+# Zookeeper
+#
+
+druid.zk.service.host=zookeeper
+druid.zk.paths.base=/druid
+
+#
+# Metadata storage
+#
+
+# For Derby server on your Druid Coordinator (only viable in a cluster with a single Coordinator, no fail-over):
+druid.metadata.storage.type=derby
+druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
+druid.metadata.storage.connector.host=localhost
+druid.metadata.storage.connector.port=1527
+
+# For MySQL (make sure to include the MySQL JDBC driver on the classpath):
+#druid.metadata.storage.type=mysql
+#druid.metadata.storage.connector.connectURI=jdbc:mysql://db.example.com:3306/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+# For PostgreSQL:
+#druid.metadata.storage.type=postgresql
+#druid.metadata.storage.connector.connectURI=jdbc:postgresql://db.example.com:5432/druid
+#druid.metadata.storage.connector.user=...
+#druid.metadata.storage.connector.password=...
+
+#
+# Deep storage
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.storage.type=local
+druid.storage.storageDirectory=var/druid/segments
+
+# For HDFS:
+#druid.storage.type=hdfs
+#druid.storage.storageDirectory=/druid/segments
+
+# For S3:
+#druid.storage.type=s3
+#druid.storage.bucket=your-bucket
+#druid.storage.baseKey=druid/segments
+#druid.s3.accessKey=...
+#druid.s3.secretKey=...
+
+#
+# Indexing service logs
+#
+
+# For local disk (only viable in a cluster if this is a network mount):
+druid.indexer.logs.type=file
+druid.indexer.logs.directory=var/druid/indexing-logs
+
+# For HDFS:
+#druid.indexer.logs.type=hdfs
+#druid.indexer.logs.directory=/druid/indexing-logs
+
+# For S3:
+#druid.indexer.logs.type=s3
+#druid.indexer.logs.s3Bucket=your-bucket
+#druid.indexer.logs.s3Prefix=druid/indexing-logs
+
+#
+# Service discovery
+#
+
+druid.selectors.indexing.serviceName=druid/overlord
+druid.selectors.coordinator.serviceName=druid/coordinator
+
+#
+# Monitoring
+#
+
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.emitter=noop
+druid.emitter.logging.logLevel=info
+
+# Storage type of double columns
+# ommiting this will lead to index double as float at the storage layer
+druid.indexing.doubleStorage=double
+#
+# Security
+#
+druid.server.hiddenProperties=["druid.s3.accessKey","druid.s3.secretKey","druid.metadata.storage.connector.password"]
+#
+# SQL
+#
+druid.sql.enable=true
+#
+# Lookups
+#
+druid.lookup.enableLookupSyncOnStartup=false

--- a/presto-druid/src/test/resources/druid-coordinator-jvm.config
+++ b/presto-druid/src/test/resources/druid-coordinator-jvm.config
@@ -1,0 +1,10 @@
+-server
+-Xms128m
+-Xmx128m
+-XX:+ExitOnOutOfMemoryError
+-XX:+UseG1GC
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+-Dderby.stream.error.file=var/druid/derby.log

--- a/presto-druid/src/test/resources/druid-coordinator.config
+++ b/presto-druid/src/test/resources/druid-coordinator.config
@@ -1,0 +1,14 @@
+druid.service=druid/coordinator
+druid.plaintextPort=8081
+
+druid.coordinator.startDelay=PT10S
+druid.coordinator.period=PT1S
+
+# Run the overlord service in the coordinator process
+druid.coordinator.asOverlord.enabled=true
+druid.coordinator.asOverlord.overlordService=druid/overlord
+
+druid.indexer.queue.startDelay=PT5S
+
+druid.indexer.runner.type=remote
+druid.indexer.storage.type=metadata

--- a/presto-druid/src/test/resources/druid-tpch-ingest-lineitem.json
+++ b/presto-druid/src/test/resources/druid-tpch-ingest-lineitem.json
@@ -1,0 +1,100 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "lineitem",
+            "parser": {
+                "type": "string",
+                "parseSpec": {
+                    "format": "tsv",
+                    "timestampSpec": {
+                        "column": "l_shipdate",
+                        "format": "auto"
+                    },
+                    "columns": [
+                        "l_orderkey",
+                        "l_partkey",
+                        "l_suppkey",
+                        "l_linenumber",
+                        "l_quantity",
+                        "l_extendedprice",
+                        "l_discount",
+                        "l_tax",
+                        "l_returnflag",
+                        "l_linestatus",
+                        "l_shipdate",
+                        "l_commitdate",
+                        "l_receiptdate",
+                        "l_shipinstruct",
+                        "l_shipmode",
+                        "l_comment"
+                    ],
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            "l_orderkey",
+                            "l_partkey",
+                            "l_suppkey",
+                            "l_linenumber",
+                            "l_returnflag",
+                            "l_linestatus",
+                            "l_shipdate",
+                            "l_commitdate",
+                            "l_receiptdate",
+                            "l_shipinstruct",
+                            "l_shipmode",
+                            "l_comment"
+                        ]
+                    }
+                }
+            },
+            "metricsSpec": [
+                {
+                    "type": "count",
+                    "name": "count"
+                },
+                {
+                    "type": "longSum",
+                    "fieldName": "l_quantity",
+                    "name": "l_quantity"
+                },
+                {
+                    "type": "doubleSum",
+                    "fieldName": "l_extendedprice",
+                    "name": "l_extendedprice"
+                },
+                {
+                    "type": "doubleSum",
+                    "fieldName": "l_discount",
+                    "name": "l_discount"
+                },
+                {
+                    "type": "doubleSum",
+                    "fieldName": "l_tax",
+                    "name": "l_tax"
+                }
+            ],
+            "granularitySpec": {
+                "type": "uniform",
+                "intervals": [
+                    "1992-01-02/1998-12-01"
+                ],
+                "segmentGranularity": "month",
+                "queryGranularity": "day"
+            }
+        },
+        "ioConfig" : {
+            "type" : "index",
+            "firehose" : {
+                "type" : "local",
+                "baseDir" : "/opt/druid/var/",
+                "filter" : "lineitem.tsv"
+            },
+            "appendToExisting" : false
+        },
+        "tuningConfig" : {
+            "type" : "index",
+            "maxRowsPerSegment" : 5000000,
+            "maxRowsInMemory" : 25000
+        }
+    }
+}

--- a/presto-druid/src/test/resources/druid-tpch-ingest-orders.json
+++ b/presto-druid/src/test/resources/druid-tpch-ingest-orders.json
@@ -1,0 +1,69 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "orders",
+            "parser": {
+                "type": "string",
+                "parseSpec": {
+                    "format": "tsv",
+                    "timestampSpec": {
+                        "column": "orderdate_druid_ts",
+                        "format": "auto"
+                    },
+                    "columns": [
+                        "orderdate",
+                        "orderdate_druid_ts",
+                        "orderkey",
+                        "custkey",
+                        "orderstatus",
+                        "totalprice",
+                        "orderpriority",
+                        "clerk",
+                        "shippriority",
+                        "comment"
+                    ],
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            { "name": "orderdate", "type": "string"},
+                            { "name": "orderkey", "type": "long" },
+                            { "name": "custkey", "type": "long" },
+                            { "name": "orderstatus", "type": "string" },
+                            { "name": "totalprice", "type": "double"},
+                            { "name": "orderpriority", "type": "string" },
+                            { "name": "clerk", "type": "string" },
+                            {"name":  "shippriority", "type": "long"},
+                            { "name": "comment", "type": "string" }
+                        ]
+                    }
+                }
+            },
+            "granularitySpec": {
+                "type": "uniform",
+                "intervals": [
+                    "1992-01-02/1998-12-01"
+                ],
+                "segmentGranularity": "year",
+                "queryGranularity": "day"
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "firehose": {
+                "type": "local",
+                "baseDir": "/opt/druid/var/",
+                "filter": "orders.tsv"
+            },
+            "appendToExisting": false
+        },
+        "tuningConfig": {
+            "type": "index",
+            "maxRowsPerSegment": 5000000,
+            "maxRowsInMemory": 250000,
+            "segmentWriteOutMediumFactory": {
+                "type": "offHeapMemory"
+            }
+        }
+    }
+}
+

--- a/presto-druid/src/test/resources/druid-tpch-ingest-some_table.json
+++ b/presto-druid/src/test/resources/druid-tpch-ingest-some_table.json
@@ -1,0 +1,69 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "some_table",
+            "parser": {
+                "type": "string",
+                "parseSpec": {
+                    "format": "tsv",
+                    "timestampSpec": {
+                        "column": "orderdate_druid_ts",
+                        "format": "auto"
+                    },
+                    "columns": [
+                        "orderdate",
+                        "orderdate_druid_ts",
+                        "orderkey",
+                        "custkey",
+                        "orderstatus",
+                        "totalprice",
+                        "orderpriority",
+                        "clerk",
+                        "shippriority",
+                        "comment"
+                    ],
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            { "name": "orderdate", "type": "string"},
+                            { "name": "orderkey", "type": "long" },
+                            { "name": "custkey", "type": "long" },
+                            { "name": "orderstatus", "type": "string" },
+                            { "name": "totalprice", "type": "double"},
+                            { "name": "orderpriority", "type": "string" },
+                            { "name": "clerk", "type": "string" },
+                            {"name":  "shippriority", "type": "long"},
+                            { "name": "comment", "type": "string" }
+                        ]
+                    }
+                }
+            },
+            "granularitySpec": {
+                "type": "uniform",
+                "intervals": [
+                    "1992-01-02/1998-12-01"
+                ],
+                "segmentGranularity": "year",
+                "queryGranularity": "day"
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "firehose": {
+                "type": "local",
+                "baseDir": "/opt/druid/var/",
+                "filter": "some_table.tsv"
+            },
+            "appendToExisting": false
+        },
+        "tuningConfig": {
+            "type": "index",
+            "maxRowsPerSegment": 5000000,
+            "maxRowsInMemory": 250000,
+            "segmentWriteOutMediumFactory": {
+                "type": "offHeapMemory"
+            }
+        }
+    }
+}
+

--- a/presto-druid/src/test/resources/druid-tpch-ingest-somextable.json
+++ b/presto-druid/src/test/resources/druid-tpch-ingest-somextable.json
@@ -1,0 +1,69 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "somextable",
+            "parser": {
+                "type": "string",
+                "parseSpec": {
+                    "format": "tsv",
+                    "timestampSpec": {
+                        "column": "orderdate_druid_ts_x",
+                        "format": "auto"
+                    },
+                    "columns": [
+                        "orderdate_x",
+                        "orderdate_druid_ts_x",
+                        "orderkey_x",
+                        "custkey_x",
+                        "orderstatus_x",
+                        "totalprice_x",
+                        "orderpriority_x",
+                        "clerk_x",
+                        "shippriority_x",
+                        "comment_x"
+                    ],
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            { "name": "orderdate_x", "type": "string"},
+                            { "name": "orderkey_x", "type": "long" },
+                            { "name": "custkey_x", "type": "long" },
+                            { "name": "orderstatus_x", "type": "string" },
+                            { "name": "totalprice_x", "type": "double"},
+                            { "name": "orderpriority_x", "type": "string" },
+                            { "name": "clerk_x", "type": "string" },
+                            {"name":  "shippriority_x", "type": "long"},
+                            { "name": "comment_x", "type": "string" }
+                        ]
+                    }
+                }
+            },
+            "granularitySpec": {
+                "type": "uniform",
+                "intervals": [
+                    "1992-01-02/1998-12-01"
+                ],
+                "segmentGranularity": "year",
+                "queryGranularity": "day"
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "firehose": {
+                "type": "local",
+                "baseDir": "/opt/druid/var/",
+                "filter": "somextable.tsv"
+            },
+            "appendToExisting": false
+        },
+        "tuningConfig": {
+            "type": "index",
+            "maxRowsPerSegment": 5000000,
+            "maxRowsInMemory": 250000,
+            "segmentWriteOutMediumFactory": {
+                "type": "offHeapMemory"
+            }
+        }
+    }
+}
+

--- a/presto-druid/src/test/resources/historical-jvm.config
+++ b/presto-druid/src/test/resources/historical-jvm.config
@@ -1,0 +1,10 @@
+-server
+-Xms128m
+-Xmx128m
+-XX:MaxDirectMemorySize=200m
+-XX:+ExitOnOutOfMemoryError
+-XX:+UseG1GC
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/presto-druid/src/test/resources/historical.config
+++ b/presto-druid/src/test/resources/historical.config
@@ -1,0 +1,21 @@
+druid.service=druid/historical
+druid.plaintextPort=8083
+
+# HTTP server threads
+druid.server.http.numThreads=6
+
+# Processing threads and buffers
+druid.processing.buffer.sizeBytes=40000000
+druid.processing.numMergeBuffers=1
+druid.processing.numThreads=1
+druid.processing.tmpDir=var/druid/processing
+
+# Segment storage
+druid.segmentCache.locations=[{"path":"var/druid/segment-cache","maxSize":300000000000}]
+druid.server.maxSize=300000000000
+
+# Query cache
+druid.historical.cache.useCache=true
+druid.historical.cache.populateCache=true
+druid.cache.type=caffeine
+druid.cache.sizeInBytes=50000000

--- a/presto-druid/src/test/resources/middleManager-jvm.config
+++ b/presto-druid/src/test/resources/middleManager-jvm.config
@@ -1,0 +1,9 @@
+-server
+-Xms64m
+-Xmx64m
+-XX:+ExitOnOutOfMemoryError
+-XX:+UseG1GC
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/presto-druid/src/test/resources/middleManager.config
+++ b/presto-druid/src/test/resources/middleManager.config
@@ -1,0 +1,30 @@
+druid.service=druid/middleManager
+druid.plaintextPort=8091
+
+# Number of tasks per middleManager
+druid.worker.capacity=1
+
+# Task launch parameters
+druid.indexer.runner.javaOpts=-server -Xmx384m -XX:MaxDirectMemorySize=200m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+druid.indexer.task.baseTaskDir=var/druid/task
+
+# HTTP server threads
+druid.server.http.numThreads=6
+
+# Processing threads and buffers on Peons
+druid.indexer.fork.property.druid.processing.numMergeBuffers=3
+druid.indexer.fork.property.druid.processing.buffer.sizeBytes=40000000
+druid.indexer.fork.property.druid.processing.numThreads=1
+druid.peon.defaultSegmentWriteOutMediumFactory.type=offHeapMemory
+
+
+# Hadoop indexing
+druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp
+
+# Segment location
+druid.storage.type=local
+druid.storage.storageDirectory=var/druid/segments
+
+# Indexer logs
+druid.indexer.logs.type=file
+druid.indexer.logs.directory=var/druid/indexing-logs

--- a/presto-server-main/etc/catalog/druid.properties
+++ b/presto-server-main/etc/catalog/druid.properties
@@ -1,0 +1,7 @@
+connector.name=druid
+
+######################################################################################
+# Please check http://druid.io/docs/latest/querying/sql                              #
+# Add druid-router node here if its multi-broker setup, or url to one of the brokers #
+######################################################################################
+connection-url=jdbc:avatica:remote:url=http://<host>:<port>/druid/v2/sql/avatica/

--- a/presto-server-main/etc/config.properties
+++ b/presto-server-main/etc/config.properties
@@ -47,6 +47,7 @@ plugin.bundles=\
   ../presto-postgresql/pom.xml, \
   ../presto-thrift/pom.xml, \
   ../presto-tpcds/pom.xml, \
-  ../presto-google-sheets/pom.xml
+  ../presto-google-sheets/pom.xml, \
+  ../presto-druid/pom.xml
 
 node-scheduler.include-coordinator=true

--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -246,4 +246,10 @@
             <unpack />
         </artifact>
     </artifactSet>
+
+    <artifactSet to="plugin/druid">
+        <artifact id="${project.groupId}:presto-druid:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
 </runtime>


### PR DESCRIPTION
Co-authored-by: Puneet Jaiswal <punit.kj@gmail.com>

This PR overtook the work done by Puneet as part of https://github.com/prestosql/presto/pull/532. 
This is a V1 version of the connector without aggregation pushdown. While some of the work from Puneet's PR has been carried over, a lot of code was removed since it is no longer needed. Note that this PR mandates that the Druid cluster runs Druid 0.18 or newer. 

The other bulk of the work done was for setting up the TestingDruidServer to run various Druid components, ingesting TPCH data by writing to a TSV file and then invoking Druid indexer job and, adding a smoke test. 
