### PR TITLE
Avoid adding local exchanges around trivial projection

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/RowNumberMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/RowNumberMatcher.java
@@ -147,9 +147,10 @@ public class RowNumberMatcher
             return this;
         }
 
-        public Builder hashSymbol(Optional<SymbolAlias> hashSymbol)
+        public Builder hashSymbol(Optional<String> hashSymbol)
         {
-            this.hashSymbol = Optional.of(requireNonNull(hashSymbol, "hashSymbol is null"));
+            requireNonNull(hashSymbol, "hashSymbol is null");
+            this.hashSymbol = Optional.of(hashSymbol.map(SymbolAlias::new));
             return this;
         }
 


### PR DESCRIPTION
Changes the strategy of adding exchanges around trivial projection. A projection is considered trivial if it has identity or renaming assignments only. This change could be extended to handle other low-cost projections.
- if parent node requires single distribution, no specific distribution will be enforced below the projection
- if parent node requires hashed distribution, no specific distribution will be enforced below the projection (repartition will be performed after pruning)
- if parent node requires random multiple distribution, it will be introduced below the projection.

Fixes #3550