### PR TITLE
Catch Errors also at getting LocalDispatchQuery QueryException

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
@@ -291,7 +291,7 @@ public class LocalDispatchQuery
         try {
             return tryGetFutureValue(queryExecutionFuture);
         }
-        catch (Exception ignored) {
+        catch (Throwable ignored) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
Recently we have a query like 

```
with test as (select 'aaa' name
union all
select 'aab' name
union all
select 'aac' name
union all
... -- 2000 more unions
select * from t where name in (select name from test)
```
And this caused `StackOverflowError` at StatementAnalyzer. After this error happens, `DispatchManager.getQueries` starts to throw StackOverflowError. 

I think we should catch Errors also at `tryGetQueryExecution`