### PR TITLE
Allow configuring `maxWait` default and limit for '/v1/statement/executing/' endpoint

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -106,6 +106,7 @@ import io.prestosql.memory.TotalReservationLowMemoryKiller;
 import io.prestosql.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import io.prestosql.metadata.CatalogManager;
 import io.prestosql.operator.ForScheduler;
+import io.prestosql.server.protocol.ExecutingStatementConfig;
 import io.prestosql.server.protocol.ExecutingStatementResource;
 import io.prestosql.server.remotetask.RemoteTaskStats;
 import io.prestosql.server.ui.WebUiModule;
@@ -204,6 +205,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(SelectedRole.class);
         jaxrsBinder(binder).bind(QueuedStatementResource.class);
         jaxrsBinder(binder).bind(ExecutingStatementResource.class);
+        configBinder(binder).bindConfig(ExecutingStatementConfig.class);
         binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();
 

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.protocol;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExecutingStatementConfig
+{
+    private Duration maxWaitDefault = new Duration(1, TimeUnit.SECONDS);
+    private Duration maxWaitLimit = new Duration(1, TimeUnit.SECONDS);
+
+    @NotNull
+    public Duration getMaxWaitDefault()
+    {
+        return maxWaitDefault;
+    }
+
+    @Config("query.max-wait.default")
+    @ConfigDescription("Specify maxWait default for executing query endpoint")
+    public ExecutingStatementConfig setMaxWaitDefault(Duration maxWaitDefault)
+    {
+        this.maxWaitDefault = maxWaitDefault;
+        return this;
+    }
+
+    @NotNull
+    public Duration getMaxWaitLimit()
+    {
+        return maxWaitLimit;
+    }
+
+    @Config("query.max-wait.max")
+    @ConfigDescription("Specify maxWait limit for executing query endpoint")
+    public ExecutingStatementConfig setMaxWaitLimit(Duration maxWaitLimit)
+    {
+        this.maxWaitLimit = maxWaitLimit;
+        return this;
+    }
+}


### PR DESCRIPTION
It should allow setting higher duration for long-polling by the client, in order to reduce the "keep-alives" needed for multiple long-running queries.