### PR TITLE
Do not used Rubix parallel warmup by default

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfig.java
@@ -20,7 +20,8 @@ import javax.validation.constraints.NotNull;
 
 public class RubixConfig
 {
-    private boolean parallelWarmupEnabled = true;
+    // TODO enable by default again after https://github.com/prestosql/presto/issues/3494 is fixed
+    private boolean parallelWarmupEnabled;
     private String cacheLocation;
     private int bookKeeperServerPort = CacheConfig.DEFAULT_BOOKKEEPER_SERVER_PORT;
     private int dataTransferServerPort = CacheConfig.DEFAULT_DATA_TRANSFER_SERVER_PORT;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixConfig.java
@@ -32,21 +32,21 @@ public class TestRubixConfig
                 .setBookKeeperServerPort(CacheConfig.DEFAULT_BOOKKEEPER_SERVER_PORT)
                 .setDataTransferServerPort(CacheConfig.DEFAULT_DATA_TRANSFER_SERVER_PORT)
                 .setCacheLocation(null)
-                .setParallelWarmupEnabled(true));
+                .setParallelWarmupEnabled(false));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("hive.cache.parallel-warmup-enabled", "false")
+                .put("hive.cache.parallel-warmup-enabled", "true")
                 .put("hive.cache.location", "/some-directory")
                 .put("hive.cache.bookkeeper-port", "1234")
                 .put("hive.cache.data-transfer-port", "1235")
                 .build();
 
         RubixConfig expected = new RubixConfig()
-                .setParallelWarmupEnabled(false)
+                .setParallelWarmupEnabled(true)
                 .setCacheLocation("/some-directory")
                 .setBookKeeperServerPort(1234)
                 .setDataTransferServerPort(1235);


### PR DESCRIPTION
Stress testing showed that Rubix caching is not stable with parallel
warmup enabled. Temporarily diabling by default.