### PR TITLE
Add TupleDomain transformations

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,13 +49,7 @@ public class CassandraClusteringPredicatesExtractor
     public TupleDomain<ColumnHandle> getUnenforcedConstraints()
     {
         Map<ColumnHandle, Domain> pushedDown = clusteringPushDownResult.getDomains();
-        Map<ColumnHandle, Domain> notPushedDown = new HashMap<>(predicates.getDomains().get());
-
-        if (!notPushedDown.isEmpty() && !pushedDown.isEmpty()) {
-            notPushedDown.entrySet().removeAll(pushedDown.entrySet());
-        }
-
-        return TupleDomain.withColumnDomains(notPushedDown);
+        return predicates.filter(((columnHandle, domain) -> !pushedDown.containsKey(columnHandle)));
     }
 
     private static ClusteringPushDownResult getClusteringKeysSet(List<CassandraColumnHandle> clusteringColumns, TupleDomain<ColumnHandle> predicates, VersionNumber cassandraVersion)

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartitionManager.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartitionManager.java
@@ -70,7 +70,7 @@ public class CassandraPartitionManager
             }
             else {
                 List<ColumnHandle> partitionColumns = ImmutableList.copyOf(partitionKeys);
-                remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(tupleDomain.getDomains().get(), not(in(partitionColumns))));
+                remainingTupleDomain = tupleDomain.filter((column, domain) -> !partitionColumns.contains(column));
             }
         }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
@@ -13,11 +13,9 @@
  */
 package io.prestosql.plugin.hive;
 
-import com.google.common.base.Predicates;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.airlift.slice.Slice;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
@@ -65,7 +63,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_EXCEEDED_PARTITION_LIMIT;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.toPartitionName;
@@ -166,8 +163,8 @@ public class HivePartitionManager
         }
 
         // All partition key domains will be fully evaluated, so we don't need to include those
-        TupleDomain<ColumnHandle> remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), not(Predicates.in(partitionColumns))));
-        TupleDomain<ColumnHandle> enforcedTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.in(partitionColumns)));
+        TupleDomain<ColumnHandle> remainingTupleDomain = effectivePredicate.filter((column, domain) -> !partitionColumns.contains(column));
+        TupleDomain<ColumnHandle> enforcedTupleDomain = effectivePredicate.filter((column, domain) -> partitionColumns.contains(column));
         return new HivePartitionResult(partitionColumns, partitionsIterable, compactEffectivePredicate, remainingTupleDomain, enforcedTupleDomain, hiveBucketHandle, bucketFilter);
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -163,7 +163,7 @@ public class ParquetPageSourceFactory
             ParquetReaderOptions options)
     {
         // Ignore predicates on partial columns for now.
-        effectivePredicate = effectivePredicate.transform(column -> column.isBaseColumn() ? column : null);
+        effectivePredicate = effectivePredicate.filter((column, domain) -> column.isBaseColumn());
 
         MessageType fileSchema;
         MessageType requestedSchema;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -84,7 +84,7 @@ public class S3SelectRecordCursorProvider
 
         Optional<ReaderProjections> projectedReaderColumns = projectBaseColumns(columns);
         // Ignore predicates on partial columns for now.
-        effectivePredicate = effectivePredicate.transform(column -> column.isBaseColumn() ? column : null);
+        effectivePredicate = effectivePredicate.filter((column, domain) -> column.isBaseColumn());
 
         String serdeName = getDeserializerClassName(schema);
         if (CSV_SERDES.contains(serdeName)) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -65,7 +65,7 @@ public class TestParquetPredicateUtils
 
         Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
         TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
-        assertTrue(tupleDomain.getDomains().get().isEmpty());
+        assertTrue(tupleDomain.isAll());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TestParquetPredicateUtils
 
         Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
         TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
-        assertTrue(tupleDomain.getDomains().get().isEmpty());
+        assertTrue(tupleDomain.isAll());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class TestParquetPredicateUtils
                         new PrimitiveType(OPTIONAL, INT32, "b")));
         Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
         TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
-        assertTrue(tupleDomain.getDomains().get().isEmpty());
+        assertTrue(tupleDomain.isAll());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class TestParquetPredicateUtils
 
         Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
         TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
-        assertTrue(tupleDomain.getDomains().get().isEmpty());
+        assertTrue(tupleDomain.isAll());
     }
 
     public static void throwUnsupportedOperationException()

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/DomainConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/DomainConverter.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.plugin.iceberg;
 
