### PR TITLE
Fix Launcher --debug

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
@@ -14,34 +14,17 @@
 package io.prestosql.tests.product.launcher.docker;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.api.command.ListNetworksCmd;
 import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
-import com.github.dockerjava.api.model.AccessMode;
-import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Network;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import org.testcontainers.DockerClientFactory;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkState;
-import static io.prestosql.tests.product.launcher.docker.DockerFiles.createTemporaryDirectoryForDocker;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.isRegularFile;
-import static java.nio.file.Files.readAllLines;
-import static java.nio.file.Files.write;
-import static java.util.Objects.requireNonNull;
 
 public final class ContainerUtil
 {
@@ -91,48 +74,5 @@ public final class ContainerUtil
     {
         container.addExposedPort(port);
         container.withFixedExposedPort(port, port);
-    }
-
-    public static void enableJavaDebugger(DockerContainer container, String jvmConfigPath, int debugPort)
-    {
-        requireNonNull(jvmConfigPath, "jvmConfigPath is null");
-        container.withCreateContainerCmdModifier(createContainerCmd -> enableDebuggerInJvmConfig(createContainerCmd, jvmConfigPath, debugPort));
-        exposePort(container, debugPort);
-    }
-
-    private static void enableDebuggerInJvmConfig(CreateContainerCmd createContainerCmd, String jvmConfigPath, int debugPort)
-    {
-        try {
-            Bind[] binds = firstNonNull(createContainerCmd.getBinds(), new Bind[0]);
-            boolean found = false;
-
-            // Last bind wins, so we can find the last one only
-            for (int bindIndex = binds.length - 1; bindIndex >= 0; bindIndex--) {
-                Bind bind = binds[bindIndex];
-                if (!bind.getVolume().getPath().equals(jvmConfigPath)) {
-                    continue;
-                }
-
-                Path hostJvmConfig = Paths.get(bind.getPath());
-                checkState(isRegularFile(hostJvmConfig), "Bind for %s is not a file", jvmConfigPath);
-
-                Path temporaryDirectory = createTemporaryDirectoryForDocker();
-                Path newJvmConfig = temporaryDirectory.resolve("jvm.config");
-
-                List<String> jvmOptions = new ArrayList<>(readAllLines(hostJvmConfig, UTF_8));
-                jvmOptions.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:" + debugPort);
-                write(newJvmConfig, jvmOptions, UTF_8);
-
-                binds[bindIndex] = new Bind(newJvmConfig.toString(), bind.getVolume(), AccessMode.ro, bind.getSecMode(), bind.getNoCopy(), bind.getPropagationMode());
-                found = true;
-                break;
-            }
-
-            checkState(found, "Could not find %s bind", jvmConfigPath);
-            createContainerCmd.withBinds(binds);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
@@ -28,12 +28,12 @@ import javax.inject.Inject;
 
 import java.io.File;
 
-import static io.prestosql.tests.product.launcher.docker.ContainerUtil.enableJavaDebugger;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_JVM_CONFIG;
 import static io.prestosql.tests.product.launcher.env.common.Standard.createPrestoContainer;
+import static io.prestosql.tests.product.launcher.env.common.Standard.enablePrestoJavaDebugger;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -86,7 +86,7 @@ public final class Multinode
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES);
 
         if (debug) {
-            enableJavaDebugger(container, CONTAINER_PRESTO_JVM_CONFIG, 5008); // debug port
+            enablePrestoJavaDebugger(container, 5008); // debug port
         }
 
         return container;

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
@@ -29,12 +29,12 @@ import javax.inject.Inject;
 
 import java.io.File;
 
-import static io.prestosql.tests.product.launcher.docker.ContainerUtil.enableJavaDebugger;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_JVM_CONFIG;
 import static io.prestosql.tests.product.launcher.env.common.Standard.createPrestoContainer;
+import static io.prestosql.tests.product.launcher.env.common.Standard.enablePrestoJavaDebugger;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -94,7 +94,7 @@ public final class MultinodeHiveCaching
                 .withTmpFs(ImmutableMap.of("/tmp/cache", "rw"));
 
         if (debug) {
-            enableJavaDebugger(container, CONTAINER_PRESTO_JVM_CONFIG, 5008 + workerNumber); // debug port
+            enablePrestoJavaDebugger(container, 5008 + workerNumber); // debug port
         }
 
         builder.addContainer("presto-worker-" + workerNumber, container);


### PR DESCRIPTION
After f648b877eafbfff297c235cb2af8f19ef84164ad, the jvm.config is
copied, not bound, so handling of `--debug` needs to be changed.