### PR TITLE
Fix flaky TestEventListener

### DIFF
--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -218,11 +218,11 @@ public class TestEventListener
         assertEquals(actualCompletedPositions, expectedCompletedPositions);
 
         QueryStatistics statistics = queryCompletedEvent.getStatistics();
-        // No memory pool usage
-        assertEquals(statistics.getPeakUserMemoryBytes(), 0);
-        assertEquals(statistics.getPeakTaskUserMemory(), 0);
-        assertEquals(statistics.getPeakTaskTotalMemory(), 0);
-        assertEquals(statistics.getCumulativeMemory(), 0.0);
+        // Aggregation can have memory pool usage
+        assertTrue(statistics.getPeakUserMemoryBytes() >= 0);
+        assertTrue(statistics.getPeakTaskUserMemory() >= 0);
+        assertTrue(statistics.getPeakTaskTotalMemory() >= 0);
+        assertTrue(statistics.getCumulativeMemory() >= 0);
 
         // Not a write query
         assertEquals(statistics.getWrittenBytes(), 0);


### PR DESCRIPTION
Since aggregation can consume some amount of memory pool, task memory must be asserted as non-negative.

It fixes the issue in https://github.com/prestosql/presto/issues/3943. 