### PR TITLE
Update error message for Hive external table CTAS

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTableDisabled.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveCreateExternalTableDisabled.java
@@ -55,7 +55,7 @@ public class TestHiveCreateExternalTableDisabled
                         "WITH (external_location = '%s') AS " +
                         "SELECT * FROM tpch.tiny.nation",
                 tempDir.toURI().toASCIIString());
-        assertQueryFails(createTableSql, "Cannot create a non-managed Hive table using CREATE TABLE AS");
+        assertQueryFails(createTableSql, "Creating non-managed Hive tables is disabled");
 
         deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3337,7 +3337,7 @@ public class TestHiveIntegrationSmokeTest
                         "SELECT * FROM tpch.tiny.nation",
                 tempDir.toURI().toASCIIString());
 
-        assertQueryFails(createTableSql, "Cannot create a non-managed Hive table using CREATE TABLE AS");
+        assertQueryFails(createTableSql, "Writes to non-managed Hive tables is disabled");
         deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
     }
 


### PR DESCRIPTION
Based on a conversation on [slack,](https://prestosql.slack.com/archives/CP1MUNEUX/p1591882325347600) the error message for creating non-managed hive tables using `CREATE TABLE AS` without the right config properties set could be more useful now that it's supported. 