### PR TITLE
Provide factory methods for datetime constants

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimeType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimeType.java
@@ -16,6 +16,8 @@ package io.prestosql.spi.type;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
 
+import static java.lang.String.format;
+
 //
 // A time is stored as milliseconds from midnight on 1970-01-01T00:00:00 in the time zone of the session.
 // When performing calculations on a time the client's time zone must be taken into account.
@@ -23,11 +25,28 @@ import io.prestosql.spi.connector.ConnectorSession;
 public final class TimeType
         extends AbstractLongType
 {
+    /**
+     * @deprecated Use {@link #createTimeType(int)} instead.
+     */
+    @Deprecated
     public static final TimeType TIME = new TimeType();
+
+    public static TimeType createTimeType(int precision)
+    {
+        if (precision != 3) {
+            throw new IllegalArgumentException(format("Precision %s is not supported", precision));
+        }
+        return TIME;
+    }
 
     private TimeType()
     {
         super(new TypeSignature(StandardTypes.TIME));
+    }
+
+    public int getPrecision()
+    {
+        return 3;
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimeWithTimeZoneType.java
@@ -17,15 +17,33 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
 
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static java.lang.String.format;
 
 public final class TimeWithTimeZoneType
         extends AbstractLongType
 {
+    /**
+     * @deprecated Use {@link #createTimeWithTimeZoneType(int)} instead.
+     */
+    @Deprecated
     public static final TimeWithTimeZoneType TIME_WITH_TIME_ZONE = new TimeWithTimeZoneType();
+
+    public static TimeWithTimeZoneType createTimeWithTimeZoneType(int precision)
+    {
+        if (precision != 3) {
+            throw new IllegalArgumentException(format("Precision %s is not supported", precision));
+        }
+        return TIME_WITH_TIME_ZONE;
+    }
 
     private TimeWithTimeZoneType()
     {
         super(new TypeSignature(StandardTypes.TIME_WITH_TIME_ZONE));
+    }
+
+    public int getPrecision()
+    {
+        return 3;
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
@@ -16,6 +16,8 @@ package io.prestosql.spi.type;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
 
+import static java.lang.String.format;
+
 /**
  * A timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC and is to be interpreted as date-time in UTC.
  * In legacy timestamp semantics, timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC and is to be
@@ -24,11 +26,28 @@ import io.prestosql.spi.connector.ConnectorSession;
 public final class TimestampType
         extends AbstractLongType
 {
+    /**
+     * @deprecated Use {@link #createTimestampType(int)} instead.
+     */
+    @Deprecated
     public static final TimestampType TIMESTAMP = new TimestampType();
+
+    public static TimestampType createTimestampType(int precision)
+    {
+        if (precision != 3) {
+            throw new IllegalArgumentException(format("Precision %s is not supported", precision));
+        }
+        return TIMESTAMP;
+    }
 
     private TimestampType()
     {
         super(new TypeSignature(StandardTypes.TIMESTAMP));
+    }
+
+    public int getPrecision()
+    {
+        return 3;
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampWithTimeZoneType.java
@@ -17,15 +17,33 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorSession;
 
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static java.lang.String.format;
 
 public final class TimestampWithTimeZoneType
         extends AbstractLongType
 {
+    /**
+     * @deprecated Use {@link #createTimestampWithTimeZoneType(int)} instead.
+     */
+    @Deprecated
     public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new TimestampWithTimeZoneType();
+
+    public static TimestampWithTimeZoneType createTimestampWithTimeZoneType(int precision)
+    {
+        if (precision != 3) {
+            throw new IllegalArgumentException(format("Precision %s is not supported", precision));
+        }
+        return TIMESTAMP_WITH_TIME_ZONE;
+    }
 
     private TimestampWithTimeZoneType()
     {
         super(new TypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+    }
+
+    public int getPrecision()
+    {
+        return 3;
     }
 
     @Override


### PR DESCRIPTION
This is preliminary step to encapsulate parametric datetime types.

This commit does not update the codebase, because this needs to be done
on case by case basis

- in some cases `instanceof` will be appropriate,
- in some cases `type.getPrecision() == n` will be appropriate.