### PR TITLE
Don't start Rubix server by default on coordinator

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixConfig.java
@@ -59,6 +59,7 @@ public class RubixConfig
     private String cacheLocation;
     private int bookKeeperServerPort = CacheConfig.DEFAULT_BOOKKEEPER_SERVER_PORT;
     private int dataTransferServerPort = CacheConfig.DEFAULT_DATA_TRANSFER_SERVER_PORT;
+    private boolean startServerOnCoordinator;
 
     @NotNull
     public ReadMode getReadMode()
@@ -107,6 +108,18 @@ public class RubixConfig
     public RubixConfig setDataTransferServerPort(int port)
     {
         this.dataTransferServerPort = port;
+        return this;
+    }
+
+    public boolean isStartServerOnCoordinator()
+    {
+        return startServerOnCoordinator;
+    }
+
+    @Config("hive.cache.start-server-on-coordinator")
+    public RubixConfig setStartServerOnCoordinator(boolean startServerOnCoordinator)
+    {
+        this.startServerOnCoordinator = startServerOnCoordinator;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixModule.java
@@ -45,6 +45,7 @@ public class RubixModule
     @Provides
     @Singleton
     public RubixInitializer createRubixInitializer(
+            RubixConfig rubixConfig,
             NodeManager nodeManager,
             CatalogName catalogName,
             Set<DynamicConfigurationProvider> configProviders,
@@ -52,6 +53,6 @@ public class RubixModule
     {
         checkArgument(configProviders.size() == 1, "Rubix cache does not work with dynamic configuration providers");
         RubixConfigurationInitializer configProvider = (RubixConfigurationInitializer) getOnlyElement(configProviders);
-        return new RubixInitializer(nodeManager, catalogName, configProvider, hdfsConfigurationInitializer);
+        return new RubixInitializer(rubixConfig, nodeManager, catalogName, configProvider, hdfsConfigurationInitializer);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixCaching.java
@@ -118,7 +118,8 @@ public class TestRubixCaching
         }
 
         // initialize rubix in master-only mode
-        RubixConfig rubixConfig = new RubixConfig();
+        RubixConfig rubixConfig = new RubixConfig()
+                .setStartServerOnCoordinator(true);
         rubixConfig.setCacheLocation(Joiner.on(",").join(
                 cacheDirectories.stream()
                         .map(java.nio.file.Path::toString)
@@ -134,6 +135,7 @@ public class TestRubixCaching
                 coordinatorNode,
                 ImmutableList.of());
         rubixInitializer = new RubixInitializer(
+                rubixConfig,
                 nodeManager,
                 new CatalogName("catalog"),
                 rubixConfigInitializer,
@@ -186,6 +188,7 @@ public class TestRubixCaching
                 false);
         RubixInitializer rubixInitializer = new RubixInitializer(
                 retry().maxAttempts(1),
+                true,
                 new TestingNodeManager(ImmutableList.of(workerNode)),
                 new CatalogName("catalog"),
                 rubixConfigInitializer,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/rubix/TestRubixConfig.java
@@ -33,7 +33,8 @@ public class TestRubixConfig
                 .setBookKeeperServerPort(CacheConfig.DEFAULT_BOOKKEEPER_SERVER_PORT)
                 .setDataTransferServerPort(CacheConfig.DEFAULT_DATA_TRANSFER_SERVER_PORT)
                 .setCacheLocation(null)
-                .setReadMode(RubixConfig.ReadMode.READ_THROUGH));
+                .setReadMode(RubixConfig.ReadMode.READ_THROUGH)
+                .setStartServerOnCoordinator(false));
     }
 
     @Test
@@ -44,13 +45,15 @@ public class TestRubixConfig
                 .put("hive.cache.location", "/some-directory")
                 .put("hive.cache.bookkeeper-port", "1234")
                 .put("hive.cache.data-transfer-port", "1235")
+                .put("hive.cache.start-server-on-coordinator", "true")
                 .build();
 
         RubixConfig expected = new RubixConfig()
                 .setReadMode(RubixConfig.ReadMode.ASYNC)
                 .setCacheLocation("/some-directory")
                 .setBookKeeperServerPort(1234)
-                .setDataTransferServerPort(1235);
+                .setDataTransferServerPort(1235)
+                .setStartServerOnCoordinator(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
In real deployments Rubix on coordinator is not
part of caching node pool. This pollutes coordinator
log with Rubix error messages whenever coordinator reads
a file (e.g ACID version file). This commit disables
caching on coordinator by default. Caching on coordinator
can still be enabled via feature toggle for development
purpose.