### PR TITLE
Add default system access control 

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -17,7 +17,9 @@ Presto offers three built-in plugins:
 ================================================== ============================================================
 Plugin Name                                        Description
 ================================================== ============================================================
-``allow-all`` (default value)                      All operations are permitted.
+``default`` (default value)                        All operations are permitted, except for user impersonation.
+
+``allow-all``                                      All operations are permitted.
 
 ``read-only``                                      Operations that read data or metadata are permitted, but
                                                    none of the operations that write data or metadata are
@@ -29,10 +31,15 @@ Plugin Name                                        Description
                                                    See :ref:`file-based-system-access-control` for details.
 ================================================== ============================================================
 
+Default System Access Control
+===============================
+
+All operations are permitted, except for user impersonation. This plugin is enabled by default.
+
 Allow All System Access Control
 ===============================
 
-All operations are permitted under this plugin. This plugin is enabled by default.
+All operations are permitted under this plugin.
 
 .. _read-only-system-access-control:
 

--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -100,6 +100,7 @@ public class AccessControlManager
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.eventListenerManager = requireNonNull(eventListenerManager, "eventListenerManager is null");
         this.configFiles = ImmutableList.copyOf(config.getAccessControlFiles());
+        addSystemAccessControlFactory(new DefaultSystemAccessControl.Factory());
         addSystemAccessControlFactory(new AllowAllSystemAccessControl.Factory());
         addSystemAccessControlFactory(new ReadOnlySystemAccessControl.Factory());
         addSystemAccessControlFactory(new FileBasedSystemAccessControl.Factory());
@@ -132,8 +133,8 @@ public class AccessControlManager
         List<File> configFiles = this.configFiles;
         if (configFiles.isEmpty()) {
             if (!CONFIG_FILE.exists()) {
-                setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
-                log.info("Using system access control %s", AllowAllSystemAccessControl.NAME);
+                setSystemAccessControl(DefaultSystemAccessControl.NAME, ImmutableMap.of());
+                log.info("Using system access control %s", DefaultSystemAccessControl.NAME);
                 return;
             }
             configFiles = ImmutableList.of(CONFIG_FILE);

--- a/presto-main/src/main/java/io/prestosql/security/DefaultSystemAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/DefaultSystemAccessControl.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.security;
+
+import io.prestosql.plugin.base.security.AllowAllSystemAccessControl;
+import io.prestosql.spi.security.SystemAccessControl;
+import io.prestosql.spi.security.SystemAccessControlFactory;
+import io.prestosql.spi.security.SystemSecurityContext;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.security.AccessDeniedException.denyImpersonateUser;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default system access control rules.
+ * By default all access is allowed except for user impersonation.
+ */
+public class DefaultSystemAccessControl
+        extends AllowAllSystemAccessControl
+{
+    public static final String NAME = "default";
+
+    private static final DefaultSystemAccessControl INSTANCE = new DefaultSystemAccessControl();
+
+    public static class Factory
+            implements SystemAccessControlFactory
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public SystemAccessControl create(Map<String, String> config)
+        {
+            requireNonNull(config, "config is null");
+            checkArgument(config.isEmpty(), "This access controller does not support any configuration properties");
+            return INSTANCE;
+        }
+    }
+
+    @Override
+    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    {
+        denyImpersonateUser(context.getIdentity().getUser(), userName);
+    }
+}

--- a/presto-server-main/etc/access-control.properties
+++ b/presto-server-main/etc/access-control.properties
@@ -1,1 +1,1 @@
-access-control.name=allow-all
+access-control.name=default


### PR DESCRIPTION
This adds a new system access control that is installed by default.  Currently this only disallows impersonation, but we could change other defaults in the future if we want.