### PR TITLE
Fix old client compatibility with parametric timestamp type

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -575,8 +575,11 @@ class Query
 
     private Column createColumn(String name, Type type)
     {
-        TypeSignature signature = type.getTypeSignature();
-        return new Column(name, type.getDisplayName(), toClientTypeSignature(signature));
+        ClientTypeSignature signature = toClientTypeSignature(type.getTypeSignature());
+
+        // TODO: the type name should be rendered by the SQL expression formatter to account for delimited field names in row types
+        // and special types such as timestamp(p) with time zone in a future version
+        return new Column(name, signature.toString(), signature);
     }
 
     private ClientTypeSignature toClientTypeSignature(TypeSignature signature)


### PR DESCRIPTION
The type was being communicated to the client via two parallel paths: a structural
form and a string form. We missed the latter when adding the capability check to
the protocol.