### PR TITLE
Make partition_values optional in drop_stats

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -859,6 +859,10 @@ with keys ``p2_value1, p2_value2``.
 Note that if statistics were previously collected for all columns, they need to be dropped
 before re-analyzing just a subset::
 
+    CALL system.drop_stats(schema_name, table_name)
+
+You can also drop statistics for selected partitions only::
+
     CALL system.drop_stats(schema_name, table_name, ARRAY[ARRAY['p2_value1', 'p2_value2']])
 
 Schema Evolution
@@ -962,8 +966,8 @@ Procedures
 
     Drops statistics for a subset of partitions or the entire table. The partitions are specified as an
     array whose elements are arrays of partition values (similar to the ``partition_values`` argument in
-    ``create_empty_partition``). A null value for the ``partition_values`` argument indicates that stats
-    should be dropped for the entire table.
+    ``create_empty_partition``). If ``partition_values`` argument is omitted, stats are dropped for the
+    entire table.
 
 .. _register_partition:
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/procedure/DropStatsProcedure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/procedure/DropStatsProcedure.java
@@ -49,7 +49,7 @@ import static org.apache.hadoop.hive.metastore.utils.FileUtils.makePartName;
 /**
  * A procedure that drops statistics.  It can be invoked for a subset of partitions (e.g.
  * {@code CALL system.drop_stats('system', 'some_table', ARRAY[ARRAY['x', '7']])}) or
- * for the entire table ({@code CALL system.drop_stats('system', 'some_table', NULL)})).
+ * for the entire table ({@code CALL system.drop_stats('system', 'some_table')})).
  */
 public class DropStatsProcedure
         implements Provider<Procedure>
@@ -81,7 +81,7 @@ public class DropStatsProcedure
                 ImmutableList.of(
                         new Argument("schema_name", VARCHAR),
                         new Argument("table_name", VARCHAR),
-                        new Argument("partition_values", new ArrayType(new ArrayType(VARCHAR)))),
+                        new Argument("partition_values", new ArrayType(new ArrayType(VARCHAR)), false, null)),
                 DROP_STATS.bindTo(this));
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -5862,7 +5862,7 @@ public class TestHiveIntegrationSmokeTest
         createUnpartitionedTableForAnalyzeTest(tableName);
 
         // Clear table stats
-        assertUpdate(format("CALL system.drop_stats('%s', '%s', null)", TPCH_SCHEMA, tableName));
+        assertUpdate(format("CALL system.drop_stats('%s', '%s')", TPCH_SCHEMA, tableName));
 
         // No stats before ANALYZE
         assertQuery(
@@ -6049,8 +6049,8 @@ public class TestHiveIntegrationSmokeTest
                         "('p_bigint', null, 0.0, 0.0, null, null, null), " +
                         "(null, null, null, null, 0.0, null, null)");
 
-        // Drop stats for the entire table (partition_values = NULL)
-        assertUpdate(format("CALL system.drop_stats('%s', '%s', NULL)", TPCH_SCHEMA, tableName));
+        // Drop stats for the entire table
+        assertUpdate(format("CALL system.drop_stats('%s', '%s')", TPCH_SCHEMA, tableName));
 
         assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1' AND p_bigint = 7)", tableName),
                 "SELECT * FROM VALUES " +
@@ -6157,8 +6157,8 @@ public class TestHiveIntegrationSmokeTest
                         "('p_bigint', null, 2.0, 0.25, null, '7', '8'), " +
                         "(null, null, null, null, 16.0, null, null)");
 
-        // Drop stats for the entire table (partition_values = NULL)
-        assertUpdate(format("CALL system.drop_stats('%s', '%s', NULL)", TPCH_SCHEMA, tableName));
+        // Drop stats for the entire table
+        assertUpdate(format("CALL system.drop_stats('%s', '%s')", TPCH_SCHEMA, tableName));
 
         // All table stats are gone
         assertQuery(


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/3937