### PR TITLE
Make Jdbc connector be extendable

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
@@ -48,9 +48,9 @@ public class JdbcConnector
 {
     private final LifeCycleManager lifeCycleManager;
     private final JdbcMetadataFactory jdbcMetadataFactory;
-    private final JdbcSplitManager jdbcSplitManager;
-    private final JdbcRecordSetProvider jdbcRecordSetProvider;
-    private final JdbcPageSinkProvider jdbcPageSinkProvider;
+    private final ConnectorSplitManager jdbcSplitManager;
+    private final ConnectorRecordSetProvider jdbcRecordSetProvider;
+    private final ConnectorPageSinkProvider jdbcPageSinkProvider;
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
@@ -61,9 +61,9 @@ public class JdbcConnector
     public JdbcConnector(
             LifeCycleManager lifeCycleManager,
             JdbcMetadataFactory jdbcMetadataFactory,
-            JdbcSplitManager jdbcSplitManager,
-            JdbcRecordSetProvider jdbcRecordSetProvider,
-            JdbcPageSinkProvider jdbcPageSinkProvider,
+            ConnectorSplitManager jdbcSplitManager,
+            ConnectorRecordSetProvider jdbcRecordSetProvider,
+            ConnectorPageSinkProvider jdbcPageSinkProvider,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
             Set<SessionPropertiesProvider> sessionProperties)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
@@ -19,6 +19,9 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.prestosql.spi.connector.ConnectorAccessControl;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorRecordSetProvider;
+import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.procedure.Procedure;
 
 import javax.inject.Provider;
@@ -48,9 +51,9 @@ public class JdbcModule
         procedureBinder(binder);
 
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
-        binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
-        binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
-        binder.bind(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorSplitManager.class).to(JdbcSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorRecordSetProvider.class).to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
@@ -51,9 +51,9 @@ public class JdbcModule
         procedureBinder(binder);
 
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorSplitManager.class).to(JdbcSplitManager.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorRecordSetProvider.class).to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorPageSinkProvider.class).to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorSplitManager.class).setDefault().to(JdbcSplitManager.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorRecordSetProvider.class).setDefault().to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorPageSinkProvider.class).setDefault().to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSet.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSet.java
@@ -23,6 +23,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.prestosql.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
@@ -63,31 +64,31 @@ public class TestJdbcRecordSet
     @Test
     public void testGetColumnTypes()
     {
-        RecordSet recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        RecordSet recordSet = createRecordSet(ImmutableList.of(
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR),
                 new JdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32)),
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(VARCHAR, createVarcharType(32), BIGINT));
 
-        recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        recordSet = createRecordSet(ImmutableList.of(
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, VARCHAR));
 
-        recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        recordSet = createRecordSet(ImmutableList.of(
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, BIGINT, VARCHAR));
 
-        recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of());
+        recordSet = createRecordSet(ImmutableList.of());
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of());
     }
 
     @Test
     public void testCursorSimple()
     {
-        RecordSet recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        RecordSet recordSet = createRecordSet(ImmutableList.of(
                 columnHandles.get("text"),
                 columnHandles.get("text_short"),
                 columnHandles.get("value")));
@@ -120,7 +121,7 @@ public class TestJdbcRecordSet
     @Test
     public void testCursorMixedOrder()
     {
-        RecordSet recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        RecordSet recordSet = createRecordSet(ImmutableList.of(
                 columnHandles.get("value"),
                 columnHandles.get("value"),
                 columnHandles.get("text")));
@@ -150,7 +151,7 @@ public class TestJdbcRecordSet
     @Test
     public void testIdempotentClose()
     {
-        RecordSet recordSet = new JdbcRecordSet(jdbcClient, SESSION, split, table, ImmutableList.of(
+        RecordSet recordSet = createRecordSet(ImmutableList.of(
                 columnHandles.get("value"),
                 columnHandles.get("value"),
                 columnHandles.get("text")));
@@ -158,5 +159,10 @@ public class TestJdbcRecordSet
         RecordCursor cursor = recordSet.cursor();
         cursor.close();
         cursor.close();
+    }
+
+    private JdbcRecordSet createRecordSet(List<JdbcColumnHandle> columnHandles)
+    {
+        return new JdbcRecordSet(jdbcClient, SESSION, split, table, columnHandles);
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -48,8 +48,6 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestJdbcRecordSetProvider
 {
-    private static final JdbcIdentity IDENTITY = JdbcIdentity.from(SESSION);
-
     private TestingDatabase database;
     private JdbcClient jdbcClient;
     private JdbcSplit split;


### PR DESCRIPTION
Make Jdbc connector be extendable

Make Jdbc connector be extendable by allowing to change the
implementations.
