### PR TITLE
Fix flaky Oracle connector test

### DIFF
--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleIntegrationSmokeTest.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleIntegrationSmokeTest.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.oracle;
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -79,5 +80,11 @@ public class TestOracleIntegrationSmokeTest
                         "   shippriority bigint,\n" +
                         "   comment varchar(79)\n" +
                         ")");
+    }
+
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        throw new SkipException("Test disabled until issue fixed"); // https://github.com/prestosql/presto/issues/3781
     }
 }


### PR DESCRIPTION
Let me disable testSelectInformationSchemaColumns as a workaround. I will send another PR to fix this.
1. https://github.com/prestosql/presto/actions/runs/108825515 (success)
2. https://github.com/prestosql/presto/actions/runs/108830613 (success) 
3. https://github.com/prestosql/presto/actions/runs/108852033 (success) 

#3781