### PR TITLE
Introduce IcebergFileWriter and collect file stats directly from ORC writers

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriter.java
@@ -55,7 +55,7 @@ public class OrcFileWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OrcFileWriter.class).instanceSize();
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
-    private final OrcWriter orcWriter;
+    protected final OrcWriter orcWriter;
     private final Callable<Void> rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -163,18 +163,6 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-orc</artifactId>
-            <version>${dep.iceberg.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-parquet</artifactId>
             <version>${dep.iceberg.version}</version>
             <exclusions>

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
@@ -204,7 +204,7 @@ public final class ExpressionConverter
             Object value = requireNonNull(marker.getValue(), "The value of the marker must be non-null");
             if (Decimals.isShortDecimal(decimalType)) {
                 checkArgument(value instanceof Long, "A short decimal should be represented by a Long value but was %s", value.getClass().getName());
-                return value;
+                return BigDecimal.valueOf((long) value).movePointLeft(decimalType.getScale());
             }
             checkArgument(value instanceof Slice, "A long decimal should be represented by a Slice value but was %s", value.getClass().getName());
             return new BigDecimal(Decimals.decodeUnscaledValue((Slice) value), decimalType.getScale());

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriter.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import io.prestosql.plugin.hive.FileWriter;
+import org.apache.iceberg.Metrics;
+
+import java.util.Optional;
+
+public interface IcebergFileWriter
+        extends FileWriter
+{
+    Optional<Metrics> getMetrics();
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergFileWriterFactory.java
@@ -22,13 +22,10 @@ import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.orc.OrcWriterStats;
 import io.prestosql.orc.OutputStreamOrcDataSink;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
-import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveStorageFormat;
 import io.prestosql.plugin.hive.NodeVersion;
-import io.prestosql.plugin.hive.RecordFileWriter;
 import io.prestosql.plugin.hive.orc.HdfsOrcDataSource;
-import io.prestosql.plugin.hive.orc.OrcFileWriter;
 import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
@@ -112,7 +109,7 @@ public class IcebergFileWriterFactory
         return orcWriterStats;
     }
 
-    public FileWriter createFileWriter(
+    public IcebergFileWriter createFileWriter(
             Path outputPath,
             Schema icebergSchema,
             List<IcebergColumnHandle> columns,
@@ -129,7 +126,7 @@ public class IcebergFileWriterFactory
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }
 
-    private FileWriter createParquetWriter(
+    private IcebergFileWriter createParquetWriter(
             Path outputPath,
             Schema icebergSchema,
             List<IcebergColumnHandle> columns,
@@ -147,7 +144,7 @@ public class IcebergFileWriterFactory
         setParquetSchema(jobConf, convert(icebergSchema, "table"));
         jobConf.set(ParquetOutputFormat.COMPRESSION, getCompressionCodec(session).getParquetCompressionCodec().name());
 
-        return new RecordFileWriter(
+        return new IcebergRecordFileWriter(
                 outputPath,
                 columns.stream()
                         .map(IcebergColumnHandle::getName)
@@ -160,7 +157,7 @@ public class IcebergFileWriterFactory
                 session);
     }
 
-    private FileWriter createOrcWriter(
+    private IcebergFileWriter createOrcWriter(
             Path outputPath,
             Schema icebergSchema,
             JobConf jobConf,
@@ -200,7 +197,8 @@ public class IcebergFileWriterFactory
                 });
             }
 
-            return new OrcFileWriter(
+            return new IcebergOrcFileWriter(
+                    icebergSchema,
                     orcDataSink,
                     rollbackAction,
                     fileColumnNames,

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -587,7 +587,7 @@ public class IcebergMetadata
         org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
 
         icebergTable.newDelete()
-                .deleteFromRowFilter(toIcebergExpression(handle.getPredicate(), session))
+                .deleteFromRowFilter(toIcebergExpression(handle.getPredicate()))
                 .commit();
 
         // TODO: it should be possible to return number of deleted records

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergOrcFileWriter.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import io.prestosql.orc.OrcDataSink;
+import io.prestosql.orc.OrcDataSource;
+import io.prestosql.orc.OrcWriteValidation;
+import io.prestosql.orc.OrcWriterOptions;
+import io.prestosql.orc.OrcWriterStats;
+import io.prestosql.orc.metadata.ColumnMetadata;
+import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.OrcColumnId;
+import io.prestosql.orc.metadata.OrcType;
+import io.prestosql.orc.metadata.statistics.ColumnStatistics;
+import io.prestosql.orc.metadata.statistics.DateStatistics;
+import io.prestosql.orc.metadata.statistics.DecimalStatistics;
+import io.prestosql.orc.metadata.statistics.DoubleStatistics;
+import io.prestosql.orc.metadata.statistics.IntegerStatistics;
+import io.prestosql.orc.metadata.statistics.StringStatistics;
+import io.prestosql.plugin.hive.orc.OrcFileWriter;
+import io.prestosql.spi.type.Type;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.joda.time.DateTimeZone;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Verify.verify;
+import static io.prestosql.orc.metadata.OrcColumnId.ROOT_COLUMN;
+import static io.prestosql.plugin.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergOrcFileWriter
+        extends OrcFileWriter
+        implements IcebergFileWriter
+{
+    private final Schema icebergSchema;
+    private final ColumnMetadata<OrcType> orcColumns;
+
+    public IcebergOrcFileWriter(
+            Schema icebergSchema,
+            OrcDataSink orcDataSink,
+            Callable<Void> rollbackAction,
+            List<String> columnNames,
+            List<Type> fileColumnTypes,
+            ColumnMetadata<OrcType> fileColumnOrcTypes,
+            CompressionKind compression,
+            OrcWriterOptions options,
+            boolean writeLegacyVersion,
+            int[] fileInputColumnIndexes,
+            Map<String, String> metadata,
+            DateTimeZone hiveStorageTimeZone,
+            Optional<Supplier<OrcDataSource>> validationInputFactory,
+            OrcWriteValidation.OrcWriteValidationMode validationMode,
+            OrcWriterStats stats)
+    {
+        super(orcDataSink, rollbackAction, columnNames, fileColumnTypes, fileColumnOrcTypes, compression, options, writeLegacyVersion, fileInputColumnIndexes, metadata, hiveStorageTimeZone, validationInputFactory, validationMode, stats);
+        this.icebergSchema = requireNonNull(icebergSchema, "icebergSchema is null");
+        orcColumns = fileColumnOrcTypes;
+    }
+
+    @Override
+    public Optional<Metrics> getMetrics()
+    {
+        return Optional.of(computeMetrics(icebergSchema, orcColumns, orcWriter.getFileRowCount(), orcWriter.getFileStats()));
+    }
+
+    private static Metrics computeMetrics(Schema icebergSchema, ColumnMetadata<OrcType> orcColumns, long fileRowCount, Optional<ColumnMetadata<ColumnStatistics>> columnStatistics)
+    {
+        if (columnStatistics.isEmpty()) {
+            return new Metrics(fileRowCount, null, null, null, null, null);
+        }
+        // Columns that are descendants of LIST or MAP types are excluded because:
+        // 1. Their stats are not used by Apache Iceberg to filter out data files
+        // 2. Their record count can be larger than table-level row count. There's no good way to calculate nullCounts for them.
+        // See https://github.com/apache/iceberg/pull/199#discussion_r429443627
+        Set<OrcColumnId> excludedColumns = getExcludedColumns(orcColumns);
+
+        ImmutableMap.Builder<Integer, Long> valueCountsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Integer, Long> nullCountsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Integer, ByteBuffer> lowerBoundsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Integer, ByteBuffer> upperBoundsBuilder = ImmutableMap.builder();
+
+        // OrcColumnId(0) is the root column that represents file-level schema
+        for (int i = 1; i < orcColumns.size(); i++) {
+            OrcColumnId orcColumnId = new OrcColumnId(i);
+            if (excludedColumns.contains(orcColumnId)) {
+                continue;
+            }
+            OrcType orcColumn = orcColumns.get(orcColumnId);
+            ColumnStatistics orcColumnStats = columnStatistics.get().get(orcColumnId);
+            int icebergId = getIcebergId(orcColumn);
+            Types.NestedField icebergField = icebergSchema.findField(icebergId);
+            verify(icebergField != null, "Cannot find Iceberg column with ID %s in schema %s", icebergId, icebergSchema);
+            valueCountsBuilder.put(icebergId, fileRowCount);
+            if (orcColumnStats.hasNumberOfValues()) {
+                nullCountsBuilder.put(icebergId, fileRowCount - orcColumnStats.getNumberOfValues());
+            }
+            toIcebergMinMax(orcColumnStats, icebergField.type()).ifPresent(minMax -> {
+                lowerBoundsBuilder.put(icebergId, minMax.getMin());
+                upperBoundsBuilder.put(icebergId, minMax.getMax());
+            });
+        }
+        Map<Integer, Long> valueCounts = valueCountsBuilder.build();
+        Map<Integer, Long> nullCounts = nullCountsBuilder.build();
+        Map<Integer, ByteBuffer> lowerBounds = lowerBoundsBuilder.build();
+        Map<Integer, ByteBuffer> upperBounds = upperBoundsBuilder.build();
+        return new Metrics(
+                fileRowCount,
+                null, // TODO: Add column size accounting to ORC column writers
+                valueCounts.isEmpty() ? null : valueCounts,
+                nullCounts.isEmpty() ? null : nullCounts,
+                lowerBounds.isEmpty() ? null : lowerBounds,
+                upperBounds.isEmpty() ? null : upperBounds);
+    }
+
+    private static Set<OrcColumnId> getExcludedColumns(ColumnMetadata<OrcType> orcColumns)
+    {
+        ImmutableSet.Builder<OrcColumnId> excludedColumns = ImmutableSet.builder();
+        populateExcludedColumns(orcColumns, ROOT_COLUMN, false, excludedColumns);
+        return excludedColumns.build();
+    }
+
+    private static void populateExcludedColumns(ColumnMetadata<OrcType> orcColumns, OrcColumnId orcColumnId, boolean exclude, ImmutableSet.Builder<OrcColumnId> excludedColumns)
+    {
+        if (exclude) {
+            excludedColumns.add(orcColumnId);
+        }
+        OrcType orcColumn = orcColumns.get(orcColumnId);
+        switch (orcColumn.getOrcTypeKind()) {
+            case LIST:
+            case MAP:
+                for (OrcColumnId child : orcColumn.getFieldTypeIndexes()) {
+                    populateExcludedColumns(orcColumns, child, true, excludedColumns);
+                }
+                return;
+            case STRUCT:
+                for (OrcColumnId child : orcColumn.getFieldTypeIndexes()) {
+                    populateExcludedColumns(orcColumns, child, exclude, excludedColumns);
+                }
+                return;
+        }
+    }
+
+    private static int getIcebergId(OrcType orcColumn)
+    {
+        String icebergId = orcColumn.getAttributes().get(ORC_ICEBERG_ID_KEY);
+        verify(icebergId != null, "ORC column %s doesn't have an associated Iceberg ID", orcColumn);
+        return Integer.parseInt(icebergId);
+    }
+
+    private static Optional<IcebergMinMax> toIcebergMinMax(ColumnStatistics orcColumnStats, org.apache.iceberg.types.Type icebergType)
+    {
+        IntegerStatistics integerStatistics = orcColumnStats.getIntegerStatistics();
+        if (integerStatistics != null) {
+            Object min = integerStatistics.getMin();
+            Object max = integerStatistics.getMax();
+            if (min == null || max == null) {
+                return Optional.empty();
+            }
+            if (icebergType.typeId() == org.apache.iceberg.types.Type.TypeID.INTEGER) {
+                min = toIntExact((Long) min);
+                max = toIntExact((Long) max);
+            }
+            return Optional.of(new IcebergMinMax(icebergType, min, max));
+        }
+        DoubleStatistics doubleStatistics = orcColumnStats.getDoubleStatistics();
+        if (doubleStatistics != null) {
+            Object min = doubleStatistics.getMin();
+            Object max = doubleStatistics.getMax();
+            if (min == null || max == null) {
+                return Optional.empty();
+            }
+            if (icebergType.typeId() == org.apache.iceberg.types.Type.TypeID.FLOAT) {
+                min = ((Double) min).floatValue();
+                max = ((Double) max).floatValue();
+            }
+            return Optional.of(new IcebergMinMax(icebergType, min, max));
+        }
+        StringStatistics stringStatistics = orcColumnStats.getStringStatistics();
+        if (stringStatistics != null) {
+            Slice min = stringStatistics.getMin();
+            Slice max = stringStatistics.getMax();
+            if (min == null || max == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new IcebergMinMax(icebergType, min.toStringUtf8(), max.toStringUtf8()));
+        }
+        DateStatistics dateStatistics = orcColumnStats.getDateStatistics();
+        if (dateStatistics != null) {
+            Integer min = dateStatistics.getMin();
+            Integer max = dateStatistics.getMax();
+            if (min == null || max == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new IcebergMinMax(icebergType, min, max));
+        }
+        DecimalStatistics decimalStatistics = orcColumnStats.getDecimalStatistics();
+        if (decimalStatistics != null) {
+            BigDecimal min = decimalStatistics.getMin();
+            BigDecimal max = decimalStatistics.getMax();
+            if (min == null || max == null) {
+                return Optional.empty();
+            }
+            min = min.setScale(((Types.DecimalType) icebergType).scale());
+            max = max.setScale(((Types.DecimalType) icebergType).scale());
+            return Optional.of(new IcebergMinMax(icebergType, min, max));
+        }
+        return Optional.empty();
+    }
+
+    private static class IcebergMinMax
+    {
+        private ByteBuffer min;
+        private ByteBuffer max;
+
+        private IcebergMinMax(org.apache.iceberg.types.Type type, Object min, Object max)
+        {
+            this.min = Conversions.toByteBuffer(type, min);
+            this.max = Conversions.toByteBuffer(type, max);
+        }
+
+        public ByteBuffer getMin()
+        {
+            return min;
+        }
+
+        public ByteBuffer getMax()
+        {
+            return max;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergRecordFileWriter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergRecordFileWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import io.airlift.units.DataSize;
+import io.prestosql.plugin.hive.RecordFileWriter;
+import io.prestosql.plugin.hive.metastore.StorageFormat;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.iceberg.Metrics;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+public class IcebergRecordFileWriter
+        extends RecordFileWriter
+        implements IcebergFileWriter
+{
+    public IcebergRecordFileWriter(
+            Path path,
+            List<String> inputColumnNames,
+            StorageFormat storageFormat,
+            Properties schema,
+            DataSize estimatedWriterSystemMemoryUsage,
+            JobConf conf,
+            TypeManager typeManager,
+            ConnectorSession session)
+    {
+        super(path, inputColumnNames, storageFormat, schema, estimatedWriterSystemMemoryUsage, conf, typeManager, session);
+    }
+
+    @Override
+    public Optional<Metrics> getMetrics()
+    {
+        return Optional.empty();
+    }
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
@@ -109,7 +109,7 @@ final class IcebergUtil
 
     public static TableScan getTableScan(ConnectorSession session, TupleDomain<IcebergColumnHandle> predicates, Optional<Long> snapshotId, Table icebergTable)
     {
-        Expression expression = ExpressionConverter.toIcebergExpression(predicates, session);
+        Expression expression = ExpressionConverter.toIcebergExpression(predicates);
         TableScan tableScan = icebergTable.newScan().filter(expression);
         return snapshotId
                 .map(id -> isSnapshot(icebergTable, id) ? tableScan.useSnapshot(id) : tableScan.asOfTime(id))

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.plugin.tpch.TpchPlugin;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.MaterializedRow;
+import io.prestosql.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static io.prestosql.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
+import static io.prestosql.SystemSessionProperties.TASK_CONCURRENCY;
+import static io.prestosql.SystemSessionProperties.TASK_WRITER_COUNT;
+import static io.prestosql.plugin.iceberg.TestIcebergOrcMetricsCollection.DataFileRecord.toDataFileRecord;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestIcebergOrcMetricsCollection
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .setSchema("test_schema")
+                .setSystemProperty(TASK_CONCURRENCY, "1")
+                .setSystemProperty(TASK_WRITER_COUNT, "1")
+                .setSystemProperty(MAX_DRIVERS_PER_TASK, "1")
+                .setCatalogSessionProperty("iceberg", "orc_string_statistics_limit", Integer.MAX_VALUE + "B")
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(1)
+                .build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+
+        HiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.createCatalog("iceberg", "iceberg");
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        queryRunner.execute("CREATE SCHEMA test_schema");
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testBasic()
+    {
+        assertUpdate("CREATE TABLE orders WITH (format = 'ORC') AS SELECT * FROM tpch.tiny.orders", 15000);
+        MaterializedResult materializedResult = computeActual("SELECT * FROM \"orders$files\"");
+        assertEquals(materializedResult.getRowCount(), 1);
+        DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
+
+        // Check file format
+        assertEquals(datafile.getFileFormat(), "ORC");
+
+        // Check file row count
+        assertEquals(datafile.getRecordCount(), 15000L);
+
+        // Check per-column value count
+        datafile.getValueCounts().values().forEach(valueCount -> assertEquals(valueCount, (Long) 15000L));
+
+        // Check per-column null value count
+        datafile.getNullValueCounts().values().forEach(nullValueCount -> assertEquals(nullValueCount, (Long) 0L));
+
+        // Check per-column lower bound
+        Map<Integer, String> lowerBounds = datafile.getLowerBounds();
+        assertQuery("SELECT min(orderkey) FROM tpch.tiny.orders", "VALUES " + lowerBounds.get(1));
+        assertQuery("SELECT min(custkey) FROM tpch.tiny.orders", "VALUES " + lowerBounds.get(2));
+        assertQuery("SELECT min(orderstatus) FROM tpch.tiny.orders", "VALUES '" + lowerBounds.get(3) + "'");
+        assertQuery("SELECT min(totalprice) FROM tpch.tiny.orders", "VALUES " + lowerBounds.get(4));
+        assertQuery("SELECT min(orderdate) FROM tpch.tiny.orders", "VALUES DATE '" + lowerBounds.get(5) + "'");
+        assertQuery("SELECT min(orderpriority) FROM tpch.tiny.orders", "VALUES '" + lowerBounds.get(6) + "'");
+        assertQuery("SELECT min(clerk) FROM tpch.tiny.orders", "VALUES '" + lowerBounds.get(7) + "'");
+        assertQuery("SELECT min(shippriority) FROM tpch.tiny.orders", "VALUES " + lowerBounds.get(8));
+        assertQuery("SELECT min(comment) FROM tpch.tiny.orders", "VALUES '" + lowerBounds.get(9) + "'");
+
+        // Check per-column upper bound
+        Map<Integer, String> upperBounds = datafile.getUpperBounds();
+        assertQuery("SELECT max(orderkey) FROM tpch.tiny.orders", "VALUES " + upperBounds.get(1));
+        assertQuery("SELECT max(custkey) FROM tpch.tiny.orders", "VALUES " + upperBounds.get(2));
+        assertQuery("SELECT max(orderstatus) FROM tpch.tiny.orders", "VALUES '" + upperBounds.get(3) + "'");
+        assertQuery("SELECT max(totalprice) FROM tpch.tiny.orders", "VALUES " + upperBounds.get(4));
+        assertQuery("SELECT max(orderdate) FROM tpch.tiny.orders", "VALUES DATE '" + upperBounds.get(5) + "'");
+        assertQuery("SELECT max(orderpriority) FROM tpch.tiny.orders", "VALUES '" + upperBounds.get(6) + "'");
+        assertQuery("SELECT max(clerk) FROM tpch.tiny.orders", "VALUES '" + upperBounds.get(7) + "'");
+        assertQuery("SELECT max(shippriority) FROM tpch.tiny.orders", "VALUES " + upperBounds.get(8));
+        assertQuery("SELECT max(comment) FROM tpch.tiny.orders", "VALUES '" + upperBounds.get(9) + "'");
+
+        assertUpdate("DROP TABLE orders");
+    }
+
+    @Test
+    public void testWithNulls()
+    {
+        assertUpdate("CREATE TABLE test_with_nulls (_integer INTEGER, _real REAL, _string VARCHAR)");
+        assertUpdate("INSERT INTO test_with_nulls VALUES (7, 3.4, 'aaa'), (3, 4.5, 'bbb'), (4, null, 'ccc'), (null, null, 'ddd')", 4);
+        MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_with_nulls$files\"");
+        assertEquals(materializedResult.getRowCount(), 1);
+        DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
+
+        // Check per-column value count
+        datafile.getValueCounts().values().forEach(valueCount -> assertEquals(valueCount, (Long) 4L));
+
+        // Check per-column null value count
+        assertEquals(datafile.getNullValueCounts().get(1), (Long) 1L);
+        assertEquals(datafile.getNullValueCounts().get(2), (Long) 2L);
+        assertEquals(datafile.getNullValueCounts().get(3), (Long) 0L);
+
+        // Check per-column lower bound
+        assertEquals(datafile.getLowerBounds().get(1), "3");
+        assertEquals(datafile.getLowerBounds().get(2), "3.4");
+        assertEquals(datafile.getLowerBounds().get(3), "aaa");
+
+        assertUpdate("DROP TABLE test_with_nulls");
+
+        assertUpdate("CREATE TABLE test_all_nulls (_integer INTEGER)");
+        assertUpdate("INSERT INTO test_all_nulls VALUES null, null, null", 3);
+        materializedResult = computeActual("SELECT * FROM \"test_all_nulls$files\"");
+        assertEquals(materializedResult.getRowCount(), 1);
+        datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
+
+        // Check per-column value count
+        assertEquals(datafile.getValueCounts().get(1), (Long) 3L);
+
+        // Check per-column null value count
+        assertEquals(datafile.getNullValueCounts().get(1), (Long) 3L);
+
+        // Check that lower bounds and upper bounds are nulls. (There's no non-null record)
+        assertNull(datafile.getLowerBounds());
+        assertNull(datafile.getUpperBounds());
+
+        assertUpdate("DROP TABLE test_all_nulls");
+    }
+
+    @Test
+    public void testNestedTypes()
+    {
+        assertUpdate("CREATE TABLE test_nested_types (col1 INTEGER, col2 ROW (f1 INTEGER, f2 ARRAY(INTEGER), f3 DOUBLE))");
+        assertUpdate("INSERT INTO test_nested_types VALUES " +
+                "(7, ROW(3, ARRAY[10, 11, 19], 1.9)), " +
+                "(-9, ROW(4, ARRAY[13, 16, 20], -2.9)), " +
+                "(8, ROW(0, ARRAY[14, 17, 21], 3.9)), " +
+                "(3, ROW(10, ARRAY[15, 18, 22], 4.9))", 4);
+        MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_nested_types$files\"");
+        assertEquals(materializedResult.getRowCount(), 1);
+        DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
+
+        Map<Integer, String> lowerBounds = datafile.getLowerBounds();
+        Map<Integer, String> upperBounds = datafile.getUpperBounds();
+
+        // Only
+        // 1. top-level primitive columns
+        // 2. and nested primitive fields that are not descendants of LISTs or MAPs
+        // should appear in lowerBounds or UpperBounds
+        assertEquals(lowerBounds.size(), 3);
+        assertEquals(upperBounds.size(), 3);
+
+        // col1
+        assertEquals(lowerBounds.get(1), "-9");
+        assertEquals(upperBounds.get(1), "8");
+
+        // col2.f1 (key in lowerBounds/upperBounds is Iceberg ID)
+        assertEquals(lowerBounds.get(3), "0");
+        assertEquals(upperBounds.get(3), "10");
+
+        // col2.f3 (key in lowerBounds/upperBounds is Iceberg ID)
+        assertEquals(lowerBounds.get(5), "-2.9");
+        assertEquals(upperBounds.get(5), "4.9");
+
+        assertUpdate("DROP TABLE test_nested_types");
+    }
+
+    public static class DataFileRecord
+    {
+        private final String filePath;
+        private final String fileFormat;
+        private final long recordCount;
+        private final long fileSizeInBytes;
+        private final Map<Integer, Long> columnSizes;
+        private final Map<Integer, Long> valueCounts;
+        private final Map<Integer, Long> nullValueCounts;
+        private final Map<Integer, String> lowerBounds;
+        private final Map<Integer, String> upperBounds;
+
+        public static DataFileRecord toDataFileRecord(MaterializedRow row)
+        {
+            assertEquals(row.getFieldCount(), 11);
+            return new DataFileRecord(
+                    (String) row.getField(0),
+                    (String) row.getField(1),
+                    (long) row.getField(2),
+                    (long) row.getField(3),
+                    row.getField(4) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(4)) : null,
+                    row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
+                    row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
+                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(7)) : null,
+                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(8)) : null);
+        }
+
+        private DataFileRecord(
+                String filePath,
+                String fileFormat,
+                long recordCount,
+                long fileSizeInBytes,
+                Map<Integer, Long> columnSizes,
+                Map<Integer, Long> valueCounts,
+                Map<Integer, Long> nullValueCounts,
+                Map<Integer, String> lowerBounds,
+                Map<Integer, String> upperBounds)
+        {
+            this.filePath = filePath;
+            this.fileFormat = fileFormat;
+            this.recordCount = recordCount;
+            this.fileSizeInBytes = fileSizeInBytes;
+            this.columnSizes = columnSizes;
+            this.valueCounts = valueCounts;
+            this.nullValueCounts = nullValueCounts;
+            this.lowerBounds = lowerBounds;
+            this.upperBounds = upperBounds;
+        }
+
+        public String getFilePath()
+        {
+            return filePath;
+        }
+
+        public String getFileFormat()
+        {
+            return fileFormat;
+        }
+
+        public long getRecordCount()
+        {
+            return recordCount;
+        }
+
+        public long getFileSizeInBytes()
+        {
+            return fileSizeInBytes;
+        }
+
+        public Map<Integer, Long> getColumnSizes()
+        {
+            return columnSizes;
+        }
+
+        public Map<Integer, Long> getValueCounts()
+        {
+            return valueCounts;
+        }
+
+        public Map<Integer, Long> getNullValueCounts()
+        {
+            return nullValueCounts;
+        }
+
+        public Map<Integer, String> getLowerBounds()
+        {
+            return lowerBounds;
+        }
+
+        public Map<Integer, String> getUpperBounds()
+        {
+            return upperBounds;
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -471,6 +471,20 @@ public class TestIcebergSmoke
         }
     }
 
+    @Test
+    public void testPredicating()
+    {
+        testWithAllFileFormats(this::testPredicating);
+    }
+
+    private void testPredicating(Session session, FileFormat fileFormat)
+    {
+        assertUpdate(session, "CREATE TABLE test_predicating_on_real (col REAL) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "INSERT INTO test_predicating_on_real VALUES 1.2", 1);
+        assertQuery(session, "SELECT * FROM test_predicating_on_real WHERE col = 1.2", "VALUES 1.2");
+        dropTable(session, "test_predicating_on_real");
+    }
+
     private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
     {
         test.accept(getSession(), FileFormat.PARQUET);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -71,8 +71,7 @@ public class TestIcebergSystemTables
     public void setUp()
     {
         assertUpdate("CREATE SCHEMA test_schema");
-        // "$partitions" tables with ORC file format are not fully supported yet. So we use Parquet here for testing
-        assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'], format = 'Parquet')");
+        assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'])");
         assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
         assertUpdate("INSERT INTO test_schema.test_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
         assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");


### PR DESCRIPTION
Umbrella issue: #1324 

### Commit `Fix predicating on REAL type in Iceberg Connector`:
Previously there was no conversion from Presto's representation of REAL type to Iceberg's, causing predicating on a REAL type to fail. Queries to reproduce the issue:
```SQL
CREATE TABLE iceberg.u_xinlin.test_real_parquet (_real REAL) WITH (format = 'parquet');
INSERT INTO iceberg.u_xinlin.test_real_parquet VALUES 1.2;
SELECT * FROM iceberg.u_xinlin.test_real_parquet WHERE _real = 1.2;
```
The SELECT query should output 1.2 but it would output no row.

### Commit `Support Files table with nested types`
Iceberg has column stats for nested columns.

### Commit `Collect file stats directly from ORC writers`
When registering a data file with Iceberg, Presto needs to provide file statistics. Previously, Presto would write an ORC file and then reads from it to get the file stats. This commit makes Presto collect file stats directly from ORC writers.

A related issue is that Avro files don't store file stats. So it would be highly-inefficient to re-read a written Avro file and compute the stats. With the new framework, it's possible to implement an Iceberg Avro writer that collects stats on the fly and then uses them when registering a file with Iceberg.

In addition, this commit removes Presto's reference to `iceberg-orc`. This can help us sidestep the ORC version conflict issue when upgrading to `iceberg-0.8.0-incubating`