### PR TITLE
Remove unused local variable in ExpressionAnalysis

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalysis.java
@@ -19,9 +19,7 @@ import io.prestosql.spi.type.Type;
 import io.prestosql.sql.tree.ExistsPredicate;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FunctionCall;
-import io.prestosql.sql.tree.Identifier;
 import io.prestosql.sql.tree.InPredicate;
-import io.prestosql.sql.tree.LambdaArgumentDeclaration;
 import io.prestosql.sql.tree.NodeRef;
 import io.prestosql.sql.tree.QuantifiedComparisonExpression;
 import io.prestosql.sql.tree.SubqueryExpression;
@@ -41,8 +39,6 @@ public class ExpressionAnalysis
     private final Set<NodeRef<SubqueryExpression>> scalarSubqueries;
     private final Set<NodeRef<ExistsPredicate>> existsSubqueries;
     private final Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons;
-    // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
-    private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences;
     private final Set<NodeRef<FunctionCall>> windowFunctions;
 
     public ExpressionAnalysis(
@@ -54,7 +50,6 @@ public class ExpressionAnalysis
             Map<NodeRef<Expression>, FieldId> columnReferences,
             Set<NodeRef<Expression>> typeOnlyCoercions,
             Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons,
-            Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences,
             Set<NodeRef<FunctionCall>> windowFunctions)
     {
         this.expressionTypes = ImmutableMap.copyOf(requireNonNull(expressionTypes, "expressionTypes is null"));
@@ -65,7 +60,6 @@ public class ExpressionAnalysis
         this.scalarSubqueries = ImmutableSet.copyOf(requireNonNull(scalarSubqueries, "subqueryInPredicates is null"));
         this.existsSubqueries = ImmutableSet.copyOf(requireNonNull(existsSubqueries, "existsSubqueries is null"));
         this.quantifiedComparisons = ImmutableSet.copyOf(requireNonNull(quantifiedComparisons, "quantifiedComparisons is null"));
-        this.lambdaArgumentReferences = ImmutableMap.copyOf(requireNonNull(lambdaArgumentReferences, "lambdaArgumentReferences is null"));
         this.windowFunctions = ImmutableSet.copyOf(requireNonNull(windowFunctions, "windowFunctions is null"));
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -1582,7 +1582,6 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getTypeOnlyCoercions(),
                 analyzer.getQuantifiedComparisons(),
-                analyzer.getLambdaArgumentReferences(),
                 analyzer.getWindowFunctions());
     }
 
@@ -1625,7 +1624,6 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getTypeOnlyCoercions(),
                 analyzer.getQuantifiedComparisons(),
-                analyzer.getLambdaArgumentReferences(),
                 analyzer.getWindowFunctions());
     }
 


### PR DESCRIPTION
The method referring to `lambdaArgumentReferences` was removed but the variable itself seems to be left.

See: https://github.com/prestosql/presto/commit/9355c910d86549e3734dd55092ab0f186ffd02b9