-import com.google.common.collect.Maps;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.EquatableValueSet;
@@ -45,13 +44,7 @@ public final class DomainConverter
 
     public static TupleDomain<IcebergColumnHandle> convertTupleDomainTypes(TupleDomain<IcebergColumnHandle> tupleDomain)
     {
-        if (tupleDomain.isAll() || tupleDomain.isNone()) {
-            return tupleDomain;
-        }
-
-        return TupleDomain.withColumnDomains(Maps.transformValues(
-                tupleDomain.getDomains().get(),
-                DomainConverter::translateDomain));
+        return tupleDomain.transformDomains((column, domain) -> translateDomain(domain));
     }
 
     private static Domain translateDomain(Domain domain)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/WindowFilterPushDown.java
@@ -39,7 +39,6 @@ import io.prestosql.sql.tree.BooleanLiteral;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.QualifiedName;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -54,7 +53,6 @@ import static io.prestosql.sql.planner.DomainTranslator.fromPredicate;
 import static io.prestosql.sql.planner.plan.ChildReplacer.replaceChildren;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 public class WindowFilterPushDown
         implements PlanOptimizer
@@ -191,12 +189,7 @@ public class WindowFilterPushDown
             }
 
             // Remove the row number domain because it is absorbed into the node
-            Map<Symbol, Domain> newDomains = tupleDomain.getDomains().get().entrySet().stream()
-                    .filter(entry -> !entry.getKey().equals(rowNumberSymbol))
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            // Construct a new predicate
-            TupleDomain<Symbol> newTupleDomain = TupleDomain.withColumnDomains(newDomains);
+            TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rowNumberSymbol));
             Expression newPredicate = ExpressionUtils.combineConjuncts(
                     metadata,
                     extractionResult.getRemainingExpression(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -1176,7 +1176,7 @@ public class PlanPrinter
         {
             checkArgument(!constraint.isNone());
             Map<ColumnHandle, Domain> domains = constraint.getDomains().get();
-            if (!constraint.isAll() && domains.containsKey(column)) {
+            if (domains.containsKey(column)) {
                 nodeOutput.appendDetailsLine("    :: %s", formatDomain(domains.get(column).simplify()));
             }
         }

--- a/presto-spi/src/test/java/io/prestosql/spi/predicate/TestTupleDomain.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/predicate/TestTupleDomain.java
@@ -105,6 +105,7 @@ public class TestTupleDomain
                         .build());
 
         assertEquals(tupleDomain1.intersect(tupleDomain2), expectedTupleDomain);
+        assertEquals(tupleDomain2.intersect(tupleDomain1), expectedTupleDomain);
     }
 
     @Test

--- a/presto-testing/src/main/java/io/prestosql/testing/tpch/TpchIndexMetadata.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/tpch/TpchIndexMetadata.java
@@ -16,7 +16,6 @@ package io.prestosql.testing.tpch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import io.prestosql.plugin.tpch.TpchMetadata;
 import io.prestosql.plugin.tpch.TpchTableHandle;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -31,8 +30,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Predicates.in;
-import static com.google.common.base.Predicates.not;
 import static io.prestosql.testing.tpch.TpchIndexProvider.handleToNames;
 import static java.util.Objects.requireNonNull;
 
@@ -76,10 +73,7 @@ public class TpchIndexMetadata
             return Optional.empty();
         }
 
-        TupleDomain<ColumnHandle> filteredTupleDomain = tupleDomain;
-        if (!tupleDomain.isNone()) {
-            filteredTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(tupleDomain.getDomains().get(), not(in(fixedValues.keySet()))));
-        }
+        TupleDomain<ColumnHandle> filteredTupleDomain = tupleDomain.filter((column, domain) -> !fixedValues.containsKey(column));
         TpchIndexHandle indexHandle = new TpchIndexHandle(
                 tpchTableHandle.getTableName(),
                 tpchTableHandle.getScaleFactor(),

--- a/presto-tpch/src/main/java/io/prestosql/plugin/tpch/util/PredicateUtils.java
+++ b/presto-tpch/src/main/java/io/prestosql/plugin/tpch/util/PredicateUtils.java
@@ -38,13 +38,6 @@ public final class PredicateUtils
 
     public static TupleDomain<ColumnHandle> filterColumns(TupleDomain<ColumnHandle> predicate, Predicate<TpchColumnHandle> filterPredicate)
     {
-        return predicate.transform(columnHandle -> {
-            TpchColumnHandle tpchColumnHandle = (TpchColumnHandle) columnHandle;
-            if (filterPredicate.test(tpchColumnHandle)) {
-                return tpchColumnHandle;
-            }
-
-            return null;
-        });
+        return predicate.filter((columnHandle, domain) -> filterPredicate.test((TpchColumnHandle) columnHandle));
     }
 }


### PR DESCRIPTION
This allows to remove some direct usages of `tupleDomain.getDomains().get()`.