### PR TITLE
Add an information_schema.role_grants table

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -2367,6 +2367,12 @@ public class HiveMetadata
     }
 
     @Override
+    public Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        return ImmutableSet.copyOf(accessControlMetadata.listAllRoleGrants(session, roles, grantees, limit));
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(ConnectorSession session, PrestoPrincipal principal)
     {
         return ImmutableSet.copyOf(accessControlMetadata.listRoleGrants(session, HivePrincipal.from(principal)));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
@@ -250,6 +250,11 @@ public class HiveMetastoreClosure
         delegate.revokeRoles(roles, grantees, adminOption, grantor);
     }
 
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        return delegate.listGrantedPrincipals(role);
+    }
+
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         return delegate.listRoleGrants(principal);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -105,6 +105,8 @@ public interface HiveMetastore
 
     void revokeRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean adminOption, HivePrincipal grantor);
 
+    Set<RoleGrant> listGrantedPrincipals(String role);
+
     Set<RoleGrant> listRoleGrants(HivePrincipal principal);
 
     void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -876,6 +876,12 @@ public class SemiTransactionalHiveMetastore
         setExclusive((delegate, hdfsEnvironment) -> delegate.revokeRoles(roles, grantees, adminOption, grantor));
     }
 
+    public synchronized Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        checkReadable();
+        return delegate.listGrantedPrincipals(role);
+    }
+
     public synchronized Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         checkReadable();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -462,6 +462,12 @@ public class AlluxioHiveMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "listRoleGrants");
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         throw new PrestoException(NOT_SUPPORTED, "listRoleGrants");

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -815,6 +815,14 @@ public class FileHiveMetastore
     }
 
     @Override
+    public synchronized Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        return listRoleGrantsSanitized().stream()
+                .filter(grant -> grant.getRoleName().equals(role))
+                .collect(toImmutableSet());
+    }
+
+    @Override
     public synchronized Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         ImmutableSet.Builder<RoleGrant> result = ImmutableSet.builder();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -985,6 +985,12 @@ public class GlueHiveMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "listPrincipals is not supported by Glue");
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         if (principal.getType() == USER) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -385,6 +385,12 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        return delegate.listGrantedPrincipals(role);
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         return delegate.listRoleGrants(principal);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -319,6 +319,13 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
+    public List<RolePrincipalGrant> listGrantedPrincipals(String role)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.listGrantedPrincipals(role));
+    }
+
+    @Override
     public List<RolePrincipalGrant> listRoleGrants(String name, PrincipalType principalType)
             throws TException
     {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -840,6 +840,27 @@ public class ThriftHiveMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        try {
+            return retry()
+                    .stopOn(MetaException.class)
+                    .stopOnIllegalExceptions()
+                    .run("listPrincipals", stats.getListGrantedPrincipals().wrap(() -> {
+                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                            return fromRolePrincipalGrants(client.listGrantedPrincipals(role));
+                        }
+                    }));
+        }
+        catch (TException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+        catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         try {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleRequest;
+import org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleResponse;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
@@ -417,6 +419,15 @@ public class ThriftHiveMetastoreClient
         if (!response.isSetSuccess()) {
             throw new MetaException("GrantRevokeResponse missing success field");
         }
+    }
+
+    @Override
+    public List<RolePrincipalGrant> listGrantedPrincipals(String role)
+            throws TException
+    {
+        GetPrincipalsInRoleRequest request = new GetPrincipalsInRoleRequest(role);
+        GetPrincipalsInRoleResponse response = client.get_principals_in_role(request);
+        return ImmutableList.copyOf(response.getPrincipalGrants());
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -98,6 +98,8 @@ public interface ThriftMetastore
 
     void revokeRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean adminOption, HivePrincipal grantor);
 
+    Set<RoleGrant> listGrantedPrincipals(String role);
+
     Set<RoleGrant> listRoleGrants(HivePrincipal principal);
 
     void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -147,6 +147,9 @@ public interface ThriftMetastoreClient
     void revokeRole(String role, String granteeName, PrincipalType granteeType, boolean grantOption)
             throws TException;
 
+    List<RolePrincipalGrant> listGrantedPrincipals(String role)
+            throws TException;
+
     List<RolePrincipalGrant> listRoleGrants(String name, PrincipalType principalType)
             throws TException;
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreStats.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreStats.java
@@ -51,6 +51,7 @@ public class ThriftMetastoreStats
     private final ThriftMetastoreApiStats grantRole = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats revokeRole = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats listRoleGrants = new ThriftMetastoreApiStats();
+    private final ThriftMetastoreApiStats listGrantedPrincipals = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats createRole = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats dropRole = new ThriftMetastoreApiStats();
     private final ThriftMetastoreApiStats openTransaction = new ThriftMetastoreApiStats();
@@ -282,6 +283,13 @@ public class ThriftMetastoreStats
     public ThriftMetastoreApiStats getRevokeRole()
     {
         return revokeRole;
+    }
+
+    @Managed
+    @Nested
+    public ThriftMetastoreApiStats getListGrantedPrincipals()
+    {
+        return listGrantedPrincipals;
     }
 
     @Managed

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/AccessControlMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/AccessControlMetadata.java
@@ -23,6 +23,7 @@ import io.prestosql.spi.security.RoleGrant;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -51,6 +52,14 @@ public interface AccessControlMetadata
      * List available roles.
      */
     default Set<String> listRoles(ConnectorSession session)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support roles");
+    }
+
+    /**
+     * List principals for a given role, not recursively.
+     */
+    default Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support roles");
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/LegacyAccessControl.java
@@ -272,6 +272,11 @@ public class LegacyAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControl.java
@@ -83,6 +83,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denySetSchemaAutho
 import static io.prestosql.spi.security.AccessDeniedException.denyShowColumns;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateTable;
