### PR TITLE
Move Thrift metastore authentication classes

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/AuthenticationModules.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/AuthenticationModules.java
@@ -19,7 +19,6 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.prestosql.plugin.base.authentication.KerberosAuthentication;
 import io.prestosql.plugin.hive.ForHdfs;
-import io.prestosql.plugin.hive.ForHiveMetastore;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 
 import javax.inject.Inject;
@@ -31,40 +30,6 @@ import static io.prestosql.plugin.hive.authentication.KerberosHadoopAuthenticati
 public final class AuthenticationModules
 {
     private AuthenticationModules() {}
-
-    public static Module noHiveMetastoreAuthenticationModule()
-    {
-        return binder -> binder
-                .bind(HiveMetastoreAuthentication.class)
-                .to(NoHiveMetastoreAuthentication.class)
-                .in(SINGLETON);
-    }
-
-    public static Module kerberosHiveMetastoreAuthenticationModule()
-    {
-        return new Module()
-        {
-            @Override
-            public void configure(Binder binder)
-            {
-                binder.bind(HiveMetastoreAuthentication.class)
-                        .to(KerberosHiveMetastoreAuthentication.class)
-                        .in(SINGLETON);
-                configBinder(binder).bindConfig(MetastoreKerberosConfig.class);
-            }
-
-            @Inject
-            @Provides
-            @Singleton
-            @ForHiveMetastore
-            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config, HdfsConfigurationInitializer updater)
-            {
-                String principal = config.getHiveMetastoreClientPrincipal();
-                String keytabLocation = config.getHiveMetastoreClientKeytab();
-                return createCachingKerberosHadoopAuthentication(principal, keytabLocation, updater);
-            }
-        };
-    }
 
     public static Module noHdfsAuthenticationModule()
     {
@@ -134,7 +99,7 @@ public final class AuthenticationModules
         };
     }
 
