### PR TITLE
Fix incorrect non-revocable memory usage calculation in QueryStatistics

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
@@ -268,6 +268,7 @@ public class FailedDispatchQuery
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
                 false,
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),

--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -240,7 +240,7 @@ public class QueryMonitor
                 Optional.of(ofMillis(queryStats.getAnalysisTime().toMillis())),
                 Optional.of(ofMillis(queryStats.getExecutionTime().toMillis())),
                 queryStats.getPeakUserMemoryReservation().toBytes(),
-                queryStats.getPeakTotalMemoryReservation().toBytes(),
+                queryStats.getPeakNonRevocableMemoryReservation().toBytes(),
                 queryStats.getPeakTaskUserMemory().toBytes(),
                 queryStats.getPeakTaskTotalMemory().toBytes(),
                 queryStats.getPhysicalInputDataSize().toBytes(),

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -115,6 +115,7 @@ public class QueryStateMachine
 
     private final AtomicLong currentRevocableMemory = new AtomicLong();
     private final AtomicLong peakRevocableMemory = new AtomicLong();
+    private final AtomicLong peakNonRevocableMemory = new AtomicLong();
 
     // peak of the user + system + revocable memory reservation
     private final AtomicLong currentTotalMemory = new AtomicLong();
@@ -272,6 +273,11 @@ public class QueryStateMachine
         return peakRevocableMemory.get();
     }
 
+    public long getPeakNonRevocableMemoryInBytes()
+    {
+        return peakNonRevocableMemory.get();
+    }
+
     public long getPeakTotalMemoryInBytes()
     {
         return peakTotalMemory.get();
@@ -310,6 +316,7 @@ public class QueryStateMachine
         currentTotalMemory.addAndGet(deltaTotalMemoryInBytes);
         peakUserMemory.updateAndGet(currentPeakValue -> Math.max(currentUserMemory.get(), currentPeakValue));
         peakRevocableMemory.updateAndGet(currentPeakValue -> Math.max(currentRevocableMemory.get(), currentPeakValue));
+        peakNonRevocableMemory.updateAndGet(currentPeakValue -> Math.max(currentTotalMemory.get() - currentRevocableMemory.get(), currentPeakValue));
         peakTotalMemory.updateAndGet(currentPeakValue -> Math.max(currentTotalMemory.get(), currentPeakValue));
         peakTaskUserMemory.accumulateAndGet(taskUserMemoryInBytes, Math::max);
         peakTaskRevocableMemory.accumulateAndGet(taskRevocableMemoryInBytes, Math::max);
@@ -565,6 +572,7 @@ public class QueryStateMachine
                 succinctBytes(totalMemoryReservation),
                 succinctBytes(getPeakUserMemoryInBytes()),
                 succinctBytes(getPeakRevocableMemoryInBytes()),
+                succinctBytes(getPeakNonRevocableMemoryInBytes()),
                 succinctBytes(getPeakTotalMemoryInBytes()),
                 succinctBytes(getPeakTaskUserMemory()),
                 succinctBytes(getPeakTaskRevocableMemory()),
@@ -1086,6 +1094,7 @@ public class QueryStateMachine
                 queryStats.getTotalMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),
                 queryStats.getPeakRevocableMemoryReservation(),
+                queryStats.getPeakNonRevocableMemoryReservation(),
                 queryStats.getPeakTotalMemoryReservation(),
                 queryStats.getPeakTaskUserMemory(),
                 queryStats.getPeakTaskRevocableMemory(),

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -69,6 +69,7 @@ public class QueryStats
     private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
     private final DataSize peakRevocableMemoryReservation;
+    private final DataSize peakNonRevocableMemoryReservation;
     private final DataSize peakTotalMemoryReservation;
     private final DataSize peakTaskUserMemory;
     private final DataSize peakTaskRevocableMemory;
@@ -135,6 +136,7 @@ public class QueryStats
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("peakRevocableMemoryReservation") DataSize peakRevocableMemoryReservation,
+            @JsonProperty("peakNonRevocableMemoryReservation") DataSize peakNonRevocableMemoryReservation,
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
             @JsonProperty("peakTaskUserMemory") DataSize peakTaskUserMemory,
             @JsonProperty("peakTaskRevocableMemory") DataSize peakTaskRevocableMemory,
@@ -207,6 +209,7 @@ public class QueryStats
         this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakRevocableMemoryReservation = requireNonNull(peakRevocableMemoryReservation, "peakRevocableMemoryReservation is null");
