### PR TITLE
Remove support for date times before 1582

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
@@ -52,10 +52,8 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -298,10 +296,7 @@ public class PrestoResultSet
         }
 
         try {
-            long millis = DATE_FORMATTER.withZone(localTimeZone).parseMillis(String.valueOf(value));
-            return Date.valueOf(Instant.ofEpochMilli(millis)
-                    .atZone(ZoneOffset.UTC)
-                    .toLocalDate());
+            return new Date(DATE_FORMATTER.withZone(localTimeZone).parseMillis(String.valueOf(value)));
         }
         catch (IllegalArgumentException e) {
             throw new SQLException("Invalid date from server: " + value, e);

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
@@ -210,18 +210,6 @@ public class TestJdbcResultSet
 //            ...
 //        });
 
-        // distant past, but apparently not an uncommon value in practice; on this date Julian and Gregorian calendars should be in sync, but they appear not to be
-        checkRepresentation("TIMESTAMP '0001-01-01 00:00:00'", Types.TIMESTAMP, (rs, column) -> {
-            assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(1, 1, 1, 0, 0, 0)));
-            assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(1, 1, 1, 0, 0, 0)));
-        });
-
-        // distant past, before Julian-Gregorian calendar "default cut-over", but after 0001-01-01 when Julian and Gregorian calendars are supposed to be in sync
-        checkRepresentation("TIMESTAMP '1300-01-01 00:00:00'", Types.TIMESTAMP, (rs, column) -> {
-            assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(1300, 1, 1, 0, 0, 0)));
-            assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(1300, 1, 1, 0, 0, 0)));
-        });
-
         checkRepresentation("TIMESTAMP '2018-02-13 13:14:15.227 Europe/Warsaw'", Types.TIMESTAMP /* TODO TIMESTAMP_WITH_TIMEZONE */, (rs, column) -> {
             assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(2018, 2, 13, 6, 14, 15, 227_000_000))); // TODO this should represent TIMESTAMP '2018-02-13 13:14:15.227 Europe/Warsaw'
             assertThrows(() -> rs.getDate(column));

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSet.java
@@ -127,18 +127,6 @@ public class TestJdbcResultSet
             assertThrows(IllegalArgumentException.class, () -> rs.getTimestamp(column));
         });
 
-        // distant past, but apparently not an uncommon value in practice; on this date Julian and Gregorian calendars should be in sync, but they appear not to be
-        checkRepresentation("DATE '0001-01-01'", Types.DATE, (rs, column) -> {
-            assertEquals(rs.getObject(column), Date.valueOf(LocalDate.of(1, 1, 1)));
-            assertEquals(rs.getDate(column), Date.valueOf(LocalDate.of(1, 1, 1)));
-        });
-
-        // distant past, before Julian-Gregorian calendar "default cut-over", but after 0001-01-01 when Julian and Gregorian calendars are supposed to be in sync
-        checkRepresentation("DATE '1300-01-01'", Types.DATE, (rs, column) -> {
-            assertEquals(rs.getObject(column), Date.valueOf(LocalDate.of(1300, 1, 1)));
-            assertEquals(rs.getDate(column), Date.valueOf(LocalDate.of(1300, 1, 1)));
-        });
-
         checkRepresentation("TIME '09:39:05'", Types.TIME, (rs, column) -> {
             assertEquals(rs.getObject(column), Time.valueOf(LocalTime.of(9, 39, 5)));
             assertThrows(() -> rs.getDate(column));


### PR DESCRIPTION
Reverts prestosql/presto#4005

This was supposed to be a fix for https://github.com/prestosql/presto/issues/4018
But it seems hard (if not impossible) to fix 4018 and https://github.com/prestosql/presto/issues/4017
