### PR TITLE
Wait for Rubix initialization in Hive connector

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -129,6 +129,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <scope>runtime</scope>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveConnectorFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveConnectorFactory.java
@@ -37,7 +37,6 @@ import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HiveMetastoreModule;
 import io.prestosql.plugin.hive.procedure.HiveProcedureModule;
 import io.prestosql.plugin.hive.rubix.RubixEnabledConfig;
-import io.prestosql.plugin.hive.rubix.RubixInitializer;
 import io.prestosql.plugin.hive.rubix.RubixModule;
 import io.prestosql.plugin.hive.s3.HiveS3Module;
 import io.prestosql.plugin.hive.security.HiveSecurityModule;
@@ -116,12 +115,6 @@ public final class InternalHiveConnectorFactory
                     .doNotInitializeLogging()
                     .setRequiredConfigurationProperties(config)
                     .initialize();
-
-            if (injector.getInstance(RubixEnabledConfig.class).isCacheEnabled()) {
-                // RubixInitializer needs ConfigurationInitializers, hence kept outside RubixModule
-                RubixInitializer rubixInitializer = injector.getInstance(RubixInitializer.class);
-                rubixInitializer.initializeRubix(context.getNodeManager());
-            }
 
             LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
             HiveMetadataFactory metadataFactory = injector.getInstance(HiveMetadataFactory.class);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.spi.HostAddress;
 import org.apache.hadoop.conf.Configuration;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.net.URI;
@@ -60,7 +61,9 @@ public class RubixConfigurationInitializer
     // Configs below are dependent on node joining the cluster
     private volatile boolean cacheReady;
     private boolean isMaster;
+    @Nullable
     private HostAddress masterAddress;
+    @Nullable
     private String nodeAddress;
 
     @Inject

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
@@ -114,22 +114,22 @@ public class RubixConfigurationInitializer
         setCacheKey(config, "rubix_enabled");
     }
 
-    public void setMaster(boolean master)
+    void setMaster(boolean master)
     {
         isMaster = master;
     }
 
-    public void setMasterAddress(HostAddress masterAddress)
+    void setMasterAddress(HostAddress masterAddress)
     {
         this.masterAddress = masterAddress;
     }
 
-    public void setCurrentNodeAddress(String nodeAddress)
+    void setCurrentNodeAddress(String nodeAddress)
     {
         this.nodeAddress = nodeAddress;
     }
 
