### PR TITLE
Fix document: result type precision of Decimal operations (Add and Subtract) is wrong

### DIFF
--- a/presto-docs/src/main/sphinx/functions/decimal.rst
+++ b/presto-docs/src/main/sphinx/functions/decimal.rst
@@ -35,8 +35,8 @@ Binary Arithmetic Decimal Operators
 |               |                                   |                                   |
 | and           |   min(38,                         | ``max(xs, ys)``                   |
 |               |       1 +                         |                                   |
-| ``x - y``     |         min(xs, ys) +             |                                   |
-|               |         min(xp - xs, yp - ys)     |                                   |
+| ``x - y``     |         max(xs, ys) +             |                                   |
+|               |         max(xp - xs, yp - ys)     |                                   |
 |               |      )                            |                                   |
 +---------------+-----------------------------------+-----------------------------------+
 | ``x * y``     | ``min(38, xp + yp)``              | ``xs + ys``                       |


### PR DESCRIPTION
I changed the "Result type precision" of Decimal operation `x + y` and `x - y`
In the source code, result type precision is `min(38, 1 + max(xs, ys) + max(xp - xs, yp - ys))`.
However, in the document, result type precision is `min(38, 1 + min(xs, ys) + min(xp - xs, yp - ys))`.

https://github.com/prestosql/presto/blob/19abcb7ddeacaf1ca7bad52f998b524dc83b6904/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java#L90

https://github.com/prestosql/presto/blob/19abcb7ddeacaf1ca7bad52f998b524dc83b6904/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java#L172