-    private static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation, HdfsConfigurationInitializer updater)
+    public static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation, HdfsConfigurationInitializer updater)
     {
         KerberosAuthentication kerberosAuthentication = new KerberosAuthentication(principal, keytabLocation);
         KerberosHadoopAuthentication kerberosHadoopAuthentication = createKerberosHadoopAuthentication(kerberosAuthentication, updater);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/HiveAuthenticationConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/HiveAuthenticationConfig.java
@@ -20,29 +20,8 @@ import javax.validation.constraints.NotNull;
 
 public class HiveAuthenticationConfig
 {
-    private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
     private HdfsAuthenticationType hdfsAuthenticationType = HdfsAuthenticationType.NONE;
     private boolean hdfsImpersonationEnabled;
-
-    public enum HiveMetastoreAuthenticationType
-    {
-        NONE,
-        KERBEROS
-    }
-
-    @NotNull
-    public HiveMetastoreAuthenticationType getHiveMetastoreAuthenticationType()
-    {
-        return hiveMetastoreAuthenticationType;
-    }
-
-    @Config("hive.metastore.authentication.type")
-    @ConfigDescription("Hive Metastore authentication type")
-    public HiveAuthenticationConfig setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType)
-    {
-        this.hiveMetastoreAuthenticationType = hiveMetastoreAuthenticationType;
-        return this;
-    }
 
     public enum HdfsAuthenticationType
     {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/HiveAuthenticationModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/authentication/HiveAuthenticationModule.java
@@ -17,16 +17,13 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HdfsAuthenticationType;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
 
 import java.util.function.Predicate;
 
 import static io.airlift.configuration.ConditionalModule.installModuleIf;
 import static io.prestosql.plugin.hive.authentication.AuthenticationModules.kerberosHdfsAuthenticationModule;
-import static io.prestosql.plugin.hive.authentication.AuthenticationModules.kerberosHiveMetastoreAuthenticationModule;
 import static io.prestosql.plugin.hive.authentication.AuthenticationModules.kerberosImpersonatingHdfsAuthenticationModule;
 import static io.prestosql.plugin.hive.authentication.AuthenticationModules.noHdfsAuthenticationModule;
-import static io.prestosql.plugin.hive.authentication.AuthenticationModules.noHiveMetastoreAuthenticationModule;
 import static io.prestosql.plugin.hive.authentication.AuthenticationModules.simpleImpersonatingHdfsAuthenticationModule;
 
 public class HiveAuthenticationModule
@@ -35,14 +32,6 @@ public class HiveAuthenticationModule
     @Override
     protected void setup(Binder binder)
     {
-        bindAuthenticationModule(
-                config -> config.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.NONE,
-                noHiveMetastoreAuthenticationModule());
-
-        bindAuthenticationModule(
-                config -> config.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.KERBEROS,
-                kerberosHiveMetastoreAuthenticationModule());
-
         bindAuthenticationModule(
                 config -> noHdfsAuth(config) && !config.isHdfsImpersonationEnabled(),
                 noHdfsAuthenticationModule());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/KerberosHiveMetastoreAuthentication.java
@@ -11,10 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.authentication;
+package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.plugin.hive.ForHiveMetastore;
+import io.prestosql.plugin.hive.authentication.HadoopAuthentication;
+import io.prestosql.plugin.hive.authentication.HiveMetastoreAuthentication;
+import io.prestosql.plugin.hive.authentication.MetastoreKerberosConfig;
 import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
 import org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport;
 import org.apache.hadoop.security.SaslRpcServer;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/NoHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/NoHiveMetastoreAuthentication.java
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.authentication;
+package io.prestosql.plugin.hive.metastore.thrift;
 
+import io.prestosql.plugin.hive.authentication.HiveMetastoreAuthentication;
 import org.apache.thrift.transport.TTransport;
 
 import java.util.Optional;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -16,9 +16,8 @@ package io.prestosql.plugin.hive.metastore.thrift;
 import com.google.common.base.Ticker;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
 import io.prestosql.plugin.hive.metastore.thrift.FailureAwareThriftMetastoreClient.Callback;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 import org.apache.thrift.TException;
 
 import javax.annotation.Nullable;
@@ -52,15 +51,15 @@ public class StaticMetastoreLocator
     private final String metastoreUsername;
 
     @Inject
-    public StaticMetastoreLocator(StaticMetastoreConfig config, HiveAuthenticationConfig hiveAuthenticationConfig, ThriftMetastoreClientFactory clientFactory)
+    public StaticMetastoreLocator(StaticMetastoreConfig config, ThriftMetastoreAuthenticationConfig authenticationConfig, ThriftMetastoreClientFactory clientFactory)
     {
         this(config.getMetastoreUris(), config.getMetastoreUsername(), clientFactory);
 
         checkArgument(
-                isNullOrEmpty(metastoreUsername) || hiveAuthenticationConfig.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.NONE,
+                isNullOrEmpty(metastoreUsername) || authenticationConfig.getAuthenticationType() == ThriftMetastoreAuthenticationType.NONE,
                 "%s cannot be used together with %s authentication",
                 HIVE_METASTORE_USERNAME,
-                hiveAuthenticationConfig.getHiveMetastoreAuthenticationType());
+                authenticationConfig.getAuthenticationType());
     }
 
     public StaticMetastoreLocator(List<URI> metastoreUris, @Nullable String metastoreUsername, ThriftMetastoreClientFactory clientFactory)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -34,14 +34,13 @@ import io.prestosql.plugin.hive.PartitionNotFoundException;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.SchemaAlreadyExistsException;
 import io.prestosql.plugin.hive.TableAlreadyExistsException;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HiveMetastoreAuthenticationType;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.HiveColumnStatistics;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 import io.prestosql.plugin.hive.util.RetryDriver;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.SchemaNotFoundException;
@@ -170,7 +169,7 @@ public class ThriftHiveMetastore
     private final boolean impersonationEnabled;
     private final LoadingCache<String, String> delegationTokenCache;
     private final boolean deleteFilesOnDrop;
-    private final HiveMetastoreAuthenticationType authenticationType;
+    private final ThriftMetastoreAuthenticationType authenticationType;
     private final boolean translateHiveViews;
 
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
@@ -184,7 +183,7 @@ public class ThriftHiveMetastore
     private static final Pattern TABLE_PARAMETER_SAFE_VALUE_PATTERN = Pattern.compile("^[a-zA-Z0-9]*$");
 
     @Inject
-    public ThriftHiveMetastore(MetastoreLocator metastoreLocator, HiveConfig hiveConfig, ThriftMetastoreConfig thriftConfig, HiveAuthenticationConfig authenticationConfig, HdfsEnvironment hdfsEnvironment)
+    public ThriftHiveMetastore(MetastoreLocator metastoreLocator, HiveConfig hiveConfig, ThriftMetastoreConfig thriftConfig, ThriftMetastoreAuthenticationConfig authenticationConfig, HdfsEnvironment hdfsEnvironment)
     {
         this.hdfsContext = new HdfsContext(ConnectorIdentity.ofUser(DEFAULT_METASTORE_USER));
         this.clientProvider = requireNonNull(metastoreLocator, "metastoreLocator is null");
@@ -196,7 +195,7 @@ public class ThriftHiveMetastore
         this.maxRetries = thriftConfig.getMaxRetries();
         this.impersonationEnabled = thriftConfig.isImpersonationEnabled();
         this.deleteFilesOnDrop = thriftConfig.isDeleteFilesOnDrop();
-        this.authenticationType = authenticationConfig.getHiveMetastoreAuthenticationType();
+        this.authenticationType = authenticationConfig.getAuthenticationType();
         this.translateHiveViews = hiveConfig.isTranslateHiveViews();
         this.maxWaitForLock = thriftConfig.getMaxWaitForTransactionLock();
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType.NONE;
+
+public class ThriftMetastoreAuthenticationConfig
+{
+    private ThriftMetastoreAuthenticationType authenticationType = NONE;
+
+    public enum ThriftMetastoreAuthenticationType
+    {
+        NONE, KERBEROS
+    }
+
+    @NotNull
+    public ThriftMetastoreAuthenticationType getAuthenticationType()
+    {
+        return authenticationType;
+    }
+
+    @Config("hive.metastore.authentication.type")
+    @ConfigDescription("Thrift metastore authentication type")
+    public ThriftMetastoreAuthenticationConfig setAuthenticationType(ThriftMetastoreAuthenticationType authenticationType)
+    {
+        this.authenticationType = authenticationType;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreAuthenticationModule.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.thrift;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.prestosql.plugin.hive.ForHiveMetastore;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.authentication.HadoopAuthentication;
+import io.prestosql.plugin.hive.authentication.HiveMetastoreAuthentication;
+import io.prestosql.plugin.hive.authentication.MetastoreKerberosConfig;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.prestosql.plugin.hive.authentication.AuthenticationModules.createCachingKerberosHadoopAuthentication;
+
+public class ThriftMetastoreAuthenticationModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        install(getAuthenticationModule());
+    }
+
+    private Module getAuthenticationModule()
+    {
+        ThriftMetastoreAuthenticationType type = buildConfigObject(ThriftMetastoreAuthenticationConfig.class).getAuthenticationType();
+        switch (type) {
+            case NONE:
+                return new NoHiveMetastoreAuthenticationModule();
+            case KERBEROS:
+                return new KerberosHiveMetastoreAuthenticationModule();
+        }
+        throw new AssertionError("Unknown authentication type: " + type);
+    }
+
+    public static class NoHiveMetastoreAuthenticationModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(HiveMetastoreAuthentication.class).to(NoHiveMetastoreAuthentication.class).in(SINGLETON);
+        }
+    }
+
+    public static class KerberosHiveMetastoreAuthenticationModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(HiveMetastoreAuthentication.class).to(KerberosHiveMetastoreAuthentication.class).in(SINGLETON);
+            configBinder(binder).bindConfig(MetastoreKerberosConfig.class);
+        }
+
+        @Provides
+        @Singleton
+        @ForHiveMetastore
+        public HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config, HdfsConfigurationInitializer updater)
+        {
+            String principal = config.getHiveMetastoreClientPrincipal();
+            String keytabLocation = config.getHiveMetastoreClientKeytab();
+            return createCachingKerberosHadoopAuthentication(principal, keytabLocation, updater);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -68,5 +68,7 @@ public class ThriftMetastoreModule
         }
 
         binder.install(new CachingHiveMetastoreModule());
