### PR TITLE
Adding schema access rules to FileBasedSystemAccessControl

### DIFF
--- a/presto-main/src/test/resources/security-config-file-with-unknown-rules.json
+++ b/presto-main/src/test/resources/security-config-file-with-unknown-rules.json
@@ -1,9 +1,13 @@
 {
-  "schemas": [
-    {
-      "user": "(alice|bob)",
-      "schema": "(default|pv)",
-      "owner": true
-    }
-  ]
+    "sessionProperties": [
+        {
+            "property": "force_local_scheduling",
+            "allow": true
+        },
+        {
+            "user": "admin",
+            "property": "max_split_size",
+            "allow": true
+        }
+    ]
 }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControlRules.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControlRules.java
@@ -26,18 +26,21 @@ public class FileBasedSystemAccessControlRules
     private final Optional<List<QueryAccessRule>> queryAccessRules;
     private final Optional<List<ImpersonationRule>> impersonationRules;
     private final Optional<List<PrincipalUserMatchRule>> principalUserMatchRules;
+    private final Optional<List<SchemaAccessControlRule>> schemaRules;
 
     @JsonCreator
     public FileBasedSystemAccessControlRules(
             @JsonProperty("catalogs") Optional<List<CatalogAccessControlRule>> catalogRules,
             @JsonProperty("queries") Optional<List<QueryAccessRule>> queryAccessRules,
             @JsonProperty("impersonation") Optional<List<ImpersonationRule>> impersonationRules,
-            @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules)
+            @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules,
+            @JsonProperty("schemas") Optional<List<SchemaAccessControlRule>> schemaAccessControlRules)
     {
         this.catalogRules = catalogRules.map(ImmutableList::copyOf).orElse(ImmutableList.of());
         this.queryAccessRules = queryAccessRules.map(ImmutableList::copyOf);
         this.principalUserMatchRules = principalUserMatchRules.map(ImmutableList::copyOf);
         this.impersonationRules = impersonationRules.map(ImmutableList::copyOf);
+        this.schemaRules = schemaAccessControlRules.map(ImmutableList::copyOf);
     }
 
     public List<CatalogAccessControlRule> getCatalogRules()
@@ -58,5 +61,10 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<PrincipalUserMatchRule>> getPrincipalUserMatchRules()
     {
         return principalUserMatchRules;
+    }
+
+    public Optional<List<SchemaAccessControlRule>> getSchemaRules()
+    {
+        return schemaRules;
     }
 }

--- a/presto-plugin-toolkit/src/test/resources/file-based-system-access-schema.json
+++ b/presto-plugin-toolkit/src/test/resources/file-based-system-access-schema.json
@@ -1,0 +1,33 @@
+{
+    "catalogs": [
+        {
+            "allow": true
+        }
+    ],
+    "schemas": [
+        {
+            "schema": "secret",
+            "owner": false
+        },
+        {
+            "user": "admin",
+            "schema": ".*",
+            "owner": true
+        },
+        {
+            "group": "staff",
+            "schema": "staff",
+            "owner": true
+        },
+        {
+            "group": "staff|guests",
+            "schema": "authenticated",
+            "owner": true
+        },
+        {
+            "user": "bob",
+            "schema": "bob",
+            "owner": true
+        }
+    ]
+}

--- a/presto-plugin-toolkit/src/test/resources/security-config-file-with-unknown-rules.json
+++ b/presto-plugin-toolkit/src/test/resources/security-config-file-with-unknown-rules.json
@@ -1,9 +1,13 @@
 {
-  "schemas": [
-    {
-      "user": "(alice|bob)",
-      "schema": "(default|pv)",
-      "owner": true
-    }
-  ]
+    "sessionProperties": [
+        {
+            "property": "force_local_scheduling",
+            "allow": true
+        },
+        {
+            "user": "admin",
+            "property": "max_split_size",
+            "allow": true
+        }
+    ]
 }


### PR DESCRIPTION
Currently FileBasedSystemAccessControl control has catalogRules, queryAccessRules, impersonationRules and principalUserMatchRules. The proposal here is to add schema access rules to it. This will give more granular access controls over the datasets.

At high level idea is to implement/enhance the below methods of FileBasedSystemAccessControl

- checkCanDropSchema - Allow if user has access to catalog and is SchemaOwner
- checkCanRenameSchema - Allow if user has access to catalog and is SchemaOwner
- checkCanSetSchemaAuthorization - Allow if user has access to catalog and is SchemaOwner
- checkCanShowCreateSchema - Allow if user has access to catalog and is SchemaOwner

Original Issue : https://github.com/prestosql/presto/issues/3733
