### PR TITLE
Remove redundant EXISTS during optimization

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -149,6 +149,7 @@ import io.prestosql.sql.planner.iterative.rule.RemoveFullSample;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantCrossJoin;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantEnforceSingleRowNode;
+import io.prestosql.sql.planner.iterative.rule.RemoveRedundantExists;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantJoin;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantLimit;
@@ -412,6 +413,7 @@ public class PlanOptimizers
                                         new RemoveRedundantCrossJoin(),
                                         new RemoveRedundantJoin(),
                                         new RemoveRedundantEnforceSingleRowNode(),
+                                        new RemoveRedundantExists(),
                                         new ImplementFilteredAggregations(metadata),
                                         new SingleDistinctAggregationToGroupBy(),
                                         new MultipleDistinctAggregationToMarkDistinct(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -261,22 +261,13 @@ class SubqueryPlanner
 
         PlanBuilder subqueryPlan = createPlanBuilder(existsPredicate.getSubquery());
 
-        PlanNode subqueryPlanRoot = subqueryPlan.getRoot();
-        if (isAggregationWithEmptyGroupBy(subqueryPlanRoot)) {
-            subPlan.getTranslations().put(existsPredicate, TRUE_LITERAL);
-            return subPlan;
-        }
-
-        // add an explicit projection that removes all columns
-        PlanNode subqueryNode = new ProjectNode(idAllocator.getNextId(), subqueryPlan.getRoot(), Assignments.of());
-
         Symbol exists = symbolAllocator.newSymbol("exists", BOOLEAN);
         subPlan.getTranslations().put(existsPredicate, exists);
         ExistsPredicate rewrittenExistsPredicate = new ExistsPredicate(TRUE_LITERAL);
         return appendApplyNode(
                 subPlan,
                 existsPredicate.getSubquery(),
-                subqueryNode,
+                subqueryPlan.getRoot(),
                 Assignments.of(exists, rewrittenExistsPredicate));
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveRedundantExists.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveRedundantExists.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.optimizations.QueryCardinalityUtil;
+import io.prestosql.sql.planner.plan.ApplyNode;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.tree.ExistsPredicate;
+import io.prestosql.sql.tree.Expression;
+
+import static io.prestosql.sql.planner.plan.Patterns.applyNode;
+import static io.prestosql.sql.tree.BooleanLiteral.FALSE_LITERAL;
+import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+/**
+ * Given:
+ *
+ * <pre>
+ * - Apply [X.*, e = EXISTS (true)]
+ *   - X
+ *   - S with cardinality >= 1
+ * </pre>
+ *
+ * Produces:
+ *
+ * <pre>
+ * - Project [X.*, e = true]
+ *   - X
+ * </pre>
+ *
+ * Given:
+ *
+ * <pre>
+ * - Apply [X.*, e = EXISTS (true)]
+ *   - X
+ *   - S with cardinality = 0
+ * </pre>
+ *
+ * Produces:
+ *
+ * <pre>
+ * - Project [X.*, e = false]
+ *   - X
+ * </pre>
+ */
+public class RemoveRedundantExists
+        implements Rule<ApplyNode>
+{
+    private static final Pattern<ApplyNode> PATTERN = applyNode()
+            .matching(node -> node.getSubqueryAssignments()
+                    .getExpressions().stream()
+                    .allMatch(expression -> expression instanceof ExistsPredicate && ((ExistsPredicate) expression).getSubquery().equals(TRUE_LITERAL)));
+
+    @Override
+    public Pattern<ApplyNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ApplyNode node, Captures captures, Context context)
+    {
+        Assignments.Builder assignments = Assignments.builder();
+        assignments.putIdentities(node.getInput().getOutputSymbols());
+
+        Expression result;
+        if (QueryCardinalityUtil.isAtMost(node.getSubquery(), context.getLookup(), 0)) {
+            result = FALSE_LITERAL;
+        }
+        else if (QueryCardinalityUtil.isAtLeast(node.getSubquery(), context.getLookup(), 1)) {
+            result = TRUE_LITERAL;
+        }
+        else {
+            return Result.empty();
+        }
+
+        for (Symbol output : node.getSubqueryAssignments().getOutputs()) {
+            assignments.put(output, result);
+        }
+
+        return Result.ofPlanNode(new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                node.getInput(),
+                assignments.build()));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveRedundantExists.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveRedundantExists.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.assertions.PlanMatchPattern;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.tree.ExistsPredicate;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+public class TestRemoveRedundantExists
+        extends BaseRuleTest
+{
+    @Test
+    public void testExistsFalse()
+    {
+        tester().assertThat(new RemoveRedundantExists())
+                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                        ImmutableList.of(),
+                        p.values(1),
+                        p.values(0)))
+                .matches(
+                        project(
+                                ImmutableMap.of("exists", PlanMatchPattern.expression("false")),
+                                values()));
+    }
+
+    @Test
+    public void testExistsTrue()
+    {
+        tester().assertThat(new RemoveRedundantExists())
+                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                        ImmutableList.of(),
+                        p.values(1),
+                        p.values(1)))
+                .matches(
+                        project(
+                                ImmutableMap.of("exists", PlanMatchPattern.expression("true")),
+                                values()));
+    }
+
+    @Test
+    public void testDoesNotFire()
+    {
+        tester().assertThat(new RemoveRedundantExists())
+                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                        ImmutableList.of(),
+                        p.values(1),
+                        p.tableScan(ImmutableList.of(), ImmutableMap.of())))
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
This was being done during initial planning, which complicates
things unnecessarily.