### PR TITLE
Implement collection of min/max values in DynamicFilterSourceOperator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -121,6 +121,7 @@ public final class SystemSessionProperties
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE = "query_max_total_memory_per_node";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
+    public static final String DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER = "dynamic_filtering_range_row_limit_per_driver";
     public static final String IGNORE_DOWNSTREAM_PREFERENCES = "ignore_downstream_preferences";
     public static final String ITERATIVE_COLUMN_PRUNING = "iterative_rule_based_column_pruning";
     public static final String REQUIRED_WORKERS_COUNT = "required_workers_count";
@@ -547,6 +548,11 @@ public final class SystemSessionProperties
                         DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE,
                         "Experimental: maximum number of bytes to be collected for dynamic filtering per-driver",
                         featuresConfig.getDynamicFilteringMaxPerDriverSize(),
+                        false),
+                integerProperty(
+                        DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER,
+                        "Maximum number of build-side rows per driver up to which min and max values will be collected for dynamic filtering",
+                        featuresConfig.getDynamicFilteringRangeRowLimitPerDriver(),
                         false),
                 booleanProperty(
                         IGNORE_DOWNSTREAM_PREFERENCES,
@@ -1004,6 +1010,11 @@ public final class SystemSessionProperties
     public static DataSize getDynamicFilteringMaxPerDriverSize(Session session)
     {
         return session.getSystemProperty(DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE, DataSize.class);
+    }
+
+    public static int getDynamicFilteringRangeRowLimitPerDriver(Session session)
+    {
+        return session.getSystemProperty(DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER, Integer.class);
     }
 
     public static boolean ignoreDownStreamPreferences(Session session)

--- a/presto-main/src/main/java/io/prestosql/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/DynamicFilterSourceOperator.java
@@ -24,7 +24,6 @@ import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.Type;
-import io.prestosql.spi.type.TypeUtils;
 import io.prestosql.sql.planner.plan.DynamicFilterId;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
@@ -36,14 +35,19 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.prestosql.spi.predicate.Range.range;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.TypeUtils.isFloatingPointNaN;
+import static io.prestosql.spi.type.TypeUtils.readNativeValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 /**
  * This operator acts as a simple "pass-through" pipe, while saving its input pages.
  * The collected pages' value are used for creating a run-time filtering constraint (for probe-side table scan in an inner join).
- * We support only small build-side pages (which should be the case when using "broadcast" join).
+ * We record all values for the run-time filter only for small build-side pages (which should be the case when using "broadcast" join).
+ * For large inputs on build side, we can optionally record the min and max values per channel for orderable types (except Double and Real).
  */
 public class DynamicFilterSourceOperator
         implements Operator
@@ -73,6 +77,7 @@ public class DynamicFilterSourceOperator
         private final List<Channel> channels;
         private final int maxFilterPositionsCount;
         private final DataSize maxFilterSize;
+        private final int minMaxCollectionLimit;
 
         private boolean closed;
 
@@ -82,7 +87,8 @@ public class DynamicFilterSourceOperator
                 Consumer<TupleDomain<DynamicFilterId>> dynamicPredicateConsumer,
                 List<Channel> channels,
                 int maxFilterPositionsCount,
-                DataSize maxFilterSize)
+                DataSize maxFilterSize,
+                int minMaxCollectionLimit)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -94,6 +100,7 @@ public class DynamicFilterSourceOperator
                     "duplicate channel indices are not allowed");
             this.maxFilterPositionsCount = maxFilterPositionsCount;
             this.maxFilterSize = maxFilterSize;
+            this.minMaxCollectionLimit = minMaxCollectionLimit;
         }
 
         @Override
@@ -106,7 +113,8 @@ public class DynamicFilterSourceOperator
                     channels,
                     planNodeId,
                     maxFilterPositionsCount,
-                    maxFilterSize);
+                    maxFilterSize,
+                    minMaxCollectionLimit);
         }
 
         @Override
