### PR TITLE
Ensure proper memory visibility in RubixConfigurationInitializer

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
@@ -53,7 +53,7 @@ public class RubixConfigurationInitializer
     private final int dataTransferServerPort;
 
     // Configs below are dependent on node joining the cluster
-    private boolean cacheNotReady = true;
+    private volatile boolean cacheNotReady = true;
     private boolean isMaster;
     private HostAddress masterAddress;
     private String nodeAddress;


### PR DESCRIPTION
Making RubixConfigurationInitializer.cacheNotReady volatile to ensure
changes made to instance variables before cacheNotReady was switched  to
false are visible to thread calling out to initializeConfiguration.