+import static io.prestosql.spi.security.AccessDeniedException.denyShowRoleAuthorizationDescriptors;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowRoles;
 import static io.prestosql.spi.security.PrincipalType.ROLE;
 import static io.prestosql.spi.security.PrincipalType.USER;
@@ -95,6 +96,7 @@ public class SqlStandardAccessControl
     public static final String ADMIN_ROLE_NAME = "admin";
     private static final String INFORMATION_SCHEMA_NAME = "information_schema";
     private static final SchemaTableName ROLES = new SchemaTableName(INFORMATION_SCHEMA_NAME, "roles");
+    private static final SchemaTableName ROLE_AUHTORIZATION_DESCRIPTORS = new SchemaTableName(INFORMATION_SCHEMA_NAME, "role_authorization_descriptors");
 
     private final String catalogName;
     private final Function<HiveTransactionHandle, SemiTransactionalHiveMetastore> metastoreProvider;
@@ -398,6 +400,14 @@ public class SqlStandardAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+        if (!isAdmin(context)) {
+            denyShowRoleAuthorizationDescriptors(catalogName);
+        }
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
         if (!isAdmin(context)) {
@@ -483,7 +493,7 @@ public class SqlStandardAccessControl
             return true;
         }
 
-        if (tableName.equals(ROLES)) {
+        if (tableName.equals(ROLES) || tableName.equals(ROLE_AUHTORIZATION_DESCRIPTORS)) {
             return false;
         }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControlMetadata.java
@@ -26,12 +26,14 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.security.GrantInfo;
+import io.prestosql.spi.security.PrincipalType;
 import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.PrivilegeInfo;
 import io.prestosql.spi.security.RoleGrant;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -39,6 +41,7 @@ import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.toHivePrivile
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.listEnabledPrincipals;
 import static io.prestosql.plugin.hive.security.SqlStandardAccessControl.ADMIN_ROLE_NAME;
 import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.prestosql.spi.security.PrincipalType.ROLE;
 import static io.prestosql.spi.security.PrincipalType.USER;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -48,6 +51,7 @@ public class SqlStandardAccessControlMetadata
         implements AccessControlMetadata
 {
     private static final Set<String> RESERVED_ROLES = ImmutableSet.of("all", "default", "none");
+    private static final String PUBLIC_ROLE_NAME = "public";
 
     private final SemiTransactionalHiveMetastore metastore;
 
@@ -82,6 +86,57 @@ public class SqlStandardAccessControlMetadata
     public Set<String> listRoles(ConnectorSession session)
     {
         return ImmutableSet.copyOf(metastore.listRoles());
+    }
+
+    @Override
+    public Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        Set<String> actualRoles = roles.orElseGet(() -> metastore.listRoles());
+
+        // choose more efficient path
+        if (grantees.isPresent() && actualRoles.size() > grantees.get().size() * 2) {
+            // 2x because we check two grantee types (ROLE or USER)
+            return getRoleGrantsByGrantees(grantees.get(), limit);
+        }
+        return getRoleGrantsByRoles(actualRoles, limit);
+    }
+
+    private Set<RoleGrant> getRoleGrantsByGrantees(Set<String> grantees, OptionalLong limit)
+    {
+        ImmutableSet.Builder<RoleGrant> roleGrants = ImmutableSet.builder();
+        int count = 0;
+        for (String grantee : grantees) {
+            for (PrincipalType type : new PrincipalType[]{USER, ROLE}) {
+                if (limit.isPresent() && count >= limit.getAsLong()) {
+                    return roleGrants.build();
+                }
+                for (RoleGrant grant : metastore.listRoleGrants(new HivePrincipal(type, grantee))) {
+                    // Filter out the "public" role since it is not explicitly granted in Hive.
+                    if (PUBLIC_ROLE_NAME.equals(grant.getRoleName())) {
+                        continue;
+                    }
+                    count++;
+                    roleGrants.add(grant);
+                }
+            }
+        }
+        return roleGrants.build();
+    }
+
+    private Set<RoleGrant> getRoleGrantsByRoles(Set<String> roles, OptionalLong limit)
+    {
+        ImmutableSet.Builder<RoleGrant> roleGrants = ImmutableSet.builder();
+        int count = 0;
+        for (String role : roles) {
+            if (limit.isPresent() && count >= limit.getAsLong()) {
+                break;
+            }
+            for (RoleGrant grant : metastore.listGrantedPrincipals(role)) {
+                count++;
+                roleGrants.add(grant);
+            }
+        }
+        return roleGrants.build();
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -143,6 +143,7 @@ public class TestRecordingHiveMetastore
         assertEquals(hiveMetastore.listTablePrivileges("database", "table", "owner", Optional.of(new HivePrincipal(USER, "user"))), ImmutableSet.of(PRIVILEGE_INFO));
         assertEquals(hiveMetastore.listRoles(), ImmutableSet.of("role"));
         assertEquals(hiveMetastore.listRoleGrants(new HivePrincipal(USER, "user")), ImmutableSet.of(ROLE_GRANT));
+        assertEquals(hiveMetastore.listGrantedPrincipals("role"), ImmutableSet.of(ROLE_GRANT));
     }
 
     private static class TestingHiveMetastore
@@ -291,6 +292,12 @@ public class TestRecordingHiveMetastore
         public Set<String> listRoles()
         {
             return ImmutableSet.of("role");
+        }
+
+        @Override
+        public Set<RoleGrant> listGrantedPrincipals(String role)
+        {
+            return ImmutableSet.of(ROLE_GRANT);
         }
 
         @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -258,6 +258,12 @@ class UnimplementedHiveMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         throw new UnsupportedOperationException();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -513,6 +513,12 @@ public class InMemoryThriftMetastore
     }
 
     @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
     {
         throw new UnsupportedOperationException();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -416,6 +416,13 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public List<RolePrincipalGrant> listGrantedPrincipals(String role)
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<RolePrincipalGrant> listRoleGrants(String name, PrincipalType principalType)
     {
         accessCount.incrementAndGet();

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaMetadata.java
@@ -60,6 +60,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.connector.informationschema.InformationSchemaTable.COLUMNS;
 import static io.prestosql.connector.informationschema.InformationSchemaTable.INFORMATION_SCHEMA;
+import static io.prestosql.connector.informationschema.InformationSchemaTable.ROLE_AUTHORIZATION_DESCRIPTORS;
 import static io.prestosql.connector.informationschema.InformationSchemaTable.TABLES;
 import static io.prestosql.connector.informationschema.InformationSchemaTable.TABLE_PRIVILEGES;
 import static io.prestosql.connector.informationschema.InformationSchemaTable.VIEWS;
@@ -77,7 +78,10 @@ public class InformationSchemaMetadata
     private static final InformationSchemaColumnHandle CATALOG_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_catalog");
     private static final InformationSchemaColumnHandle SCHEMA_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_schema");
     private static final InformationSchemaColumnHandle TABLE_NAME_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_name");
+    private static final InformationSchemaColumnHandle ROLE_NAME_COLUMN_HANDLE = new InformationSchemaColumnHandle("role_name");
+    private static final InformationSchemaColumnHandle GRANTEE_COLUMN_HANDLE = new InformationSchemaColumnHandle("grantee");
     private static final int MAX_PREFIXES_COUNT = 100;
+    private static final int MAX_ROLE_COUNT = 100;
 
     private final String catalogName;
     private final Metadata metadata;
@@ -98,7 +102,7 @@ public class InformationSchemaMetadata
     public ConnectorTableHandle getTableHandle(ConnectorSession connectorSession, SchemaTableName tableName)
     {
         return InformationSchemaTable.of(tableName)
-                .map(table -> new InformationSchemaTableHandle(catalogName, table, defaultPrefixes(catalogName), OptionalLong.empty()))
+                .map(table -> new InformationSchemaTableHandle(catalogName, table, defaultPrefixes(catalogName), Optional.empty(), Optional.empty(), OptionalLong.empty()))
                 .orElse(null);
     }
 
@@ -182,7 +186,7 @@ public class InformationSchemaMetadata
         }
 
         return Optional.of(new LimitApplicationResult<>(
-                new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), table.getPrefixes(), OptionalLong.of(limit)),
+                new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), table.getPrefixes(), table.getRoles(), table.getGrantees(), OptionalLong.of(limit)),
                 true));
     }
 