@@ -131,6 +139,7 @@ public class DynamicFilterSourceOperator
     private final long maxFilterSizeInBytes;
 
     private final List<Channel> channels;
+    private final List<Integer> minMaxChannels;
 
     // May be dropped if the predicate becomes too large.
     @Nullable
@@ -138,13 +147,20 @@ public class DynamicFilterSourceOperator
     @Nullable
     private TypedSet[] valueSets;
 
+    private int minMaxCollectionLimit;
+    @Nullable
+    private Block[] minValues;
+    @Nullable
+    private Block[] maxValues;
+
     private DynamicFilterSourceOperator(
             OperatorContext context,
             Consumer<TupleDomain<DynamicFilterId>> dynamicPredicateConsumer,
             List<Channel> channels,
             PlanNodeId planNodeId,
             int maxFilterPositionsCount,
-            DataSize maxFilterSize)
+            DataSize maxFilterSize,
+            int minMaxCollectionLimit)
     {
         this.context = requireNonNull(context, "context is null");
         this.maxFilterPositionsCount = maxFilterPositionsCount;
@@ -155,8 +171,13 @@ public class DynamicFilterSourceOperator
 
         this.blockBuilders = new BlockBuilder[channels.size()];
         this.valueSets = new TypedSet[channels.size()];
+        ImmutableList.Builder<Integer> minMaxChannelsBuilder = ImmutableList.builder();
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
             Type type = channels.get(channelIndex).type;
+            // Skipping DOUBLE and REAL in collectMinMaxValues to avoid dealing with NaN values
+            if (minMaxCollectionLimit > 0 && type.isOrderable() && type != DOUBLE && type != REAL) {
+                minMaxChannelsBuilder.add(channelIndex);
+            }
             this.blockBuilders[channelIndex] = type.createBlockBuilder(null, EXPECTED_BLOCK_BUILDER_SIZE);
             this.valueSets[channelIndex] = new TypedSet(
                     type,
@@ -165,6 +186,13 @@ public class DynamicFilterSourceOperator
                     EXPECTED_BLOCK_BUILDER_SIZE,
                     String.format("DynamicFilterSourceOperator_%s_%d", planNodeId, channelIndex),
                     Optional.empty() /* maxBlockMemory */);
+        }
+
+        this.minMaxCollectionLimit = minMaxCollectionLimit;
+        this.minMaxChannels = minMaxChannelsBuilder.build();
+        if (!minMaxChannels.isEmpty()) {
+            this.minValues = new Block[channels.size()];
+            this.maxValues = new Block[channels.size()];
         }
     }
 
@@ -186,9 +214,23 @@ public class DynamicFilterSourceOperator
         verify(!finished, "DynamicFilterSourceOperator: addInput() may not be called after finish()");
         current = page;
         if (valueSets == null) {
-            return;  // the predicate became too large.
+            if (minValues == null) {
+                // there are too many rows to collect min/max range
+                return;
+            }
+            minMaxCollectionLimit -= page.getPositionCount();
+            if (minMaxCollectionLimit < 0) {
+                handleMinMaxCollectionLimitExceeded();
+                return;
+            }
+            // the predicate became too large, record only min and max values for each orderable channel
+            for (Integer channelIndex : minMaxChannels) {
+                Block block = page.getBlock(channels.get(channelIndex).index);
+                updateMinMaxValues(block, channelIndex);
+            }
+            return;
         }
-
+        minMaxCollectionLimit -= page.getPositionCount();
         // TODO: we should account for the memory used for collecting build-side values using MemoryContext
         long filterSizeInBytes = 0;
         int filterPositionsCount = 0;
