### PR TITLE
Remove obsolete comment

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
@@ -152,8 +152,6 @@ public class RubixInitializer
 
         Configuration configuration = getInitialConfiguration();
         // Perform standard HDFS configuration initialization.
-        // This will also call out to RubixConfigurationInitializer but this will be no-op because
-        // cacheReady is not yet set.
         hdfsConfigurationInitializer.initializeConfiguration(configuration);
         // Apply RubixConfigurationInitializer directly suppressing cacheReady check
         rubixConfigurationInitializer.updateConfiguration(configuration);


### PR DESCRIPTION
RubixConfigurationInitializer is DynamicConfigurationProvider
so it won't be called as part of
HdfsConfigurationInitializer#initializeConfiguration