### PR TITLE
Remove unnecessary sleep

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/io/prestosql/server/GracefulShutdownHandler.java
@@ -90,6 +90,8 @@ public class GracefulShutdownHandler
             // wait for grace period for shutting down state to be observed by the coordinator
             sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
 
+            // At this point no new tasks should be scheduled by coordinator on this worker node.
+            // Wait for all remaining tasks to finish.
             while (activeTasks.size() > 0) {
                 CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
 
@@ -112,9 +114,6 @@ public class GracefulShutdownHandler
                 }
 
                 activeTasks = getActiveTasks();
-
-                // wait for another grace period for all task states to be observed by the coordinator
-                sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
             }
 
             // wait for another grace period for all task states to be observed by the coordinator


### PR DESCRIPTION
After first grace period coordinator
should have observed that worker node
is in shutting down state and no new
tasks should be scheduled. Therefore
it's enough to just have another grace
period after all remaining tasks finish
for coordinator to observe their states.