### PR TITLE
Add a query with WHERE clause to DataTypeTest

### DIFF
--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
@@ -51,6 +51,7 @@ public class DataType<T>
     private final String insertType;
     private final Type prestoResultType;
     private final Function<T, String> toLiteral;
+    private final Function<T, String> toPrestoLiteral;
     private final Function<T, ?> toPrestoQueryResult;
 
     public static DataType<Boolean> booleanDataType()
@@ -217,24 +218,30 @@ public class DataType<T>
 
     private static <T> DataType<T> dataType(String insertType, Type prestoResultType)
     {
-        return new DataType<>(insertType, prestoResultType, Object::toString, Function.identity());
+        return new DataType<>(insertType, prestoResultType, Object::toString, Object::toString, Function.identity());
     }
 
     public static <T> DataType<T> dataType(String insertType, Type prestoResultType, Function<T, String> toLiteral)
     {
-        return new DataType<>(insertType, prestoResultType, toLiteral, Function.identity());
+        return new DataType<>(insertType, prestoResultType, toLiteral, toLiteral, Function.identity());
     }
 
     public static <T> DataType<T> dataType(String insertType, Type prestoResultType, Function<T, String> toLiteral, Function<T, ?> toPrestoQueryResult)
     {
-        return new DataType<>(insertType, prestoResultType, toLiteral, toPrestoQueryResult);
+        return new DataType<>(insertType, prestoResultType, toLiteral, toLiteral, toPrestoQueryResult);
     }
 
-    private DataType(String insertType, Type prestoResultType, Function<T, String> toLiteral, Function<T, ?> toPrestoQueryResult)
+    public static <T> DataType<T> dataType(String insertType, Type prestoResultType, Function<T, String> toLiteral, Function<T, String> toPrestoLiteral, Function<T, ?> toPrestoQueryResult)
+    {
+        return new DataType<>(insertType, prestoResultType, toLiteral, toPrestoLiteral, toPrestoQueryResult);
+    }
+
+    private DataType(String insertType, Type prestoResultType, Function<T, String> toLiteral, Function<T, String> toPrestoLiteral, Function<T, ?> toPrestoQueryResult)
     {
         this.insertType = insertType;
         this.prestoResultType = prestoResultType;
         this.toLiteral = toLiteral;
+        this.toPrestoLiteral = toPrestoLiteral;
         this.toPrestoQueryResult = toPrestoQueryResult;
     }
 
@@ -244,6 +251,14 @@ public class DataType<T>
             return "NULL";
         }
         return toLiteral.apply(inputValue);
+    }
+
+    public String toPrestoLiteral(T inputValue)
+    {
+        if (inputValue == null) {
+            return "NULL";
+        }
+        return toPrestoLiteral.apply(inputValue);
     }
 
     public Object toPrestoQueryResult(T inputValue)

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/DataTypeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/DataTypeTest.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.testing.datatype;
 
+import io.airlift.log.Logger;
 import io.prestosql.Session;
 import io.prestosql.spi.type.Type;
 import io.prestosql.testing.MaterializedResult;
