### PR TITLE
Make hdfs not entering safe-mode on HDP3

### DIFF
--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/hadoop-entrypoint.sh
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/hadoop-entrypoint.sh
@@ -12,6 +12,7 @@ DIR="${BASH_SOURCE%/*}"
 echo "[$(date)] $0: configuring hadoop services"
 
 apply-site-xml-override /etc/hive/conf/hive-site.xml "${DIR}/hive-site-overrides.xml" || fail "Could not apply hive-site-overrides.xml"
+apply-site-xml-override /etc/hadoop/conf/hdfs-site.xml "${DIR}/hdfs-site-overrides.xml" || fail "Could not apply hdfs-site-overrides.xml"
 
 echo "[$(date)] $0: starting hadoop services"
 set -x

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/hdfs-site-overrides.xml
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdp3/hdfs-site-overrides.xml
@@ -1,0 +1,7 @@
+<configuration>
+    <!-- This property explicitly forbids datanode to enter safe mode which results in 30 s penalty on environment startup -->
+    <property>
+        <name>dfs.safemode.threshold.pct</name>
+        <value>0</value>
+    </property>
+</configuration>


### PR DESCRIPTION
This makes HDP3 environment startup faster (on my laptop ~30s vs 1m 25s)