### PR TITLE
Remove predicate from IcebergSplit and IcebergSplitSource

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
@@ -167,7 +167,7 @@ public class IcebergPageSourceProvider
                 split.getLength(),
                 split.getFileFormat(),
                 regularColumns,
-                split.getPredicate());
+                table.getPredicate());
 
         return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource, session.getTimeZoneKey());
     }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplit.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.HostAddress;
 import io.prestosql.spi.connector.ConnectorSplit;
-import io.prestosql.spi.predicate.TupleDomain;
 import org.apache.iceberg.FileFormat;
 
 import java.util.Collections;
@@ -37,7 +36,6 @@ public class IcebergSplit
     private final long length;
     private final FileFormat fileFormat;
     private final List<HostAddress> addresses;
-    private final TupleDomain<IcebergColumnHandle> predicate;
     private final Map<Integer, String> partitionKeys;
 
     @JsonCreator
@@ -47,7 +45,6 @@ public class IcebergSplit
             @JsonProperty("length") long length,
             @JsonProperty("fileFormat") FileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate,
             @JsonProperty("partitionKeys") Map<Integer, String> partitionKeys)
     {
         this.path = requireNonNull(path, "path is null");
@@ -55,7 +52,6 @@ public class IcebergSplit
         this.length = length;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
-        this.predicate = requireNonNull(predicate, "predicate is null");
         this.partitionKeys = Collections.unmodifiableMap(requireNonNull(partitionKeys, "partitionKeys is null"));
     }
 
@@ -94,12 +90,6 @@ public class IcebergSplit
     public FileFormat getFileFormat()
     {
         return fileFormat;
-    }
-
-    @JsonProperty
-    public TupleDomain<IcebergColumnHandle> getPredicate()
-    {
-        return predicate;
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
@@ -58,7 +58,7 @@ public class IcebergSplitManager
 
         // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
         //      propagate it at split level so the parquet pushdown can leverage it.
-        IcebergSplitSource splitSource = new IcebergSplitSource(tableScan.planTasks(), table.getPredicate());
+        IcebergSplitSource splitSource = new IcebergSplitSource(tableScan.planTasks());
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());
     }


### PR DESCRIPTION
Table contains predicate, so predicate isn't needed in the splits.