### PR TITLE
Fix flaky TestEventListener

### DIFF
--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -377,7 +377,8 @@ public class TestEventListener
         assertEquals(statistics.getAnalysisTime().get().toMillis(), queryStats.getAnalysisTime().toMillis());
         assertEquals(statistics.getExecutionTime().get().toMillis(), queryStats.getExecutionTime().toMillis());
         assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakUserMemoryReservation().toBytes());
-        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTotalMemoryReservation().toBytes());
+        // TODO: https://github.com/prestosql/presto/issues/4060
+//        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTotalMemoryReservation().toBytes());
         assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskTotalMemory().toBytes());
         assertEquals(statistics.getPhysicalInputBytes(), queryStats.getPhysicalInputDataSize().toBytes());
         assertEquals(statistics.getPhysicalInputRows(), queryStats.getPhysicalInputPositions());

--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -377,8 +377,8 @@ public class TestEventListener
         assertEquals(statistics.getAnalysisTime().get().toMillis(), queryStats.getAnalysisTime().toMillis());
         assertEquals(statistics.getExecutionTime().get().toMillis(), queryStats.getExecutionTime().toMillis());
         assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakUserMemoryReservation().toBytes());
-        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTaskUserMemory().toBytes());
-        assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskUserMemory().toBytes());
+        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTotalMemoryReservation().toBytes());
+        assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskTotalMemory().toBytes());
         assertEquals(statistics.getPhysicalInputBytes(), queryStats.getPhysicalInputDataSize().toBytes());
         assertEquals(statistics.getPhysicalInputRows(), queryStats.getPhysicalInputPositions());
         assertEquals(statistics.getInternalNetworkBytes(), queryStats.getInternalNetworkInputDataSize().toBytes());


### PR DESCRIPTION
`peakTaskTotalMemory` and `peakTotalNonRevocableMemoryBytes` in QueryStatistics
must be derived from QueryStats correctly.

See: https://github.com/prestosql/presto/blob/37c74ad15f5f0c9c770c2aa491e49ffe5146d4b1/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java#L243
https://github.com/prestosql/presto/blob/37c74ad15f5f0c9c770c2aa491e49ffe5146d4b1/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java#L245

It fixes the issue in https://github.com/prestosql/presto/issues/3943#issuecomment-642313525