+        this.peakNonRevocableMemoryReservation = requireNonNull(peakNonRevocableMemoryReservation, "peakNonRevocableMemoryReservation is null");
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
         this.peakTaskUserMemory = requireNonNull(peakTaskUserMemory, "peakTaskUserMemory is null");
         this.peakTaskRevocableMemory = requireNonNull(peakTaskRevocableMemory, "peakTaskRevocableMemory is null");
@@ -401,6 +404,12 @@ public class QueryStats
     public DataSize getPeakRevocableMemoryReservation()
     {
         return peakRevocableMemoryReservation;
+    }
+
+    @JsonProperty
+    public DataSize getPeakNonRevocableMemoryReservation()
+    {
+        return peakNonRevocableMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -188,6 +188,7 @@ public class MockManagedQueryExecution
                         DataSize.ofBytes(20),
                         DataSize.ofBytes(21),
                         DataSize.ofBytes(22),
+                        DataSize.ofBytes(30),
                         DataSize.ofBytes(23),
                         DataSize.ofBytes(24),
                         DataSize.ofBytes(25),

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
@@ -186,6 +186,7 @@ public class TestQueryStats
             DataSize.ofBytes(20),
             DataSize.ofBytes(21),
             DataSize.ofBytes(22),
+            DataSize.ofBytes(30),
             DataSize.ofBytes(23),
             DataSize.ofBytes(24),
             DataSize.ofBytes(25),

--- a/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
@@ -79,6 +79,7 @@ public class TestBasicQueryInfo
                                 DataSize.valueOf("23GB"),
                                 DataSize.valueOf("24GB"),
                                 DataSize.valueOf("25GB"),
+                                DataSize.valueOf("30GB"),
                                 DataSize.valueOf("26GB"),
                                 DataSize.valueOf("27GB"),
                                 DataSize.valueOf("28GB"),

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
@@ -130,6 +130,7 @@ public class TestQueryStateInfo
                         DataSize.valueOf("23GB"),
                         DataSize.valueOf("24GB"),
                         DataSize.valueOf("25GB"),
+                        DataSize.valueOf("30GB"),
                         DataSize.valueOf("26GB"),
                         DataSize.valueOf("27GB"),
                         DataSize.valueOf("28GB"),

--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -378,7 +378,7 @@ public class TestEventListener
         assertEquals(statistics.getExecutionTime().get().toMillis(), queryStats.getExecutionTime().toMillis());
         assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakUserMemoryReservation().toBytes());
         assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakNonRevocableMemoryReservation().toBytes());
-        assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskUserMemory().toBytes());
+        assertEquals(statistics.getPeakTaskUserMemory(), queryStats.getPeakTaskUserMemory().toBytes());
         assertEquals(statistics.getPhysicalInputBytes(), queryStats.getPhysicalInputDataSize().toBytes());
         assertEquals(statistics.getPhysicalInputRows(), queryStats.getPhysicalInputPositions());
         assertEquals(statistics.getInternalNetworkBytes(), queryStats.getInternalNetworkInputDataSize().toBytes());

--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -377,9 +377,8 @@ public class TestEventListener
         assertEquals(statistics.getAnalysisTime().get().toMillis(), queryStats.getAnalysisTime().toMillis());
         assertEquals(statistics.getExecutionTime().get().toMillis(), queryStats.getExecutionTime().toMillis());
         assertEquals(statistics.getPeakUserMemoryBytes(), queryStats.getPeakUserMemoryReservation().toBytes());
-        // TODO: https://github.com/prestosql/presto/issues/4060
-//        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakTotalMemoryReservation().toBytes());
-        assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskTotalMemory().toBytes());
+        assertEquals(statistics.getPeakTotalNonRevocableMemoryBytes(), queryStats.getPeakNonRevocableMemoryReservation().toBytes());
+        assertEquals(statistics.getPeakTaskTotalMemory(), queryStats.getPeakTaskUserMemory().toBytes());
         assertEquals(statistics.getPhysicalInputBytes(), queryStats.getPhysicalInputDataSize().toBytes());
         assertEquals(statistics.getPhysicalInputRows(), queryStats.getPhysicalInputPositions());
         assertEquals(statistics.getInternalNetworkBytes(), queryStats.getInternalNetworkInputDataSize().toBytes());


### PR DESCRIPTION
QueryStatistics returns the peak total memory reservation as the peak non-revocable memory reservation due to the lack of a dedicated counter. This change adds a dedicated counter in QueryStateMachine to count the correct non-revocable memory reservation.

See: https://github.com/prestosql/presto/issues/4060

Originally it comes from https://github.com/prestosql/presto/pull/3996#discussion_r440061567.