### PR TITLE
Fix failure when unnest inputs are repeated

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -1393,7 +1393,11 @@ public class LocalExecutionPlanner
             for (Symbol symbol : node.getReplicateSymbols()) {
                 replicateTypes.add(context.getTypes().get(symbol));
             }
-            List<Symbol> unnestSymbols = ImmutableList.copyOf(node.getUnnestSymbols().keySet());
+
+            List<Symbol> unnestSymbols = node.getMappings().stream()
+                    .map(UnnestNode.Mapping::getInput)
+                    .collect(toImmutableList());
+
             ImmutableList.Builder<Type> unnestTypes = ImmutableList.builder();
             for (Symbol symbol : unnestSymbols) {
                 unnestTypes.add(context.getTypes().get(symbol));
@@ -1412,12 +1416,14 @@ public class LocalExecutionPlanner
                 outputMappings.put(symbol, channel);
                 channel++;
             }
-            for (Symbol symbol : unnestSymbols) {
-                for (Symbol unnestedSymbol : node.getUnnestSymbols().get(symbol)) {
+
+            for (UnnestNode.Mapping mapping : node.getMappings()) {
+                for (Symbol unnestedSymbol : mapping.getOutputs()) {
                     outputMappings.put(unnestedSymbol, channel);
                     channel++;
                 }
             }
+
             if (ordinalitySymbol.isPresent()) {
                 outputMappings.put(ordinalitySymbol.get(), channel);
                 channel++;

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -689,14 +689,15 @@ class RelationPlanner
                 .collect(toImmutableMap(Function.identity(), symbolAllocator::newSymbol));
 
         UnnestAnalysis unnestAnalysis = analysis.getUnnest(node);
-        ImmutableMap.Builder<Symbol, List<Symbol>> mappings = ImmutableMap.builder();
+
+        ImmutableList.Builder<UnnestNode.Mapping> mappings = ImmutableList.builder();
         for (Expression expression : node.getExpressions()) {
             Symbol input = subPlan.translate(expression);
             List<Symbol> outputs = unnestAnalysis.getMappings().get(NodeRef.of(expression)).stream()
                     .map(allocations::get)
                     .collect(toImmutableList());
 
-            mappings.put(input, outputs);
+            mappings.add(new UnnestNode.Mapping(input, outputs));
         }
 
         UnnestNode unnestNode = new UnnestNode(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -574,7 +574,7 @@ class SubqueryPlanner
                     node.getId(),
                     rewrittenNode.getSource(),
                     rewrittenNode.getReplicateSymbols(),
-                    rewrittenNode.getUnnestSymbols(),
+                    rewrittenNode.getMappings(),
                     rewrittenNode.getOrdinalitySymbol(),
                     rewrittenNode.getJoinType(),
                     rewrittenNode.getFilter().map(expression -> replaceExpression(expression, mapping)));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -607,7 +607,7 @@ public class ExtractSpatialJoins
                 context.getIdAllocator().getNextId(),
                 new ProjectNode(context.getIdAllocator().getNextId(), node, projections.build()),
                 node.getOutputSymbols(),
-                ImmutableMap.of(partitionsSymbol, ImmutableList.of(partitionSymbol)),
+                ImmutableList.of(new UnnestNode.Mapping(partitionsSymbol, ImmutableList.of(partitionSymbol))),
                 Optional.empty(),
                 INNER,
                 Optional.empty());

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -668,7 +668,7 @@ public class HashGenerationOptimizer
                                     .addAll(node.getReplicateSymbols())
                                     .addAll(hashSymbols.values())
                                     .build(),
-                            node.getUnnestSymbols(),
+                            node.getMappings(),
                             node.getOrdinalitySymbol(),
                             node.getJoinType(),
                             node.getFilter()),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -1387,7 +1387,7 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource()) {
-                output = new UnnestNode(node.getId(), rewrittenSource, node.getReplicateSymbols(), node.getUnnestSymbols(), node.getOrdinalitySymbol(), node.getJoinType(), node.getFilter());
+                output = new UnnestNode(node.getId(), rewrittenSource, node.getReplicateSymbols(), node.getMappings(), node.getOrdinalitySymbol(), node.getJoinType(), node.getFilter());
             }
             if (!postUnnestConjuncts.isEmpty()) {
                 output = new FilterNode(idAllocator.getNextId(), output, combineConjuncts(metadata, postUnnestConjuncts));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -189,15 +189,18 @@ public class UnaliasSymbolReferences
         public PlanNode visitUnnest(UnnestNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-            ImmutableMap.Builder<Symbol, List<Symbol>> builder = ImmutableMap.builder();
-            for (Map.Entry<Symbol, List<Symbol>> entry : node.getUnnestSymbols().entrySet()) {
-                builder.put(canonicalize(entry.getKey()), entry.getValue());
+
+            ImmutableList.Builder<UnnestNode.Mapping> mappings = ImmutableList.builder();
+
+            for (UnnestNode.Mapping mapping : node.getMappings()) {
+                mappings.add(new UnnestNode.Mapping(canonicalize(mapping.getInput()), mapping.getOutputs()));
             }
+
             return new UnnestNode(
                     node.getId(),
                     source,
                     canonicalizeAndDistinct(node.getReplicateSymbols()),
-                    builder.build(),
+                    mappings.build(),
                     node.getOrdinalitySymbol(),
                     node.getJoinType(),
                     node.getFilter().map(this::canonicalize));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/UnnestNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/UnnestNode.java
@@ -16,7 +16,6 @@ package io.prestosql.sql.planner.plan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.JoinNode.Type;
@@ -24,11 +23,12 @@ import io.prestosql.sql.tree.Expression;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -37,7 +37,7 @@ public class UnnestNode
 {
     private final PlanNode source;
     private final List<Symbol> replicateSymbols;
-    private final Map<Symbol, List<Symbol>> unnestSymbols;
+    private final List<Mapping> mappings;
     private final Optional<Symbol> ordinalitySymbol;
     private final Type joinType;
     private final Optional<Expression> filter;
@@ -47,7 +47,7 @@ public class UnnestNode
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("replicateSymbols") List<Symbol> replicateSymbols,
-            @JsonProperty("unnestSymbols") Map<Symbol, List<Symbol>> unnestSymbols,
+            @JsonProperty("mappings") List<Mapping> mappings,
             @JsonProperty("ordinalitySymbol") Optional<Symbol> ordinalitySymbol,
             @JsonProperty("joinType") Type joinType,
             @JsonProperty("filter") Optional<Expression> filter)
@@ -56,13 +56,9 @@ public class UnnestNode
         this.source = requireNonNull(source, "source is null");
         this.replicateSymbols = ImmutableList.copyOf(requireNonNull(replicateSymbols, "replicateSymbols is null"));
         checkArgument(source.getOutputSymbols().containsAll(replicateSymbols), "Source does not contain all replicateSymbols");
-        requireNonNull(unnestSymbols, "unnestSymbols is null");
-        checkArgument(!unnestSymbols.isEmpty(), "unnestSymbols is empty");
-        ImmutableMap.Builder<Symbol, List<Symbol>> builder = ImmutableMap.builder();
-        for (Map.Entry<Symbol, List<Symbol>> entry : unnestSymbols.entrySet()) {
-            builder.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
-        }
-        this.unnestSymbols = builder.build();
+        requireNonNull(mappings, "mappings is null");
+        checkArgument(!mappings.isEmpty(), "mappings is empty");
+        this.mappings = ImmutableList.copyOf(mappings);
         this.ordinalitySymbol = requireNonNull(ordinalitySymbol, "ordinalitySymbol is null");
         this.joinType = requireNonNull(joinType, "type is null");
         this.filter = requireNonNull(filter, "filter is null");
@@ -73,7 +69,11 @@ public class UnnestNode
     {
         ImmutableList.Builder<Symbol> outputSymbolsBuilder = ImmutableList.<Symbol>builder()
                 .addAll(replicateSymbols)
-                .addAll(Iterables.concat(unnestSymbols.values()));
+                .addAll(mappings.stream()
+                        .map(Mapping::getOutputs)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableList()));
+
         ordinalitySymbol.ifPresent(outputSymbolsBuilder::add);
         return outputSymbolsBuilder.build();
     }
@@ -91,9 +91,9 @@ public class UnnestNode
     }
 
     @JsonProperty
-    public Map<Symbol, List<Symbol>> getUnnestSymbols()
+    public List<Mapping> getMappings()
     {
-        return unnestSymbols;
+        return mappings;
     }
 
     @JsonProperty
@@ -129,6 +129,34 @@ public class UnnestNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, unnestSymbols, ordinalitySymbol, joinType, filter);
+        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, mappings, ordinalitySymbol, joinType, filter);
+    }
+
+    public static class Mapping
+    {
+        private final Symbol input;
+        private final List<Symbol> outputs;
+
+        @JsonCreator
+        public Mapping(
+                @JsonProperty("input") Symbol input,
+                @JsonProperty("outputs") List<Symbol> outputs)
+        {
+            this.input = requireNonNull(input, "input is null");
+            requireNonNull(outputs, "outputs is null");
+            this.outputs = ImmutableList.copyOf(outputs);
+        }
+
+        @JsonProperty
+        public Symbol getInput()
+        {
+            return input;
+        }
+
+        @JsonProperty
+        public List<Symbol> getOutputs()
+        {
+            return outputs;
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -873,10 +873,15 @@ public class PlanPrinter
             else {
                 name = "Unnest";
             }
+
+            List<Symbol> unnestInputs = node.getMappings().stream()
+                    .map(UnnestNode.Mapping::getInput)
+                    .collect(toImmutableList());
+
             addNode(
                     node,
                     name,
-                    format("[replicate=%s, unnest=%s", formatOutputs(types, node.getReplicateSymbols()), formatOutputs(types, node.getUnnestSymbols().keySet()))
+                    format("[replicate=%s, unnest=%s", formatOutputs(types, node.getReplicateSymbols()), formatOutputs(types, unnestInputs))
                             + (node.getFilter().isPresent() ? format(", filter=%s]", node.getFilter().get().toString()) : "]"));
             return processChildren(node, context);
         }

--- a/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
@@ -398,7 +398,12 @@ public final class GraphvizPrinter
             else {
                 label.append("Unnest");
             }
-            label.append(format(" [%s", node.getUnnestSymbols().keySet()))
+
+            List<Symbol> unnestInputs = node.getMappings().stream()
+                    .map(UnnestNode.Mapping::getInput)
+                    .collect(toImmutableList());
+
+            label.append(format(" [%s", unnestInputs))
                     .append(node.getOrdinalitySymbol().isPresent() ? " (ordinality)]" : "]");
 
             String details = node.getFilter().isPresent() ? " filter " + node.getFilter().get().toString() : "";

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
@@ -188,4 +188,12 @@ public class TestUnnest
                 "SELECT * FROM (VALUES ARRAY[1, null]) a(x) INNER JOIN UNNEST(x) b(y) ON b.y = 1",
                 "line .*: INNER JOIN involving UNNEST is only supported with condition ON TRUE");
     }
+
+    @Test
+    public void testRepeatedExpressions()
+    {
+        assertions.assertQuery(
+                "SELECT * FROM (VALUES 1) t, UNNEST(ARRAY['a', 'b'], ARRAY['a', 'b']) u (x, y)",
+                "VALUES (1, 'a', 'a'), (1, 'b', 'b')");
+    }
 }


### PR DESCRIPTION
The mappings to unnest are keyed based on input symbol.
When input expression are repeated, the deduplication logic
replaces them with references to the same symbol. This
causes a conflict that results in a planning failure.