+
+        install(new ThriftMetastoreAuthenticationModule());
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -27,7 +27,6 @@ import io.prestosql.GroupByHashPageIndexerFactory;
 import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.LocationService.WriteInfo;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.azure.HiveAzureConfig;
@@ -51,6 +50,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.orc.OrcPageSource;
 import io.prestosql.plugin.hive.parquet.ParquetPageSource;
@@ -728,7 +728,7 @@ public abstract class AbstractTestHive
 
         hdfsEnvironment = new HdfsEnvironment(createTestHdfsConfiguration(), new HdfsConfig(), new NoHdfsAuthentication());
         HiveMetastore metastore = cachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new HiveAuthenticationConfig(), hdfsEnvironment)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new ThriftMetastoreAuthenticationConfig(), hdfsEnvironment)),
                 executor,
                 Duration.valueOf("1m"),
                 Optional.of(Duration.valueOf("15s")),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -25,7 +25,6 @@ import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.AbstractTestHive.HiveTransaction;
 import io.prestosql.plugin.hive.AbstractTestHive.Transaction;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Database;
@@ -37,6 +36,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.TestingMetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.security.SqlStandardAccessControlMetadata;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -180,7 +180,7 @@ public abstract class AbstractTestHiveFileSystem
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, new HdfsConfig(), new NoHdfsAuthentication());
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new HiveAuthenticationConfig(), hdfsEnvironment)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new ThriftMetastoreAuthenticationConfig(), hdfsEnvironment)),
                 executor,
                 getBasePath(),
                 hdfsEnvironment);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -21,7 +21,6 @@ import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HiveMetastoreClosure;
 import io.prestosql.plugin.hive.PartitionStatistics;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.Table;
