### PR TITLE
Prevent OutputBufferMemoryManager from becoming negative

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/buffer/OutputBufferMemoryManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/OutputBufferMemoryManager.java
@@ -81,7 +81,12 @@ class OutputBufferMemoryManager
             return;
         }
 
-        long currentBufferedBytes = bufferedBytes.addAndGet(bytesAdded);
+        long currentBufferedBytes = bufferedBytes.updateAndGet(bytes -> {
+            long result = bytes + bytesAdded;
+            checkArgument(result >= 0, "bufferedBytes (%s) plus delta (%s) would be negative", bytes, bytesAdded);
+            return result;
+        });
+
         peakMemoryUsage.accumulateAndGet(currentBufferedBytes, Math::max);
         this.blockedOnMemory = systemMemoryContext.get().setBytes(currentBufferedBytes);
         if (!isBufferFull() && !isBlockedOnMemory() && !bufferBlockedFuture.isDone()) {


### PR DESCRIPTION
This should never occur, but if it does, we should prevent the object
from entering an invalid state, as this breaks stats using DataSize.