### PR TITLE
Add FQDN configuration property

### DIFF
--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -2,16 +2,15 @@
 Coordinator Kerberos Authentication
 ===================================
 
-The Presto coordinator can be configured to enable Kerberos authentication over
-HTTPS for clients, such as the :doc:`Presto CLI </security/cli>`, or the
-JDBC and ODBC drivers.
+Presto can be configured to enable Kerberos authentication over HTTPS for
+clients, such as the :doc:`Presto CLI </security/cli>`, or the JDBC and ODBC
+drivers.
 
 To enable Kerberos authentication for Presto, configuration changes are made on
 the Presto coordinator. No changes are required to the worker configuration.
 The worker nodes continue to connect to the coordinator over
 unauthenticated HTTP. However, if you want to secure the communication between
 Presto nodes with SSL/TLS, configure :doc:`/security/internal-communication`.
-
 
 Environment Configuration
 -------------------------
@@ -97,6 +96,8 @@ Kerberos authentication is configured in the coordinator node's
     http-server.https.keystore.path=/etc/presto_keystore.jks
     http-server.https.keystore.key=keystore_password
 
+    node.internal-address-source=FQDN
+
 ========================================================= ======================================================
 Property                                                  Description
 ========================================================= ======================================================
@@ -124,6 +125,9 @@ Property                                                  Description
                                                           authentication is denied.  Default is ``(.*)``.
 ``http-server.authentication.krb5.user-mapping.file``     File containing rules for mapping user.  See
                                                           :doc:`/security/user-mapping` for more information.
+``node.internal-address-source``                          Kerberos is typically sensitive to DNS names. Setting
+                                                          this property to use ``FQDN`` ensures correct
+                                                          operation and usage of valid DNS host names.
 ========================================================= ======================================================
 
 .. note::


### PR DESCRIPTION
This implements a suggestion from @dain .. we might also make the HTTPS requirement more explicit or push harder to configure secure internal communication.