### PR TITLE
Refactor BackgroundHiveSplitLoader to be reusable

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -58,7 +58,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.transform;
-import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
+import static io.prestosql.plugin.hive.AsyncHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
@@ -211,7 +211,7 @@ public class HiveSplitManager
 
         Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(session, metastore, table, tableName, partitions, bucketHandle.map(HiveBucketHandle::toTableBucketProperty));
 
-        HiveSplitLoader hiveSplitLoader = new BackgroundHiveSplitLoader(
+        AsyncHiveSplitLoader hiveSplitLoader = new AsyncHiveSplitLoader(
                 table,
                 hivePartitions,
                 hiveTable.getCompactEffectivePredicate(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveLocationService.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveLocationService.java
@@ -15,7 +15,7 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.hive.LocationService.WriteInfo;
-import io.prestosql.plugin.hive.TestBackgroundHiveSplitLoader.TestingHdfsEnvironment;
+import io.prestosql.plugin.hive.TestAsyncHiveSplitLoader.TestingHdfsEnvironment;
 import io.prestosql.spi.PrestoException;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
+import io.prestosql.plugin.base.splitloader.AbstractAsyncSplitSource;
+import io.prestosql.plugin.base.splitloader.AsyncSplitLoader;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorSplitSource;
@@ -54,7 +56,7 @@ public class TestHiveSplitSource
                 10,
                 DataSize.of(1, MEGABYTE),
                 Integer.MAX_VALUE,
-                new TestingHiveSplitLoader(),
+                new TestingAsyncSplitLoader(),
                 Executors.newFixedThreadPool(5),
                 new CounterStat());
 
@@ -88,7 +90,7 @@ public class TestHiveSplitSource
                 10,
                 DataSize.of(1, MEGABYTE),
                 Integer.MAX_VALUE,
-                new TestingHiveSplitLoader(),
+                new TestingAsyncSplitLoader(),
                 Executors.newFixedThreadPool(5),
                 new CounterStat());
 
@@ -146,7 +148,7 @@ public class TestHiveSplitSource
                 10,
                 DataSize.of(1, MEGABYTE),
                 Integer.MAX_VALUE,
-                new TestingHiveSplitLoader(),
+                new TestingAsyncSplitLoader(),
                 Executors.newFixedThreadPool(5),
                 new CounterStat());
 
@@ -205,7 +207,7 @@ public class TestHiveSplitSource
                 10000,
                 maxOutstandingSplitsSize,
                 Integer.MAX_VALUE,
-                new TestingHiveSplitLoader(),
+                new TestingAsyncSplitLoader(),
                 Executors.newFixedThreadPool(5),
                 new CounterStat());
         int testSplitSizeInBytes = new TestSplit(0).getEstimatedSizeInBytes();
@@ -242,7 +244,7 @@ public class TestHiveSplitSource
                 10,
                 DataSize.of(1, MEGABYTE),
                 Integer.MAX_VALUE,
-                new TestingHiveSplitLoader(),
+                new TestingAsyncSplitLoader(),
                 Executors.newFixedThreadPool(5),
                 new CounterStat());
         hiveSplitSource.addToQueue(new TestSplit(0, OptionalInt.of(2)));
@@ -268,11 +270,11 @@ public class TestHiveSplitSource
         }
     }
 
