### PR TITLE
Add rpm for presto-cli

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -126,6 +126,19 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -166,6 +179,87 @@
                         <phase>package</phase>
                         <goals>
                             <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>rpm-maven-plugin</artifactId>
+                <version>2.2.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-rpm</id>
+                        <goals>
+                            <goal>rpm</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <name>${project.name}</name>
+                    <version>${project.version}</version>
+                    <release>1</release>
+                    <group>Applications/Databases</group>
+                    <description>Presto CLI RPM Package.</description>
+                    <needarch>x86_64</needarch>
+                    <copyTo>${project.build.directory}/rpm/${project.build.finalName}.x86_64.rpm</copyTo>
+
+                    <mappings>
+                        <mapping>
+                            <directory>/usr/local/bin</directory>
+                            <filemode>755</filemode>
+                            <sources>
+                                <source>
+                                    <location>target/presto-cli-${project.version}-executable.jar</location>
+                                    <destination>presto-cli</destination>
+                                </source>
+                            </sources>
+                        </mapping>
+                    </mappings>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-file-size</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesSize>
+                                    <!-- CLI RPM shouldn't be too large -->
+                                    <maxsize>26214400</maxsize>
+                                    <files>
+                                        <file>${project.build.directory}/rpm/${project.build.finalName}.x86_64.rpm</file>
+                                    </files>
+                                </requireFilesSize>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <rpm>${project.build.directory}/rpm/${project.build.finalName}.x86_64.rpm</rpm>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/presto-cli/src/test/java/io/prestosql/cli/ClientIT.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/ClientIT.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cli;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
+
+@Test(singleThreaded = true)
+public class ClientIT
+{
+    @Parameters("rpm")
+    @Test
+    public void testWithJava11(String rpm)
+    {
+        testClient("prestodev/centos7-oj11", rpm, "11");
+    }
+
+    private static void testClient(String baseImage, String rpmHostPath, String expectedJavaVersion)
+    {
+        String rpm = "/" + new File(rpmHostPath).getName();
+
+        String command = "" +
+                // install RPM
+                "yum localinstall -y " + rpm + "\n" +
+                "presto-cli --help\n";
+
+        try (GenericContainer<?> container = new GenericContainer<>(baseImage)) {
+            container.withFileSystemBind(rpmHostPath, rpm, BindMode.READ_ONLY)
+                    .withCommand("sh", "-xeuc", command)
+                    .waitingFor(forLogMessage(".*presto - Presto command line interface.*", 1).withStartupTimeout(Duration.ofMinutes(1)))
+                    .start();
+        }
+    }
+}


### PR DESCRIPTION
Adds the rpm-maven-plugin to the package phase to create an RPM that
will install the presto-cli executable jar as presto-cli to
/usr/local/bin. Fixes #1882.