### PR TITLE
Add substring function alias with CHAR argument

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -154,11 +154,19 @@ String Functions
     Positions start with ``1``. A negative starting position is interpreted
     as being relative to the end of the string.
 
+.. function:: substring(string, start) -> varchar
+
+    This is an alias for :func:`substr`.
+
 .. function:: substr(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
+
+.. function:: substring(string, start, length) -> varchar
+
+    This is an alias for :func:`substr`.
 
 .. function:: trim(string) -> varchar
 

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -150,23 +150,23 @@ String Functions
 
 .. function:: substr(string, start) -> varchar
 
+    This is an alias for :func:`substring`.
+
+.. function:: substring(string, start) -> varchar
+
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
     as being relative to the end of the string.
 
-.. function:: substring(string, start) -> varchar
-
-    This is an alias for :func:`substr`.
-
 .. function:: substr(string, start, length) -> varchar
+
+    This is an alias for :func:`substring`.
+
+.. function:: substring(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
-
-.. function:: substring(string, start, length) -> varchar
-
-    This is an alias for :func:`substr`.
 
 .. function:: trim(string) -> varchar
 

--- a/presto-docs/src/main/sphinx/functions/teradata.rst
+++ b/presto-docs/src/main/sphinx/functions/teradata.rst
@@ -15,14 +15,6 @@ String Functions
 
     Alias for :func:`strpos` function.
 
-.. function:: substring(string, start) -> varchar
-
-    Alias for :func:`substr` function.
-
-.. function:: substring(string, start, length) -> varchar
-
-    Alias for :func:`substr` function.
-
 Date Functions
 --------------
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -307,7 +307,7 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction("substr")
+    @ScalarFunction(value = "substr", alias = "substring")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charSubstr(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
@@ -365,7 +365,7 @@ public final class StringFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction("substr")
+    @ScalarFunction(value = "substr", alias = "substring")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charSubstr(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -269,10 +269,10 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction(alias = "substring")
+    @ScalarFunction(alias = "substr")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice substr(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
+    public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
     {
         if ((start == 0) || utf8.length() == 0) {
             return Slices.EMPTY_SLICE;
@@ -307,19 +307,19 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction(value = "substr", alias = "substring")
+    @ScalarFunction(value = "substring", alias = "substr")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice charSubstr(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
+    public static Slice charSubstring(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
     {
-        return substr(padSpaces(utf8, x.intValue()), start);
+        return substring(padSpaces(utf8, x.intValue()), start);
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction(alias = "substring")
+    @ScalarFunction(alias = "substr")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice substr(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
+    public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
         if (start == 0 || (length <= 0) || (utf8.length() == 0)) {
             return Slices.EMPTY_SLICE;
@@ -365,12 +365,12 @@ public final class StringFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction(value = "substr", alias = "substring")
+    @ScalarFunction(value = "substring", alias = "substr")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charSubstr(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
-        return substr(padSpaces(utf8, x.intValue()), start, length);
+        return substring(padSpaces(utf8, x.intValue()), start, length);
     }
 
     @ScalarFunction

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -269,7 +269,7 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction
+    @ScalarFunction(alias = "substring")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice substr(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
@@ -316,7 +316,7 @@ public final class StringFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction
+    @ScalarFunction(alias = "substring")
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice substr(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/BenchmarkStringFunctions.java
@@ -41,7 +41,7 @@ import static io.prestosql.operator.scalar.StringFunctions.length;
 import static io.prestosql.operator.scalar.StringFunctions.lower;
 import static io.prestosql.operator.scalar.StringFunctions.reverse;
 import static io.prestosql.operator.scalar.StringFunctions.rightTrim;
-import static io.prestosql.operator.scalar.StringFunctions.substr;
+import static io.prestosql.operator.scalar.StringFunctions.substring;
 import static io.prestosql.operator.scalar.StringFunctions.trim;
 import static io.prestosql.operator.scalar.StringFunctions.upper;
 import static java.lang.Character.MAX_CODE_POINT;
@@ -72,7 +72,7 @@ public class BenchmarkStringFunctions
     {
         Slice slice = data.getSlice();
         int length = data.getLength();
-        return substr(slice, (length / 2) - 1);
+        return substring(slice, (length / 2) - 1);
     }
 
     @Benchmark
@@ -80,7 +80,7 @@ public class BenchmarkStringFunctions
     {
         Slice slice = data.getSlice();
         int length = data.getLength();
-        return substr(slice, (length / 2) - 1, length / 2);
+        return substring(slice, (length / 2) - 1, length / 2);
     }
 
     @Benchmark
@@ -88,7 +88,7 @@ public class BenchmarkStringFunctions
     {
         Slice slice = data.getSlice();
         int length = data.getLength();
-        return substr(slice, -((length / 2) + 1));
+        return substring(slice, -((length / 2) + 1));
     }
 
     @Benchmark
@@ -96,7 +96,7 @@ public class BenchmarkStringFunctions
     {
         Slice slice = data.getSlice();
         int length = data.getLength();
-        return substr(slice, -((length / 2) + 1), length / 2);
+        return substring(slice, -((length / 2) + 1), length / 2);
     }
 
     @Benchmark

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
@@ -410,12 +410,14 @@ public class TestStringFunctions
         assertFunction("SUBSTR(CAST('keep trailing' AS CHAR(14)), 1)", createVarcharType(14), "keep trailing ");
         assertFunction("SUBSTR(CAST('keep trailing' AS CHAR(14)), 1, 14)", createVarcharType(14), "keep trailing ");
 
+        assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)), 5)", createVarcharType(13), "ratically");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM 5)", createVarcharType(13), "ratically");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM 50)", createVarcharType(13), "");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM -5)", createVarcharType(13), "cally");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM -50)", createVarcharType(13), "");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM 0)", createVarcharType(13), "");
 
+        assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)), 5, 6)", createVarcharType(13), "ratica");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM 5 FOR 6)", createVarcharType(13), "ratica");
         assertFunction("SUBSTRING(CAST('Quadratically' AS CHAR(13)) FROM 5 FOR 50)", createVarcharType(13), "ratically");
         //

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -1444,7 +1444,7 @@ public class TestExpressionCompiler
                         expected = null;
                     }
                     else {
-                        expected = StringFunctions.substr(utf8Slice(value), start, length).toStringUtf8();
+                        expected = StringFunctions.substring(utf8Slice(value), start, length).toStringUtf8();
                     }
                     VarcharType expectedType = value != null ? createVarcharType(value.length()) : VARCHAR;
 

--- a/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataStringFunctions.java
+++ b/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataStringFunctions.java
@@ -19,7 +19,6 @@ import io.airlift.slice.Slices;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.function.Description;
 import io.prestosql.spi.function.FunctionDependency;
-import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
@@ -47,51 +46,6 @@ public final class TeradataStringFunctions
     {
         try {
             return (long) method.invokeExact(string, substring);
-        }
-        catch (Throwable t) {
-            throwIfInstanceOf(t, Error.class);
-            throwIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
-        }
-    }
-
-    @Description("Suffix starting at given index")
-    @ScalarFunction
-    @LiteralParameters("x")
-    @SqlType("varchar(x)")
-    public static Slice substring(
-            @FunctionDependency(
-                    name = "substr",
-                    argumentTypes = {"varchar(x)", StandardTypes.BIGINT})
-                    MethodHandle method,
-            @SqlType("varchar(x)") Slice utf8,
-            @SqlType(StandardTypes.BIGINT) long start)
-    {
-        try {
-            return (Slice) method.invokeExact(utf8, start);
-        }
-        catch (Throwable t) {
-            throwIfInstanceOf(t, Error.class);
-            throwIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
-        }
-    }
-
-    @Description("Substring of given length starting at an index")
-    @ScalarFunction
-    @LiteralParameters("x")
-    @SqlType("varchar(x)")
-    public static Slice substring(
-            @FunctionDependency(
-                    name = "substr",
-                    argumentTypes = {"varchar(x)", StandardTypes.BIGINT, StandardTypes.BIGINT})
-                    MethodHandle method,
-            @SqlType("varchar(x)") Slice utf8,
-            @SqlType(StandardTypes.BIGINT) long start,
-            @SqlType(StandardTypes.BIGINT) long length)
-    {
-        try {
-            return (Slice) method.invokeExact(utf8, start, length);
         }
         catch (Throwable t) {
             throwIfInstanceOf(t, Error.class);

--- a/presto-teradata-functions/src/test/java/io/prestosql/teradata/functions/TestTeradataFunctions.java
+++ b/presto-teradata-functions/src/test/java/io/prestosql/teradata/functions/TestTeradataFunctions.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.spi.type.VarcharType.createVarcharType;
 
 public class TestTeradataFunctions
         extends AbstractTestFunctions
@@ -45,13 +44,6 @@ public class TestTeradataFunctions
         assertFunction("INDEX(NULL, '')", BIGINT, null);
         assertFunction("INDEX('', NULL)", BIGINT, null);
         assertFunction("INDEX(NULL, NULL)", BIGINT, null);
-    }
-
-    @Test
-    public void testSubstring()
-    {
-        assertFunction("SUBSTRING('Quadratically', 5)", createVarcharType(13), "ratically");
-        assertFunction("SUBSTRING('Quadratically', 5, 6)", createVarcharType(13), "ratica");
     }
 
     @Test


### PR DESCRIPTION
Fixes #3457

Three are three changes:
* Move Teradata substring function to presto-main module (https://github.com/prestosql/presto/issues/3456#issuecomment-615297700)
* Add substring function alias with CHAR argument
* Promote substring function from alias instead of substr
