### PR TITLE
Remove Unused Code in TypeSignatureParser

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/TypeSignatureParser.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TypeSignatureParser.java
@@ -52,7 +52,7 @@ public class TypeSignatureParser
 
     public static TypeSignature parseTypeSignature(String signature, Set<String> literalCalculationParameters)
     {
-        if (!signature.contains("<") && !signature.contains("(")) {
+        if (!signature.contains("(")) {
             if (signature.equalsIgnoreCase(StandardTypes.VARCHAR)) {
                 return VarcharType.createUnboundedVarcharType().getTypeSignature();
             }


### PR DESCRIPTION
`<` is not unsupported already for current presto(in commit  [15f41be](https://github.prod.hulu.com/SOXBDI/metrics-prestodb/commit/15f41be5b7a2badd4e0d3880054bab69df370716#diff-b33835e6fbf82e3284883e6807fede82) ) but the code still contains the '<' check logic which confused user a lot after upgrading .
We need to remove this legacy code;