### PR TITLE
Run a test with dynamic filtering enabled too

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/AbstractPredicatePushdownTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/AbstractPredicatePushdownTest.java
@@ -497,9 +497,6 @@ public abstract class AbstractPredicatePushdownTest
                 "SELECT t1.orderstatus " +
                         "FROM (SELECT orderstatus FROM orders WHERE rand() = orderkey AND orderkey = 123) t1, (VALUES 'F', 'K') t2(col) " +
                         "WHERE t1.orderstatus = t2.col AND (t2.col = 'F' OR t2.col = 'K') AND length(t1.orderstatus) < 42",
-                Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "false")
-                        .build(),
                 anyTree(
                         node(
                                 JoinNode.class,


### PR DESCRIPTION
After this change the `testRemovesRedundantTableScanPredicate` is now
run in two configurations.