### PR TITLE
Remove deprecated missingAttributeException usage

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -479,7 +479,7 @@ public class ExpressionAnalyzer
             }
 
             if (rowFieldType == null) {
-                throw missingAttributeException(node);
+                throw missingAttributeException(node, qualifiedName);
             }
 
             return setExpressionType(node, rowFieldType);

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/SemanticExceptions.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/SemanticExceptions.java
@@ -33,15 +33,6 @@ public final class SemanticExceptions
         throw semanticException(COLUMN_NOT_FOUND, node, "Column '%s' cannot be resolved", name);
     }
 
-    /**
-     * Use {@link #missingAttributeException(Expression, QualifiedName)} instead.
-     */
-    @Deprecated
-    public static PrestoException missingAttributeException(Expression node)
-    {
-        throw semanticException(COLUMN_NOT_FOUND, node, "Column '%s' cannot be resolved", node);
-    }
-
     public static PrestoException ambiguousAttributeException(Expression node, QualifiedName name)
     {
         throw semanticException(AMBIGUOUS_NAME, node, "Column '%s' is ambiguous", name);


### PR DESCRIPTION
Since `missingAttributeException(Expression)}` was deprecated, we can remove the usage of it.