### PR TITLE
Increase range of allowed timestamp (w/tz) literals

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/Timestamps.java
+++ b/presto-main/src/main/java/io/prestosql/type/Timestamps.java
@@ -39,7 +39,7 @@ import static java.time.temporal.ChronoField.MICRO_OF_SECOND;
 public final class Timestamps
 {
     public static final Pattern DATETIME_PATTERN = Pattern.compile("" +
-            "(?<year>\\d\\d\\d\\d)-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
+            "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
             "(?: (?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
             "\\s*(?<timezone>.+)?");
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");

--- a/presto-main/src/main/java/io/prestosql/util/DateTimeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/util/DateTimeUtils.java
@@ -74,28 +74,28 @@ public final class DateTimeUtils
 
     static {
         DateTimeParser[] timestampWithoutTimeZoneParser = {
-                DateTimeFormat.forPattern("yyyy-M-d").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser()};
+                DateTimeFormat.forPattern("yyyyyy-M-d").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s.SSS").getParser()};
 
         DateTimeParser[] timestampWithTimeZoneParser = {
-                DateTimeFormat.forPattern("yyyy-M-dZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d Z").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:mZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m Z").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:sZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s Z").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS Z").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-dZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d ZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:mZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m ZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:sZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s ZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS ZZZ").getParser()};
+                DateTimeFormat.forPattern("yyyyyy-M-dZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d Z").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:mZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m Z").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:sZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s Z").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s.SSSZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s.SSS Z").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-dZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d ZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:mZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m ZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:sZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s ZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s.SSSZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyyyy-M-d H:m:s.SSS ZZZ").getParser()};
 
         DateTimePrinter timestampWithTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS ZZZ").getPrinter();
         TIMESTAMP_WITH_TIME_ZONE_FORMATTER = new DateTimeFormatterBuilder()

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/BaseTestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/BaseTestTimestamp.java
@@ -170,6 +170,126 @@ public abstract class BaseTestTimestamp
 
         assertThat(assertions.expression("TIMESTAMP '1500-05-01 12:34:56.123456789012'"))
                 .isEqualTo(timestamp(12, 1500, 5, 1, 12, 34, 56, 123_456_789_012L));