-    public void initializationDone()
+    void initializationDone()
     {
         checkState(masterAddress != null, "masterAddress is not set");
         cacheReady = true;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
@@ -45,6 +45,7 @@ import static com.qubole.rubix.spi.CacheConfig.setRubixClusterType;
 import static com.qubole.rubix.spi.CacheConfig.setWorkerNodeInfoExpiryPeriod;
 import static com.qubole.rubix.spi.ClusterType.PRESTOSQL_CLUSTER_MANAGER;
 import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
+import static java.util.Objects.requireNonNull;
 
 public class RubixConfigurationInitializer
         implements DynamicConfigurationProvider
@@ -90,6 +91,7 @@ public class RubixConfigurationInitializer
     void updateConfiguration(Configuration config)
     {
         checkState(masterAddress != null, "masterAddress is not set");
+        checkState(nodeAddress != null, "nodeAddress is not set");
         setCacheDataEnabled(config, true);
         setOnMaster(config, isMaster);
         setCoordinatorHostName(config, masterAddress.getHostText());
@@ -124,12 +126,12 @@ public class RubixConfigurationInitializer
 
     void setMasterAddress(HostAddress masterAddress)
     {
-        this.masterAddress = masterAddress;
+        this.masterAddress = requireNonNull(masterAddress, "masterAddress is null");
     }
 
     void setCurrentNodeAddress(String nodeAddress)
     {
-        this.nodeAddress = nodeAddress;
+        this.nodeAddress = requireNonNull(nodeAddress, "nodeAddress is null");
     }
 
     void initializationDone()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
@@ -79,7 +79,7 @@ public class RubixInitializer
         addSuccessCallback(
                 nodeJoinFuture,
                 () -> {
-                    Node master = nodeManager.getAllNodes().stream().filter(node -> node.isCoordinator()).findFirst().get();
+                    Node master = nodeManager.getAllNodes().stream().filter(Node::isCoordinator).findFirst().get();
                     boolean isMaster = nodeManager.getCurrentNode().isCoordinator();
 
                     rubixConfigurationInitializer.setMaster(isMaster);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Scopes;
 import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.DynamicConfigurationProvider;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.spi.NodeManager;
 
 import javax.inject.Singleton;
 
@@ -44,12 +45,13 @@ public class RubixModule
     @Provides
     @Singleton
     public RubixInitializer createRubixInitializer(
+            NodeManager nodeManager,
             CatalogName catalogName,
             Set<DynamicConfigurationProvider> configProviders,
             HdfsConfigurationInitializer hdfsConfigurationInitializer)
     {
         checkArgument(configProviders.size() == 1, "Rubix cache does not work with dynamic configuration providers");
         RubixConfigurationInitializer configProvider = (RubixConfigurationInitializer) getOnlyElement(configProviders);
-        return new RubixInitializer(catalogName, configProvider, hdfsConfigurationInitializer);
+        return new RubixInitializer(nodeManager, catalogName, configProvider, hdfsConfigurationInitializer);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
@@ -125,9 +125,11 @@ public class TestRubixCaching
                         .map(java.nio.file.Path::toString)
                         .collect(toImmutableList())));
         RubixConfigurationInitializer rubixConfigInitializer = new RubixConfigurationInitializer(rubixConfig);
-        HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(config, ImmutableSet.of(
-                // make sure that dummy cluster manager is used
-                initConfig -> setPrestoClusterManager(initConfig, DummyClusterManager.class.getName())));
+        HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(
+                config,
+                ImmutableSet.of(
+                        // make sure that dummy cluster manager is used
+                        initConfig -> setPrestoClusterManager(initConfig, DummyClusterManager.class.getName())));
         RubixInitializer rubixInitializer = new RubixInitializer(
                 new CatalogName("catalog"),
                 rubixConfigInitializer,
@@ -162,11 +164,13 @@ public class TestRubixCaching
             throws IOException
     {
         HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(config, ImmutableSet.of());
-        HiveHdfsConfiguration configuration = new HiveHdfsConfiguration(configurationInitializer, ImmutableSet.of(
-                (dynamicConfig, ignoredContext, ignoredUri) -> {
-                    dynamicConfig.set("fs.file.impl", CachingLocalFileSystem.class.getName());
-                },
-                rubixConfigInitializer));
+        HiveHdfsConfiguration configuration = new HiveHdfsConfiguration(
+                configurationInitializer,
+                ImmutableSet.of(
+                        (dynamicConfig, ignoredContext, ignoredUri) -> {
+                            dynamicConfig.set("fs.file.impl", CachingLocalFileSystem.class.getName());
+                        },
+                        rubixConfigInitializer));
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
         return environment.getFileSystem(context, path);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
@@ -80,6 +80,9 @@ public class TestRubixCaching
     private static final DataSize LARGE_FILE_SIZE = DataSize.of(100, MEGABYTE);
 
     private java.nio.file.Path tempDirectory;
+    private Path cacheStoragePath;
+    private HdfsConfig config;
+    private HdfsContext context;
     private FileSystem nonCachingFileSystem;
     private FileSystem cachingFileSystem;
 
@@ -88,26 +91,24 @@ public class TestRubixCaching
             throws IOException
     {
         tempDirectory = createTempDirectory(getClass().getSimpleName());
-        Path path = getStoragePath("/");
-        HdfsConfig config = new HdfsConfig();
-        ConnectorIdentity identity = ConnectorIdentity.ofUser("user");
-        HdfsContext context = new HdfsContext(identity);
+        cacheStoragePath = getStoragePath("/");
+        config = new HdfsConfig();
+        context = new HdfsContext(ConnectorIdentity.ofUser("user"));
 
-        nonCachingFileSystem = getNonCachingFileSystem(config, context, path);
-        RubixConfigurationInitializer rubixConfigInitializer = initializeRubix(config);
-        cachingFileSystem = getCachingFileSystem(config, context, path, rubixConfigInitializer);
+        nonCachingFileSystem = getNonCachingFileSystem();
+        cachingFileSystem = getCachingFileSystem(initializeRubix());
     }
 
-    private FileSystem getNonCachingFileSystem(HdfsConfig config, HdfsContext context, Path path)
+    private FileSystem getNonCachingFileSystem()
             throws IOException
     {
         HdfsConfigurationInitializer configurationInitializer = new HdfsConfigurationInitializer(config);
         HiveHdfsConfiguration configuration = new HiveHdfsConfiguration(configurationInitializer, ImmutableSet.of());
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
-        return environment.getFileSystem(context, path);
+        return environment.getFileSystem(context, cacheStoragePath);
     }
 
-    private RubixConfigurationInitializer initializeRubix(HdfsConfig config)
+    private RubixConfigurationInitializer initializeRubix()
             throws IOException
     {
         // create cache directories
@@ -157,9 +158,6 @@ public class TestRubixCaching
     }
 
     private FileSystem getCachingFileSystem(
-            HdfsConfig config,
-            HdfsContext context,
-            Path path,
             RubixConfigurationInitializer rubixConfigInitializer)
             throws IOException
     {
@@ -172,7 +170,7 @@ public class TestRubixCaching
                         },
                         rubixConfigInitializer));
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
-        return environment.getFileSystem(context, path);
+        return environment.getFileSystem(context, cacheStoragePath);
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
This way we can fail fast whenever Rubix cannot be initialized of configuration is faulty.

Fixes: https://github.com/prestosql/presto/issues/3489