### PR TITLE
Document why no CHAR → VARCHAR coercion

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
+++ b/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
@@ -437,6 +437,9 @@ public final class TypeCoercion
             case StandardTypes.CHAR: {
                 switch (resultTypeBase) {
                     case StandardTypes.VARCHAR:
+                        // CHAR could be coercible to VARCHAR, but they cannot be both coercible to each other.
+                        // VARCHAR to CHAR coercion provides natural semantics when comparing VARCHAR literals to CHAR columns.
+                        // WITH CHAR to VARCHAR coercion one would need to pad literals with spaces: char_column_len_5 = 'abc  ', so we would not run unmodified TPC-DS queries.
                         return Optional.empty();
                     case JoniRegexpType.NAME:
                         return Optional.of(JONI_REGEXP);


### PR DESCRIPTION
This is based on 3d9d004bde77c847108ece06c727536669b6a640.
The original commit message became inaccessible after a refactor
(4408334bb637501dd3d037c45b2cc0118caaa83c).