@@ -210,11 +252,82 @@ public class DynamicFilterSourceOperator
 
     private void handleTooLargePredicate()
     {
-        // The resulting predicate is too large, allow all probe-side values to be read.
-        dynamicPredicateConsumer.accept(TupleDomain.all());
+        // The resulting predicate is too large
+        if (minMaxChannels.isEmpty()) {
+            // allow all probe-side values to be read.
+            dynamicPredicateConsumer.accept(TupleDomain.all());
+        }
+        else {
+            if (minMaxCollectionLimit < 0) {
+                handleMinMaxCollectionLimitExceeded();
+            }
+            else {
+                // convert to min/max per column for orderable types
+                for (Integer channelIndex : minMaxChannels) {
+                    Block block = blockBuilders[channelIndex].build();
+                    updateMinMaxValues(block, channelIndex);
+                }
+            }
+        }
         // Drop references to collected values.
         valueSets = null;
         blockBuilders = null;
+    }
+
+    private void handleMinMaxCollectionLimitExceeded()
+    {
+        // allow all probe-side values to be read.
+        dynamicPredicateConsumer.accept(TupleDomain.all());
+        // Drop references to collected values.
+        minValues = null;
+        maxValues = null;
+    }
+
+    private void updateMinMaxValues(Block block, int channelIndex)
+    {
+        checkState(minValues != null && maxValues != null);
+        Type type = channels.get(channelIndex).type;
+        int minValuePosition = -1;
+        int maxValuePosition = -1;
+
+        for (int position = 0; position < block.getPositionCount(); ++position) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            if (minValuePosition == -1) {
+                // First non-null value
+                minValuePosition = position;
+                maxValuePosition = position;
+                continue;
+            }
+            if (type.compareTo(block, position, block, minValuePosition) < 0) {
+                minValuePosition = position;
+            }
+            else if (type.compareTo(block, position, block, maxValuePosition) > 0) {
+                maxValuePosition = position;
+            }
+        }
+
+        if (minValuePosition == -1) {
+            // all block values are nulls
+            return;
+        }
+        if (minValues[channelIndex] == null) {
+            // First Page with non-null value for this block
+            minValues[channelIndex] = block.getSingleValueBlock(minValuePosition);
+            maxValues[channelIndex] = block.getSingleValueBlock(maxValuePosition);
+            return;
+        }
+        // Compare with min/max values from previous Pages
+        Block currentMin = minValues[channelIndex];
+        Block currentMax = maxValues[channelIndex];
+
+        if (type.compareTo(block, minValuePosition, currentMin, 0) < 0) {
+            minValues[channelIndex] = block.getSingleValueBlock(minValuePosition);
+        }
+        if (type.compareTo(block, maxValuePosition, currentMax, 0) > 0) {
+            maxValues[channelIndex] = block.getSingleValueBlock(maxValuePosition);
+        }
     }
 
     @Override
@@ -233,11 +346,34 @@ public class DynamicFilterSourceOperator
             return;
         }
         finished = true;
-        if (valueSets == null) {
-            return; // the predicate became too large.
-        }
-
         ImmutableMap.Builder<DynamicFilterId, Domain> domainsBuilder = new ImmutableMap.Builder<>();
+        if (valueSets == null) {
+            if (minValues == null) {
+                // there were too many rows to collect collect min/max range
+                // dynamicPredicateConsumer was notified with 'all' in handleTooLargePredicate if there are no orderable types,
+                // else it was notified with 'all' in handleMinMaxCollectionLimitExceeded
+                return;
+            }
+            // valueSets became too large, create TupleDomain from min/max values
+            for (Integer channelIndex : minMaxChannels) {
+                Type type = channels.get(channelIndex).type;
+                if (minValues[channelIndex] == null) {
+                    // all values were null
+                    domainsBuilder.put(channels.get(channelIndex).filterId, Domain.none(type));
+                    continue;
+                }
+                Object min = readNativeValue(type, minValues[channelIndex], 0);
+                Object max = readNativeValue(type, maxValues[channelIndex], 0);
+                Domain domain = Domain.create(
+                        ValueSet.ofRanges(range(type, min, true, max, true)),
+                        false);
+                domainsBuilder.put(channels.get(channelIndex).filterId, domain);
+            }
+            minValues = null;
+            maxValues = null;
+            dynamicPredicateConsumer.accept(TupleDomain.withColumnDomains(domainsBuilder.build()));
+            return;
+        }
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
             Block block = blockBuilders[channelIndex].build();
             Type type = channels.get(channelIndex).type;
