### PR TITLE
Support DELETE statement with partition key for Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartition.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPartition.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.plugin.cassandra;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.predicate.TupleDomain;
 
@@ -38,7 +40,12 @@ public class CassandraPartition
         indexedColumnPredicatePushdown = false;
     }
 
-    public CassandraPartition(byte[] key, String partitionId, TupleDomain<ColumnHandle> tupleDomain, boolean indexedColumnPredicatePushdown)
+    @JsonCreator
+    public CassandraPartition(
+            @JsonProperty("key") byte[] key,
+            @JsonProperty("partitionId") String partitionId,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain,
+            @JsonProperty("indexedColumnPredicatePushdown") boolean indexedColumnPredicatePushdown)
     {
         this.key = key;
         this.partitionId = partitionId;
@@ -51,16 +58,19 @@ public class CassandraPartition
         return partitionId.equals(UNPARTITIONED_ID);
     }
 
+    @JsonProperty
     public boolean isIndexedColumnPredicatePushdown()
     {
         return indexedColumnPredicatePushdown;
     }
 
+    @JsonProperty
     public TupleDomain<ColumnHandle> getTupleDomain()
     {
         return tupleDomain;
     }
 
+    @JsonProperty
     public String getPartitionId()
     {
         return partitionId;
@@ -77,6 +87,7 @@ public class CassandraPartition
         return ByteBuffer.wrap(key);
     }
 
+    @JsonProperty
     public byte[] getKey()
     {
         return key;

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraTableHandle.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraTableHandle.java
@@ -14,7 +14,6 @@
 package io.prestosql.plugin.cassandra;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.connector.ConnectorTableHandle;
@@ -34,19 +33,17 @@ public class CassandraTableHandle
     private final Optional<List<CassandraPartition>> partitions;
     private final String clusteringKeyPredicates;
 
-    @JsonCreator
-    public CassandraTableHandle(
-            @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+    public CassandraTableHandle(String schemaName, String tableName)
     {
         this(schemaName, tableName, Optional.empty(), "");
     }
 
+    @JsonCreator
     public CassandraTableHandle(
-            String schemaName,
-            String tableName,
-            Optional<List<CassandraPartition>> partitions,
-            String clusteringKeyPredicates)
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("partitions") Optional<List<CassandraPartition>> partitions,
+            @JsonProperty("clusteringKeyPredicates") String clusteringKeyPredicates)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -66,15 +63,13 @@ public class CassandraTableHandle
         return tableName;
     }
 
-    // do not serialize partitions as they are not needed on workers
-    @JsonIgnore
+    @JsonProperty
     public Optional<List<CassandraPartition>> getPartitions()
     {
         return partitions;
     }
 
-    // do not serialize clustered predicate as they are not needed on workers
-    @JsonIgnore
+    @JsonProperty
     public String getClusteringKeyPredicates()
     {
         return clusteringKeyPredicates;

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
@@ -29,12 +29,6 @@ public abstract class BaseCassandraDistributedQueries
         extends AbstractTestDistributedQueries
 {
     @Override
-    protected boolean supportsDelete()
-    {
-        return false;
-    }
-
-    @Override
     protected boolean supportsViews()
     {
         return false;
@@ -98,6 +92,13 @@ public abstract class BaseCassandraDistributedQueries
         assertThatThrownBy(super::testInsertArray)
                 .hasMessage("unsupported type: array(double)");
         throw new SkipException("Unsupported");
+    }
+
+    @Override
+    public void testDelete()
+    {
+        assertThatThrownBy(super::testDelete)
+                .hasStackTraceContaining("This connector only supports delete with primary key or partition key");
     }
 
     @Override

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestJsonCassandraHandles.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestJsonCassandraHandles.java
@@ -77,7 +77,7 @@ public class TestJsonCassandraHandles
                     TupleDomain.all(),
                     true)));
 
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
 
     @Test
     public void testTableHandleSerialize()
@@ -85,8 +85,8 @@ public class TestJsonCassandraHandles
     {
         CassandraTableHandle tableHandle = new CassandraTableHandle("cassandra_schema", "cassandra_table");
 
-        assertTrue(objectMapper.canSerialize(CassandraTableHandle.class));
-        String json = objectMapper.writeValueAsString(tableHandle);
+        assertTrue(OBJECT_MAPPER.canSerialize(CassandraTableHandle.class));
+        String json = OBJECT_MAPPER.writeValueAsString(tableHandle);
         testJsonEquals(json, TABLE_HANDLE_AS_MAP);
     }
 
@@ -95,8 +95,8 @@ public class TestJsonCassandraHandles
             throws Exception
     {
         CassandraTableHandle tableHandle = new CassandraTableHandle("cassandra_schema", "cassandra_table", PARTITIONS, "clusteringKey1 = 33");
-        assertTrue(objectMapper.canSerialize(CassandraTableHandle.class));
-        String json = objectMapper.writeValueAsString(tableHandle);
+        assertTrue(OBJECT_MAPPER.canSerialize(CassandraTableHandle.class));
+        String json = OBJECT_MAPPER.writeValueAsString(tableHandle);
         testJsonEquals(json, TABLE2_HANDLE_AS_MAP);
     }
 