@@ -191,18 +195,23 @@ public class InformationSchemaMetadata
     {
         InformationSchemaTableHandle table = (InformationSchemaTableHandle) handle;
 
-        if (!isTablesEnumeratingTable(table.getTable()) || !table.getPrefixes().equals(defaultPrefixes(catalogName))) {
+        Optional<Set<String>> roles = table.getRoles();
+        Optional<Set<String>> grantees = table.getGrantees();
+        if (ROLE_AUTHORIZATION_DESCRIPTORS.equals(table.getTable()) && table.getRoles().isEmpty() && table.getGrantees().isEmpty()) {
+            roles = calculateRoles(session, constraint.getSummary(), constraint.predicate());
+            grantees = calculateGrantees(session, constraint.getSummary(), constraint.predicate());
+        }
+
+        Set<QualifiedTablePrefix> prefixes = table.getPrefixes();
+        if (isTablesEnumeratingTable(table.getTable()) && table.getPrefixes().equals(defaultPrefixes(catalogName))) {
+            prefixes = getPrefixes(session, table, constraint);
+        }
+
+        if (roles.equals(table.getRoles()) && grantees.equals(table.getGrantees()) && prefixes.equals(table.getPrefixes())) {
             return Optional.empty();
         }
 
-        Set<QualifiedTablePrefix> prefixes = getPrefixes(session, table, constraint);
-
-        if (prefixes.equals(table.getPrefixes())) {
-            return Optional.empty();
-        }
-
-        table = new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), prefixes, table.getLimit());
-
+        table = new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), prefixes, roles, grantees, table.getLimit());
         return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary()));
     }
 