@@ -23,24 +24,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
+import static java.lang.String.join;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 
 public class DataTypeTest
 {
+    private static final Logger log = Logger.get(DataTypeTest.class);
+
     private final List<Input<?>> inputs = new ArrayList<>();
 
-    private DataTypeTest() {}
+    private boolean runSelectWithWhere;
+
+    private DataTypeTest(boolean runSelectWithWhere)
+    {
+        this.runSelectWithWhere = runSelectWithWhere;
+    }
 
     public static DataTypeTest create()
     {
-        return new DataTypeTest();
+        return new DataTypeTest(false);
+    }
+
+    public static DataTypeTest create(boolean runSelectWithWhere)
+    {
+        return new DataTypeTest(runSelectWithWhere);
     }
 
     public <T> DataTypeTest addRoundTrip(DataType<T> dataType, T value)
     {
-        inputs.add(new Input<>(dataType, value));
+        return addRoundTrip(dataType, value, true);
+    }
+
+    public <T> DataTypeTest addRoundTrip(DataType<T> dataType, T value, boolean useInWhereClause)
+    {
+        inputs.add(new Input<>(dataType, value, useInWhereClause));
         return this;
     }
 
@@ -55,12 +75,58 @@ public class DataTypeTest
         List<Object> expectedResults = inputs.stream().map(Input::toPrestoQueryResult).collect(toList());
         try (TestTable testTable = dataSetup.setupTestTable(unmodifiableList(inputs))) {
             MaterializedResult materializedRows = prestoExecutor.execute(session, "SELECT * from " + testTable.getName());
-            assertEquals(materializedRows.getTypes(), expectedTypes);
-            List<Object> actualResults = getOnlyElement(materializedRows).getFields();
-            assertEquals(actualResults.size(), expectedResults.size(), "lists don't have the same size");
-            for (int i = 0; i < expectedResults.size(); i++) {
-                assertEquals(actualResults.get(i), expectedResults.get(i), "Element " + i);
+            checkResults(expectedTypes, expectedResults, materializedRows);
+            if (runSelectWithWhere) {
+                queryWithWhere(prestoExecutor, session, expectedTypes, expectedResults, testTable);
             }
+        }
+    }
+
+    private void queryWithWhere(QueryRunner prestoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TestTable testTable)
+    {
+        String prestoQuery = buildPrestoQueryWithWhereClauses(testTable);
+        try {
+            MaterializedResult filteredRows = prestoExecutor.execute(session, prestoQuery);
+            checkResults(expectedTypes, expectedResults, filteredRows);
+        }
+        catch (RuntimeException e) {
+            log.error("Exception caught during query with merged WHERE clause, querying one column at a time", e);
+            debugTypes(prestoExecutor, session, expectedTypes, expectedResults, testTable);
+        }
+    }
+
+    private void debugTypes(QueryRunner prestoExecutor, Session session, List<Type> expectedTypes, List<Object> expectedResults, TestTable testTable)
+    {
+        for (int i = 0; i < inputs.size(); i++) {
+            Input<?> input = inputs.get(i);
+            if (input.isUseInWhereClause()) {
+                String debugQuery = String.format("SELECT col_%d FROM %s WHERE col_%d IS NOT DISTINCT FROM %s", i, testTable.getName(), i, input.toPrestoLiteral());
+                log.info("Querying input: %d (expected type: %s, expectedResult: %s) using: %s", i, expectedTypes.get(i), expectedResults.get(i), debugQuery);
+                MaterializedResult debugRows = prestoExecutor.execute(session, debugQuery);
+                checkResults(expectedTypes.subList(i, i + 1), expectedResults.subList(i, i + 1), debugRows);
+            }
+        }
+    }
+
+    private String buildPrestoQueryWithWhereClauses(TestTable testTable)
+    {
+        List<String> predicates = new ArrayList<>();
+        for (int i = 0; i < inputs.size(); i++) {
+            Input<?> input = inputs.get(i);
+            if (input.isUseInWhereClause()) {
+                predicates.add(format("col_%d IS NOT DISTINCT FROM %s", i, input.toPrestoLiteral()));
+            }
+        }
+        return "SELECT * FROM " + testTable.getName() + " WHERE " + join(" AND ", predicates);
+    }
+
+    private void checkResults(List<Type> expectedTypes, List<Object> expectedResults, MaterializedResult materializedRows)
+    {
+        assertEquals(materializedRows.getTypes(), expectedTypes);
+        List<Object> actualResults = getOnlyElement(materializedRows).getFields();
+        assertEquals(actualResults.size(), expectedResults.size(), "lists don't have the same size");
+        for (int i = 0; i < expectedResults.size(); i++) {
+            assertEquals(actualResults.get(i), expectedResults.get(i), "Element " + i);
         }
     }
 
@@ -68,14 +134,21 @@ public class DataTypeTest
     {
         private final DataType<T> dataType;
         private final T value;
+        private final boolean useInWhereClause;
 
-        public Input(DataType<T> dataType, T value)
+        public Input(DataType<T> dataType, T value, boolean useInWhereClause)
         {
             this.dataType = dataType;
             this.value = value;
+            this.useInWhereClause = useInWhereClause;
         }
 
-        String getInsertType()
+        public boolean isUseInWhereClause()
+        {
+            return useInWhereClause;
+        }
+
+        public String getInsertType()
         {
             return dataType.getInsertType();
         }
@@ -90,9 +163,14 @@ public class DataTypeTest
             return dataType.toPrestoQueryResult(value);
         }
 
-        String toLiteral()
+        public String toLiteral()
         {
             return dataType.toLiteral(value);
+        }
+
+        public String toPrestoLiteral()
+        {
+            return dataType.toPrestoLiteral(value);
         }
     }
 }


### PR DESCRIPTION
This is useful for testing predicate pushdown.

Please note that this doesn't fail if predicate evaluation happens on Presto side, you still need an assertion that checks for that.

Fixes https://github.com/prestosql/presto/issues/496