### PR TITLE
Exit from product test launcher when all containers have been killed

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -71,6 +72,11 @@ public final class Environment
     {
         return Optional.ofNullable(containers.get(requireNonNull(name, "name is null")))
                 .orElseThrow(() -> new IllegalArgumentException("No container with name " + name));
+    }
+
+    public Collection<DockerContainer> getContainers()
+    {
+        return containers.values();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
@@ -74,9 +74,9 @@ public final class Environment
                 .orElseThrow(() -> new IllegalArgumentException("No container with name " + name));
     }
 
-    public Collection<DockerContainer> getContainers()
+    public Collection<Container<?>> getContainers()
     {
-        return containers.values();
+        return ImmutableList.copyOf(containers.values());
     }
 
     @Override


### PR DESCRIPTION
Check the container status every 10 seconds, and exit if all have been killed. 

Issue: https://github.com/prestosql/presto/issues/2964