### PR TITLE
S3 streaming upload with multipart upload api

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-s3.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-s3.rst
@@ -81,6 +81,11 @@ Property Name                                Description
 ``hive.s3.skip-glacier-objects``             Ignore Glacier objects rather than failing the query. This
                                              skips data that may be expected to be part of the table
                                              or partition. Defaults to ``false``.
+
+``hive.s3.streaming.enabled``                Use S3 multipart upload API to upload file in streaming way,
+                                             without staging file to be created in the local file system.
+
+``hive.s3.streaming.part-size``              The part size for S3 streaming upload. Defaults to ``16MB``.
 ============================================ =================================================================
 
 .. _hive-s3-credentials:

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 
@@ -65,6 +66,8 @@ public class HiveS3Config
     private PrestoS3AclType s3AclType = PrestoS3AclType.PRIVATE;
     private boolean skipGlacierObjects;
     private boolean requesterPaysEnabled;
+    private boolean s3StreamingUploadEnabled;
+    private DataSize s3StreamingPartSize = DataSize.of(16, MEGABYTE);
 
     public String getS3AwsAccessKey()
     {
@@ -460,6 +463,34 @@ public class HiveS3Config
     public HiveS3Config setRequesterPaysEnabled(boolean requesterPaysEnabled)
     {
         this.requesterPaysEnabled = requesterPaysEnabled;
+        return this;
+    }
+
+    public boolean isS3StreamingUploadEnabled()
+    {
+        return s3StreamingUploadEnabled;
+    }
+
+    @Config("hive.s3.streaming.enabled")
+    public HiveS3Config setS3StreamingUploadEnabled(boolean s3StreamingUploadEnabled)
+    {
+        this.s3StreamingUploadEnabled = s3StreamingUploadEnabled;
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("5MB")
+    @MaxDataSize("256MB")
+    public DataSize getS3StreamingPartSize()
+    {
+        return s3StreamingPartSize;
+    }
+
+    @Config("hive.s3.streaming.part-size")
+    @ConfigDescription("Part size for S3 streaming upload")
+    public HiveS3Config setS3StreamingPartSize(DataSize s3StreamingPartSize)
+    {
+        this.s3StreamingPartSize = s3StreamingPartSize;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ConfigurationInitializer.java
@@ -51,6 +51,8 @@ import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_SSE_TYPE;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_SSL_ENABLED;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STAGING_DIRECTORY;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STORAGE_CLASS;
+import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STREAMING_UPLOAD_ENABLED;
+import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STREAMING_UPLOAD_PART_SIZE;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_PREFIX;
 
 public class PrestoS3ConfigurationInitializer
@@ -86,6 +88,8 @@ public class PrestoS3ConfigurationInitializer
     private final String signerClass;
     private final boolean requesterPaysEnabled;
     private final boolean skipGlacierObjects;
+    private final boolean s3StreamingUploadEnabled;
+    private final DataSize streamingPartSize;
 
     @Inject
     public PrestoS3ConfigurationInitializer(HiveS3Config config)
@@ -120,6 +124,8 @@ public class PrestoS3ConfigurationInitializer
         this.aclType = config.getS3AclType();
         this.skipGlacierObjects = config.isSkipGlacierObjects();
         this.requesterPaysEnabled = config.isRequesterPaysEnabled();
+        this.s3StreamingUploadEnabled = config.isS3StreamingUploadEnabled();
+        this.streamingPartSize = config.getS3StreamingPartSize();
     }
 
     @Override
@@ -180,5 +186,7 @@ public class PrestoS3ConfigurationInitializer
         config.set(S3_ACL_TYPE, aclType.name());
         config.setBoolean(S3_SKIP_GLACIER_OBJECTS, skipGlacierObjects);
         config.setBoolean(S3_REQUESTER_PAYS_ENABLED, requesterPaysEnabled);
+        config.setBoolean(S3_STREAMING_UPLOAD_ENABLED, s3StreamingUploadEnabled);
+        config.setLong(S3_STREAMING_UPLOAD_PART_SIZE, streamingPartSize.toBytes());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
@@ -66,7 +66,9 @@ public class TestHiveS3Config
                 .setS3UserAgentPrefix("")
                 .setS3AclType(PrestoS3AclType.PRIVATE)
                 .setSkipGlacierObjects(false)
-                .setRequesterPaysEnabled(false));
+                .setRequesterPaysEnabled(false)
+                .setS3StreamingUploadEnabled(false)
+                .setS3StreamingPartSize(DataSize.of(16, Unit.MEGABYTE)));
     }
 
     @Test
@@ -106,6 +108,8 @@ public class TestHiveS3Config
                 .put("hive.s3.upload-acl-type", "PUBLIC_READ")
                 .put("hive.s3.skip-glacier-objects", "true")
                 .put("hive.s3.requester-pays.enabled", "true")
+                .put("hive.s3.streaming.enabled", "true")
+                .put("hive.s3.streaming.part-size", "15MB")
                 .build();
 
         HiveS3Config expected = new HiveS3Config()
@@ -138,7 +142,9 @@ public class TestHiveS3Config
                 .setS3UserAgentPrefix("user-agent-prefix")
                 .setS3AclType(PrestoS3AclType.PUBLIC_READ)
                 .setSkipGlacierObjects(true)
-                .setRequesterPaysEnabled(true);
+                .setRequesterPaysEnabled(true)
+                .setS3StreamingUploadEnabled(true)
+                .setS3StreamingPartSize(DataSize.of(15, Unit.MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Implements S3 streaming upload with multipart upload api.

The original implementation upload file after the all query result is fetched (which was stored in a file), it might be a bottleneck if the query result is slow or very large.

It's a draft, please kindly let me know if you have any suggestion, thanks!