### PR TITLE
Add Remote exchange forcefully if aggregation has empty grouping set

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddExchanges.java
@@ -227,7 +227,8 @@ public class AddExchanges
                         gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),
                         child.getProperties());
             }
-            else if (!child.getProperties().isStreamPartitionedOn(partitioningRequirement) && !child.getProperties().isNodePartitionedOn(partitioningRequirement)) {
+            else if ((!child.getProperties().isStreamPartitionedOn(partitioningRequirement) && !child.getProperties().isNodePartitionedOn(partitioningRequirement)) ||
+                    node.hasEmptyGroupingSet()) {
                 child = withDerivedProperties(
                         partitionedExchange(idAllocator.getNextId(), REMOTE, child.getNode(), node.getGroupingKeys(), node.getHashSymbol()),
                         child.getProperties());

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
@@ -1307,4 +1307,12 @@ public abstract class AbstractTestAggregations
     {
         assertQuery("SELECT count(1) FROM (SELECT count(custkey) FROM orders LIMIT 10) a");
     }
+
+    @Test
+    public void testGroupingSetsWithDefaultValue()
+    {
+        assertQuery(
+                "SELECT orderkey, COUNT(DISTINCT k) FROM (SELECT orderkey, 1 k FROM orders) GROUP BY GROUPING SETS ((), orderkey) HAVING orderkey IS NULL",
+                "VALUES (null, 1)");
+    }
 }


### PR DESCRIPTION
Fixes #3154, fixes #2716