@@ -240,6 +249,67 @@ public class InformationSchemaMetadata
     public static boolean isTablesEnumeratingTable(InformationSchemaTable table)
     {
         return ImmutableSet.of(COLUMNS, VIEWS, TABLES, TABLE_PRIVILEGES).contains(table);
+    }
+
+    private Optional<Set<String>> calculateRoles(
+            ConnectorSession connectorSession,
+            TupleDomain<ColumnHandle> constraint,
+            Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate)
+    {
+        if (constraint.isNone()) {
+            return Optional.empty();
+        }
+
+        Optional<Set<String>> roles = filterString(constraint, ROLE_NAME_COLUMN_HANDLE);
+        if (roles.isPresent()) {
+            Set<String> result = roles.get().stream()
+                    .filter(this::isLowerCase)
+                    .filter(role -> !predicate.isPresent() || predicate.get().test(roleAsFixedValues(role)))
+                    .collect(toImmutableSet());
+
+            if (result.isEmpty()) {
+                return Optional.empty();
+            }
+            if (result.size() <= MAX_ROLE_COUNT) {
+                return Optional.of(result);
+            }
+        }
+
+        if (predicate.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+        return Optional.of(metadata.listRoles(session, catalogName)
+                .stream()
+                .filter(role -> predicate.get().test(roleAsFixedValues(role)))
+                .collect(toImmutableSet()));
+    }
+
+    private Optional<Set<String>> calculateGrantees(
+            ConnectorSession connectorSession,
+            TupleDomain<ColumnHandle> constraint,
+            Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate)
+    {
+        if (constraint.isNone()) {
+            return Optional.empty();
+        }
+
+        Optional<Set<String>> grantees = filterString(constraint, GRANTEE_COLUMN_HANDLE);
+        if (grantees.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Set<String> result = grantees.get().stream()
+                .filter(this::isLowerCase)
+                .filter(role -> !predicate.isPresent() || predicate.get().test(granteeAsFixedValues(role)))
+                .collect(toImmutableSet());
+
+        if (!result.isEmpty() && result.size() <= MAX_ROLE_COUNT) {
+            return Optional.of(result);
+        }
+
+        return Optional.empty();
     }
 
     private Set<QualifiedTablePrefix> calculatePrefixesWithSchemaName(
@@ -355,6 +425,16 @@ public class InformationSchemaMetadata
     private Map<ColumnHandle, NullableValue> schemaAsFixedValues(String schema)
     {
         return ImmutableMap.of(SCHEMA_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
+    }
+
+    private Map<ColumnHandle, NullableValue> roleAsFixedValues(String schema)
+    {
+        return ImmutableMap.of(ROLE_NAME_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
+    }
+
+    private Map<ColumnHandle, NullableValue> granteeAsFixedValues(String schema)
+    {
+        return ImmutableMap.of(GRANTEE_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
     }
 
     private Map<ColumnHandle, NullableValue> asFixedValues(QualifiedObjectName objectName)

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTable.java
@@ -82,6 +82,14 @@ public enum InformationSchemaTable
             .build()),
     ENABLED_ROLES(table("enabled_roles")
             .column("role_name", createUnboundedVarcharType())
+            .build()),
+    ROLE_AUTHORIZATION_DESCRIPTORS(table("role_authorization_descriptors")
+            .column("role_name", createUnboundedVarcharType())
+            .column("grantor", createUnboundedVarcharType())
+            .column("grantor_type", createUnboundedVarcharType())
+            .column("grantee", createUnboundedVarcharType())
+            .column("grantee_type", createUnboundedVarcharType())
+            .column("is_grantable", createUnboundedVarcharType())
             .build());
 
     public static final String INFORMATION_SCHEMA = "information_schema";

--- a/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
+++ b/presto-main/src/main/java/io/prestosql/connector/informationschema/InformationSchemaTableHandle.java
@@ -20,6 +20,7 @@ import io.prestosql.metadata.QualifiedTablePrefix;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -32,6 +33,8 @@ public class InformationSchemaTableHandle
     private final String catalogName;
     private final InformationSchemaTable table;
     private final Set<QualifiedTablePrefix> prefixes;
+    private final Optional<Set<String>> roles;
+    private final Optional<Set<String>> grantees;
     private final OptionalLong limit;
 
     @JsonCreator
@@ -39,11 +42,15 @@ public class InformationSchemaTableHandle
             @JsonProperty("catalogName") String catalogName,
             @JsonProperty("table") InformationSchemaTable table,
             @JsonProperty("prefixes") Set<QualifiedTablePrefix> prefixes,
+            @JsonProperty("roles") Optional<Set<String>> roles,
+            @JsonProperty("grantees") Optional<Set<String>> grantees,
             @JsonProperty("limit") OptionalLong limit)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.table = requireNonNull(table, "table is null");
         this.prefixes = ImmutableSet.copyOf(requireNonNull(prefixes, "prefixes is null"));
+        this.roles = requireNonNull(roles, "roles is null");
+        this.grantees = requireNonNull(grantees, "grantees is null");
         this.limit = requireNonNull(limit, "limit is null");
     }
 
@@ -57,6 +64,18 @@ public class InformationSchemaTableHandle
     public InformationSchemaTable getTable()
     {
         return table;
+    }
+
+    @JsonProperty
+    public Optional<Set<String>> getRoles()
+    {
+        return roles;
+    }
+
+    @JsonProperty
+    public Optional<Set<String>> getGrantees()
+    {
+        return grantees;
     }
 
     @JsonProperty
@@ -78,6 +97,8 @@ public class InformationSchemaTableHandle
                 .add("catalogName", catalogName)
                 .add("table", table)
                 .add("prefixes", prefixes)
+                .add("roles", roles)
+                .add("grantees", grantees)
                 .add("limit", limit)
                 .toString();
     }
@@ -100,6 +121,8 @@ public class InformationSchemaTableHandle
         InformationSchemaTableHandle other = (InformationSchemaTableHandle) obj;
         return Objects.equals(this.catalogName, other.catalogName) &&
                 this.table == other.table &&
+                Objects.equals(this.roles, other.roles) &&
+                Objects.equals(this.grantees, other.grantees) &&
                 Objects.equals(this.prefixes, other.prefixes) &&
                 Objects.equals(this.limit, other.limit);
     }

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -376,6 +376,12 @@ public interface Metadata
     Set<String> listRoles(Session session, String catalog);
 
     /**
+     * List all role grants in the specified catalog,
+     * optionally filtered by passed role, grantee, and limit predicates.
+     */
+    Set<RoleGrant> listAllRoleGrants(Session session, String catalog, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit);
+
+    /**
      * List roles grants in the specified catalog for a given principal, not recursively.
      */
     Set<RoleGrant> listRoleGrants(Session session, String catalog, PrestoPrincipal principal);

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -1204,6 +1204,19 @@ public final class MetadataManager
     }
 
     @Override
