### PR TITLE
Return null columns in result to match previous behaviour

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -466,7 +466,7 @@ class Query
                 queryHtmlUri,
                 partialCancelUri,
                 nextResultsUri,
-                resultRows.getColumns(),
+                resultRows.getColumns().orElse(null),
                 resultRows.isEmpty() ? null : resultRows, // client excepts null that indicates "no data"
                 toStatementStats(queryInfo),
                 toQueryError(queryInfo, typeSerializationException),
@@ -499,7 +499,7 @@ class Query
                 // Intercept serialization exceptions and fail query if it's still possible.
                 // Put serialization exception aside to return failed query result.
                 .withExceptionConsumer(this::handleSerializationException)
-                .withColumns(columns, types);
+                .withColumnsAndTypes(columns, types);
 
         try {
             long bytes = 0;

--- a/presto-main/src/main/java/io/prestosql/server/protocol/QueryResultRows.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/QueryResultRows.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.spi.StandardErrorCode.SERIALIZATION_ERROR;
@@ -75,6 +76,8 @@ public class QueryResultRows
         this.totalRows = countRows(pages);
         this.currentPage = this.pages.pollFirst();
         this.supportsParametricDateTime = session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
+
+        verify(totalRows == 0 || (totalRows > 0 && columns.isPresent()), "data present without columns and types");
     }
 
     public boolean isEmpty()

--- a/presto-main/src/test/java/io/prestosql/server/TestServer.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServer.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
@@ -77,6 +78,7 @@ import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SEE_OTHER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -125,6 +127,39 @@ public class TestServer
         assertEquals(queryError.getErrorName(), expected.getErrorCode().getName());
         assertEquals(queryError.getErrorType(), expected.getErrorCode().getType().name());
         assertEquals(queryError.getMessage(), expected.getMessage());