@@ -252,7 +388,7 @@ public class DynamicFilterSourceOperator
     {
         ImmutableList.Builder<Object> values = ImmutableList.builder();
         for (int position = 0; position < block.getPositionCount(); ++position) {
-            Object value = TypeUtils.readNativeValue(type, block, position);
+            Object value = readNativeValue(type, block, position);
             if (value != null) {
                 // join doesn't match rows with NaN values.
                 if (!isFloatingPointNaN(type, value)) {

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -138,6 +138,7 @@ public class FeaturesConfig
     private int dynamicFilteringMaxPerDriverRowCount = 100;
     private DataSize dynamicFilteringMaxPerDriverSize = DataSize.of(10, KILOBYTE);
     private Duration dynamicFilteringRefreshInterval = new Duration(200, MILLISECONDS);
+    private int dynamicFilteringRangeRowLimitPerDriver;
 
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
     private int filterAndProjectMinOutputPageRowCount = 256;
@@ -793,6 +794,19 @@ public class FeaturesConfig
     public FeaturesConfig setDynamicFilteringRefreshInterval(Duration dynamicFilteringRefreshInterval)
     {
         this.dynamicFilteringRefreshInterval = dynamicFilteringRefreshInterval;
+        return this;
+    }
+
+    public int getDynamicFilteringRangeRowLimitPerDriver()
+    {
+        return dynamicFilteringRangeRowLimitPerDriver;
+    }
+
+    @Config("dynamic-filtering-range-row-limit-per-driver")
+    @ConfigDescription("Maximum number of build-side rows per driver up to which min and max values will be collected for dynamic filtering")
+    public FeaturesConfig setDynamicFilteringRangeRowLimitPerDriver(int dynamicFilteringRangeRowLimitPerDriver)
+    {
+        this.dynamicFilteringRangeRowLimitPerDriver = dynamicFilteringRangeRowLimitPerDriver;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -229,6 +229,7 @@ import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
 import static io.prestosql.SystemSessionProperties.getAggregationOperatorUnspillMemoryLimit;
 import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverRowCount;
 import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverSize;
+import static io.prestosql.SystemSessionProperties.getDynamicFilteringRangeRowLimitPerDriver;
 import static io.prestosql.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
 import static io.prestosql.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static io.prestosql.SystemSessionProperties.getTaskConcurrency;
@@ -2149,7 +2150,8 @@ public class LocalExecutionPlanner
                     dynamicFilter.getTupleDomainConsumer(),
                     filterBuildChannels,
                     getDynamicFilteringMaxPerDriverRowCount(context.getSession()),
-                    getDynamicFilteringMaxPerDriverSize(context.getSession()));
+                    getDynamicFilteringMaxPerDriverSize(context.getSession()),
+                    getDynamicFilteringRangeRowLimitPerDriver(context.getSession()));
         }
 
         private Optional<LocalDynamicFilterConsumer> createDynamicFilter(PhysicalOperation buildSource, JoinNode node, LocalExecutionPlanContext context, int partitionCount)
@@ -2259,7 +2261,8 @@ public class LocalExecutionPlanner
                         filterConsumer.getTupleDomainConsumer(),
                         ImmutableList.of(new DynamicFilterSourceOperator.Channel(filterId, buildSource.getTypes().get(buildChannel), buildChannel)),
                         getDynamicFilteringMaxPerDriverRowCount(context.getSession()),
-                        getDynamicFilteringMaxPerDriverSize(context.getSession())));
+                        getDynamicFilteringMaxPerDriverSize(context.getSession()),
+                        getDynamicFilteringRangeRowLimitPerDriver(context.getSession())));
             });
 
             Optional<Integer> buildHashChannel = node.getFilteringSourceHashSymbol().map(channelGetter(buildSource));

--- a/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
@@ -46,6 +46,7 @@ import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIM
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static io.prestosql.type.ColorType.COLOR;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
@@ -558,6 +559,15 @@ public final class BlockAssertions
             type.writeSlice(builder, encodeUnscaledValue(BigInteger.valueOf(i).multiply(base)));
         }
 