+    public Set<RoleGrant> listAllRoleGrants(Session session, String catalog, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        Optional<CatalogMetadata> catalogMetadata = getOptionalCatalogMetadata(session, catalog);
+        if (!catalogMetadata.isPresent()) {
+            return ImmutableSet.of();
+        }
+        CatalogName catalogName = catalogMetadata.get().getCatalogName();
+        ConnectorSession connectorSession = session.toConnectorSession(catalogName);
+        ConnectorMetadata metadata = catalogMetadata.get().getMetadataFor(catalogName);
+        return metadata.listAllRoleGrants(connectorSession, roles, grantees, limit);
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(Session session, String catalog, PrestoPrincipal principal)
     {
         Optional<CatalogMetadata> catalogMetadata = getOptionalCatalogMetadata(session, catalog);

--- a/presto-main/src/main/java/io/prestosql/security/AccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControl.java
@@ -341,6 +341,12 @@ public interface AccessControl
     void checkCanSetRole(SecurityContext context, String role, String catalogName);
 
     /**
+     * Check if identity is allowed to show role authorization descriptors (i.e. RoleGrants).
+     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanShowRoleAuthorizationDescriptors(SecurityContext context, String catalogName);
+
+    /**
      * Check if identity is allowed to show roles on the specified catalog.
      * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
      */

--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -753,6 +753,17 @@ public class AccessControlManager
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(SecurityContext securityContext, String catalogName)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(catalogName, "catalogName is null");
+
+        checkCanAccessCatalog(securityContext, catalogName);
+
+        catalogAuthorizationCheck(catalogName, securityContext, (control, context) -> control.checkCanShowRoleAuthorizationDescriptors(context, catalogName));
+    }
+
+    @Override
     public void checkCanShowRoles(SecurityContext securityContext, String catalogName)
     {
         requireNonNull(securityContext, "securityContext is null");

--- a/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
@@ -251,6 +251,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(SecurityContext context, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanShowRoles(SecurityContext context, String catalogName)
     {
     }

--- a/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
@@ -67,6 +67,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denyShowColumns;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCurrentRoles;
+import static io.prestosql.spi.security.AccessDeniedException.denyShowRoleAuthorizationDescriptors;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowRoleGrants;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowRoles;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowSchemas;
@@ -332,6 +333,12 @@ public class DenyAllAccessControl
     public void checkCanSetRole(SecurityContext context, String role, String catalog)
     {
         denySetRole(role);
+    }
+
+    @Override
+    public void checkCanShowRoleAuthorizationDescriptors(SecurityContext context, String catalogName)
+    {
+        denyShowRoleAuthorizationDescriptors(catalogName);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
@@ -310,6 +310,12 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(SecurityContext context, String catalogName)
+    {
+        delegate().checkCanShowRoleAuthorizationDescriptors(context, catalogName);
+    }
+
+    @Override
     public void checkCanShowRoles(SecurityContext context, String catalogName)
     {
         delegate().checkCanShowRoles(context, catalogName);

--- a/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/io/prestosql/connector/MockConnectorFactory.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.tpch.TpchColumnHandle;
 import io.prestosql.plugin.tpch.TpchHandleResolver;
 import io.prestosql.plugin.tpch.TpchRecordSetProvider;
@@ -44,12 +45,16 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.eventlistener.EventListener;
 import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.security.PrestoPrincipal;
+import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,6 +62,7 @@ import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
 
@@ -72,6 +78,7 @@ public class MockConnectorFactory
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout;
     private final BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout;
     private final Supplier<Iterable<EventListener>> eventListeners;
+    private final ListRoleGrants roleGrants;
 
     private MockConnectorFactory(
             Function<ConnectorSession, List<String>> listSchemaNames,
@@ -82,7 +89,8 @@ public class MockConnectorFactory
             ApplyProjection applyProjection,
             BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout,
             BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout,
-            Supplier<Iterable<EventListener>> eventListeners)
+            Supplier<Iterable<EventListener>> eventListeners,
+            ListRoleGrants roleGrants)
     {
         this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
         this.listTables = requireNonNull(listTables, "listTables is null");
@@ -93,6 +101,7 @@ public class MockConnectorFactory
         this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
         this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
         this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
+        this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
     }
 
     @Override
@@ -110,7 +119,7 @@ public class MockConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return new MockConnector(context, listSchemaNames, listTables, getViews, getTableHandle, getColumns, applyProjection, getInsertLayout, getNewTableLayout, eventListeners);
+        return new MockConnector(context, listSchemaNames, listTables, getViews, getTableHandle, getColumns, applyProjection, getInsertLayout, getNewTableLayout, eventListeners, roleGrants);
     }
 
     public static Builder builder()
@@ -122,6 +131,12 @@ public class MockConnectorFactory
     public interface ApplyProjection
     {
         Optional<ProjectionApplicationResult<ConnectorTableHandle>> apply(ConnectorSession session, ConnectorTableHandle handle, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments);
+    }
+
+    @FunctionalInterface
+    public interface ListRoleGrants
+    {
+        Set<RoleGrant> apply(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit);
     }
 
     public static class MockConnector
@@ -137,6 +152,7 @@ public class MockConnectorFactory
         private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout;
         private final BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout;
         private final Supplier<Iterable<EventListener>> eventListeners;
+        private final ListRoleGrants roleGrants;
 
         private MockConnector(
                 ConnectorContext context,
@@ -148,7 +164,8 @@ public class MockConnectorFactory
                 ApplyProjection applyProjection,
                 BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout,
                 BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout,
-                Supplier<Iterable<EventListener>> eventListeners)
+                Supplier<Iterable<EventListener>> eventListeners,
+                ListRoleGrants roleGrants)
         {
             this.context = requireNonNull(context, "context is null");
             this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
@@ -160,6 +177,7 @@ public class MockConnectorFactory
             this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
             this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
             this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
+            this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
         }
 
         @Override
@@ -304,6 +322,36 @@ public class MockConnectorFactory
             {
                 return new ConnectorTableProperties();
             }
+
+            @Override
+            public Set<String> listRoles(ConnectorSession session)
+            {
+                return roleGrants.apply(session, Optional.empty(), Optional.empty(), OptionalLong.empty()).stream().map(grant -> grant.getRoleName()).collect(toImmutableSet());
+            }
+
+            @Override
+            public Set<RoleGrant> listRoleGrants(ConnectorSession session, PrestoPrincipal principal)
+            {
+                return roleGrants.apply(session, Optional.empty(), Optional.empty(), OptionalLong.empty()).stream().filter(grant -> grant.getGrantee().equals(principal)).collect(toImmutableSet());
+            }
+
+            @Override
+            public Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+            {
+                return roleGrants.apply(session, roles, grantees, limit);
+            }
+
+            @Override
+            public Set<RoleGrant> listApplicableRoles(ConnectorSession session, PrestoPrincipal principal)
+            {
+                return listRoleGrants(session, principal);
+            }
+
+            @Override
+            public Set<String> listEnabledRoles(ConnectorSession session)
+            {
+                return listRoles(session);
+            }
         }
     }
 