+
+        // 6-digit year
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56'"))
+                .isEqualTo(timestamp(0, 123001, 5, 1, 12, 34, 56, 0));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.1'"))
+                .isEqualTo(timestamp(1, 123001, 5, 1, 12, 34, 56, 100_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.12'"))
+                .isEqualTo(timestamp(2, 123001, 5, 1, 12, 34, 56, 120_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.123'"))
+                .isEqualTo(timestamp(3, 123001, 5, 1, 12, 34, 56, 123_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.1234'"))
+                .isEqualTo(timestamp(4, 123001, 5, 1, 12, 34, 56, 123_400_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.12345'"))
+                .isEqualTo(timestamp(5, 123001, 5, 1, 12, 34, 56, 123_450_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.123456'"))
+                .isEqualTo(timestamp(6, 123001, 5, 1, 12, 34, 56, 123_456_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.1234567'"))
+                .isEqualTo(timestamp(7, 123001, 5, 1, 12, 34, 56, 123_456_700_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.12345678'"))
+                .isEqualTo(timestamp(8, 123001, 5, 1, 12, 34, 56, 123_456_780_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.123456789'"))
+                .isEqualTo(timestamp(9, 123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.1234567890'"))
+                .isEqualTo(timestamp(10, 123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.12345678901'"))
+                .isEqualTo(timestamp(11, 123001, 5, 1, 12, 34, 56, 123_456_789_010L));
+
+        assertThat(assertions.expression("TIMESTAMP '123001-05-01 12:34:56.123456789012'"))
+                .isEqualTo(timestamp(12, 123001, 5, 1, 12, 34, 56, 123_456_789_012L));
+
+        // 6-digit year with + sign
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56'"))
+                .isEqualTo(timestamp(0, 123001, 5, 1, 12, 34, 56, 0));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.1'"))
+                .isEqualTo(timestamp(1, 123001, 5, 1, 12, 34, 56, 100_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.12'"))
+                .isEqualTo(timestamp(2, 123001, 5, 1, 12, 34, 56, 120_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.123'"))
+                .isEqualTo(timestamp(3, 123001, 5, 1, 12, 34, 56, 123_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.1234'"))
+                .isEqualTo(timestamp(4, 123001, 5, 1, 12, 34, 56, 123_400_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.12345'"))
+                .isEqualTo(timestamp(5, 123001, 5, 1, 12, 34, 56, 123_450_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.123456'"))
+                .isEqualTo(timestamp(6, 123001, 5, 1, 12, 34, 56, 123_456_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.1234567'"))
+                .isEqualTo(timestamp(7, 123001, 5, 1, 12, 34, 56, 123_456_700_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.12345678'"))
+                .isEqualTo(timestamp(8, 123001, 5, 1, 12, 34, 56, 123_456_780_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.123456789'"))
+                .isEqualTo(timestamp(9, 123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.1234567890'"))
+                .isEqualTo(timestamp(10, 123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.12345678901'"))
+                .isEqualTo(timestamp(11, 123001, 5, 1, 12, 34, 56, 123_456_789_010L));
+
+        assertThat(assertions.expression("TIMESTAMP '+123001-05-01 12:34:56.123456789012'"))
+                .isEqualTo(timestamp(12, 123001, 5, 1, 12, 34, 56, 123_456_789_012L));
+
+        // 6-digit year with - sign
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56'"))
+                .isEqualTo(timestamp(0, -123001, 5, 1, 12, 34, 56, 0));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.1'"))
+                .isEqualTo(timestamp(1, -123001, 5, 1, 12, 34, 56, 100_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.12'"))
+                .isEqualTo(timestamp(2, -123001, 5, 1, 12, 34, 56, 120_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.123'"))
+                .isEqualTo(timestamp(3, -123001, 5, 1, 12, 34, 56, 123_000_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.1234'"))
+                .isEqualTo(timestamp(4, -123001, 5, 1, 12, 34, 56, 123_400_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.12345'"))
+                .isEqualTo(timestamp(5, -123001, 5, 1, 12, 34, 56, 123_450_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.123456'"))
+                .isEqualTo(timestamp(6, -123001, 5, 1, 12, 34, 56, 123_456_000_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.1234567'"))
+                .isEqualTo(timestamp(7, -123001, 5, 1, 12, 34, 56, 123_456_700_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.12345678'"))
+                .isEqualTo(timestamp(8, -123001, 5, 1, 12, 34, 56, 123_456_780_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.123456789'"))
+                .isEqualTo(timestamp(9, -123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.1234567890'"))
+                .isEqualTo(timestamp(10, -123001, 5, 1, 12, 34, 56, 123_456_789_000L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.12345678901'"))
+                .isEqualTo(timestamp(11, -123001, 5, 1, 12, 34, 56, 123_456_789_010L));
+
+        assertThat(assertions.expression("TIMESTAMP '-123001-05-01 12:34:56.123456789012'"))
+                .isEqualTo(timestamp(12, -123001, 5, 1, 12, 34, 56, 123_456_789_012L));
     }
 
     @Test
@@ -441,6 +561,12 @@ public abstract class BaseTestTimestamp
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.5555555555' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '2020-05-01 12:34:56.556 America/Los_Angeles'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.55555555555' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '2020-05-01 12:34:56.556 America/Los_Angeles'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.555555555555' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '2020-05-01 12:34:56.556 America/Los_Angeles'");
+
+        // 5-digit year in the future
+        assertThat(assertions.expression("CAST(TIMESTAMP '12001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '12001-05-01 12:34:56 America/Los_Angeles'");
+
+        // 5-digit year in the past
+        assertThat(assertions.expression("CAST(TIMESTAMP '-12001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '-12001-05-01 12:34:56 America/Los_Angeles'");
     }
 
     @Test
@@ -493,6 +619,12 @@ public abstract class BaseTestTimestamp
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.1234567890' AS JSON)")).matches("JSON '\"2020-05-01 12:34:56.1234567890\"'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.12345678901' AS JSON)")).matches("JSON '\"2020-05-01 12:34:56.12345678901\"'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.123456789012' AS JSON)")).matches("JSON '\"2020-05-01 12:34:56.123456789012\"'");
+
+        // 6-digit year in the future
+        assertThat(assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56.123456789012' AS JSON)")).matches("JSON '\"+123001-05-01 12:34:56.123456789012\"'");
+
+        // 6-digit year in the past
+        assertThat(assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56.123456789012' AS JSON)")).matches("JSON '\"-123001-05-01 12:34:56.123456789012\"'");
     }
 
     @Test
@@ -526,6 +658,12 @@ public abstract class BaseTestTimestamp
         assertThat(assertions.expression("CAST(TIMESTAMP '1500-05-01 12:34:56.1234567890' AS VARCHAR)")).isEqualTo("1500-05-01 12:34:56.1234567890");
         assertThat(assertions.expression("CAST(TIMESTAMP '1500-05-01 12:34:56.12345678901' AS VARCHAR)")).isEqualTo("1500-05-01 12:34:56.12345678901");
         assertThat(assertions.expression("CAST(TIMESTAMP '1500-05-01 12:34:56.123456789012' AS VARCHAR)")).isEqualTo("1500-05-01 12:34:56.123456789012");
+
+        // 6-digit year in the future
+        assertThat(assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56' AS VARCHAR)")).isEqualTo("+123001-05-01 12:34:56");
+
+        // 6-digit year in the past
+        assertThat(assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56' AS VARCHAR)")).isEqualTo("-123001-05-01 12:34:56");
     }
 
     @Test
@@ -590,6 +728,51 @@ public abstract class BaseTestTimestamp
         assertThat(assertions.expression("CAST('1500-05-01 12:34:56.555555555555' AS TIMESTAMP(10))")).matches("TIMESTAMP '1500-05-01 12:34:56.5555555556'");
         assertThat(assertions.expression("CAST('1500-05-01 12:34:56.555555555555' AS TIMESTAMP(11))")).matches("TIMESTAMP '1500-05-01 12:34:56.55555555556'");
         assertThat(assertions.expression("CAST('1500-05-01 12:34:56.555555555555' AS TIMESTAMP(12))")).matches("TIMESTAMP '1500-05-01 12:34:56.555555555555'");
+
+        // 6-digit year
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST('123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111111'");
+
+        // 6-digit year with + sign
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST('+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111111'");
+
+        // 6-digit year with - sign
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '-123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST('-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111111111'");
     }
 
     @Test
@@ -1076,6 +1259,36 @@ public abstract class BaseTestTimestamp
         assertThat(assertions.expression("format('%s', TIMESTAMP '2020-05-10 12:34:56.5555555555')")).isEqualTo("2020-05-10T12:34:56.555555556");
         assertThat(assertions.expression("format('%s', TIMESTAMP '2020-05-10 12:34:56.55555555555')")).isEqualTo("2020-05-10T12:34:56.555555556");
         assertThat(assertions.expression("format('%s', TIMESTAMP '2020-05-10 12:34:56.555555555555')")).isEqualTo("2020-05-10T12:34:56.555555556");
+
+        // 6-digit year in the future
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56')")).isEqualTo("+123001-05-10T12:34:56");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.1')")).isEqualTo("+123001-05-10T12:34:56.100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.11')")).isEqualTo("+123001-05-10T12:34:56.110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.111')")).isEqualTo("+123001-05-10T12:34:56.111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.1111')")).isEqualTo("+123001-05-10T12:34:56.111100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.11111')")).isEqualTo("+123001-05-10T12:34:56.111110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.111111')")).isEqualTo("+123001-05-10T12:34:56.111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.1111111')")).isEqualTo("+123001-05-10T12:34:56.111111100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.11111111')")).isEqualTo("+123001-05-10T12:34:56.111111110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.111111111')")).isEqualTo("+123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.1111111111')")).isEqualTo("+123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.11111111111')")).isEqualTo("+123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '123001-05-10 12:34:56.111111111111')")).isEqualTo("+123001-05-10T12:34:56.111111111");
+
+        // 6-digit year in the past
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56')")).isEqualTo("-123001-05-10T12:34:56");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.1')")).isEqualTo("-123001-05-10T12:34:56.100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.11')")).isEqualTo("-123001-05-10T12:34:56.110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.111')")).isEqualTo("-123001-05-10T12:34:56.111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.1111')")).isEqualTo("-123001-05-10T12:34:56.111100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.11111')")).isEqualTo("-123001-05-10T12:34:56.111110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.111111')")).isEqualTo("-123001-05-10T12:34:56.111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.1111111')")).isEqualTo("-123001-05-10T12:34:56.111111100");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.11111111')")).isEqualTo("-123001-05-10T12:34:56.111111110");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.111111111')")).isEqualTo("-123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.1111111111')")).isEqualTo("-123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.11111111111')")).isEqualTo("-123001-05-10T12:34:56.111111111");
+        assertThat(assertions.expression("format('%s', TIMESTAMP '-123001-05-10 12:34:56.111111111111')")).isEqualTo("-123001-05-10T12:34:56.111111111");
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/BaseTestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/BaseTestTimestamp.java
@@ -567,6 +567,12 @@ public abstract class BaseTestTimestamp
 
         // 5-digit year in the past
         assertThat(assertions.expression("CAST(TIMESTAMP '-12001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)", session)).matches("TIMESTAMP '-12001-05-01 12:34:56 America/Los_Angeles'");
+
+        // Overflow
+        assertThatThrownBy(() -> assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)", session))
+                .hasMessage("Out of range for timestamp with time zone: 3819379894496000");
+        assertThatThrownBy(() -> assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)", session))
+                .hasMessage("Out of range for timestamp with time zone: -3943693366326000");
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestampBase.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestampBase.java
@@ -86,6 +86,10 @@ public abstract class TestTimestampBase
         assertFunction("TIMESTAMP '2001-1-2 3:4'", createTimestampType(0), sqlTimestampOf(0, 2001, 1, 2, 3, 4, 0, 0, session));
         assertFunction("TIMESTAMP '2001-1-2'", createTimestampType(0), sqlTimestampOf(0, 2001, 1, 2, 0, 0, 0, 0, session));
 
+        assertFunction("TIMESTAMP '123001-01-22 03:04:05.321'", createTimestampType(3), sqlTimestampOf(3, 123001, 1, 22, 3, 4, 5, 321, session));
+        assertFunction("TIMESTAMP '+123001-01-22 03:04:05.321'", createTimestampType(3), sqlTimestampOf(3, 123001, 1, 22, 3, 4, 5, 321, session));
+        assertFunction("TIMESTAMP '-123001-01-22 03:04:05.321'", createTimestampType(3), sqlTimestampOf(3, -123001, 1, 22, 3, 4, 5, 321, session));
+
         assertInvalidFunction("TIMESTAMP 'text'", INVALID_LITERAL, "line 1:1: 'text' is not a valid timestamp literal");
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZoneBase.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZoneBase.java
@@ -96,6 +96,16 @@ public abstract class TestTimestampWithTimeZoneBase
         assertFunction("TIMESTAMP '2001-01-02 Europe/Berlin'",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 2, 0, 0, 0, 0, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+
+        assertFunction("TIMESTAMP '12001-01-02 03:04:05.321 Europe/Berlin'",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(12001, 1, 2, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+        assertFunction("TIMESTAMP '+12001-01-02 03:04:05.321 Europe/Berlin'",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(12001, 1, 2, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+        assertFunction("TIMESTAMP '-12001-01-02 03:04:05.321 Europe/Berlin'",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(-12001, 1, 2, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZoneBase.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZoneBase.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.prestosql.spi.StandardErrorCode.INVALID_LITERAL;
 import static io.prestosql.spi.function.OperatorType.INDETERMINATE;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
@@ -106,6 +107,11 @@ public abstract class TestTimestampWithTimeZoneBase
         assertFunction("TIMESTAMP '-12001-01-02 03:04:05.321 Europe/Berlin'",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(-12001, 1, 2, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+
+        // Overflow
+        assertInvalidFunction("TIMESTAMP '123001-01-02 03:04:05.321 Europe/Berlin'", INVALID_LITERAL, "line 1:1: '123001-01-02 03:04:05.321 Europe/Berlin' is not a valid timestamp literal");
+        assertInvalidFunction("TIMESTAMP '+123001-01-02 03:04:05.321 Europe/Berlin'", INVALID_LITERAL, "line 1:1: '+123001-01-02 03:04:05.321 Europe/Berlin' is not a valid timestamp literal");
+        assertInvalidFunction("TIMESTAMP '-123001-01-02 03:04:05.321 Europe/Berlin'", INVALID_LITERAL, "line 1:1: '-123001-01-02 03:04:05.321 Europe/Berlin' is not a valid timestamp literal");
     }
 
     @Test

--- a/presto-spi/src/main/java/io/prestosql/spi/type/DateTimeEncoding.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/DateTimeEncoding.java
@@ -26,6 +26,10 @@ public final class DateTimeEncoding
 
     private static long pack(long millisUtc, short timeZoneKey)
     {
+        if (millisUtc << MILLIS_SHIFT >> MILLIS_SHIFT != millisUtc) {
+            throw new IllegalArgumentException("Millis overflow: " + millisUtc);
+        }
+
         return (millisUtc << MILLIS_SHIFT) | (timeZoneKey & TIME_ZONE_MASK);
     }
 


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/3956 (but not only)