### PR TITLE
Use ZSTD as the default compression code in Hive

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -77,7 +77,7 @@ public class HiveConfig
     private long perTransactionMetastoreCacheMaximumSize = 1000;
 
     private HiveStorageFormat hiveStorageFormat = HiveStorageFormat.ORC;
-    private HiveCompressionCodec hiveCompressionCodec = HiveCompressionCodec.GZIP;
+    private HiveCompressionCodec hiveCompressionCodec = HiveCompressionCodec.ZSTD;
     private boolean respectTableFormat = true;
     private boolean immutablePartitions;
     private boolean createEmptyBucketFiles = true;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -56,7 +56,7 @@ public class TestHiveConfig
                 .setRecursiveDirWalkerEnabled(false)
                 .setIgnoreAbsentPartitions(false)
                 .setHiveStorageFormat(HiveStorageFormat.ORC)
-                .setHiveCompressionCodec(HiveCompressionCodec.GZIP)
+                .setHiveCompressionCodec(HiveCompressionCodec.ZSTD)
                 .setRespectTableFormat(true)
                 .setImmutablePartitions(false)
                 .setCreateEmptyBucketFiles(true)


### PR DESCRIPTION
ZSTD is now the recommended compression codec for general purpose
compression, so we should use this by default, instead of GZIP (ZLIB).