### PR TITLE
Enable testColumnName in TestCassandraDistributedQueries

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraMetadata.java
@@ -54,6 +54,7 @@ import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.prestosql.plugin.cassandra.CassandraType.toCassandraType;
 import static io.prestosql.plugin.cassandra.util.CassandraCqlUtils.ID_COLUMN_NAME;
 import static io.prestosql.plugin.cassandra.util.CassandraCqlUtils.cqlNameToSqlName;
+import static io.prestosql.plugin.cassandra.util.CassandraCqlUtils.quoteStringLiteral;
 import static io.prestosql.plugin.cassandra.util.CassandraCqlUtils.validColumnName;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
@@ -310,7 +311,7 @@ public class CassandraMetadata
 
         // encode column ordering in the cassandra table comment field since there is no better place to store this
         String columnMetadata = extraColumnMetadataCodec.toJson(columnExtra.build());
-        queryBuilder.append("WITH comment='").append(PRESTO_COMMENT_METADATA).append(" ").append(columnMetadata).append("'");
+        queryBuilder.append("WITH comment=").append(quoteStringLiteral(PRESTO_COMMENT_METADATA + " " + columnMetadata));
 
         // We need to create the Cassandra table before commit because the record needs to be written to the table.
         cassandraSession.execute(queryBuilder.toString());

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/util/CassandraCqlUtils.java
@@ -23,6 +23,7 @@ import io.prestosql.spi.connector.ColumnHandle;
 
 import java.util.List;
 
+import static com.datastax.driver.core.Metadata.quote;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class CassandraCqlUtils
@@ -34,12 +35,12 @@ public final class CassandraCqlUtils
 
     public static String validSchemaName(String identifier)
     {
-        return quoteIdentifier(identifier);
+        return quote(identifier);
     }
 
     public static String validTableName(String identifier)
     {
-        return quoteIdentifier(identifier);
+        return quote(identifier);
     }
 
     public static String validColumnName(String identifier)
@@ -48,12 +49,7 @@ public final class CassandraCqlUtils
             return "\"\"";
         }
 
-        return quoteIdentifier(identifier);
-    }
-
-    private static String quoteIdentifier(String identifier)
-    {
-        return '"' + identifier + '"';
+        return quote(identifier);
     }
 
     public static String quoteStringLiteral(String string)

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -151,16 +151,6 @@ public class TestCassandraDistributedQueries
     }
 
     @Override
-    public void testColumnName(String columnName)
-    {
-        // TODO Enable after fixing the following error messages
-        // - Multiple definition of identifier id
-        // - Column family names shouldn't be more than 48 characters long
-        // - mismatched character '<EOF>'
-        // - missing EOF at 'apostrophe'
-    }
-
-    @Override
     public void testDataMappingSmokeTest(DataMappingTestSetup dataMappingTestSetup)
     {
         // TODO Enable after fixing the following error messages

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -1180,7 +1180,7 @@ public abstract class AbstractTestDistributedQueries
 
         try {
             // TODO test with both CTAS *and* CREATE TABLE + INSERT, since they use different connector API methods.
-            assertUpdate("CREATE TABLE " + tableName + "(id varchar, " + nameInSql + " varchar)");
+            assertUpdate("CREATE TABLE " + tableName + "(key varchar, " + nameInSql + " varchar)");
         }
         catch (RuntimeException e) {
             if (isColumnNameRejected(e, columnName, delimited)) {
@@ -1198,8 +1198,8 @@ public abstract class AbstractTestDistributedQueries
         assertQuery("SELECT " + nameInSql + " FROM " + tableName, "VALUES (NULL), ('abc'), ('xyz')");
 
         // predicate
-        assertQuery("SELECT id FROM " + tableName + " WHERE " + nameInSql + " IS NULL", "VALUES ('null value')");
-        assertQuery("SELECT id FROM " + tableName + " WHERE " + nameInSql + " = 'abc'", "VALUES ('sample value')");
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " IS NULL", "VALUES ('null value')");
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " = 'abc'", "VALUES ('sample value')");
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -1237,7 +1237,7 @@ public abstract class AbstractTestDistributedQueries
                 {"a/slash`"},
                 {"a\\backslash`"},
                 {"adigit0"},
-                {"0startingwithdigit"},
+                {"0startwithdigit"},
         };
     }
 


### PR DESCRIPTION
This requires changes of AbstractTestDistributedQueries. 
* Cassandra allows only 48 characters for column names
* Column name `id` is automatically generated in Cassandra connector

(Ongoing Oracle PR's column length limitation is 30 due to the image version)