### PR TITLE
Fix localtime in legacy timestamp semantics

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
@@ -124,10 +124,13 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.TIME)
     public static long localTime(ConnectorSession session)
     {
-        if (session.isLegacyTimestamp()) {
-            return UTC_CHRONOLOGY.millisOfDay().get(session.getStart().toEpochMilli());
-        }
         ISOChronology localChronology = getChronology(session.getTimeZoneKey());
+        if (session.isLegacyTimestamp()) {
+            // It is ok for this method to use the Object interfaces because it is constant folded during plan optimization
+            return new DateTime(session.getStart().toEpochMilli(), localChronology)
+                    .withDate(new LocalDate(1970, 1, 1))
+                    .getMillis();
+        }
         return localChronology.millisOfDay().get(session.getStart().toEpochMilli());
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
@@ -109,13 +109,12 @@ public final class DateTimeFunctions
         // and we need to have UTC millis for packDateTimeWithZone
         long millis = UTC_CHRONOLOGY.millisOfDay().get(session.getStart().toEpochMilli());
 
-        if (!session.isLegacyTimestamp()) {
-            // However, those UTC millis are pointing to the correct UTC timestamp
-            // Our TIME WITH TIME ZONE representation does use UTC 1970-01-01 representation
-            // So we have to hack here in order to get valid representation
-            // of TIME WITH TIME ZONE
-            millis -= valueToSessionTimeZoneOffsetDiff(session.getStart().toEpochMilli(), getDateTimeZone(session.getTimeZoneKey()));
-        }
+        // However, those UTC millis are pointing to the correct UTC timestamp
+        // Our TIME WITH TIME ZONE representation does use UTC 1970-01-01 representation
+        // So we have to hack here in order to get valid representation
+        // of TIME WITH TIME ZONE
+        millis -= valueToSessionTimeZoneOffsetDiff(session.getStart().toEpochMilli(), getDateTimeZone(session.getTimeZoneKey()));
+
         return packDateTimeWithZone(millis, session.getTimeZoneKey());
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
@@ -15,7 +15,6 @@
 package io.prestosql.operator.scalar;
 
 import io.prestosql.Session;
-import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
@@ -46,17 +45,6 @@ public class TestDateTimeFunctions
         assertInvalidFunction(
                 "format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')",
                 "format_datetime for TIMESTAMP type, cannot use 'Z' nor 'z' in format, as this type does not contain TZ information");
-    }
-
-    @Test
-    public void testLocalTime()
-    {
-        Session localSession = Session.builder(session)
-                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "14:30:00.000");
-        }
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 
 import java.time.Instant;
 
-import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 
@@ -45,20 +44,6 @@ public class TestDateTimeFunctions
         assertInvalidFunction(
                 "format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')",
                 "format_datetime for TIMESTAMP type, cannot use 'Z' nor 'z' in format, as this type does not contain TZ information");
-    }
-
-    @Test
-    public void testCurrentTime()
-    {
-        Session localSession = Session.builder(session)
-                // we use Asia/Kathmandu here to test the difference in semantic change of current_time
-                // between legacy and non-legacy timestamp
-                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:45:00.000 Asia/Kathmandu");
-        }
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
@@ -196,6 +196,21 @@ public abstract class TestDateTimeFunctionsBase
     }
 
     @Test
+    public void testCurrentTime()
+    {
+        functionAssertions.assertFunctionString("current_time", TIME_WITH_TIME_ZONE, "02:34:56.789 Pacific/Apia");
+
+        Session localSession = Session.builder(session)
+                // we use Asia/Kathmandu here, as it has different zone offset on 2017-03-01 and on 1970-01-01
+                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
+                .build();
+        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
+            localAssertion.assertFunctionString("current_time", TIME_WITH_TIME_ZONE, "15:45:00.000 Asia/Kathmandu");
+        }
+    }
+
+    @Test
     public void testFromUnixTime()
     {
         DateTime dateTime = new DateTime(2001, 1, 22, 3, 4, 5, 0, DATE_TIME_ZONE);

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
@@ -174,6 +174,28 @@ public abstract class TestDateTimeFunctionsBase
     }
 
     @Test
+    public void testLocalTime()
+    {
+        functionAssertions.assertFunctionString("localtime", TimeType.TIME, "02:34:56.789");
+
+        Session localSession = Session.builder(session)
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
+                .build();
+        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
+            localAssertion.assertFunctionString("localtime", TimeType.TIME, "14:30:00.000");
+        }
+
+        localSession = Session.builder(session)
+                // we use Asia/Kathmandu here, as it has different zone offset on 2017-03-01 and on 1970-01-01
+                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
+                .build();
+        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
+            localAssertion.assertFunctionString("localtime", TimeType.TIME, "15:45:00.000");
+        }
+    }
+
+    @Test
     public void testFromUnixTime()
     {
         DateTime dateTime = new DateTime(2001, 1, 22, 3, 4, 5, 0, DATE_TIME_ZONE);

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 
 import java.time.Instant;
 
-import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
@@ -44,20 +43,6 @@ public class TestDateTimeFunctionsLegacy
     public void testFormatDateCanImplicitlyAddTimeZoneToTimestampLiteral()
     {
         assertFunction("format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')", VARCHAR, "2001/08/22 03:04 " + DATE_TIME_ZONE.getID());
-    }
-
-    @Test
-    public void testCurrentTime()
-    {
-        Session localSession = Session.builder(session)
-                // we use Asia/Kathmandu here to test the difference in semantic change of current_time
-                // between legacy and non-legacy timestamp
-                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:30:00.000 Asia/Kathmandu");
-        }
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
@@ -15,7 +15,6 @@
 package io.prestosql.operator.scalar;
 
 import io.prestosql.Session;
-import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
@@ -45,17 +44,6 @@ public class TestDateTimeFunctionsLegacy
     public void testFormatDateCanImplicitlyAddTimeZoneToTimestampLiteral()
     {
         assertFunction("format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')", VARCHAR, "2001/08/22 03:04 " + DATE_TIME_ZONE.getID());
-    }
-
-    @Test
-    public void testLocalTime()
-    {
-        Session localSession = Session.builder(session)
-                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "13:30:00.000");
-        }
     }
 
     @Test


### PR DESCRIPTION
Fix `localtime` in legacy timestamp semantics when session zone has
different zone offset on current date compared to offset on 1970-01-01.

Fixes https://github.com/prestosql/presto/issues/3846
Fixes https://github.com/prestosql/presto/issues/3850