### PR TITLE
Do not set extra credentials in internal Rubix configuration

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfigurationInitializer.java
@@ -93,6 +93,7 @@ public class RubixConfigurationInitializer
         }
 
         updateConfiguration(config);
+        setCacheKey(config, "rubix_enabled");
     }
 
     void updateConfiguration(Configuration config)
@@ -129,8 +130,6 @@ public class RubixConfigurationInitializer
 
         // TODO: remove after https://github.com/qubole/rubix/pull/385 is merged
         setPrestoClusterManager(config, "com.qubole.rubix.prestosql.PrestoClusterManager");
-
-        setCacheKey(config, "rubix_enabled");
     }
 
     void setMaster(boolean master)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 
 import static com.google.common.base.Throwables.propagateIfPossible;
+import static io.prestosql.plugin.hive.DynamicConfigurationProvider.setCacheKey;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.getInitialConfiguration;
 import static io.prestosql.plugin.hive.util.RetryDriver.DEFAULT_SCALE_FACTOR;
 import static io.prestosql.plugin.hive.util.RetryDriver.retry;
@@ -155,6 +156,7 @@ public class RubixInitializer
         hdfsConfigurationInitializer.initializeConfiguration(configuration);
         // Apply RubixConfigurationInitializer directly suppressing cacheReady check
         rubixConfigurationInitializer.updateConfiguration(configuration);
+        setCacheKey(configuration, "rubix_internal");
 
         MetricRegistry metricRegistry = new MetricRegistry();
         bookKeeperServer = new BookKeeperServer();

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCaching.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCaching.java
@@ -35,8 +35,14 @@ public class TestHiveCaching
     @Test(groups = {HIVE_CACHING, PROFILE_SPECIFIC_TESTS})
     public void testReadFromCache()
     {
-        String cachedTableName = "hive.default.test_cache_read";
-        String nonCachedTableName = "hivenoncached.default.test_cache_read";
+        testReadFromTable("table1");
+        testReadFromTable("table2");
+    }
+
+    private void testReadFromTable(String tableNameSuffix)
+    {
+        String cachedTableName = "hive.default.test_cache_read" + tableNameSuffix;
+        String nonCachedTableName = "hivenoncached.default.test_cache_read" + tableNameSuffix;
 
         query("DROP TABLE IF EXISTS " + nonCachedTableName);
         query("CREATE TABLE " + nonCachedTableName + " WITH (format='ORC') AS SELECT 'Hello world' as col");


### PR DESCRIPTION
Such configuration is modified internally by Rubix (BookKeeper
and LocalDataTransferServer) and causes wrong FileSystem to
be cached by PrestoFileSystemCache.