### PR TITLE
Add support for passthrough Elasticsearch queries

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchTableHandle.java
@@ -28,14 +28,21 @@ import static java.util.Objects.requireNonNull;
 public final class ElasticsearchTableHandle
         implements ConnectorTableHandle
 {
+    public enum Type
+    {
+        SCAN, QUERY
+    }
+
+    private final Type type;
     private final String schema;
     private final String index;
     private final TupleDomain<ColumnHandle> constraint;
     private final Optional<String> query;
     private final OptionalLong limit;
 
-    public ElasticsearchTableHandle(String schema, String index, Optional<String> query)
+    public ElasticsearchTableHandle(Type type, String schema, String index, Optional<String> query)
     {
+        this.type = requireNonNull(type, "type is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.index = requireNonNull(index, "index is null");
         this.query = requireNonNull(query, "query is null");
@@ -46,17 +53,25 @@ public final class ElasticsearchTableHandle
 
     @JsonCreator
     public ElasticsearchTableHandle(
+            @JsonProperty("type") Type type,
             @JsonProperty("schema") String schema,
             @JsonProperty("index") String index,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("query") Optional<String> query,
             @JsonProperty("limit") OptionalLong limit)
     {
+        this.type = requireNonNull(type, "type is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.index = requireNonNull(index, "index is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.query = requireNonNull(query, "query is null");
         this.limit = requireNonNull(limit, "limit is null");
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
     }
 
     @JsonProperty
@@ -78,15 +93,15 @@ public final class ElasticsearchTableHandle
     }
 
     @JsonProperty
-    public Optional<String> getQuery()
-    {
-        return query;
-    }
-
-    @JsonProperty
     public OptionalLong getLimit()
     {
         return limit;
+    }
+
+    @JsonProperty
+    public Optional<String> getQuery()
+    {
+        return query;
     }
 
     @Override
@@ -99,7 +114,8 @@ public final class ElasticsearchTableHandle
             return false;
         }
         ElasticsearchTableHandle that = (ElasticsearchTableHandle) o;
-        return schema.equals(that.schema) &&
+        return type == that.type &&
+                schema.equals(that.schema) &&
                 index.equals(that.index) &&
                 constraint.equals(that.constraint) &&
                 query.equals(that.query) &&
@@ -109,6 +125,6 @@ public final class ElasticsearchTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schema, index, constraint, query, limit);
+        return Objects.hash(type, schema, index, constraint, query, limit);
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/PassthroughQueryPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/PassthroughQueryPageSource.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.elasticsearch;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.prestosql.elasticsearch.client.ElasticsearchClient;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.type.Type;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class PassthroughQueryPageSource
+        implements ConnectorPageSource
+{
+    private final long readTimeNanos;
+    private final String result;
+    private final Type jsonType;
+    private boolean done;
+
+    public PassthroughQueryPageSource(ElasticsearchClient client, ElasticsearchTableHandle table, Type jsonType)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(table, "table is null");
+        this.jsonType = requireNonNull(jsonType, "jsonType is null");
+
+        long start = System.nanoTime();
+        result = client.executeQuery(table.getIndex(), table.getQuery().get());
+        readTimeNanos = System.nanoTime() - start;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return result.length();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return done;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (done) {
+            return null;
+        }
+
+        done = true;
+
+        PageBuilder page = new PageBuilder(1, ImmutableList.of(jsonType));
+        page.declarePosition();
+        BlockBuilder column = page.getBlockBuilder(0);
+        jsonType.writeSlice(column, Slices.utf8Slice(result));
+        return page.build();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+    }
+}

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
@@ -36,6 +36,7 @@ import io.prestosql.spi.PrestoException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
@@ -100,6 +101,7 @@ import static io.prestosql.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_QU
 import static io.prestosql.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_SSL_INITIALIZATION_FAILURE;
 import static java.lang.StrictMath.toIntExact;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.list;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -528,6 +530,36 @@ public class ElasticsearchClient
             return NullNode.getInstance();
         }
         return jsonNode.get(name);
+    }
+
+    public String executeQuery(String index, String query)
+    {
+        String path = format("/%s/_search", index);
+
+        Response response;
+        try {
+            response = client.getLowLevelClient()
+                    .performRequest(
+                            "GET",
+                            path,
+                            ImmutableMap.of(),
+                            new ByteArrayEntity(query.getBytes(UTF_8)),
+                            new BasicHeader("Content-Type", "application/json"),
+                            new BasicHeader("Accept-Encoding", "application/json"));
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+
+        String body;
+        try {
+            body = EntityUtils.toString(response.getEntity());
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+        }
+
+        return body;
     }
 
     public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort, OptionalLong limit)


### PR DESCRIPTION
This allows running queries over the results of a raw Elasticsearch query.
It extends the syntax of the enhanced ES table names with the following:

    SELECT * FROM es.default."<index>$query:<base32-encoded ES query>"

The query is base32-encoded to avoid having to deal with escaping quotes and case
sensitivity issues in table identifiers.

The result of these query tables is a table with a single row and a single column
named "result" of type JSON.

Depends on #3718