@@ -365,10 +413,17 @@ public class MockConnectorFactory
         private BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout = defaultGetInsertLayout();
         private BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout = defaultGetNewTableLayout();
         private Supplier<Iterable<EventListener>> eventListeners = ImmutableList::of;
+        private ListRoleGrants roleGrants = defaultRoleAuthorizations();
 
         public Builder withListSchemaNames(Function<ConnectorSession, List<String>> listSchemaNames)
         {
             this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
+            return this;
+        }
+
+        public Builder withListRoleGrants(ListRoleGrants roleGrants)
+        {
+            this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
             return this;
         }
 
@@ -432,12 +487,17 @@ public class MockConnectorFactory
 
         public MockConnectorFactory build()
         {
-            return new MockConnectorFactory(listSchemaNames, listTables, getViews, getTableHandle, getColumns, applyProjection, getInsertLayout, getNewTableLayout, eventListeners);
+            return new MockConnectorFactory(listSchemaNames, listTables, getViews, getTableHandle, getColumns, applyProjection, getInsertLayout, getNewTableLayout, eventListeners, roleGrants);
         }
 
         public static Function<ConnectorSession, List<String>> defaultListSchemaNames()
         {
             return (session) -> ImmutableList.of();
+        }
+
+        public static ListRoleGrants defaultRoleAuthorizations()
+        {
+            return (session, roles, grantees, limit) -> ImmutableSet.of();
         }
 
         public static BiFunction<ConnectorSession, String, List<SchemaTableName>> defaultListTables()

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -494,6 +494,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Set<RoleGrant> listAllRoleGrants(Session session, String catalog, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(Session session, String catalog, PrestoPrincipal principal)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/test/java/io/prestosql/metadata/TestInformationSchemaTableHandle.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/TestInformationSchemaTableHandle.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
@@ -38,11 +39,14 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestInformationSchemaTableHandle
 {
-    private static final Map<String, Object> SCHEMA_AS_MAP = ImmutableMap.of(
-            "@type", "$info_schema",
-            "catalogName", "information_schema_catalog",
-            "table", "COLUMNS",
-            "prefixes", ImmutableList.of(ImmutableMap.of("catalogName", "abc", "schemaName", INFORMATION_SCHEMA)));
+    private static final Map<String, Object> SCHEMA_AS_MAP = new ImmutableMap.Builder<String, Object>()
+            .put("@type", "$info_schema")
+            .put("catalogName", "information_schema_catalog")
+            .put("table", "COLUMNS")
+            .put("prefixes", ImmutableList.of(ImmutableMap.of("catalogName", "abc", "schemaName", INFORMATION_SCHEMA)))
+            .put("roles", ImmutableList.of("role"))
+            .put("grantees", ImmutableList.of("grantee"))
+            .build();
 
     private ObjectMapper objectMapper;
 
@@ -62,6 +66,8 @@ public class TestInformationSchemaTableHandle
                 "information_schema_catalog",
                 COLUMNS,
                 ImmutableSet.of(new QualifiedTablePrefix("abc", INFORMATION_SCHEMA)),
+                Optional.of(ImmutableSet.of("role")),
+                Optional.of(ImmutableSet.of("grantee")),
                 OptionalLong.empty());
 
         assertTrue(objectMapper.canSerialize(InformationSchemaTableHandle.class));

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -318,6 +318,14 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanShowRoleAuthorizationDescriptors(context, catalogName);
+        }
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -576,6 +576,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listAllRoleGrants(session, roles, grantees, limit);
+        }
+    }
+
+    @Override
     public Set<RoleGrant> listRoleGrants(ConnectorSession session, PrestoPrincipal principal)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllAccessControl.java
