### PR TITLE
Add support for null format property of Hive tables

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -175,6 +175,7 @@ import static io.prestosql.plugin.hive.HiveTableProperties.CSV_ESCAPE;
 import static io.prestosql.plugin.hive.HiveTableProperties.CSV_QUOTE;
 import static io.prestosql.plugin.hive.HiveTableProperties.CSV_SEPARATOR;
 import static io.prestosql.plugin.hive.HiveTableProperties.EXTERNAL_LOCATION_PROPERTY;
+import static io.prestosql.plugin.hive.HiveTableProperties.NULL_FORMAT_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static io.prestosql.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.prestosql.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
@@ -191,6 +192,7 @@ import static io.prestosql.plugin.hive.HiveTableProperties.getExternalLocation;
 import static io.prestosql.plugin.hive.HiveTableProperties.getFooterSkipCount;
 import static io.prestosql.plugin.hive.HiveTableProperties.getHeaderSkipCount;
 import static io.prestosql.plugin.hive.HiveTableProperties.getHiveStorageFormat;
+import static io.prestosql.plugin.hive.HiveTableProperties.getNullFormat;
 import static io.prestosql.plugin.hive.HiveTableProperties.getOrcBloomFilterColumns;
 import static io.prestosql.plugin.hive.HiveTableProperties.getOrcBloomFilterFpp;
 import static io.prestosql.plugin.hive.HiveTableProperties.getPartitionedBy;
@@ -269,6 +271,7 @@ public class HiveMetadata
 
     private static final String TEXT_FIELD_SEPARATOR_KEY = serdeConstants.FIELD_DELIM;
     private static final String TEXT_FIELD_SEPARATOR_ESCAPE_KEY = serdeConstants.ESCAPE_CHAR;
+    private static final String NULL_FORMAT_KEY = serdeConstants.SERIALIZATION_NULL_FORMAT;
 
     public static final String AVRO_SCHEMA_URL_KEY = "avro.schema.url";
     public static final String SPARK_TABLE_PROVIDER_KEY = "spark.sql.sources.provider";
@@ -610,6 +613,8 @@ public class HiveMetadata
                 .ifPresent(fieldSeparator -> properties.put(TEXTFILE_FIELD_SEPARATOR, fieldSeparator));
         getSerdeProperty(table, TEXT_FIELD_SEPARATOR_ESCAPE_KEY)
                 .ifPresent(fieldEscape -> properties.put(TEXTFILE_FIELD_SEPARATOR_ESCAPE, fieldEscape));
+        getSerdeProperty(table, NULL_FORMAT_KEY)
+                .ifPresent(nullFormat -> properties.put(NULL_FORMAT_PROPERTY, nullFormat));
 
         // CSV specific property
         getCsvSerdeProperty(table, CSV_SEPARATOR_KEY)
@@ -920,6 +925,13 @@ public class HiveMetadata
                 throw new PrestoException(HIVE_INVALID_METADATA, format("Invalid value for %s property: %s", SKIP_FOOTER_LINE_COUNT, footerSkipCount));
             }
         });
