### PR TITLE
Use only first char from escapeChar table property in Hive

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -624,12 +624,7 @@ public class HiveMetadata
 
     private static Optional<String> getCsvSerdeProperty(Table table, String key)
     {
-        return getSerdeProperty(table, key).map(csvSerdeProperty -> {
-            if (csvSerdeProperty.length() > 1) {
-                throw new PrestoException(HIVE_INVALID_METADATA, "Only single character can be set for property: " + key);
-            }
-            return csvSerdeProperty;
-        });
+        return getSerdeProperty(table, key).map(csvSerdeProperty -> csvSerdeProperty.substring(0, 1));
     }
 
     private static Optional<String> getSerdeProperty(Table table, String key)


### PR DESCRIPTION
Hive's CSV Serde only reads the first character of the serde properties
(https://github.com/apache/hive/blob/60ff1fc7f8a9b010b99db0b1add788289f836b77/serde/src/java/org/apache/hadoop/hive/serde2/OpenCSVSerde.java#L98-L106)
This change allows Presto to use the same behaviour when reading
existing tables. Note that creating new tables with CSV serde from
Presto still validates the length of the serde properties.

Fixes #3868