@@ -204,6 +204,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedAccessControl.java
@@ -339,6 +339,11 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -253,6 +253,12 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+        delegate().checkCanShowRoleAuthorizationDescriptors(context, catalogName);
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
         delegate().checkCanShowRoles(context, catalogName);

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlyAccessControl.java
@@ -188,6 +188,12 @@ public class ReadOnlyAccessControl
     }
 
     @Override
+    public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+        // allow
+    }
+
+    @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
         // allow

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveSchema.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveSchema.java
@@ -137,14 +137,17 @@ public class TestHiveSchema
                 .add("roles")
                 .add("applicable_roles")
                 .add("enabled_roles")
+                .add("role_authorization_descriptors")
                 .build();
         List<QueryAssert.Row> allInformationSchemaTablesAsRows = allInformationSchemaTables.stream()
                 .map(QueryAssert.Row::row)
                 .collect(toImmutableList());
 
-        // This test is run in various setups and we may or may not have access to hive.information_schema.roles table
+        // This test is run in various setups and we may or may not have access to hive.information_schema.roles
+        // or hive.information_schema.role_authorization_descriptors tables
         List<String> allInformationSchemaTablesExceptRoles = allInformationSchemaTables.stream()
                 .filter(tableName -> !tableName.equals("roles"))
+                .filter(tableName -> !tableName.equals("role_authorization_descriptors"))
                 .collect(toImmutableList());
         List<QueryAssert.Row> allInformationSchemaTablesExceptRolesAsRows = allInformationSchemaTablesExceptRoles.stream()
                 .map(QueryAssert.Row::row)
@@ -200,12 +203,13 @@ public class TestHiveSchema
         // information_schema.columns -- it has a special handling path in metadata, which also depends on query predicates
         assertThat(onPresto().executeQuery("SELECT DISTINCT table_schema FROM information_schema.columns"))
                 .satisfies(containsFirstColumnValue("information_schema"));
-        assertThat(onPresto().executeQuery("SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = 'information_schema' AND table_name != 'roles'"))
+        assertThat(onPresto().executeQuery("SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = 'information_schema' AND table_name != 'roles' AND table_name != 'role_authorization_descriptors'"))
                 .containsOnly(allInformationSchemaTablesExceptRolesAsRows);
         Assertions.assertThat(onPresto().executeQuery("SELECT table_schema, table_name, column_name FROM information_schema.columns").rows().stream()
                 .filter(row -> row.get(0).equals("information_schema"))
                 .map(row -> (String) row.get(1))
                 .filter(tableName -> !tableName.equals("roles"))
+                .filter(tableName -> !tableName.equals("role_authorization_descriptors"))
                 .distinct())
                 .containsOnly(allInformationSchemaTablesExceptRoles.toArray(new String[0]));
         assertThat(onPresto().executeQuery("SELECT column_name FROM information_schema.columns WHERE table_schema = 'information_schema' AND table_name = 'columns'"))

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -12,6 +12,12 @@ system| information_schema| columns| column_default| varchar| YES| null| null|
 system| information_schema| columns| is_nullable| varchar| YES| null| null|
 system| information_schema| columns| data_type| varchar| YES| null| null|
 system| information_schema| enabled_roles| role_name| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| role_name| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| grantor| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| grantor_type| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| grantee| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| grantee_type| varchar| YES| null| null|