+
+        // Textfile-specific properties
+        getNullFormat(tableMetadata.getProperties())
+                .ifPresent(format -> {
+                    checkFormatForProperty(hiveStorageFormat, HiveStorageFormat.TEXTFILE, NULL_FORMAT_PROPERTY);
+                    tableProperties.put(NULL_FORMAT_KEY, format);
+                });
 
         getSingleCharacterProperty(tableMetadata.getProperties(), TEXTFILE_FIELD_SEPARATOR)
                 .ifPresent(separator -> {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -264,8 +264,8 @@ public class HiveMetadata
     private static final String ORC_BLOOM_FILTER_COLUMNS_KEY = "orc.bloom.filter.columns";
     private static final String ORC_BLOOM_FILTER_FPP_KEY = "orc.bloom.filter.fpp";
 
-    public static final String SKIP_HEADER_COUNT_KEY = "skip.header.line.count";
-    public static final String SKIP_FOOTER_COUNT_KEY = "skip.footer.line.count";
+    public static final String SKIP_HEADER_COUNT_KEY = serdeConstants.HEADER_COUNT;
+    public static final String SKIP_FOOTER_COUNT_KEY = serdeConstants.FOOTER_COUNT;
 
     private static final String TEXT_FIELD_SEPARATOR_KEY = serdeConstants.FIELD_DELIM;
     private static final String TEXT_FIELD_SEPARATOR_ESCAPE_KEY = serdeConstants.ESCAPE_CHAR;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveTableProperties.java
@@ -63,6 +63,7 @@ public class HiveTableProperties
     public static final String AVRO_SCHEMA_URL = "avro_schema_url";
     public static final String TEXTFILE_FIELD_SEPARATOR = "textfile_field_separator";
     public static final String TEXTFILE_FIELD_SEPARATOR_ESCAPE = "textfile_field_separator_escape";
+    public static final String NULL_FORMAT_PROPERTY = "null_format";
     public static final String SKIP_HEADER_LINE_COUNT = "skip_header_line_count";
     public static final String SKIP_FOOTER_LINE_COUNT = "skip_footer_line_count";
     public static final String CSV_SEPARATOR = "csv_separator";
@@ -149,6 +150,7 @@ public class HiveTableProperties
                 integerProperty(SKIP_FOOTER_LINE_COUNT, "Number of footer lines", null, false),
                 stringProperty(TEXTFILE_FIELD_SEPARATOR, "TEXTFILE field separator character", null, false),
                 stringProperty(TEXTFILE_FIELD_SEPARATOR_ESCAPE, "TEXTFILE field separator escape character", null, false),
+                stringProperty(NULL_FORMAT_PROPERTY, "Serialization format for NULL value", null, false),
                 stringProperty(CSV_SEPARATOR, "CSV separator character", null, false),
                 stringProperty(CSV_QUOTE, "CSV quote character", null, false),
                 stringProperty(CSV_ESCAPE, "CSV escape character", null, false));
@@ -177,6 +179,11 @@ public class HiveTableProperties
     public static Optional<Integer> getFooterSkipCount(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((Integer) tableProperties.get(SKIP_FOOTER_LINE_COUNT));
+    }
+
+    public static Optional<String> getNullFormat(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((String) tableProperties.get(NULL_FORMAT_PROPERTY));
     }
 
     public static HiveStorageFormat getHiveStorageFormat(Map<String, Object> tableProperties)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3326,6 +3326,16 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCreateExternalTableWithNullFormat() throws Exception
+    {
+        testCreateExternalTable(
+                "test_create_external_textfile_with_null_format",
+                "hello\u0001NULL_VALUE\nNULL_VALUE\u0001123",
+                "VALUES ('hello', NULL), (NULL, 123)",
+                ImmutableList.of("null_format = 'NULL_VALUE'"));
+    }
+
+    @Test
     public void testCreateExternalTableWithDataNotAllowed()
             throws IOException
     {
@@ -3597,6 +3607,8 @@ public class TestHiveIntegrationSmokeTest
                 .hasMessageMatching("Cannot specify skip_header_line_count table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_orc_skip_footer (col1 bigint) WITH (format = 'ORC', skip_footer_line_count = 1)"))
                 .hasMessageMatching("Cannot specify skip_footer_line_count table property for storage format: ORC");
+        assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_orc_skip_footer (col1 bigint) WITH (format = 'ORC', null_format = 'ERROR')"))
+                .hasMessageMatching("Cannot specify null_format table property for storage format: ORC");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_invalid_skip_header (col1 bigint) WITH (format = 'TEXTFILE', skip_header_line_count = -1)"))
                 .hasMessageMatching("Invalid value for skip_header_line_count property: -1");
         assertThatThrownBy(() -> assertUpdate("CREATE TABLE test_invalid_skip_footer (col1 bigint) WITH (format = 'TEXTFILE', skip_footer_line_count = -1)"))

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3417,116 +3417,72 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate("DROP TABLE test_comment_table");
     }
 
