### PR TITLE
Fix flaky TestEventListener#testOutputStats

### DIFF
--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -376,7 +376,7 @@ public class TestEventListener
         assertEquals(statistics.getResourceWaitingTime().get().toMillis(), queryStats.getResourceWaitingTime().toMillis());
         assertEquals(statistics.getAnalysisTime().get().toMillis(), queryStats.getAnalysisTime().toMillis());
         assertEquals(statistics.getExecutionTime().get().toMillis(), queryStats.getExecutionTime().toMillis());
-        assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakRevocableMemoryReservation().toBytes());
+        assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakUserMemoryReservation().toBytes());
         assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTaskUserMemory().toBytes());
         assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskUserMemory().toBytes());
         assertEquals(statistics.getPhysicalInputBytes(), queryStats.getPhysicalInputDataSize().toBytes());


### PR DESCRIPTION
peakUserMemoryBytes is derived from peakUserMemoryReservation in QueryStats, not revocable memory reservation.

See in the QueryMonitor. https://github.com/prestosql/presto/blob/37c74ad15f5f0c9c770c2aa491e49ffe5146d4b1/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java#L242

Fixes https://github.com/prestosql/presto/issues/3943.

