### PR TITLE
Refactor RubixConfigurationInitializer into dynamic provider

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
@@ -16,7 +16,7 @@ package io.prestosql.plugin.hive.rubix;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
-import io.prestosql.plugin.hive.ConfigurationInitializer;
+import io.prestosql.plugin.hive.DynamicConfigurationProvider;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -29,7 +29,7 @@ public class RubixModule
     {
         configBinder(binder).bindConfig(RubixConfig.class);
         binder.bind(RubixConfigurationInitializer.class).in(Scopes.SINGLETON);
-        newSetBinder(binder, ConfigurationInitializer.class).addBinding().to(RubixConfigurationInitializer.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, DynamicConfigurationProvider.class).addBinding().to(RubixConfigurationInitializer.class).in(Scopes.SINGLETON);
         binder.bind(RubixInitializer.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
@@ -56,7 +56,6 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.qubole.rubix.spi.CacheConfig.setPrestoClusterManager;
 import static io.airlift.testing.Assertions.assertGreaterThan;
 import static io.prestosql.client.NodeVersion.UNKNOWN;
-import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
 import static java.lang.String.format;
 import static java.lang.Thread.sleep;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -149,15 +148,12 @@ public class TestRubixCaching
             RubixConfigurationInitializer rubixConfigInitializer)
             throws IOException
     {
-        HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(
-                config,
-                ImmutableSet.of(rubixConfigInitializer));
+        HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(config, ImmutableSet.of());
         HiveHdfsConfiguration configuration = new HiveHdfsConfiguration(configurationInitializer, ImmutableSet.of(
                 (dynamicConfig, ignoredContext, ignoredUri) -> {
-                    // make sure a new FS is created with Rubix caching enabled
-                    setCacheKey(dynamicConfig, "rubix");
                     dynamicConfig.set("fs.file.impl", CachingLocalFileSystem.class.getName());
-                }));
+                },
+                rubixConfigInitializer));
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
         return environment.getFileSystem(context, path);
     }


### PR DESCRIPTION
Previously there was a race condition between first
FileSystem request and Rubix cache initialization.
Now RubixConfigurationInitializer is dynamic provider so
Rubix cache should start being used once Rubix is initialized.