### PR TITLE
Fix python scripts to be able to run with python3

### DIFF
--- a/presto-benchto-benchmarks/README.md
+++ b/presto-benchto-benchmarks/README.md
@@ -11,8 +11,8 @@ measuring time and gathering various metrics.
 Even though benchmarks exercise Presto end-to-end, a single benchmark cannot use all Presto
 features. Therefore benchmarks are organized in suites, like:
 
-* *tpch* - queries closely following the [TPC-H](http://www.tpc.org/tpch/) benchmark 
-* *tpcds* - queries closely following the [TPC-DS](http://www.tpc.org/tpcds/) benchmark 
+* *tpch* - queries closely following the [TPC-H](http://www.tpc.org/tpch/) benchmark
+* *tpcds* - queries closely following the [TPC-DS](http://www.tpc.org/tpcds/) benchmark
 
 ## Usage
 
@@ -29,7 +29,7 @@ Benchto driver needs to know two things: what benchmark is to be run and what en
 it is to be run on. For the purpose of the following example, we will use `tpch` benchmark
 and Presto server running at `localhost:8080`, with Benchto service running at `localhost:8081`.
 
-Benchto driver uses Sprint Boot to locate environment configuration file, so to pass the
+Benchto driver uses Spring Boot to locate environment configuration file, so to pass the
 configuration. To continue with our example, one needs to place an `application-presto-devenv.yaml`
 file in the current directory (i.e. the directory from which the benchmark will be invoked),
 with the following content:
@@ -59,7 +59,6 @@ benchmark:
 macros:
   sleep-4s:
     command: echo "Sleeping for 4s" && sleep 4
-      
 ```
 
 ### Bootstrapping benchmark data

--- a/presto-benchto-benchmarks/generate_schemas/generate-tpcds.py
+++ b/presto-benchto-benchmarks/generate_schemas/generate-tpcds.py
@@ -47,7 +47,7 @@ for (new_schema, source_schema) in schemas:
     else:
         raise ValueError(new_schema)
 
-    print 'CREATE SCHEMA hive.%s;' % (new_schema,)
+    print('CREATE SCHEMA hive.{};'.format(new_schema,))
     for table in tables:
-        print 'CREATE TABLE "hive"."%s"."%s" WITH (format = \'%s\') AS SELECT * FROM %s."%s";' % \
-              (new_schema, table, format, source_schema, table)
+        print('CREATE TABLE "hive"."{}"."{}" WITH (format = \'{}\') AS SELECT * FROM {}."{}";'.format(
+              new_schema, table, format, source_schema, table))

--- a/presto-benchto-benchmarks/generate_schemas/generate-tpch.py
+++ b/presto-benchto-benchmarks/generate_schemas/generate-tpch.py
@@ -31,7 +31,7 @@ for (new_schema, source_schema) in schemas:
     else:
         raise ValueError(new_schema)
 
-    print 'CREATE SCHEMA hive.%s;' % (new_schema,)
+    print('CREATE SCHEMA hive.{};'.format(new_schema,))
     for table in tables:
-        print 'CREATE TABLE "hive"."%s"."%s" WITH (format = \'%s\') AS SELECT * FROM %s."%s";' % \
-              (new_schema, table, format, source_schema, table)
+        print('CREATE TABLE "hive"."{}"."{}" WITH (format = \'{}\') AS SELECT * FROM {}."{}";'.format(
+              new_schema, table, format, source_schema, table))


### PR DESCRIPTION
<!--
When I run generate-tpch.py with python3, I got a below error.
```
python3 generate_schemas/generate-tpch.py
  File "generate_schemas/generate-tpch.py", line 34
    print 'CREATE SCHEMA hive.%s;' % (new_schema,)
                                 ^
SyntaxError: invalid syntax
```
-->
Fix python scripts to be able to run both with python2.7 and python3

- I verified outputs for these scripts are same before and after this change.