### PR TITLE
Fix Iceberg ORC timestamps

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
@@ -24,10 +24,6 @@ import io.prestosql.spi.predicate.SortedRangeSet;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.DateType;
-import io.prestosql.spi.type.TimeType;
-import io.prestosql.spi.type.TimeWithTimeZoneType;
-import io.prestosql.spi.type.TimestampType;
-import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
 import io.prestosql.spi.type.VarcharType;
@@ -40,9 +36,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.prestosql.spi.predicate.Marker.Bound.ABOVE;
 import static io.prestosql.spi.predicate.Marker.Bound.BELOW;
 import static io.prestosql.spi.predicate.Marker.Bound.EXACTLY;
-import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static java.lang.Math.toIntExact;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
@@ -168,14 +162,6 @@ public final class ExpressionConverter
 
     private static Object getValue(Type type, Marker marker, ConnectorSession session)
     {
-        if (type instanceof TimestampWithTimeZoneType || type instanceof TimeWithTimeZoneType) {
-            return MILLISECONDS.toMicros(unpackMillisUtc((Long) marker.getValue()));
-        }
-
-        if (type instanceof TimestampType || type instanceof TimeType) {
-            return MILLISECONDS.toMicros((Long) marker.getValue());
-        }
-
         // TODO: Remove this conversion once we move to next iceberg version
         if (type instanceof DateType) {
             return toIntExact(((Long) marker.getValue()));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -112,6 +112,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.FileFormat.ORC;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.Transactions.createTableTransaction;
@@ -381,14 +382,15 @@ public class IcebergMetadata
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        boolean orcFormat = ORC == getFileFormat(icebergTable);
 
         for (NestedField column : icebergTable.schema().columns()) {
             io.prestosql.spi.type.Type type = toPrestoType(column.type(), typeManager);
             if (type instanceof DecimalType) {
                 throw new PrestoException(NOT_SUPPORTED, "Writing to columns of type decimal not yet supported");
             }
-            if (type instanceof TimestampType) {
-                throw new PrestoException(NOT_SUPPORTED, "Writing to columns of type timestamp not yet supported");
+            if (type instanceof TimestampType && !orcFormat) {
+                throw new PrestoException(NOT_SUPPORTED, "Writing to columns of type timestamp not yet supported for PARQUET format");
             }
         }
 

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
@@ -59,6 +59,7 @@ import static java.lang.Float.parseFloat;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 public class IcebergPageSource
         implements ConnectorPageSource
@@ -215,7 +216,7 @@ public class IcebergPageSource
                 return parseLong(valueString);
             }
             if (type.equals(TIMESTAMP)) {
-                return parseLong(valueString);
+                return MICROSECONDS.toMillis(parseLong(valueString));
             }
             if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                 return packDateTimeWithZone(parseLong(valueString), timeZoneKey);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -112,8 +112,8 @@ public class TestIcebergSmoke
     public void testTimestamp()
     {
         assertUpdate("CREATE TABLE test_timestamp (x timestamp)");
-        assertQueryFails("INSERT INTO test_timestamp VALUES (timestamp '2017-05-01 10:12:34')", "Writing to columns of type timestamp not yet supported");
-//        assertQuery("SELECT * FROM test_timestamp", "SELECT CAST('2017-05-01 10:12:34' AS TIMESTAMP)");
+        assertUpdate("INSERT INTO test_timestamp VALUES (timestamp '2017-05-01 10:12:34')", 1);
+        assertQuery("SELECT * FROM test_timestamp", "SELECT CAST('2017-05-01 10:12:34' AS TIMESTAMP)");
         dropTable(getSession(), "test_timestamp");
     }
 


### PR DESCRIPTION
This commit enables Timestamp columns in Iceberg ORC data files,
and fixes two bugs in handling of Iceberg ORC timestamps,
both a consequence of performing conversion from the
Presto representation to/from the ORC representation twice.

Timestamps in Parquet are still handled incorrectly - -
the Presto Parquet writer is attempting to write the timestamp
as a string, but it should be a long.  The proper fix is to
switch to use the Parquet writer.

This uncomments the timestamp test in TestIcebergSmoke.  However,
it leaves timestamps in testCreatePartitionedTable commented out
until writing Parquet timestamps is fixed.