### PR TITLE
Add Java requirement to JDBC driver documentation

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -15,6 +15,12 @@ The driver is also available from Maven Central:
         <version>\ |version|\ </version>
     </dependency>
 
+Requirements
+------------
+
+The JDBC driver is compatible with Java 8, and can be used with applications
+running on Java virtual machines version 8 and higher.
+
 Driver Name
 -----------
 


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/3751

Important to specify since Presto requires Java 11 now .. but JDBC driver remains with Java 8 and up. Not sure if we should specifically call this out.