-    @Test
-    public void testCreateTableWithHeaderAndFooterForTextFile()
+    private void testCreateTableWithHeaderAndFooter(String format)
     {
+        String name = format.toLowerCase(ENGLISH);
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+
         @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.%s.test_table_skip_header (\n" +
+                        "CREATE TABLE %s.%s.%s_table_skip_header (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'TEXTFILE',\n" +
+                        "   format = '%s',\n" +
                         "   skip_header_line_count = 1\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                catalog, schema, name, format);
 
         assertUpdate(createTableSql);
 
-        MaterializedResult actual = computeActual("SHOW CREATE TABLE test_table_skip_header");
+        MaterializedResult actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_header", format));
         assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE test_table_skip_header");
+        assertUpdate(format("DROP TABLE %s_table_skip_header", format));
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.test_table_skip_footer (\n" +
+                        "CREATE TABLE %s.%s.%s_table_skip_footer (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'TEXTFILE',\n" +
+                        "   format = '%s',\n" +
                         "   skip_footer_line_count = 1\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                catalog, schema, name, format);
 
         assertUpdate(createTableSql);
 
-        actual = computeActual("SHOW CREATE TABLE test_table_skip_footer");
+        actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_footer", format));
         assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE test_table_skip_footer");
+        assertUpdate(format("DROP TABLE %s_table_skip_footer", format));
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.test_table_skip_header_footer (\n" +
+                        "CREATE TABLE %s.%s.%s_table_skip_header_footer (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'TEXTFILE',\n" +
+                        "   format = '%s',\n" +
                         "   skip_footer_line_count = 1,\n" +
                         "   skip_header_line_count = 1\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                catalog, schema, name, format);
 
         assertUpdate(createTableSql);
 
-        actual = computeActual("SHOW CREATE TABLE test_table_skip_header_footer");
+        actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_header_footer", format));
         assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE test_table_skip_header_footer");
+        assertUpdate(format("DROP TABLE %s_table_skip_header_footer", format));
+    }
+
+    @Test
+    public void testCreateTableWithHeaderAndFooterForTextFile()
+    {
+        testCreateTableWithHeaderAndFooter("TEXTFILE");
     }
 
     @Test
     public void testCreateTableWithHeaderAndFooterForCsv()
     {
-        @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_header (\n" +
-                        "   name varchar\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'CSV',\n" +
-                        "   skip_header_line_count = 1\n" +
-                        ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
-
-        assertUpdate(createTableSql);
-
-        MaterializedResult actual = computeActual("SHOW CREATE TABLE csv_table_skip_header");
-        assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE csv_table_skip_header");
-
-        createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_footer (\n" +
-                        "   name varchar\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'CSV',\n" +
-                        "   skip_footer_line_count = 1\n" +
-                        ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
-
-        assertUpdate(createTableSql);
-
-        actual = computeActual("SHOW CREATE TABLE csv_table_skip_footer");
-        assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE csv_table_skip_footer");
-
-        createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_header_footer (\n" +
-                        "   name varchar\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'CSV',\n" +
-                        "   skip_footer_line_count = 1,\n" +
-                        "   skip_header_line_count = 1\n" +
-                        ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
-
-        assertUpdate(createTableSql);
-
-        actual = computeActual("SHOW CREATE TABLE csv_table_skip_header_footer");
-        assertEquals(actual.getOnlyValue(), createTableSql);
-        assertUpdate("DROP TABLE csv_table_skip_header_footer");
+        testCreateTableWithHeaderAndFooter("CSV");
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3300,7 +3300,17 @@ public class TestHiveIntegrationSmokeTest
                 "test_create_external",
                 "hello\u0001world\nbye\u0001world",
                 "VALUES ('hello', 'world'), ('bye', 'world')",
-                ImmutableList.of("textfile_field_separator = U&'\\0001'"));
+                ImmutableList.of());
+    }
+
+    @Test
+    public void testCreateExternalTableWithFieldSeparator() throws Exception
+    {
+        testCreateExternalTable(
+                "test_create_external",
+                "helloXworld\nbyeXworld",
+                "VALUES ('hello', 'world'), ('bye', 'world')",
+                ImmutableList.of("textfile_field_separator = 'X'"));
     }
 
     @Test


### PR DESCRIPTION
Allow Presto to correctly read from exernal Hive tables that use `serialization.null.format` to sotre NULL in an alternate format.

This works with `TEXTFILE`, `RCTEXT`, and `SEQUENCEFILE` formats. There are no tests for the latter two (because they can't be easily embedded in the tests because they are binary file formats and Presto can't insert data into external Hive tables).