### PR TITLE
Add presto-ml doc

### DIFF
--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -41,4 +41,5 @@ If you are looking for more information about a specific function or operator,
     functions/color
     functions/session
     functions/teradata
+    functions/ml
     functions/list

--- a/presto-docs/src/main/sphinx/functions/list.rst
+++ b/presto-docs/src/main/sphinx/functions/list.rst
@@ -83,6 +83,7 @@ C
 - :func:`checksum`
 - :func:`char2hexint`
 - :func:`chr`
+- :func:`classify`
 - :ref:`coalesce <coalesce_function>`
 - :func:`codepoint`
 - :func:`color`
@@ -135,6 +136,7 @@ E
 
 F
 
+- :func:`features`
 - :func:`filter`
 - :func:`first_value`
 - :func:`flatten`
@@ -212,6 +214,10 @@ L
 - :func:`last_day_of_month`
 - :func:`last_value`
 - :func:`lead`
+- :func:`learn_classifier`
+- :func:`learn_libsvm_classifier`
+- :func:`learn_libsvm_regressor`
+- :func:`learn_regressor`
 - :func:`least`
 - :func:`length`
 - :func:`levenshtein_distance`
@@ -301,6 +307,7 @@ R
 - :func:`regexp_position`
 - :func:`regexp_replace`
 - :func:`regexp_split`
+- :func:`regress`
 - :func:`regr_intercept`
 - :func:`regr_slope`
 - :func:`render`

--- a/presto-docs/src/main/sphinx/functions/ml.rst
+++ b/presto-docs/src/main/sphinx/functions/ml.rst
@@ -1,0 +1,158 @@
+==========================
+Machine Learning Functions
+==========================
+
+The machine learning plugin provides machine learning functionality
+as an aggregation function. It enables you to train Support Vector Machine (SVM)
+based classifiers and regressors for the supervised learning problems.
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+.. note::
+
+  The machine learning functions are not optimized for distributed processing.
+  The capability to train large data sets is limited by this execution of the
+  final training on a single instance.
+
+Feature Vector
+--------------
+
+To solve a problem with the machine learning technique, especially as a
+supervised learning problem, it is necessary to represent the data set
+with the sequence of pairs of labels and feature vector. A label is a
+target value you want to predict from the unseen feature and a feature is a
+A N-dimensional vector whose elements are numerical values. In Presto, a
+feature vector is represented as a map-type value, whose key is an index
+of each feature, so that it can express a sparse vector.
+Since classifiers and regressors can recognize the map-type feature
+vector, there is a function to construct the feature from the existing
+numerical values, :func:`features`::
+
+    SELECT features(1.0, 2.0, 3.0) AS features;
+
+.. code-block:: none
+
+           features
+    -----------------------
+     {0=1.0, 1=2.0, 2=3.0}
+
+The output from :func:`features` can be directly passed to ML functions.
+
+Classification
+--------------
+
+Classification is a type of supervised learning problem to predict the distinct
+label from the given feature vector. The interface looks similar to the
+construction of the SVM model from the sequence of pairs of labels and features
+implemented in Teradata Aster or `BigQuery ML <https://cloud.google.com/bigquery-ml/docs/bigqueryml-intro>`_.
+The function to train a classification model looks like as follows::
+
+    SELECT
+      learn_classifier(
+        species,
+        features(sepal_length, sepal_width, petal_length, petal_width)
+      ) AS model
+    FROM
+      iris
+
+It returns the trained model in a serialized format.
+
+.. code-block:: none
+
+                          model
+    -------------------------------------------------
+     3c 43 6c 61 73 73 69 66 69 65 72 28 76 61 72 63
+     68 61 72 29 3e
+
+:func:`classify` returns the predicted label by using the trained model.
+The trained model can not be saved natively, and needs to be passed in
+the format of a nested query::
+
+    SELECT
+      classify(features(5.9, 3, 5.1, 1.8), model) AS predicted_label
+    FROM (
+      SELECT
+        learn_classifier(species, features(sepal_length, sepal_width, petal_length, petal_width)) AS model
+      FROM
+        iris
+    ) t
+
+.. code-block:: none
+
+     predicted_label
+    -----------------
+     Iris-virginica
+
+As a result you need to run the training process at the same time when predicting values.
+Internally, the model is trained by `libsvm <https://www.csie.ntu.edu.tw/~cjlin/libsvm/>`_.
+You can use :func:`learn_libsvm_classifier` to control the internal parameters of the model.
+
+Regression
+----------
+
+Regression is another type of supervised learning problem, predicting continuous
+value, unlike the classification problem. The target must be numerical values that can
+be described as ``double``.
+
+The following code shows the creation of the model predicting ``sepal_length``
+from the other 3 features::
+
+    SELECT
+      learn_regressor(sepal_length, features(sepal_width, petal_length, petal_width)) AS model
+    FROM
+      iris
+
+The way to use the model is similar to the classification case::
+
+    SELECT
+      regress(features(3, 5.1, 1.8), model) AS predicted_target
+    FROM (
+      SELECT
+        learn_regressor(sepal_length, features(sepal_width, petal_length, petal_width)) AS model
+      FROM iris
+    ) t;
+
+.. code-block:: none
+
+     predicted_target
+    -------------------
+     6.407376822560477
+
+Internally, the model is trained by `libsvm <https://www.csie.ntu.edu.tw/~cjlin/libsvm/>`_.
+:func:`learn_libsvm_regressor` provides you a way to control the training process.
+
+Machine Learning Functions
+--------------------------
+
+.. function:: features(double, ...) -> map(bigint, double)
+
+    Returns the map representing the feature vector.
+
+.. function:: learn_classifier(label, features) -> Classifier
+
+    Returns an SVM-based classifier model, trained with the given label and feature data sets.
+
+.. function:: learn_libsvm_classifier(label, features, params) -> Classifier
+
+    Returns an SVM-based classifier model, trained with the given label and feature data sets.
+    You can control the training process by libsvm parameters.
+
+.. function:: classify(features, model) -> label
+
+    Returns a label predicted by the given classifier SVM model.
+
+.. function:: learn_regressor(target, features) -> Regressor
+
+    Returns an SVM-based regressor model, trained with the given target and feature data sets.
+
+.. function:: learn_libsvm_regressor(target, features, params) -> Regressor
+
+    Returns an SVM-based regressor model, trained with the given target and feature data sets.
+    You can control the training process by libsvm parameters.
+
+.. function:: regress(features, model) -> target
+
+    Returns a predicted target value by the given regressor SVM model.


### PR DESCRIPTION
# Purpose

Presto has been providing machine learning functionality. Although its capability is limited and no active development happens in this module, partially that might result from the lack of official documentation. Without any clear description of the feature, we cannot expect even any feedback from the community. 

This change is for adding the new page in the documentation describing the available functionality in `presto-ml` module. The page would be helpful for the community to keep in touch with the ML module and collecting some interests or feedback for it.

<img width="1127" alt="Screen Shot 2020-05-09 at 21 44 11" src="https://user-images.githubusercontent.com/1713047/81474199-bde8ce00-923e-11ea-8e2e-79c7bb528086.png">

Fixes: https://github.com/prestosql/presto/issues/662

# Overview

- Add a new page describing the available functionality of presto-ml in the official documentation.

