### PR TITLE
Fix a trivial typo: hive to cassandra

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraClientConfig.java
@@ -182,7 +182,7 @@ public class CassandraClientConfig
     }
 
     @Config("cassandra.allow-drop-table")
-    @ConfigDescription("Allow hive connector to drop table")
+    @ConfigDescription("Allow cassandra connector to drop table")
     public CassandraClientConfig setAllowDropTable(boolean allowDropTable)
     {
         this.allowDropTable = allowDropTable;


### PR DESCRIPTION
I found `@ConfigDescription` has a typo.

```
2020-06-15T17:38:13.325+0900	INFO	io.prestosql.server.PrestoServer.main()	Bootstrap	PROPERTY                                                  DEFAULT     RUNTIME                            DESCRIPTION
2020-06-15T17:38:13.325+0900	INFO	io.prestosql.server.PrestoServer.main()	Bootstrap	cassandra.allow-drop-table                                false       false                              Allow hive connector to drop table
```