+    }
+
+    @Test
+    public void testFirstResponseColumns()
+    {
+        List<QueryResults> queryResults = postQuery(request -> request
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .setHeader(PRESTO_PATH, "path"))
+                .map(JsonResponse::getValue)
+                .collect(toImmutableList());
+
+        QueryResults first = queryResults.get(0);
+        QueryResults last = queryResults.get(queryResults.size() - 1);
+
+        Optional<QueryResults> data = queryResults.stream().filter(results -> results.getData() != null).findFirst();
+
+        assertNull(first.getColumns());
+        assertEquals(first.getStats().getState(), "QUEUED");
+        assertNull(first.getData());
+
+        assertThat(last.getColumns()).hasSize(1);
+        assertThat(last.getColumns().get(0).getName()).isEqualTo("Catalog");
+        assertThat(last.getColumns().get(0).getType()).isEqualTo("varchar(6)");
+        assertEquals(last.getStats().getState(), "FINISHED");
+
+        assertThat(data).isPresent();
+
+        QueryResults results = data.orElseThrow();
+
+        assertThat(results.getStats().getState()).isEqualTo("RUNNING");
+        assertThat(results.getData()).containsOnly(ImmutableList.of("system"));
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
+++ b/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static io.prestosql.RowPagesBuilder.rowPagesBuilder;
 import static io.prestosql.client.ClientStandardTypes.BIGINT;
@@ -45,6 +46,10 @@ import static org.testng.collections.Lists.newArrayList;
 
 public class TestQueryResultRows
 {
+    private static final Function<String, Column> BOOLEAN_COLUMN = name -> new Column(name, BOOLEAN, new ClientTypeSignature(BOOLEAN));
+    private static final Function<String, Column> BIGINT_COLUMN = name -> new Column(name, BIGINT, new ClientTypeSignature(BIGINT));
+    private static final Function<String, Column> INT_COLUMN = name -> new Column(name, INTEGER, new ClientTypeSignature(INTEGER));
+
     @Test
     public void shouldNotReturnValues()
     {
@@ -59,7 +64,7 @@ public class TestQueryResultRows
     @Test
     public void shouldReturnSingleValue()
     {
-        Column column = new Column("_col0", BOOLEAN, new ClientTypeSignature(BOOLEAN));
+        Column column = BOOLEAN_COLUMN.apply("_col0");
 
         QueryResultRows rows = queryResultRowsBuilder(getSession())
                 .withSingleBooleanValue(column, true)
@@ -74,7 +79,7 @@ public class TestQueryResultRows
     @Test
     public void shouldReturnUpdateCount()
     {
-        Column column = new Column("_col0", BIGINT, new ClientTypeSignature(BIGINT));
+        Column column = BIGINT_COLUMN.apply("_col0");
         long value = 10123;
 
         QueryResultRows rows = queryResultRowsBuilder(getSession())
@@ -94,7 +99,7 @@ public class TestQueryResultRows
     @Test
     public void shouldNotHaveUpdateCount()
     {
-        Column column = new Column("_col0", BOOLEAN, new ClientTypeSignature(BOOLEAN));
+        Column column = BOOLEAN_COLUMN.apply("_col0");
 
         QueryResultRows rows = queryResultRowsBuilder(getSession())
                 .withSingleBooleanValue(column, false)
@@ -108,7 +113,7 @@ public class TestQueryResultRows
     @Test
     public void shouldReadAllValuesFromMultiplePages()
     {
-        List<Column> columns = ImmutableList.of(new Column("_col0", INTEGER, new ClientTypeSignature(INTEGER)), new Column("_col1", BIGINT, new ClientTypeSignature(BIGINT)));
+        List<Column> columns = ImmutableList.of(INT_COLUMN.apply("_col0"), BIGINT_COLUMN.apply("_col1"));
         List<Type> types = ImmutableList.of(IntegerType.INTEGER, BigintType.BIGINT);
 
         List<Page> pages = rowPagesBuilder(types)
@@ -155,7 +160,7 @@ public class TestQueryResultRows
     @Test
     public void shouldOmitBadRows()
     {
-        List<Column> columns = ImmutableList.of(new Column("_col0", BOOLEAN, new ClientTypeSignature(BOOLEAN)), new Column("_col1", BOOLEAN, new ClientTypeSignature(BOOLEAN)));
+        List<Column> columns = ImmutableList.of(BOOLEAN_COLUMN.apply("_col0"), BOOLEAN_COLUMN.apply("_col1"));
         List<Type> types = ImmutableList.of(BogusType.BOGUS, BogusType.BOGUS);
 
         List<Page> pages = rowPagesBuilder(types)
@@ -248,7 +253,7 @@ public class TestQueryResultRows
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "columns and types size mismatch")
     public void shouldThrowWhenColumnsAndTypesSizeMismatch()
     {
-        List<Column> columns = ImmutableList.of(new Column("_col0", INTEGER, new ClientTypeSignature(INTEGER)));
+        List<Column> columns = ImmutableList.of(INT_COLUMN.apply("_col0"));
         List<Type> types = ImmutableList.of(IntegerType.INTEGER, BooleanType.BOOLEAN);
 
         List<Page> pages = rowPagesBuilder(types)
@@ -287,7 +292,7 @@ public class TestQueryResultRows
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "columns and types must be present at the same time")
     public void shouldThrowWhenTypesAreNull()
     {
-        List<Column> columns = ImmutableList.of(new Column("_col0", INTEGER, new ClientTypeSignature(INTEGER)));
+        List<Column> columns = ImmutableList.of(INT_COLUMN.apply("_col0"));
         List<Type> types = ImmutableList.of(IntegerType.INTEGER, BooleanType.BOOLEAN);
 
         List<Page> pages = rowPagesBuilder(types)

--- a/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
+++ b/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
@@ -300,6 +300,18 @@ public class TestQueryResultRows
                 .build();
     }
 
+    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "data present without columns and types")
+    public void shouldThrowWhenDataIsPresentWithoutColumns()
+    {
+        List<Page> pages = rowPagesBuilder(ImmutableList.of(IntegerType.INTEGER, BooleanType.BOOLEAN))
+                .row(0, null)
+                .build();
+
+        queryResultRowsBuilder(getSession())
+                .addPages(pages)
+                .build();
+    }
+
     private static List<List<Object>> getAllValues(QueryResultRows rows)
     {
         ImmutableList.Builder<List<Object>> builder = ImmutableList.builder();

--- a/presto-tests/src/test/java/io/prestosql/tests/TestQuerySerializationFailures.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestQuerySerializationFailures.java
@@ -51,7 +51,7 @@ public class TestQuerySerializationFailures
     public void shouldFailOnFirstSerializationError()
     {
         // BOGUS(value) returns BogusType that fails to serialize when value is true
-        assertQueryFails("SELECT * FROM (VALUES BOGUS(true), BOGUS(false), BOGUS(true))", "Could not serialize type 'Bogus' value at position 1:1");
+        assertQueryFails("SELECT * FROM (VALUES BOGUS(true), BOGUS(false), BOGUS(true))", "Could not serialize column '_col0' of type 'Bogus' at position 1:1");
     }
 
     @Test


### PR DESCRIPTION
https://github.com/prestosql/presto/pull/2860 broke `TestingPrestoClient` inside `addResults` function:

```
if (types.get() == null && statusInfo.getColumns() != null) {
     types.set(getTypes(statusInfo.getColumns()));
}
```

This PR restores old behaviour.

Fixes https://github.com/prestosql/presto/issues/4169