### PR TITLE
Refactor presto-orc module

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
@@ -552,8 +552,7 @@ public class OrcRecordReader
             throws OrcCorruptionException
     {
         ColumnReader[] columnReaders = new ColumnReader[columns.size()];
-        for (int i = 0; i < columns.size(); i++) {
-            int columnIndex = i;
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
             Type readType = readTypes.get(columnIndex);
             OrcColumn column = columns.get(columnIndex);
             OrcReader.ProjectedLayout projectedLayout = readLayouts.get(columnIndex);

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -126,10 +126,7 @@ public class TupleDomainOrcPredicate
         }
 
         // if none of the discrete predicate values are found in the bloom filter, there is no overlap and the section should be skipped
-        if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()))) {
-            return false;
-        }
-        return true;
+        return discreteValues.get().stream().anyMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()));
     }
 
     @VisibleForTesting

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/SliceDictionaryColumnWriter.java
@@ -38,7 +38,6 @@ import io.prestosql.orc.stream.StreamDataOutput;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.DictionaryBlock;
 import io.prestosql.spi.type.Type;
-import it.unimi.dsi.fastutil.ints.AbstractIntComparator;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -408,32 +407,26 @@ public class SliceDictionaryColumnWriter
             sortedPositions[i] = i;
         }
 
-        IntArrays.quickSort(sortedPositions, 0, sortedPositions.length, new AbstractIntComparator()
-        {
-            @Override
-            public int compare(int left, int right)
-            {
-                boolean nullLeft = elementBlock.isNull(left);
-                boolean nullRight = elementBlock.isNull(right);
-                if (nullLeft && nullRight) {
-                    return 0;
-                }
-                if (nullLeft) {
-                    return 1;
-                }
-                if (nullRight) {
-                    return -1;
-                }
-
-                return elementBlock.compareTo(
-                        left,
-                        0,
-                        elementBlock.getSliceLength(left),
-                        elementBlock,
-                        right,
-                        0,
-                        elementBlock.getSliceLength(right));
+        IntArrays.quickSort(sortedPositions, 0, sortedPositions.length, (int left, int right) -> {
+            boolean nullLeft = elementBlock.isNull(left);
+            boolean nullRight = elementBlock.isNull(right);
+            if (nullLeft && nullRight) {
+                return 0;
             }
+            if (nullLeft) {
+                return 1;
+            }
+            if (nullRight) {
+                return -1;
+            }
+            return elementBlock.compareTo(
+                    left,
+                    0,
+                    elementBlock.getSliceLength(left),
+                    elementBlock,
+                    right,
+                    0,
+                    elementBlock.getSliceLength(right));
         });
 
         return sortedPositions;

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -497,7 +497,7 @@ public class OrcTester
     private static void assertColumnValueEquals(Type type, Object actual, Object expected)
     {
         if (actual == null) {
-            assertEquals(actual, expected);
+            assertNull(expected);
             return;
         }
         if (type instanceof ArrayType) {

--- a/presto-orc/src/test/java/io/prestosql/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestingOrcPredicate.java
@@ -149,11 +149,6 @@ public final class TestingOrcPredicate
                 List<T> chunk = expectedValues.subList((int) (expectedValues.size() - numberOfRows), expectedValues.size());
                 assertChunkStats(chunk, columnStatistics);
             }
-            else if (numberOfRows == expectedValues.size() % ORC_STRIPE_SIZE) {
-                // tail section
-                List<T> chunk = expectedValues.subList((int) (expectedValues.size() - numberOfRows), expectedValues.size());
-                assertChunkStats(chunk, columnStatistics);
-            }
             else {
                 fail("Unexpected number of rows: " + numberOfRows);
             }
@@ -180,11 +175,7 @@ public final class TestingOrcPredicate
         protected boolean chunkMatchesStats(List<T> chunk, ColumnStatistics columnStatistics)
         {
             // verify non null count
-            if (columnStatistics.getNumberOfValues() != chunk.stream().filter(Objects::nonNull).count()) {
-                return false;
-            }
-
-            return true;
+            return columnStatistics.getNumberOfValues() == chunk.stream().filter(Objects::nonNull).count();
         }
     }
 


### PR DESCRIPTION
# Purpose
Refactor the codebase of the presto-orc module.

# Overview

- Omit the redundant variable usage
- Omit redundant condition check
- Simplify the conditions returning boolean values
- Prefer the lambda expression when it's applicable
