### PR TITLE
Implement toString() for JDBC driver Array result

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoArray.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoArray.java
@@ -115,4 +115,10 @@ public class PrestoArray
     {
         // no-op
     }
+
+    @Override
+    public String toString()
+    {
+        return Arrays.toString(array);
+    }
 }


### PR DESCRIPTION
This is not required by the specification, but provides a nicer
experience for clients that simply convert the returned object
into a string. Some clients may expect this behavior due to the
PostgreSQL driver supporting toString() for arrays.