+        return builder.build();
+    }
+
+    public static Block createColorSequenceBlock(int start, int end)
+    {
+        BlockBuilder builder = COLOR.createBlockBuilder(null, end - start);
+        for (int i = start; i < end; ++i) {
+            COLOR.writeLong(builder, i);
+        }
         return builder.build();
     }
 

--- a/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
@@ -440,7 +440,7 @@ public final class BlockAssertions
         return createBlockOfReals(Arrays.asList(values));
     }
 
-    private static Block createBlockOfReals(Iterable<Float> values)
+    public static Block createBlockOfReals(Iterable<Float> values)
     {
         BlockBuilder builder = REAL.createBlockBuilder(null, 100);
         for (Float value : values) {

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -50,6 +50,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverRowCount;
 import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverSize;
+import static io.prestosql.SystemSessionProperties.getDynamicFilteringRangeRowLimitPerDriver;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -89,7 +90,8 @@ public class BenchmarkDynamicFilterSourceOperator
                     (tupleDomain -> {}),
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel(new DynamicFilterId("0"), BIGINT, 0)),
                     getDynamicFilteringMaxPerDriverRowCount(TEST_SESSION),
-                    getDynamicFilteringMaxPerDriverSize(TEST_SESSION));
+                    getDynamicFilteringMaxPerDriverSize(TEST_SESSION),
+                    getDynamicFilteringRangeRowLimitPerDriver(TEST_SESSION));
         }
 
         @TearDown

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -114,6 +114,7 @@ public class TestFeaturesConfig
                 .setDynamicFilteringMaxPerDriverRowCount(100)
                 .setDynamicFilteringMaxPerDriverSize(DataSize.of(10, KILOBYTE))
                 .setDynamicFilteringRefreshInterval(new Duration(200, MILLISECONDS))
+                .setDynamicFilteringRangeRowLimitPerDriver(0)
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
                 .setIterativeRuleBasedColumnPruning(true));
@@ -191,6 +192,7 @@ public class TestFeaturesConfig
                 .put("dynamic-filtering-max-per-driver-row-count", "256")
                 .put("dynamic-filtering-max-per-driver-size", "64kB")
                 .put("experimental.dynamic-filtering-refresh-interval", "300ms")
+                .put("dynamic-filtering-range-row-limit-per-driver", "10000")
                 .put("optimizer.ignore-downstream-preferences", "true")
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
@@ -265,6 +267,7 @@ public class TestFeaturesConfig
                 .setDynamicFilteringMaxPerDriverRowCount(256)
                 .setDynamicFilteringMaxPerDriverSize(DataSize.of(64, KILOBYTE))
                 .setDynamicFilteringRefreshInterval(new Duration(300, MILLISECONDS))
+                .setDynamicFilteringRangeRowLimitPerDriver(10000)
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
                 .setIterativeRuleBasedColumnPruning(false);

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
@@ -108,7 +108,7 @@ public class TestShowQueries
     {
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page_row_c%'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(96)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(115)))");
     }
 
     @Test
@@ -120,7 +120,7 @@ public class TestShowQueries
                 .hasMessage("Escape string must be a single character");
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page$_row$_c%' ESCAPE '$'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(96)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(115)))");
     }
 
     @Test

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
@@ -226,7 +226,7 @@ public class TestMemorySmoke
                 ImmutableSet.of(1, ORDERS_COUNT, PART_COUNT));
     }
 
-    private void assertDynamicFiltering(String selectQuery, Session session, int expectedRowCount, Set<Integer> expectedOperatorRowsRead)
+    private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, Set<Integer> expectedOperatorRowsRead)
     {
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();
         ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, selectQuery);


### PR DESCRIPTION
Added a flag dynamic-filtering-min-max-values to allow fallback to collecting min and max values for dynamic filtering in replicated joins  when build side exceeds per driver max size or row count thresholds.