+system| information_schema| role_authorization_descriptors| is_grantable| varchar| YES| null| null|
 system| information_schema| roles| role_name| varchar| YES| null| null|
 system| information_schema| schemata| catalog_name| varchar| YES| null| null|
 system| information_schema| schemata| schema_name| varchar| YES| null| null|

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorAccessControl.java
@@ -54,6 +54,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denyShowColumns;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCurrentRoles;
+import static io.prestosql.spi.security.AccessDeniedException.denyShowRoleAuthorizationDescriptors;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowRoleGrants;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowRoles;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowSchemas;
@@ -381,6 +382,16 @@ public interface ConnectorAccessControl
     default void checkCanSetRole(ConnectorSecurityContext context, String role, String catalogName)
     {
         denySetRole(role);
+    }
+
+    /**
+     * Check if identity is allowed to show role authorization descriptors (i.e. RoleGrants).
+     *
+     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
+    {
+        denyShowRoleAuthorizationDescriptors(catalogName);
     }
 
     /**

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -617,6 +617,15 @@ public interface ConnectorMetadata
     }
 
     /**
+     * List all role grants in the specified catalog,
+     * optionally filtered by passed role, grantee, and limit predicates.
+     */
+    default Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support roles");
+    }
+
+    /**
      * Grants the specified roles to the specified grantees
      *
      * @param grantor represents the principal specified by GRANTED BY statement

--- a/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
@@ -356,6 +356,11 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot show roles from catalog %s", catalogName));
     }
 
+    public static void denyShowRoleAuthorizationDescriptors(String catalogName)
+    {
+        throw new AccessDeniedException(format("Cannot show role authorizatin descriptors from catalog %s", catalogName));
+    }
+
     public static void denyShowCurrentRoles(String catalogName)
     {
         throw new AccessDeniedException(format("Cannot show current roles from catalog %s", catalogName));

--- a/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestInformationSchemaConnector.java
@@ -35,12 +35,12 @@ public class TestInformationSchemaConnector
     public void testBasic()
     {
         assertQuery("SELECT count(*) FROM tpch.information_schema.schemata", "VALUES 10");
-        assertQuery("SELECT count(*) FROM tpch.information_schema.tables", "VALUES 80");
-        assertQuery("SELECT count(*) FROM tpch.information_schema.columns", "VALUES 583");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.tables", "VALUES 81");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns", "VALUES 589");
         assertQuery("SELECT * FROM tpch.information_schema.schemata ORDER BY 1 DESC, 2 DESC LIMIT 1", "VALUES ('tpch', 'tiny')");
         assertQuery("SELECT * FROM tpch.information_schema.tables ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'BASE TABLE')");
         assertQuery("SELECT * FROM tpch.information_schema.columns ORDER BY 1 DESC, 2 DESC, 3 DESC, 4 DESC LIMIT 1", "VALUES ('tpch', 'tiny', 'supplier', 'suppkey', 1, NULL, 'YES', 'bigint')");
-        assertQuery("SELECT count(*) FROM test_catalog.information_schema.columns", "VALUES 300034");
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.columns", "VALUES 300040");
     }
 
     @Test
@@ -49,9 +49,9 @@ public class TestInformationSchemaConnector
         assertQuery("SELECT count(*) FROM tpch.information_schema.schemata WHERE schema_name = 'sf1'", "VALUES 1");
         assertQuery("SELECT count(*) FROM tpch.information_schema.tables WHERE table_schema = 'sf1'", "VALUES 8");
         assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'sf1'", "VALUES 61");
-        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'information_schema'", "VALUES 34");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema = 'information_schema'", "VALUES 40");
         assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema > 'sf100'", "VALUES 427");
-        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema != 'sf100'", "VALUES 522");
+        assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema != 'sf100'", "VALUES 528");
         assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema LIKE 'sf100'", "VALUES 61");
         assertQuery("SELECT count(*) FROM tpch.information_schema.columns WHERE table_schema LIKE 'sf%'", "VALUES 488");
     }
@@ -97,6 +97,55 @@ public class TestInformationSchemaConnector
         assertQuery("SELECT count(*) FROM (SELECT * FROM test_catalog.information_schema.tables LIMIT 1000)", "VALUES 1000");
     }
 
+    @Test
+    public void testRoleAuthorizationDescriptor()
+    {
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.role_authorization_descriptors", "VALUES 100");
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.roles", "VALUES 50");
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.enabled_roles", "VALUES 50");
+        assertQuery("SELECT count(*) FROM test_catalog.information_schema.applicable_roles", "VALUES 1");
+        assertQuery("SELECT role_name FROM test_catalog.information_schema.role_authorization_descriptors WHERE grantee = 'user5'", "VALUES ('role2')");
+        assertQuery("SELECT grantee FROM test_catalog.information_schema.role_authorization_descriptors WHERE role_name = 'role2'", "VALUES ('user4'), ('user5')");
+
+        assertMetadataCalls(
+                "SELECT count(*) FROM test_catalog.information_schema.role_authorization_descriptors", "VALUES 100",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1));
+
+        assertMetadataCalls(
+                "SELECT role_name FROM test_catalog.information_schema.role_authorization_descriptors WHERE grantee = 'user5'", "VALUES ('role2')",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1)
+                        .withGranteesPushedCount(1));
+
+        assertMetadataCalls(
+                "SELECT grantee FROM test_catalog.information_schema.role_authorization_descriptors WHERE role_name = 'role2'", "VALUES ('user4'), ('user5')",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1)
+                        .withRolesPushedCount(1));
+
+        assertMetadataCalls(
+                "SELECT grantee FROM test_catalog.information_schema.role_authorization_descriptors WHERE role_name = 'role2' AND grantee = 'user4'", "VALUES 'user4'",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1)
+                        .withRolesPushedCount(1)
+                        .withGranteesPushedCount(1));
+
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM test_catalog.information_schema.role_authorization_descriptors LIMIT 1)", "VALUES 1",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1)
+                        .withLimitPushedCount(1));
+
+        // verify that predicate and LIMIT are not pushed down together
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM test_catalog.information_schema.role_authorization_descriptors WHERE grantee = 'user5' LIMIT 1)", "VALUES 1",
+                new MetadataCallsCount()
+                        .withListRoleGrantsCount(1)
+                        .withGranteesPushedCount(1)
+                        .withLimitPushedCount(0));
+    }
+
     @Test(timeOut = 60_000)
     public void testMetadataCalls()
     {
@@ -112,7 +161,7 @@ public class TestInformationSchemaConnector
                         .withListSchemasCount(1));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.tables",
-                "VALUES 3008",
+                "VALUES 3009",
                 new MetadataCallsCount()
                         .withListSchemasCount(1)
                         .withListTablesCount(2));


### PR DESCRIPTION
Update:
this is now called information_schema.role_authorization_descriptors
The schema of this table is:
| role_name | grantor | grantor_type | grantee | grantee_type | is_grantable |

Connectors can use that to make role grant information available to (admin) users by implementing ConnectorMetadata.listAllRoleGrants, with an option to filter by predicates for optimization.

Currently this is implemented in the Hive Connector only.

grantor and grantor_type are not yet supported and always null. (but it could be added in a separate DR).

Continued from #3232