### PR TITLE
Constraint cleanup

### DIFF
--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryMetadata.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryMetadata.java
@@ -294,7 +294,7 @@ public class BigQueryMetadata
             Constraint constraint)
     {
         log.debug("applyFilter(session=%s, handle=%s, summary=%s, predicate=%s, columns=%s)",
-                session, handle, constraint.getSummary(), constraint.predicate(), constraint.getColumns());
+                session, handle, constraint.getSummary(), constraint.predicate(), constraint.getPredicateColumns());
         BigQueryTableHandle bigQueryTableHandle = (BigQueryTableHandle) handle;
 
         TupleDomain<ColumnHandle> oldDomain = bigQueryTableHandle.getConstraint();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1930,7 +1930,7 @@ public class HiveMetadata
         checkArgument(!handle.getAnalyzePartitionValues().isPresent() || constraint.getSummary().isAll(), "Analyze should not have a constraint");
 
         HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, new HiveIdentity(session), handle, constraint);
-        HiveTableHandle newHandle = partitionManager.applyPartitionResult(handle, partitionResult, constraint.getColumns());
+        HiveTableHandle newHandle = partitionManager.applyPartitionResult(handle, partitionResult, constraint.getPredicateColumns());
 
         if (handle.getPartitions().equals(newHandle.getPartitions()) &&
                 handle.getCompactEffectivePredicate().equals(newHandle.getCompactEffectivePredicate()) &&

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/Constraint.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/Constraint.java
@@ -27,47 +27,56 @@ public class Constraint
 {
     private final TupleDomain<ColumnHandle> summary;
     private final Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate;
-    private final Optional<Set<ColumnHandle>> columns;
+    private final Optional<Set<ColumnHandle>> predicateColumns;
 
     public static Constraint alwaysTrue()
     {
-        return new Constraint(TupleDomain.all(), Optional.empty());
+        return new Constraint(TupleDomain.all(), Optional.empty(), Optional.empty());
     }
 
     public static Constraint alwaysFalse()
     {
-        return new Constraint(TupleDomain.none(), Optional.of(bindings -> false));
+        return new Constraint(TupleDomain.none(), Optional.of(bindings -> false), Optional.empty());
     }
 
     public Constraint(TupleDomain<ColumnHandle> summary)
     {
-        this(summary, Optional.empty());
+        this(summary, Optional.empty(), Optional.empty());
     }
 
+    /**
+     * @deprecated Use {@link #Constraint(TupleDomain, Predicate, Set)} instead.
+     */
+    @Deprecated
     public Constraint(TupleDomain<ColumnHandle> summary, Predicate<Map<ColumnHandle, NullableValue>> predicate)
     {
-        this(summary, Optional.of(predicate));
+        this(summary, Optional.of(predicate), Optional.empty());
     }
 
-    public Constraint(TupleDomain<ColumnHandle> summary, Predicate<Map<ColumnHandle, NullableValue>> predicate, Set<ColumnHandle> columns)
+    public Constraint(TupleDomain<ColumnHandle> summary, Predicate<Map<ColumnHandle, NullableValue>> predicate, Set<ColumnHandle> predicateColumns)
     {
-        this(summary, Optional.of(predicate), Optional.of(columns));
+        this(summary, Optional.of(predicate), Optional.of(predicateColumns));
     }
 
+    /**
+     * @deprecated Use {@link #Constraint(TupleDomain, Optional, Optional)} instead.
+     */
+    @Deprecated
     public Constraint(TupleDomain<ColumnHandle> summary, Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate)
     {
         this(summary, predicate, Optional.empty());
     }
 
-    public Constraint(TupleDomain<ColumnHandle> summary, Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate, Optional<Set<ColumnHandle>> columns)
+    public Constraint(TupleDomain<ColumnHandle> summary, Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate, Optional<Set<ColumnHandle>> predicateColumns)
     {
-        requireNonNull(summary, "summary is null");
-        requireNonNull(predicate, "predicate is null");
-        requireNonNull(columns, "columns is null");
+        this.summary = requireNonNull(summary, "summary is null");
+        this.predicate = requireNonNull(predicate, "predicate is null");
+        this.predicateColumns = requireNonNull(predicateColumns, "predicateColumns is null");
 
-        this.summary = summary;
-        this.predicate = predicate;
-        this.columns = columns;
+        // TODO remove deprecated constructors and validate that predicate is present *iff* predicateColumns is present
+        if (predicateColumns.isPresent() && !predicate.isPresent()) {
+            throw new IllegalArgumentException("predicateColumns cannot be present when predicate is not present");
+        }
     }
 
     public TupleDomain<ColumnHandle> getSummary()
@@ -80,8 +89,20 @@ public class Constraint
         return predicate;
     }
 
+    /**
+     * @deprecated Use {@link #getPredicateColumns()} instead.
+     */
+    @Deprecated
     public Optional<Set<ColumnHandle>> getColumns()
     {
-        return columns;
+        return getPredicateColumns();
+    }
+
+    /**
+     * Set of columns the {@link #predicate()} result depends on.
+     */
+    public Optional<Set<ColumnHandle>> getPredicateColumns()
+    {
+        return predicateColumns;
     }
 }


### PR DESCRIPTION
* rename `columns` to `predicateColumns` to make the semantics clearer
* deprecate constructors that should not be used anymore
* add javadoc for `predicateColumns` accessor