### PR TITLE
Skip whitespace padded char data mapping test for Kudu

### DIFF
--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
@@ -150,7 +150,8 @@ public class TestKuduDistributedQueries
         }
 
         if (typeName.equals("date") // date gets stored as varchar
-                || typeName.equals("varbinary")) { // TODO (https://github.com/prestosql/presto/issues/3416)
+                || typeName.equals("varbinary") // TODO (https://github.com/prestosql/presto/issues/3416)
+                || (typeName.startsWith("char") && dataMappingTestSetup.getSampleValueLiteral().contains(" "))) { // TODO: https://github.com/prestosql/presto/issues/3597
             // TODO this should either work or fail cleanly
             return Optional.empty();
         }


### PR DESCRIPTION
The tests we added in https://github.com/prestosql/presto/pull/3588 uncovered a bug in the Kudu connector: https://github.com/prestosql/presto/issues/3597

But we can just skip the test for now.