@@ -104,9 +104,9 @@ public class TestJsonCassandraHandles
     public void testTableHandleDeserialize()
             throws Exception
     {
-        String json = objectMapper.writeValueAsString(TABLE_HANDLE_AS_MAP);
+        String json = OBJECT_MAPPER.writeValueAsString(TABLE_HANDLE_AS_MAP);
 
-        CassandraTableHandle tableHandle = objectMapper.readValue(json, CassandraTableHandle.class);
+        CassandraTableHandle tableHandle = OBJECT_MAPPER.readValue(json, CassandraTableHandle.class);
 
         assertEquals(tableHandle.getSchemaName(), "cassandra_schema");
         assertEquals(tableHandle.getTableName(), "cassandra_table");
@@ -118,9 +118,9 @@ public class TestJsonCassandraHandles
     public void testTable2HandleDeserialize()
             throws Exception
     {
-        String json = objectMapper.writeValueAsString(TABLE2_HANDLE_AS_MAP);
+        String json = OBJECT_MAPPER.writeValueAsString(TABLE2_HANDLE_AS_MAP);
 
-        CassandraTableHandle tableHandle = objectMapper.readValue(json, CassandraTableHandle.class);
+        CassandraTableHandle tableHandle = OBJECT_MAPPER.readValue(json, CassandraTableHandle.class);
 
         assertEquals(tableHandle.getSchemaName(), "cassandra_schema");
         assertEquals(tableHandle.getTableName(), "cassandra_table");
@@ -135,8 +135,8 @@ public class TestJsonCassandraHandles
     {
         CassandraColumnHandle columnHandle = new CassandraColumnHandle("column", 42, CassandraType.BIGINT, false, true, false, false);
 
-        assertTrue(objectMapper.canSerialize(CassandraColumnHandle.class));
-        String json = objectMapper.writeValueAsString(columnHandle);
+        assertTrue(OBJECT_MAPPER.canSerialize(CassandraColumnHandle.class));
+        String json = OBJECT_MAPPER.writeValueAsString(columnHandle);
         testJsonEquals(json, COLUMN_HANDLE_AS_MAP);
     }
 
@@ -153,8 +153,8 @@ public class TestJsonCassandraHandles
                 false,
                 false);
 
-        assertTrue(objectMapper.canSerialize(CassandraColumnHandle.class));
-        String json = objectMapper.writeValueAsString(columnHandle);
+        assertTrue(OBJECT_MAPPER.canSerialize(CassandraColumnHandle.class));
+        String json = OBJECT_MAPPER.writeValueAsString(columnHandle);
         testJsonEquals(json, COLUMN2_HANDLE_AS_MAP);
     }
 
@@ -162,9 +162,9 @@ public class TestJsonCassandraHandles
     public void testColumnHandleDeserialize()
             throws Exception
     {
-        String json = objectMapper.writeValueAsString(COLUMN_HANDLE_AS_MAP);
+        String json = OBJECT_MAPPER.writeValueAsString(COLUMN_HANDLE_AS_MAP);
 
-        CassandraColumnHandle columnHandle = objectMapper.readValue(json, CassandraColumnHandle.class);
+        CassandraColumnHandle columnHandle = OBJECT_MAPPER.readValue(json, CassandraColumnHandle.class);
 
         assertEquals(columnHandle.getName(), "column");
         assertEquals(columnHandle.getOrdinalPosition(), 42);
@@ -177,9 +177,9 @@ public class TestJsonCassandraHandles
     public void testColumn2HandleDeserialize()
             throws Exception
     {
-        String json = objectMapper.writeValueAsString(COLUMN2_HANDLE_AS_MAP);
+        String json = OBJECT_MAPPER.writeValueAsString(COLUMN2_HANDLE_AS_MAP);
 
-        CassandraColumnHandle columnHandle = objectMapper.readValue(json, CassandraColumnHandle.class);
+        CassandraColumnHandle columnHandle = OBJECT_MAPPER.readValue(json, CassandraColumnHandle.class);
 
         assertEquals(columnHandle.getName(), "column2");
         assertEquals(columnHandle.getOrdinalPosition(), 0);
@@ -191,7 +191,7 @@ public class TestJsonCassandraHandles
     private void testJsonEquals(String json, Map<String, Object> expectedMap)
             throws Exception
     {
-        Map<String, Object> jsonMap = objectMapper.readValue(json, new TypeReference<>() {});
+        Map<String, Object> jsonMap = OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
         assertEqualsIgnoreOrder(jsonMap.entrySet(), expectedMap.entrySet());
     }
 }


### PR DESCRIPTION
# Description

## Why

Cassandra Connector doesn't support DELETE statement at all.

This PR adds to support DELETE statement with a given partition key only. Deleting with the partition key is not useful for production use. It can be done with [cqlsh](https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlsh.html). So I expect this feature is for development/testing use.

However, this is a first step to support DELETE statement for Cassandra Connector. For production use, I want to add a select-delete feature divides split tasks using `TOKEN` function in Cassandra. But, I know it has another issue though I won't mention here.

## What

I added these interface methods for CassandraMetadata.

* getUpdateRowIdColumnHandle()
* applyDelete()
* executeDelete()

~~To be able to delete data, we set `cassandra.allow-delete-data` property.~~

# Reference

* https://prestosql.io/docs/current/connector/cassandra.html