### PR TITLE
Support Iceberg table comments

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -84,6 +84,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.prestosql.plugin.iceberg.DomainConverter.convertTupleDomainTypes;
 import static io.prestosql.plugin.iceberg.ExpressionConverter.toIcebergExpression;
@@ -97,6 +98,7 @@ import static io.prestosql.plugin.iceberg.IcebergUtil.getColumns;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getIcebergTable;
+import static io.prestosql.plugin.iceberg.IcebergUtil.getTableComment;
 import static io.prestosql.plugin.iceberg.IcebergUtil.isIcebergTable;
 import static io.prestosql.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.prestosql.plugin.iceberg.PartitionFields.toPartitionFields;
@@ -330,6 +332,20 @@ public class IcebergMetadata
     }
 
     @Override
+    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        if (comment.isEmpty()) {
+            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+        }
+        else {
+            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+        }
+    }
+
+    @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
         SchemaTableName schemaTableName = tableMetadata.getTable();
@@ -355,8 +371,14 @@ public class IcebergMetadata
             throw new TableAlreadyExistsException(schemaTableName);
         }
 
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
         FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
-        TableMetadata metadata = newTableMetadata(operations, schema, partitionSpec, targetPath, ImmutableMap.of(DEFAULT_FILE_FORMAT, fileFormat.toString()));
+        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
+        if (tableMetadata.getComment().isPresent()) {
+            propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
+        }
+
+        TableMetadata metadata = newTableMetadata(operations, schema, partitionSpec, targetPath, propertiesBuilder.build());
 
         transaction = createTableTransaction(operations, metadata);
 
@@ -509,7 +531,7 @@ public class IcebergMetadata
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
         }
 
-        return new ConnectorTableMetadata(table, columns, properties.build(), Optional.empty());
+        return new ConnectorTableMetadata(table, columns, properties.build(), getTableComment(icebergTable));
     }
 
     private List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
+import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
@@ -99,6 +100,11 @@ final class IcebergUtil
         return FileFormat.valueOf(table.properties()
                 .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toUpperCase(Locale.ENGLISH));
+    }
+
+    public static Optional<String> getTableComment(Table table)
+    {
+        return Optional.ofNullable(table.properties().get(TABLE_COMMENT));
     }
 
     public static TableScan getTableScan(ConnectorSession session, TupleDomain<IcebergColumnHandle> predicates, Optional<Long> snapshotId, Table icebergTable)

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
@@ -52,13 +52,6 @@ public class TestIcebergDistributed
     }
 
     @Override
-    public void testCommentTable()
-    {
-        // Iceberg connector does not support comment on table
-        assertQueryFails("COMMENT ON TABLE orders IS 'hello'", "This connector does not support setting table comments");
-    }
-
-    @Override
     public void testRenameTable()
     {
         assertQueryFails("ALTER TABLE orders RENAME TO rename_orders", "Rename not supported for Iceberg tables");

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -318,6 +318,42 @@ public class TestIcebergSmoke
     }
 
     @Test
+    public void testTableComments()
+    {
+        Session session = getSession();
+        String createTableTemplate = "" +
+                        "CREATE TABLE iceberg.tpch.test_table_comments (\n" +
+                        "   _x bigint\n" +
+                        ")\n" +
+                        "COMMENT '%s'\n" +
+                        "WITH (\n" +
+                        "   format = 'ORC'\n" +
+                        ")";
+        String createTableSql = format(createTableTemplate, "test table comment");
+        assertUpdate(createTableSql);
+        MaterializedResult resultOfCreate = computeActual("SHOW CREATE TABLE test_table_comments");
+        assertEquals(getOnlyElement(resultOfCreate.getOnlyColumnAsSet()), createTableSql);
+
+        assertUpdate("COMMENT ON TABLE test_table_comments IS 'different test table comment'");
+        MaterializedResult resultOfCommentChange = computeActual("SHOW CREATE TABLE test_table_comments");
+        String afterChangeSql = format(createTableTemplate, "different test table comment");
+        assertEquals(getOnlyElement(resultOfCommentChange.getOnlyColumnAsSet()), afterChangeSql);
+
+        String createTableWithoutComment = "" +
+                "CREATE TABLE iceberg.tpch.test_table_comments (\n" +
+                "   _x bigint\n" +
+                ")\n" +
+                "WITH (\n" +
+                "   format = 'ORC'\n" +
+                ")";
+        assertUpdate("COMMENT ON TABLE test_table_comments IS NULL");
+        MaterializedResult resultOfRemovingComment = computeActual("SHOW CREATE TABLE test_table_comments");
+        assertEquals(getOnlyElement(resultOfRemovingComment.getOnlyColumnAsSet()), createTableWithoutComment);
+
+        dropTable(session, "test_table_comments");
+    }
+
+    @Test
     public void testSchemaEvolution()
     {
         // Schema evolution should be id based


### PR DESCRIPTION
This commit adds support for Iceberg table comments in both
ORC and Parquet formats.    In addition to supporting comments
in table definitions, this commit also support table comment
updates, e.g., COMMENT ON TABLE tablename IS 'table comment',
and adds unit tests for creating, updating and removing
table comments.
