### PR TITLE
Remove unused RowNumberNode with non empty partitionBy

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneRowNumberColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneRowNumberColumns.java
@@ -38,15 +38,18 @@ public class PruneRowNumberColumns
     @Override
     protected Optional<PlanNode> pushDownProjectOff(Context context, RowNumberNode rowNumberNode, Set<Symbol> referencedOutputs)
     {
-        if (!referencedOutputs.contains(rowNumberNode.getRowNumberSymbol()) && rowNumberNode.getPartitionBy().isEmpty()) {
-            if (rowNumberNode.getMaxRowCountPerPartition().isPresent()) {
+        // Remove unused RowNumberNode
+        if (!referencedOutputs.contains(rowNumberNode.getRowNumberSymbol())) {
+            if (!rowNumberNode.getMaxRowCountPerPartition().isPresent()) {
+                return Optional.of(rowNumberNode.getSource());
+            }
+            if (rowNumberNode.getPartitionBy().isEmpty()) {
                 return Optional.of(new LimitNode(
                         rowNumberNode.getId(),
                         rowNumberNode.getSource(),
                         rowNumberNode.getMaxRowCountPerPartition().get(),
                         false));
             }
-            return Optional.of(rowNumberNode.getSource());
         }
 
         Set<Symbol> requiredInputs = Streams.concat(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -609,12 +609,14 @@ public class PruneUnreferencedOutputs
         public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Set<Symbol>> context)
         {
             // Remove unused RowNumberNode
-            if (!context.get().contains(node.getRowNumberSymbol()) && node.getPartitionBy().isEmpty()) {
+            if (!context.get().contains(node.getRowNumberSymbol())) {
                 PlanNode source = context.rewrite(node.getSource(), context.get());
-                if (node.getMaxRowCountPerPartition().isPresent()) {
+                if (!node.getMaxRowCountPerPartition().isPresent()) {
+                    return source;
+                }
+                if (node.getPartitionBy().isEmpty()) {
                     return new LimitNode(node.getId(), source, node.getMaxRowCountPerPartition().get(), false);
                 }
-                return source;
             }
 
             ImmutableSet.Builder<Symbol> inputsBuilder = ImmutableSet.builder();


### PR DESCRIPTION
In PruneUnreferencedOutputs and PruneRowNumberColumns rule,
when rowNumberSymbol is unreferenced, the RowNumberNode can
be removed from the plan if partitionBy columns are defined
as long as maxRowCountPerPartition is not present.

Before this change, RowNumberNode was removed only if
partitionBy list was empty.