@@ -29,6 +28,7 @@ import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.MetastoreLocator;
 import io.prestosql.plugin.hive.metastore.thrift.MockThriftMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreClient;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreStats;
@@ -94,7 +94,7 @@ public class TestCachingHiveMetastore
     private ThriftHiveMetastore createThriftHiveMetastore()
     {
         MetastoreLocator metastoreLocator = new MockMetastoreLocator(mockClient);
-        return new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new HiveAuthenticationConfig(), HDFS_ENVIRONMENT);
+        return new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), new ThriftMetastoreAuthenticationConfig(), HDFS_ENVIRONMENT);
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.hive.authentication.NoHiveMetastoreAuthentication;
 import org.apache.thrift.transport.TTransportException;
 
 import java.net.URI;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestStaticMetastoreLocator.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.hive.metastore.thrift;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
@@ -161,7 +160,7 @@ public class TestStaticMetastoreLocator
 
     private static MetastoreLocator createMetastoreLocator(StaticMetastoreConfig config, Map<String, Optional<ThriftMetastoreClient>> clients)
     {
-        return new StaticMetastoreLocator(config, new HiveAuthenticationConfig(), new MockThriftMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
+        return new StaticMetastoreLocator(config, new ThriftMetastoreAuthenticationConfig(), new MockThriftMetastoreClientFactory(Optional.empty(), new Duration(1, SECONDS), clients));
     }
 
     private static ThriftMetastoreClient createFakeMetastoreClient()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreAuthenticationConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestThriftMetastoreAuthenticationConfig.java
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.plugin.hive.authentication;
+package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.collect.ImmutableMap;
-import io.prestosql.plugin.hive.authentication.HiveAuthenticationConfig.HdfsAuthenticationType;
+import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreAuthenticationConfig.ThriftMetastoreAuthenticationType;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -23,27 +23,24 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestHiveAuthenticationConfig
+public class TestThriftMetastoreAuthenticationConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(HiveAuthenticationConfig.class)
-                .setHdfsAuthenticationType(HdfsAuthenticationType.NONE)
-                .setHdfsImpersonationEnabled(false));
+        assertRecordedDefaults(recordDefaults(ThriftMetastoreAuthenticationConfig.class)
+                .setAuthenticationType(ThriftMetastoreAuthenticationType.NONE));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("hive.hdfs.authentication.type", "KERBEROS")
-                .put("hive.hdfs.impersonation.enabled", "true")
+                .put("hive.metastore.authentication.type", "KERBEROS")
                 .build();
 
-        HiveAuthenticationConfig expected = new HiveAuthenticationConfig()
-                .setHdfsAuthenticationType(HdfsAuthenticationType.KERBEROS)
-                .setHdfsImpersonationEnabled(true);
+        ThriftMetastoreAuthenticationConfig expected = new ThriftMetastoreAuthenticationConfig()
+                .setAuthenticationType(ThriftMetastoreAuthenticationType.KERBEROS);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/TestingMetastoreLocator.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.hive.metastore.thrift;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import io.prestosql.plugin.hive.authentication.HiveMetastoreAuthentication;
-import io.prestosql.plugin.hive.authentication.NoHiveMetastoreAuthentication;
 import org.apache.thrift.TException;
 
 import java.util.Optional;


### PR DESCRIPTION
These classes are only needed by the Thrift metastore.