### PR TITLE
Recognize tempto annotations in ReportUnannotatedMethods

### DIFF
--- a/presto-main/src/test/java/io/prestosql/tests/ReportUnannotatedMethods.java
+++ b/presto-main/src/test/java/io/prestosql/tests/ReportUnannotatedMethods.java
@@ -92,6 +92,10 @@ public class ReportUnannotatedMethods
                         // testng annotation (@Test, @Before*, @DataProvider, etc.)
                         return true;
                     }
+                    if ("io.prestosql.tempto".equals(annotationClass.getPackage().getName())) {
+                        // tempto annotation (@BeforeTestWithContext, @AfterTestWithContext)
+                        return true;
+                    }
                     return false;
                 });
     }


### PR DESCRIPTION
TBD: run `ReportUnannotatedMethods` over product tests.

cc @jvanzyl 