### PR TITLE
Reduce idle CPU consumption in the resource group manager.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/resourcegroups/InternalResourceGroupManager.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
 import io.prestosql.execution.ManagedQueryExecution;
-import io.prestosql.execution.resourcegroups.InternalResourceGroup.RootInternalResourceGroup;
 import io.prestosql.server.ResourceGroupInfo;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.memory.ClusterMemoryPoolManager;
@@ -72,7 +71,7 @@ public final class InternalResourceGroupManager<C>
     private static final String NAME_PROPERTY = "resource-groups.configuration-manager";
 
     private final ScheduledExecutorService refreshExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("ResourceGroupManager"));
-    private final List<RootInternalResourceGroup> rootGroups = new CopyOnWriteArrayList<>();
+    private final List<InternalResourceGroup> rootGroups = new CopyOnWriteArrayList<>();
     private final ConcurrentMap<ResourceGroupId, InternalResourceGroup> groups = new ConcurrentHashMap<>();
     private final AtomicReference<ResourceGroupConfigurationManager<C>> configurationManager;
     private final ResourceGroupConfigurationManagerContext configurationManagerContext;
@@ -183,7 +182,7 @@ public final class InternalResourceGroupManager<C>
     public void start()
     {
         if (started.compareAndSet(false, true)) {
-            refreshExecutor.scheduleWithFixedDelay(this::refreshAndStartQueries, 1, 1, TimeUnit.MILLISECONDS);
+            refreshExecutor.scheduleWithFixedDelay(this::refreshAndStartQueries, 1, 100, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -199,7 +198,7 @@ public final class InternalResourceGroupManager<C>
             // nano time has overflowed
             lastCpuQuotaGenerationNanos.set(nanoTime);
         }
-        for (RootInternalResourceGroup group : rootGroups) {
+        for (InternalResourceGroup group : rootGroups) {
             try {
                 if (elapsedSeconds > 0) {
                     group.generateCpuQuota(elapsedSeconds);
@@ -229,7 +228,7 @@ public final class InternalResourceGroupManager<C>
                 group = parent.getOrCreateSubGroup(id.getLastSegment());
             }
             else {
-                RootInternalResourceGroup root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor);
+                InternalResourceGroup root = new InternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor);
                 group = root;
                 rootGroups.add(root);
             }
@@ -257,7 +256,7 @@ public final class InternalResourceGroupManager<C>
     public int getQueriesQueuedOnInternal()
     {
         int queriesQueuedInternal = 0;
-        for (RootInternalResourceGroup rootGroup : rootGroups) {
+        for (InternalResourceGroup rootGroup : rootGroups) {
             synchronized (rootGroup) {
                 queriesQueuedInternal += getQueriesQueuedOnInternal(rootGroup);
             }

--- a/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/io/prestosql/execution/resourcegroups/BenchmarkResourceGroup.java
@@ -16,7 +16,6 @@ package io.prestosql.execution.resourcegroups;
 import io.airlift.units.DataSize;
 import io.prestosql.execution.MockManagedQueryExecution;
 import io.prestosql.execution.MockManagedQueryExecution.MockManagedQueryExecutionBuilder;
-import io.prestosql.execution.resourcegroups.InternalResourceGroup.RootInternalResourceGroup;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -67,12 +66,12 @@ public class BenchmarkResourceGroup
         private int queries = 100;
 
         private final ExecutorService executor = Executors.newSingleThreadExecutor();
-        private RootInternalResourceGroup root;
+        private InternalResourceGroup root;
 
         @Setup
         public void setup()
         {
-            root = new RootInternalResourceGroup("root", (group, export) -> {}, executor);
+            root = new InternalResourceGroup("root", (group, export) -> {}, executor);
             root.setSoftMemoryLimitBytes(DataSize.of(1, MEGABYTE).toBytes());
             root.setMaxQueuedQueries(queries);
             root.setHardConcurrencyLimit(queries);
@@ -97,7 +96,7 @@ public class BenchmarkResourceGroup
             executor.shutdownNow();
         }
 
-        public RootInternalResourceGroup getRoot()
+        public InternalResourceGroup getRoot()
         {
             return root;
         }

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
@@ -45,7 +45,7 @@ public class TestQueryStateInfo
     @Test
     public void testQueryStateInfo()
     {
-        InternalResourceGroup.RootInternalResourceGroup root = new InternalResourceGroup.RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
         root.setSoftMemoryLimitBytes(DataSize.of(1, MEGABYTE).toBytes());
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(0);

--- a/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -81,7 +81,7 @@ public class TestDbResourceGroupConfigurationManager
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), prodEnvironment);
         List<ResourceGroupSpec> groups = manager.getRootGroups();
         assertEquals(groups.size(), 1);
-        InternalResourceGroup prodGlobal = new InternalResourceGroup.RootInternalResourceGroup("prod_global", (group, export) -> {}, directExecutor());
+        InternalResourceGroup prodGlobal = new InternalResourceGroup("prod_global", (group, export) -> {}, directExecutor());
         manager.configure(prodGlobal, new SelectionContext<>(prodGlobal.getId(), new ResourceGroupIdTemplate("prod_global")));
         assertEqualsResourceGroup(prodGlobal, "10MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertEquals(manager.getSelectors().size(), 1);
@@ -92,7 +92,7 @@ public class TestDbResourceGroupConfigurationManager
         // check the dev configuration
         manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), devEnvironment);
         assertEquals(groups.size(), 1);
-        InternalResourceGroup devGlobal = new InternalResourceGroup.RootInternalResourceGroup("dev_global", (group, export) -> {}, directExecutor());
+        InternalResourceGroup devGlobal = new InternalResourceGroup("dev_global", (group, export) -> {}, directExecutor());
         manager.configure(devGlobal, new SelectionContext<>(prodGlobal.getId(), new ResourceGroupIdTemplate("dev_global")));
         assertEqualsResourceGroup(devGlobal, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertEquals(manager.getSelectors().size(), 1);
@@ -115,7 +115,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertSelector(2, 1, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         AtomicBoolean exported = new AtomicBoolean();
-        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
+        InternalResourceGroup global = new InternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
         manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
         assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         exported.set(false);
@@ -175,7 +175,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertSelector(2, 1, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
-        InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor());
+        InternalResourceGroup missing = new InternalResourceGroup("missing", (group, export) -> {}, directExecutor());
 
         assertThatThrownBy(() -> manager.configure(missing, new SelectionContext<>(missing.getId(), new ResourceGroupIdTemplate("missing"))))
                 .isInstanceOf(IllegalStateException.class)
@@ -198,7 +198,7 @@ public class TestDbResourceGroupConfigurationManager
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         manager.start();
         AtomicBoolean exported = new AtomicBoolean();
-        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
+        InternalResourceGroup global = new InternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
         manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
         InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub");
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new ResourceGroupIdTemplate("global.sub")));


### PR DESCRIPTION
The InternalResourceGroupManager is waking up periodically to calculate CPU quotas and to unblock queries waiting to be run.
This change increases the period of this wake up from 1ms to 100ms.

Some data...
Before this change
- Presto consumes about 5-10% of CPU when idle.
- The main consumer of a CPU is the periodic task scheduled on the ResourceGroupManager. About 4s in a 5 minute interval
- The CPU package does not reach deeper powerstates

After this change:
- Presto consumes about 2-3% (so still some work to do)
- The ResourceGroupManager threads consume about 200ms in a 5 minute interval
- The CPU package reaches deeper c-states at least 50% of the time.

See discussion on #3966 .