-    private static class TestingHiveSplitLoader
-            implements HiveSplitLoader
+    private static class TestingAsyncSplitLoader
+            implements AsyncSplitLoader<InternalHiveSplit>
     {
         @Override
-        public void start(HiveSplitSource splitSource)
+        public void start(AbstractAsyncSplitSource<InternalHiveSplit> splitSource)
         {
         }
 

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AbstractAsyncSplitLoader.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AbstractAsyncSplitLoader.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.base.splitloader;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.MoreFutures;
+import io.prestosql.plugin.base.util.ResumableTask;
+import io.prestosql.plugin.base.util.ResumableTasks;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
+public abstract class AbstractAsyncSplitLoader<S>
+        implements AsyncSplitLoader<S>
+{
+    protected static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
+
+    // Purpose of this lock:
+    // * Write lock: when you need a consistent view across partitions, fileIterators, and hiveSplitSource.
+    // * Read lock: when you need to modify any of the above.
+    //   Make sure the lock is held throughout the period during which they may not be consistent with each other.
+    // Details:
+    // * When write lock is acquired, except the holder, no one can do any of the following:
+    // ** poll from (or check empty) partitions
+    // ** poll from (or check empty) or push to fileIterators
+    // ** push to hiveSplitSource
+    // * When any of the above three operations is carried out, either a read lock or a write lock must be held.
+    // * When a series of operations involving two or more of the above three operations are carried out, the lock
+    //   must be continuously held throughout the series of operations.
+    // Implications:
+    // * if you hold a read lock but not a write lock, you can do any of the above three operations, but you may
+    //   see a series of operations involving two or more of the operations carried out half way.
+    private final ReadWriteLock taskExecutionLock = new ReentrantReadWriteLock();
+    private AbstractAsyncSplitSource<S> splitSource;
+
+    private final Executor executor;
+    private final int loaderConcurrency;
+    private volatile boolean stopped;
+
+    protected AbstractAsyncSplitLoader(int loaderConcurrency, Executor executor)
+    {
+        this.loaderConcurrency = loaderConcurrency;
+        this.executor = executor;
+        this.stopped = false;
+    }
+
+    protected abstract ListenableFuture<?> loadSplits() throws IOException;
+
+    protected abstract boolean isFinished();
+
+    private void invokeNoMoreSplitsIfNecessary()
+    {
+        taskExecutionLock.readLock().lock();
+        try {
+            // This is an opportunistic check to avoid getting the write lock unnecessarily
+            if (!isFinished()) {
+                return;
+            }
+        }
+        catch (Exception e) {
+            fail(e);
+            checkState(isStopped(), "Task is not marked as stopped even though it failed");
+            return;
+        }
+        finally {
+            taskExecutionLock.readLock().unlock();
+        }
+
+        taskExecutionLock.writeLock().lock();
+        try {
+            // the write lock guarantees that no one is operating on the partitions, fileIterators, or hiveSplitSource, or half way through doing so.
+            if (isFinished()) {
+                // It is legal to call `noMoreSplits` multiple times or after `stop` was called.
+                // Nothing bad will happen if `noMoreSplits` implementation calls methods that will try to obtain a read lock because the lock is re-entrant.
+                noMoreSplits();
+            }
+        }
+        catch (Exception e) {
+            fail(e);
+            checkState(isStopped(), "Task is not marked as stopped even though it failed");
+        }
+        finally {
+            taskExecutionLock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void start(AbstractAsyncSplitSource<S> splitSource)
+    {
+        this.splitSource = splitSource;
+        for (int i = 0; i < loaderConcurrency; i++) {
+            ListenableFuture<?> future = ResumableTasks.submit(executor, new SplitLoaderTask());
+            MoreFutures.addExceptionCallback(future, this.splitSource::fail); // best effort; hiveSplitSource could be already completed
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        stopped = true;
+    }
+
+    protected ListenableFuture<?> addToQueue(List<S> splits)
+    {
+        ListenableFuture<?> lastResult = immediateFuture(null);
+        for (S split : splits) {
+            lastResult = addToQueue(split);
+        }
+        return lastResult;
+    }
+
+    protected ListenableFuture<?> addToQueue(S split)
+    {
+        return splitSource.addToQueue(split);
+    }
+
+    protected void fail(Throwable e)
+    {
+        splitSource.fail(e);
+    }
+
+    protected void noMoreSplits()
+    {
+        splitSource.noMoreSplits();
+    }
+
+    protected boolean isStopped()
+    {
+        return stopped;
+    }
+
+    private class SplitLoaderTask
+            implements ResumableTask
+    {
+        @Override
+        public TaskStatus process()
+        {
+            while (true) {
+                if (stopped) {
+                    return TaskStatus.finished();
+                }
+                ListenableFuture<?> future;
+                taskExecutionLock.readLock().lock();
+                try {
+                    future = loadSplits();
+                }
+                catch (Throwable e) {
+                    // TODO: Make these error codes non-hive specific
+//                    if (e instanceof IOException) {
+//                        e = new PrestoException(HiveErrorCode.HIVE_FILESYSTEM_ERROR, e);
+//                    }
+//                    else if (!(e instanceof PrestoException)) {
+//                        e = new PrestoException(UNKNOWN_ER, e);
+//                    }
+                    // Fail the split source before releasing the execution lock
+                    // Otherwise, a race could occur where the split source is completed before we fail it.
+                    splitSource.fail(e);
+                    checkState(stopped);
+                    return TaskStatus.finished();
+                }
+                finally {
+                    taskExecutionLock.readLock().unlock();
+                }
+                invokeNoMoreSplitsIfNecessary();
+                if (!future.isDone()) {
+                    return TaskStatus.continueOn(future);
+                }
+            }
+        }
+    }
+}

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AbstractAsyncSplitSource.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AbstractAsyncSplitSource.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.base.splitloader;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.MoreFutures;
+import io.prestosql.plugin.base.util.AsyncQueue;
+import io.prestosql.plugin.base.util.ThrottledAsyncQueue;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorPartitionHandle;
+import io.prestosql.spi.connector.ConnectorSplit;
+import io.prestosql.spi.connector.ConnectorSplitSource;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractAsyncSplitSource<S>
+        implements ConnectorSplitSource
+{
+    protected final String queryId;
+    protected final String databaseName;
+    protected final String tableName;
+
+    private final QueueManager<S> queues;
+
+    private final AsyncSplitLoader<S> splitLoader;
+    private final AtomicReference<State> stateReference;
+    private final AtomicInteger bufferedInternalSplitCount = new AtomicInteger();
+
+    protected AbstractAsyncSplitSource(
+            String queryId,
+            String databaseName,
+            String tableName,
+            QueueManager<S> queues,
+            AsyncSplitLoader<S> splitLoader)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.databaseName = requireNonNull(databaseName, "databaseName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.queues = requireNonNull(queues, "queues is null");
+        this.splitLoader = requireNonNull(splitLoader, "splitLoader is null");
+        this.stateReference = new AtomicReference<>(State.initial());
+    }
+
+    protected abstract void validateSplit(S split);
+
+    /**
+     * Convert a list of intermediate splits into ConnectorSplits
+     * @param splits Raw splits to process
+     * @return A list of intermediate splits not processed, and a list of ready ConnectorSplits
+     */
+    protected abstract SplitProcessingResult processSplits(List<S> splits);
+
+    public ListenableFuture<?> addToQueue(S split)
+    {
+        if (stateReference.get().getKind() != StateKind.INITIAL) {
+            return immediateFuture(null);
+        }
+        validateSplit(split);
+        bufferedInternalSplitCount.incrementAndGet();
+        return queues.offer(split);
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
+    {
+        boolean noMoreSplits;
+        State state = stateReference.get();
+        switch (state.getKind()) {
+            case INITIAL:
+                noMoreSplits = false;
+                break;
+            case NO_MORE_SPLITS:
+                noMoreSplits = true;
+                break;
+            case FAILED:
+                return MoreFutures.failedFuture(state.getThrowable());
+            case CLOSED:
+                throw new IllegalStateException("HiveSplitSource is already closed");
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        ListenableFuture<List<ConnectorSplit>> future = queues.queueForPartition(partitionHandle).borrowBatchAsync(maxSize, splits -> {
+            SplitProcessingResult splitResults = processSplits(splits);
+            bufferedInternalSplitCount.addAndGet(splitResults.getIncompleteSplits().size() - splitResults.getReadySplits().size());
+            return new AsyncQueue.BorrowResult<>(splitResults.getIncompleteSplits(), splitResults.getReadySplits());
+        });
+
+        ListenableFuture<ConnectorSplitBatch> transform = Futures.transform(future, splits -> {
+            requireNonNull(splits, "splits is null");
+            if (noMoreSplits) {
+                // Checking splits.isEmpty() here is required for thread safety.
+                // Let's say there are 10 splits left, and max number of splits per batch is 5.
+                // The futures constructed in two getNextBatch calls could each fetch 5, resulting in zero splits left.
+                // After fetching the splits, both futures reach this line at the same time.
+                // Without the isEmpty check, both will claim they are the last.
+                // Side note 1: In such a case, it doesn't actually matter which one gets to claim it's the last.
+                //              But having both claim they are the last would be a surprising behavior.
+                // Side note 2: One could argue that the isEmpty check is overly conservative.
+                //              The caller of getNextBatch will likely need to make an extra invocation.
+                //              But an extra invocation likely doesn't matter.
+                return new ConnectorSplitBatch(splits, splits.isEmpty() && queues.isFinished(partitionHandle));
+            }
+            else {
+                return new ConnectorSplitBatch(splits, false);
+            }
+        }, directExecutor());
+
+        return MoreFutures.toCompletableFuture(transform);
+    }
+
+    /**
+     * The upper bound of outstanding split count.
+     * It might be larger than the actual number when called concurrently with other methods.
+     */
+    @VisibleForTesting
+    public int getBufferedInternalSplitCount()
+    {
+        return bufferedInternalSplitCount.get();
+    }
+
+    public void noMoreSplits()
+    {
+        if (setIf(stateReference, State.noMoreSplits(), state -> state.getKind() == StateKind.INITIAL)) {
+            // Stop the split loader before finishing the queue.
+            // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
+            // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
+            splitLoader.stop();
+            queues.finish();
+        }
+    }
+
+    public void fail(Throwable e)
+    {
+        // The error must be recorded before setting the finish marker to make sure
+        // isFinished will observe failure instead of successful completion.
+        // Only record the first error message.
+        if (setIf(stateReference, State.failed(e), state -> state.getKind() == StateKind.INITIAL)) {
+            // Stop the split loader before finishing the queue.
+            // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
+            // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
+            splitLoader.stop();
+            queues.finish();
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        State state = stateReference.get();
+
+        switch (state.getKind()) {
+            case INITIAL:
+                return false;
+            case NO_MORE_SPLITS:
+                return bufferedInternalSplitCount.get() == 0;
+            case FAILED:
+                throw propagatePrestoException(state.getThrowable());
+            case CLOSED:
+                throw new IllegalStateException("HiveSplitSource is already closed");
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if (setIf(stateReference, State.closed(), state -> state.getKind() == StateKind.INITIAL || state.getKind() == StateKind.NO_MORE_SPLITS)) {
+            // Stop the split loader before finishing the queue.
+            // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
+            // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
+            splitLoader.stop();
+            queues.finish();
+        }
+    }
+
+    private static RuntimeException propagatePrestoException(Throwable throwable)
+    {
+        if (throwable instanceof PrestoException) {
+            throw (PrestoException) throwable;
+        }
+        // TODO: Make these not Hive specific
+        //if (throwable instanceof FileNotFoundException) {
+        //    throw new PrestoException(HiveErrorCode.HIVE_FILE_NOT_FOUND, throwable);
+        //}
+        //throw new PrestoException(HiveErrorCode.HIVE_UNKNOWN_ERROR, throwable);
+        throw new RuntimeException(throwable);
+    }
+
+    private static <T> boolean setIf(AtomicReference<T> atomicReference, T newValue, Predicate<T> predicate)
+    {
+        while (true) {
+            T current = atomicReference.get();
+            if (!predicate.test(current)) {
+                return false;
+            }
+            if (atomicReference.compareAndSet(current, newValue)) {
+                return true;
+            }
+        }
+    }
+
+    protected class SplitProcessingResult
+    {
+        // Pair<List<S>, List<ConnectorSplit>>
+        private final List<S> incompleteSplits;
+        private final List<ConnectorSplit> readySplits;
+
+        public SplitProcessingResult(List<S> incompleteSplits, List<ConnectorSplit> readySplits)
+        {
+            this.incompleteSplits = incompleteSplits;
+            this.readySplits = readySplits;
+        }
+
+        public List<S> getIncompleteSplits()
+        {
+            return incompleteSplits;
+        }
+
+        public List<ConnectorSplit> getReadySplits()
+        {
+            return readySplits;
+        }
+    }
+
+    protected static class State
+    {
+        private final StateKind kind;
+        private final Throwable throwable;
+
+        private State(StateKind kind, Throwable throwable)
+        {
+            this.kind = kind;
+            this.throwable = throwable;
+        }
+
+        public StateKind getKind()
+        {
+            return kind;
+        }
+
+        public Throwable getThrowable()
+        {
+            checkState(throwable != null);
+            return throwable;
+        }
+
+        public static State initial()
+        {
+            return new State(StateKind.INITIAL, null);
+        }
+
+        public static State noMoreSplits()
+        {
+            return new State(StateKind.NO_MORE_SPLITS, null);
+        }
+
+        public static State failed(Throwable throwable)
+        {
+            return new State(StateKind.FAILED, throwable);
+        }
+
+        public static State closed()
+        {
+            return new State(StateKind.CLOSED, null);
+        }
+    }
+
+    protected enum StateKind
+    {
+        INITIAL,
+        NO_MORE_SPLITS,
+        FAILED,
+        CLOSED,
+    }
+
+    protected interface QueueManager<S>
+    {
+        ListenableFuture<?> offer(S split);
+
+        AsyncQueue<S> queueForPartition(ConnectorPartitionHandle partitionHandle);
+
+        void finish();
+
+        boolean isFinished(ConnectorPartitionHandle partitionHandle);
+    }
+
+    protected static class NonBucketedQueueManager<S>
+            implements QueueManager<S>
+    {
+        private final AsyncQueue<S> queue;
+
+        public NonBucketedQueueManager(int maxSplitsPerSecond, int maxOutstandingSplits, Executor executor)
+        {
+            queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
+        }
+
+        @Override
+        public ListenableFuture<?> offer(S connectorSplit)
+        {
+            // bucketNumber can be non-empty because BackgroundHiveSplitLoader does not have knowledge of execution plan
+            return queue.offer(connectorSplit);
+        }
+
+        @Override
+        public AsyncQueue<S> queueForPartition(ConnectorPartitionHandle partitionHandle)
+        {
+            return queue;
+        }
+
+        @Override
+        public void finish()
+        {
+            queue.finish();
+        }
+
+        @Override
+        public boolean isFinished(ConnectorPartitionHandle partitionHandle)
+        {
+            return queue.isFinished();
+        }
+    }
+}

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AsyncSplitLoader.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/splitloader/AsyncSplitLoader.java
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive;
+package io.prestosql.plugin.base.splitloader;
 
-interface HiveSplitLoader
+public interface AsyncSplitLoader<S>
 {
-    void start(HiveSplitSource splitSource);
+    void start(AbstractAsyncSplitSource<S> splitSource);
 
     void stop();
 }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/AsyncQueue.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/AsyncQueue.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ResumableTask.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ResumableTask.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ResumableTasks.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ResumableTasks.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ThrottledAsyncQueue.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/util/ThrottledAsyncQueue.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/util/TestAsyncQueue.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/util/TestAsyncQueue.java
@@ -12,12 +12,12 @@
  * limitations under the License.
  */
 
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.Threads;
-import io.prestosql.plugin.hive.util.AsyncQueue.BorrowResult;
+import io.prestosql.plugin.base.util.AsyncQueue.BorrowResult;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/util/TestThrottledAsyncQueue.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/util/TestThrottledAsyncQueue.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package io.prestosql.plugin.hive.util;
+package io.prestosql.plugin.base.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;


### PR DESCRIPTION
Splits out the async handling logic from `BackgroundHiveSplitLoader` and `HiveSplitSource` into separate abstract classes for re-use by other connectors wanting to load splits asynchronously. 

It's a bigger change than I thought it would be, so maybe this isn't a great idea. 