### PR TITLE
Improve handing of insecure authentication over HTTP and HTTPS

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -81,8 +81,9 @@ The config file is specified in JSON format.
 * The query rules specifying which queries can be managed by which user (see Query Rules below).
 * The impersonation rules specify which user impersonations are allowed (see Impersonation Rules below).
 * The principal rules specifying what principals can identify as what users (see Principal Rules below).
+* The system information rules specifying what users can access system management information (see System Information Rules below).
 
-This plugin currently supports catalog access, query, impersonation. and principal
+This plugin currently supports catalog access, query, impersonation, principal, and system information
 rules. If you want to limit access on a system level in any other way, you
 must implement a custom SystemAccessControl plugin
 (see :doc:`/develop/system-access-control`).
@@ -309,3 +310,24 @@ name, and allow ``alice`` and ``bob`` to use a group principal named as
         }
       ]
     }
+
+.. _system_information_rules:
+
+System Information Rules
+------------------------
+
+These rules specify which users can access the system information management interface.
+The user is granted or denied access, based on the first matching rule read from top to
+bottom. If no rules are specified, all access to system information is denied. If
+no rule matches, system access is denied. Each rule is composed of the following fields:
+
+* ``user`` (optional): regex to match against user name. If matched, it
+  will grant or deny the authorization based on the value of ``allow``.
+* ``allow`` (required): set of access permissions granted to user. Values: ``read``, ``write``
+
+For example, if you want to allow only the user ``admin`` to read and write
+system information, allow ``alice`` to read system information, and deny all other access, you
+can use the following rules:
+
+.. literalinclude:: system-information-access.json
+    :language: json

--- a/presto-docs/src/main/sphinx/security/system-information-access.json
+++ b/presto-docs/src/main/sphinx/security/system-information-access.json
@@ -1,0 +1,17 @@
+{
+  "catalogs": [
+    {
+      "allow": true
+    }
+  ],
+  "system_information": [
+    {
+      "user": "admin",
+      "allow": ["read", "write"]
+    },
+    {
+      "user": "alice",
+      "allow": ["read"]
+    }
+  ]
+}

--- a/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
@@ -28,6 +28,7 @@ import io.prestosql.execution.QueryState;
 import io.prestosql.server.HttpRequestSessionContext;
 import io.prestosql.server.SessionContext;
 import io.prestosql.server.protocol.Slug;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.ErrorCode;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.security.GroupProvider;
@@ -75,6 +76,8 @@ import static io.prestosql.execution.QueryState.QUEUED;
 import static io.prestosql.server.HttpRequestSessionContext.AUTHENTICATED_IDENTITY;
 import static io.prestosql.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.prestosql.server.protocol.Slug.Context.QUEUED_QUERY;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.AUTHENTICATED_USER;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -154,6 +157,7 @@ public class QueuedStatementResource
         queryPurger.shutdownNow();
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @POST
     @Produces(APPLICATION_JSON)
     public Response postStatement(
@@ -180,6 +184,7 @@ public class QueuedStatementResource
         return Response.ok(query.getQueryResults(query.getLastToken(), uriInfo)).build();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("queued/{queryId}/{slug}/{token}")
     @Produces(APPLICATION_JSON)
@@ -214,6 +219,7 @@ public class QueuedStatementResource
         bindAsyncResponse(asyncResponse, response, responseExecutor);
     }
 
+    @ResourceSecurity(PUBLIC)
     @DELETE
     @Path("queued/{queryId}/{slug}/{token}")
     @Produces(APPLICATION_JSON)

--- a/presto-main/src/main/java/io/prestosql/memory/MemoryResource.java
+++ b/presto-main/src/main/java/io/prestosql/memory/MemoryResource.java
@@ -30,7 +30,7 @@ import javax.ws.rs.core.Response;
 import static io.prestosql.memory.LocalMemoryManager.GENERAL_POOL;
 import static io.prestosql.memory.LocalMemoryManager.RESERVED_POOL;
 import static io.prestosql.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
-import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
@@ -60,7 +60,7 @@ public class MemoryResource
         return memoryManager.getInfo();
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Path("{poolId}")
     public Response getMemoryInfo(@PathParam("poolId") String poolId)

--- a/presto-main/src/main/java/io/prestosql/memory/MemoryResource.java
+++ b/presto-main/src/main/java/io/prestosql/memory/MemoryResource.java
@@ -14,6 +14,7 @@
 package io.prestosql.memory;
 
 import io.prestosql.execution.TaskManager;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.memory.MemoryPoolInfo;
 
 import javax.inject.Inject;
@@ -28,6 +29,8 @@ import javax.ws.rs.core.Response;
 
 import static io.prestosql.memory.LocalMemoryManager.GENERAL_POOL;
 import static io.prestosql.memory.LocalMemoryManager.RESERVED_POOL;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
@@ -47,6 +50,7 @@ public class MemoryResource
         this.taskManager = requireNonNull(taskManager, "taskManager is null");
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
@@ -56,6 +60,7 @@ public class MemoryResource
         return memoryManager.getInfo();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("{poolId}")
     public Response getMemoryInfo(@PathParam("poolId") String poolId)

--- a/presto-main/src/main/java/io/prestosql/security/AccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControl.java
@@ -36,7 +36,7 @@ public interface AccessControl
     /**
      * Check if the principal is allowed to be the specified user.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      * @deprecated replaced with user mapping during authentication and {@link #checkCanImpersonateUser}
      */
     @Deprecated
@@ -48,6 +48,23 @@ public interface AccessControl
      * @throws AccessDeniedException if not allowed
      */
     void checkCanImpersonateUser(Identity identity, String userName);
+
+    /**
+     * Check if identity is allowed to read system information such as statistics,
+     * service registry, thread stacks, etc.  This is typically allowed for administrators
+     * and management tools.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanReadSystemInformation(Identity identity);
+
+    /**
+     * Check if identity is allowed to write system information such as marking nodes
+     * offline, or changing runtime flags.  This is typically allowed for administrators.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanWriteSystemInformation(Identity identity);
 
     /**
      * Checks if identity can execute a query.
@@ -86,28 +103,28 @@ public interface AccessControl
     /**
      * Check if identity is allowed to create the specified schema.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanCreateSchema(SecurityContext context, CatalogSchemaName schemaName);
 
     /**
      * Check if identity is allowed to drop the specified schema.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDropSchema(SecurityContext context, CatalogSchemaName schemaName);
 
     /**
      * Check if identity is allowed to rename the specified schema.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRenameSchema(SecurityContext context, CatalogSchemaName schemaName, String newSchemaName);
 
     /**
      * Check if identity is allowed to change the specified schema's user/role.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSetSchemaAuthorization(SecurityContext context, CatalogSchemaName schemaName, PrestoPrincipal principal);
 
@@ -118,7 +135,7 @@ public interface AccessControl
      * The {@link #filterSchemas} method must filter all results for unauthorized users,
      * since there are multiple ways to list schemas.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowSchemas(SecurityContext context, String catalogName);
 
@@ -130,42 +147,42 @@ public interface AccessControl
     /**
      * Check if identity is allowed to execute SHOW CREATE SCHEMA.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowCreateSchema(SecurityContext context, CatalogSchemaName schemaName);
 
     /**
      * Check if identity is allowed to execute SHOW CREATE TABLE or SHOW CREATE VIEW.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowCreateTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to create the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanCreateTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to drop the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDropTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to rename the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRenameTable(SecurityContext context, QualifiedObjectName tableName, QualifiedObjectName newTableName);
 
     /**
      * Check if identity is allowed to comment the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSetTableComment(SecurityContext context, QualifiedObjectName tableName);
 
@@ -176,7 +193,7 @@ public interface AccessControl
      * The {@link #filterTables} method must filter all results for unauthorized users,
      * since there are multiple ways to list tables.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowTables(SecurityContext context, CatalogSchemaName schema);
 
@@ -192,7 +209,7 @@ public interface AccessControl
      * The {@link #filterColumns} method must filter all results for unauthorized users,
      * since there are multiple ways to list columns.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowColumns(SecurityContext context, CatalogSchemaTableName table);
 
@@ -204,182 +221,182 @@ public interface AccessControl
     /**
      * Check if identity is allowed to add columns to the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanAddColumns(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to drop columns from the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDropColumn(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to rename a column in the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRenameColumn(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to insert into the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to delete from the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
      * Check if identity is allowed to create the specified view.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanCreateView(SecurityContext context, QualifiedObjectName viewName);
 
     /**
      * Check if identity is allowed to rename the specified view.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRenameView(SecurityContext context, QualifiedObjectName viewName, QualifiedObjectName newViewName);
 
     /**
      * Check if identity is allowed to drop the specified view.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDropView(SecurityContext context, QualifiedObjectName viewName);
 
     /**
      * Check if identity is allowed to create a view that selects from the specified columns.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames);
 
     /**
      * Check if identity is allowed to create a view that executes the function.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanGrantExecuteFunctionPrivilege(SecurityContext context, String functionName, Identity grantee, boolean grantOption);
 
     /**
      * Check if identity is allowed to grant a privilege to the grantee on the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanGrantTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, PrestoPrincipal grantee, boolean grantOption);
 
     /**
      * Check if identity is allowed to revoke a privilege from the revokee on the specified table.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRevokeTablePrivilege(SecurityContext context, Privilege privilege, QualifiedObjectName tableName, PrestoPrincipal revokee, boolean grantOption);
 
     /**
      * Check if identity is allowed to set the specified system property.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSetSystemSessionProperty(Identity identity, String propertyName);
 
     /**
      * Check if identity is allowed to set the specified catalog property.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSetCatalogSessionProperty(SecurityContext context, String catalogName, String propertyName);
 
     /**
      * Check if identity is allowed to select from the specified columns.  The column set can be empty.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames);
 
     /**
      * Check if identity is allowed to create the specified role.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanCreateRole(SecurityContext context, String role, Optional<PrestoPrincipal> grantor, String catalogName);
 
     /**
      * Check if identity is allowed to drop the specified role.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanDropRole(SecurityContext context, String role, String catalogName);
 
     /**
      * Check if identity is allowed to grant the specified roles to the specified principals.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanGrantRoles(SecurityContext context, Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOption, Optional<PrestoPrincipal> grantor, String catalogName);
 
     /**
      * Check if identity is allowed to revoke the specified roles from the specified principals.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanRevokeRoles(SecurityContext context, Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOption, Optional<PrestoPrincipal> grantor, String catalogName);
 
     /**
      * Check if identity is allowed to set role for specified catalog.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanSetRole(SecurityContext context, String role, String catalogName);
 
     /**
      * Check if identity is allowed to show role authorization descriptors (i.e. RoleGrants).
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowRoleAuthorizationDescriptors(SecurityContext context, String catalogName);
 
     /**
      * Check if identity is allowed to show roles on the specified catalog.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowRoles(SecurityContext context, String catalogName);
 
     /**
      * Check if identity is allowed to show current roles on the specified catalog.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowCurrentRoles(SecurityContext context, String catalogName);
 
     /**
      * Check if identity is allowed to show its own role grants on the specified catalog.
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanShowRoleGrants(SecurityContext context, String catalogName);
 
     /**
      * Check if identity is allowed to execute procedure
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanExecuteProcedure(SecurityContext context, QualifiedObjectName procedureName);
 
     /**
      * Check if identity is allowed to execute function
      *
-     * @throws io.prestosql.spi.security.AccessDeniedException if not allowed
+     * @throws AccessDeniedException if not allowed
      */
     void checkCanExecuteFunction(SecurityContext context, String functionName);
 

--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -212,6 +212,22 @@ public class AccessControlManager
     }
 
     @Override
+    public void checkCanReadSystemInformation(Identity identity)
+    {
+        requireNonNull(identity, "identity is null");
+
+        systemAuthorizationCheck(control -> control.checkCanReadSystemInformation(new SystemSecurityContext(identity, Optional.empty())));
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(Identity identity)
+    {
+        requireNonNull(identity, "identity is null");
+
+        systemAuthorizationCheck(control -> control.checkCanWriteSystemInformation(new SystemSecurityContext(identity, Optional.empty())));
+    }
+
+    @Override
     public void checkCanExecuteQuery(Identity identity)
     {
         requireNonNull(identity, "identity is null");

--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -192,6 +192,16 @@ public class AccessControlManager
         this.systemAccessControls.set(ImmutableList.of(systemAccessControl));
     }
 
+    @VisibleForTesting
+    public void addSystemAccessControl(SystemAccessControl systemAccessControl)
+    {
+        systemAccessControls.updateAndGet(currentControls ->
+                ImmutableList.<SystemAccessControl>builder()
+                        .addAll(currentControls)
+                        .add(systemAccessControl)
+                        .build());
+    }
+
     @Override
     public void checkCanImpersonateUser(Identity identity, String userName)
     {

--- a/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
@@ -41,6 +41,16 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanReadSystemInformation(Identity identity)
+    {
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(Identity identity)
+    {
+    }
+
+    @Override
     public void checkCanExecuteQuery(Identity identity)
     {
     }

--- a/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
@@ -51,6 +51,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denyGrantTablePriv
 import static io.prestosql.spi.security.AccessDeniedException.denyImpersonateUser;
 import static io.prestosql.spi.security.AccessDeniedException.denyInsertTable;
 import static io.prestosql.spi.security.AccessDeniedException.denyKillQuery;
+import static io.prestosql.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
 import static io.prestosql.spi.security.AccessDeniedException.denyRenameColumn;
 import static io.prestosql.spi.security.AccessDeniedException.denyRenameSchema;
 import static io.prestosql.spi.security.AccessDeniedException.denyRenameTable;
@@ -73,6 +74,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denyShowRoles;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowSchemas;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowTables;
 import static io.prestosql.spi.security.AccessDeniedException.denyViewQuery;
+import static io.prestosql.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
 
 public class DenyAllAccessControl
         implements AccessControl
@@ -87,6 +89,18 @@ public class DenyAllAccessControl
     public void checkCanSetUser(Optional<Principal> principal, String userName)
     {
         denySetUser(principal, userName);
+    }
+
+    @Override
+    public void checkCanReadSystemInformation(Identity identity)
+    {
+        denyReadSystemInformationAccess();
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(Identity identity)
+    {
+        denyWriteSystemInformationAccess();
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
@@ -57,6 +57,18 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
+    public void checkCanReadSystemInformation(Identity identity)
+    {
+        delegate().checkCanReadSystemInformation(identity);
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(Identity identity)
+    {
+        delegate().checkCanWriteSystemInformation(identity);
+    }
+
+    @Override
     @Deprecated
     public void checkCanSetUser(Optional<Principal> principal, String userName)
     {

--- a/presto-main/src/main/java/io/prestosql/server/InternalAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/InternalAuthenticationManager.java
@@ -24,7 +24,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.prestosql.server.security.InternalPrincipal;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.security.Principal;
 import java.time.ZonedDateTime;
@@ -72,14 +72,14 @@ public class InternalAuthenticationManager
         this.nodeId = nodeId;
     }
 
-    public boolean isInternalRequest(HttpServletRequest request)
+    public boolean isInternalRequest(ContainerRequestContext request)
     {
-        return request.getHeader(PRESTO_INTERNAL_BEARER) != null;
+        return request.getHeaders().getFirst(PRESTO_INTERNAL_BEARER) != null;
     }
 
-    public Principal authenticateInternalRequest(HttpServletRequest request)
+    public Principal authenticateInternalRequest(ContainerRequestContext request)
     {
-        String internalBarer = request.getHeader(PRESTO_INTERNAL_BEARER);
+        String internalBarer = request.getHeaders().getFirst(PRESTO_INTERNAL_BEARER);
         try {
             String subject = parseJwt(internalBarer);
             return new InternalPrincipal(subject);

--- a/presto-main/src/main/java/io/prestosql/server/InternalAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/InternalAuthenticationManager.java
@@ -22,17 +22,21 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.prestosql.server.security.InternalPrincipal;
+import io.prestosql.spi.security.Identity;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
 
-import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
 import static io.airlift.http.client.Request.Builder.fromRequest;
+import static io.prestosql.server.ServletSecurityUtils.setAuthenticatedIdentity;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public class InternalAuthenticationManager
         implements HttpRequestFilter
@@ -72,25 +76,32 @@ public class InternalAuthenticationManager
         this.nodeId = nodeId;
     }
 
-    public boolean isInternalRequest(ContainerRequestContext request)
+    public static boolean isInternalRequest(ContainerRequestContext request)
     {
         return request.getHeaders().getFirst(PRESTO_INTERNAL_BEARER) != null;
     }
 
-    public Principal authenticateInternalRequest(ContainerRequestContext request)
+    public void handleInternalRequest(ContainerRequestContext request)
     {
-        String internalBarer = request.getHeaders().getFirst(PRESTO_INTERNAL_BEARER);
+        String subject;
         try {
-            String subject = parseJwt(internalBarer);
-            return new InternalPrincipal(subject);
+            subject = parseJwt(request.getHeaders().getFirst(PRESTO_INTERNAL_BEARER));
         }
         catch (JwtException e) {
             log.error(e, "Internal authentication failed");
-            return null;
+            request.abortWith(Response.status(UNAUTHORIZED)
+                    .type(TEXT_PLAIN_TYPE.toString())
+                    .build());
+            return;
         }
         catch (RuntimeException e) {
             throw new RuntimeException("Authentication error", e);
         }
+
+        Identity identity = Identity.forUser("<internal>")
+                .withPrincipal(new InternalPrincipal(subject))
+                .build();
+        setAuthenticatedIdentity(request, identity);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/server/NodeResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/NodeResource.java
@@ -24,7 +24,7 @@ import javax.ws.rs.Path;
 import java.util.Collection;
 
 import static com.google.common.base.Predicates.in;
-import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 
 @Path("/v1/node")
 public class NodeResource
@@ -37,14 +37,14 @@ public class NodeResource
         this.failureDetector = failureDetector;
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     public Collection<HeartbeatFailureDetector.Stats> getNodeStats()
     {
         return failureDetector.getStats().values();
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Path("failed")
     public Collection<HeartbeatFailureDetector.Stats> getFailed()

--- a/presto-main/src/main/java/io/prestosql/server/NodeResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/NodeResource.java
@@ -15,6 +15,7 @@ package io.prestosql.server;
 
 import com.google.common.collect.Maps;
 import io.prestosql.failuredetector.HeartbeatFailureDetector;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -23,6 +24,7 @@ import javax.ws.rs.Path;
 import java.util.Collection;
 
 import static com.google.common.base.Predicates.in;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 
 @Path("/v1/node")
 public class NodeResource
@@ -35,12 +37,14 @@ public class NodeResource
         this.failureDetector = failureDetector;
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     public Collection<HeartbeatFailureDetector.Stats> getNodeStats()
     {
         return failureDetector.getStats().values();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("failed")
     public Collection<HeartbeatFailureDetector.Stats> getFailed()

--- a/presto-main/src/main/java/io/prestosql/server/QueryResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/QueryResource.java
@@ -18,6 +18,7 @@ import io.prestosql.dispatcher.DispatchManager;
 import io.prestosql.execution.QueryInfo;
 import io.prestosql.execution.QueryState;
 import io.prestosql.security.AccessControl;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.security.AccessDeniedException;
@@ -48,6 +49,7 @@ import static io.prestosql.security.AccessControlUtil.checkCanKillQueryOwnedBy;
 import static io.prestosql.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.prestosql.security.AccessControlUtil.filterQueries;
 import static io.prestosql.server.HttpRequestSessionContext.extractAuthorizedIdentity;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.AUTHENTICATED_USER;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -68,6 +70,7 @@ public class QueryResource
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @GET
     public List<BasicQueryInfo> getAllQueryInfo(@QueryParam("state") String stateFilter, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
     {
@@ -85,6 +88,7 @@ public class QueryResource
         return builder.build();
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @GET
     @Path("{queryId}")
     public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -104,6 +108,7 @@ public class QueryResource
         }
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @DELETE
     @Path("{queryId}")
     public void cancelQuery(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -122,6 +127,7 @@ public class QueryResource
         }
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @PUT
     @Path("{queryId}/killed")
     public Response killQuery(@PathParam("queryId") QueryId queryId, String message, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -129,6 +135,7 @@ public class QueryResource
         return failQuery(queryId, createKillQueryException(message), servletRequest, httpHeaders);
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @PUT
     @Path("{queryId}/preempted")
     public Response preemptQuery(@PathParam("queryId") QueryId queryId, String message, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)

--- a/presto-main/src/main/java/io/prestosql/server/QueryStateInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/QueryStateInfoResource.java
@@ -16,6 +16,7 @@ package io.prestosql.server;
 import io.prestosql.dispatcher.DispatchManager;
 import io.prestosql.execution.resourcegroups.ResourceGroupManager;
 import io.prestosql.security.AccessControl;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.security.AccessDeniedException;
@@ -47,6 +48,7 @@ import static io.prestosql.security.AccessControlUtil.filterQueries;
 import static io.prestosql.server.HttpRequestSessionContext.extractAuthorizedIdentity;
 import static io.prestosql.server.QueryStateInfo.createQueryStateInfo;
 import static io.prestosql.server.QueryStateInfo.createQueuedQueryStateInfo;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.AUTHENTICATED_USER;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
@@ -71,6 +73,7 @@ public class QueryStateInfoResource
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<QueryStateInfo> getQueryStateInfos(@QueryParam("user") String user, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -103,6 +106,7 @@ public class QueryStateInfoResource
         return createQueryStateInfo(queryInfo, groupId);
     }
 
+    @ResourceSecurity(AUTHENTICATED_USER)
     @GET
     @Path("{queryId}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/presto-main/src/main/java/io/prestosql/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ResourceGroupStateInfoResource.java
@@ -14,6 +14,7 @@
 package io.prestosql.server;
 
 import io.prestosql.execution.resourcegroups.ResourceGroupManager;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 
 import javax.inject.Inject;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -46,6 +48,7 @@ public class ResourceGroupStateInfoResource
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Encoded

--- a/presto-main/src/main/java/io/prestosql/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ResourceGroupStateInfoResource.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -48,7 +48,7 @@ public class ResourceGroupStateInfoResource
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Encoded

--- a/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
@@ -36,6 +36,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.Duration.nanosSince;
 import static io.prestosql.metadata.NodeState.ACTIVE;
 import static io.prestosql.metadata.NodeState.SHUTTING_DOWN;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_WRITE;
 import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -71,7 +72,7 @@ public class ServerInfoResource
         return new ServerInfo(version, environment, coordinator, starting, Optional.of(nanosSince(startTime)));
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_WRITE)
     @PUT
     @Path("state")
     @Consumes(APPLICATION_JSON)

--- a/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerInfoResource.java
@@ -17,6 +17,7 @@ import io.airlift.node.NodeInfo;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.client.ServerInfo;
 import io.prestosql.metadata.NodeState;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -35,6 +36,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.Duration.nanosSince;
 import static io.prestosql.metadata.NodeState.ACTIVE;
 import static io.prestosql.metadata.NodeState.SHUTTING_DOWN;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -60,6 +62,7 @@ public class ServerInfoResource
         this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Produces(APPLICATION_JSON)
     public ServerInfo getInfo()
@@ -68,6 +71,7 @@ public class ServerInfoResource
         return new ServerInfo(version, environment, coordinator, starting, Optional.of(nanosSince(startTime)));
     }
 
+    @ResourceSecurity(PUBLIC)
     @PUT
     @Path("state")
     @Consumes(APPLICATION_JSON)
@@ -95,6 +99,7 @@ public class ServerInfoResource
         }
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("state")
     @Produces(APPLICATION_JSON)
@@ -108,6 +113,7 @@ public class ServerInfoResource
         }
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("coordinator")
     @Produces(TEXT_PLAIN)

--- a/presto-main/src/main/java/io/prestosql/server/ServletSecurityUtils.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServletSecurityUtils.java
@@ -13,86 +13,94 @@
  */
 package io.prestosql.server;
 
+import io.prestosql.spi.security.BasicPrincipal;
 import io.prestosql.spi.security.Identity;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
 import java.security.Principal;
-import java.util.Optional;
+import java.util.Collection;
 
-import static com.google.common.io.ByteStreams.copy;
-import static com.google.common.io.ByteStreams.nullOutputStream;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static io.prestosql.server.HttpRequestSessionContext.AUTHENTICATED_IDENTITY;
-import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public final class ServletSecurityUtils
 {
     private ServletSecurityUtils() {}
 
-    public static void sendErrorMessage(HttpServletResponse response, int errorCode, String errorMessage)
-            throws IOException
+    public static void sendErrorMessage(ContainerRequestContext request, Status errorCode, String errorMessage)
+    {
+        request.abortWith(errorResponse(errorCode, errorMessage).build());
+    }
+
+    public static void sendWwwAuthenticate(ContainerRequestContext request, String errorMessage, Collection<String> authenticateHeaders)
+    {
+        request.abortWith(authenticateResponse(errorMessage, authenticateHeaders).build());
+    }
+
+    private static ResponseBuilder authenticateResponse(String errorMessage, Collection<String> authenticateHeaders)
+    {
+        ResponseBuilder response = errorResponse(UNAUTHORIZED, errorMessage);
+        for (String value : authenticateHeaders) {
+            response.header(WWW_AUTHENTICATE, value);
+        }
+        return response;
+    }
+
+    private static ResponseBuilder errorResponse(Status errorCode, String errorMessage)
     {
         // Clients should use the response body rather than the HTTP status
         // message (which does not exist with HTTP/2), but the status message
         // still needs to be sent for compatibility with existing clients.
-        response.setStatus(errorCode, errorMessage);
-        response.setContentType(PLAIN_TEXT_UTF_8.toString());
-        try (PrintWriter writer = response.getWriter()) {
-            writer.write(errorMessage);
-        }
+        return Response.status(errorCode.getStatusCode(), errorMessage)
+                .type(PLAIN_TEXT_UTF_8.toString())
+                .entity(errorMessage);
     }
 
-    public static void withAuthenticatedIdentity(FilterChain nextFilter, HttpServletRequest request, HttpServletResponse response, Identity authenticatedIdentity)
-            throws IOException, ServletException
+    public static void setAuthenticatedIdentity(ContainerRequestContext request, String username)
     {
-        request.setAttribute(AUTHENTICATED_IDENTITY, authenticatedIdentity);
-        try {
-            nextFilter.doFilter(withPrincipal(request, authenticatedIdentity.getPrincipal()), response);
-        }
-        finally {
-            // destroy identity if identity is still attached to the request
-            Optional.ofNullable(request.getAttribute(AUTHENTICATED_IDENTITY))
-                    .map(Identity.class::cast)
-                    .ifPresent(Identity::destroy);
-        }
+        setAuthenticatedIdentity(request, Identity.forUser(username)
+                        .withPrincipal(new BasicPrincipal(username))
+                        .build());
     }
 
-    public static ServletRequest withPrincipal(HttpServletRequest request, Optional<Principal> principal)
+    public static void setAuthenticatedIdentity(ContainerRequestContext request, Identity authenticatedIdentity)
     {
-        requireNonNull(principal, "principal is null");
-        if (principal.isEmpty()) {
-            return request;
-        }
-        return new HttpServletRequestWrapper(request)
+        request.setProperty(AUTHENTICATED_IDENTITY, authenticatedIdentity);
+
+        boolean secure = request.getSecurityContext().isSecure();
+        Principal principal = authenticatedIdentity.getPrincipal().orElse(null);
+        request.setSecurityContext(new SecurityContext()
         {
             @Override
             public Principal getUserPrincipal()
             {
-                return principal.get();
+                return principal;
             }
-        };
-    }
 
-    public static void skipRequestBody(HttpServletRequest request)
-            throws IOException
-    {
-        // If we send the challenge without consuming the body of the request,
-        // the server will close the connection after sending the response.
-        // The client may interpret this as a failed request and not resend the
-        // request with the authentication header. We can avoid this behavior
-        // in the client by reading and discarding the entire body of the
-        // unauthenticated request before sending the response.
-        try (InputStream inputStream = request.getInputStream()) {
-            copy(inputStream, nullOutputStream());
-        }
+            @Override
+            public boolean isUserInRole(String role)
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isSecure()
+            {
+                return secure;
+            }
+
+            @Override
+            public String getAuthenticationScheme()
+            {
+                return "presto";
+            }
+        });
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/StatusResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/StatusResource.java
@@ -17,6 +17,7 @@ import com.sun.management.OperatingSystemMXBean;
 import io.airlift.node.NodeInfo;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.memory.LocalMemoryManager;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -29,6 +30,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 
 import static io.airlift.units.Duration.nanosSince;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -63,6 +65,7 @@ public class StatusResource
         }
     }
 
+    @ResourceSecurity(PUBLIC)
     @HEAD
     @Produces(APPLICATION_JSON) // to match the GET route
     public Response statusPing()
@@ -70,6 +73,7 @@ public class StatusResource
         return Response.ok().build();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Produces(APPLICATION_JSON)
     public NodeStatus getStatus()

--- a/presto-main/src/main/java/io/prestosql/server/TaskExecutorResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskExecutorResource.java
@@ -14,6 +14,7 @@
 package io.prestosql.server;
 
 import io.prestosql.execution.executor.TaskExecutor;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -21,6 +22,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.util.Objects.requireNonNull;
 
 @Path("/v1/maxActiveSplits")
@@ -35,6 +37,7 @@ public class TaskExecutorResource
         this.taskExecutor = requireNonNull(taskExecutor, "taskExecutor is null");
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String getMaxActiveSplit()

--- a/presto-main/src/main/java/io/prestosql/server/TaskExecutorResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskExecutorResource.java
@@ -22,7 +22,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 import static java.util.Objects.requireNonNull;
 
 @Path("/v1/maxActiveSplits")
@@ -37,7 +37,7 @@ public class TaskExecutorResource
         this.taskExecutor = requireNonNull(taskExecutor, "taskExecutor is null");
     }
 
-    @ResourceSecurity(PUBLIC)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String getMaxActiveSplit()

--- a/presto-main/src/main/java/io/prestosql/server/TaskResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/TaskResource.java
@@ -31,6 +31,7 @@ import io.prestosql.execution.buffer.BufferResult;
 import io.prestosql.execution.buffer.OutputBuffers.OutputBufferId;
 import io.prestosql.execution.buffer.SerializedPage;
 import io.prestosql.metadata.SessionPropertyManager;
+import io.prestosql.server.security.ResourceSecurity;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -72,6 +73,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_MAX_WAIT;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
 import static io.prestosql.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
 import static io.prestosql.client.PrestoHeaders.PRESTO_TASK_INSTANCE_ID;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -105,6 +107,7 @@ public class TaskResource
         this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<TaskInfo> getAllTaskInfo(@Context UriInfo uriInfo)
@@ -116,6 +119,7 @@ public class TaskResource
         return allTaskInfo;
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @POST
     @Path("{taskId}")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -139,6 +143,7 @@ public class TaskResource
         return Response.ok().entity(taskInfo).build();
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Path("{taskId}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -177,6 +182,7 @@ public class TaskResource
                 .withTimeout(timeout);
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Path("{taskId}/status")
     @Produces(MediaType.APPLICATION_JSON)
@@ -211,6 +217,7 @@ public class TaskResource
                 .withTimeout(timeout);
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @DELETE
     @Path("{taskId}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -235,6 +242,7 @@ public class TaskResource
         return taskInfo;
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Path("{taskId}/results/{bufferId}/{token}")
     @Produces(PRESTO_PAGES)
@@ -294,6 +302,7 @@ public class TaskResource
         asyncResponse.register((CompletionCallback) throwable -> resultsRequestTime.add(Duration.nanosSince(start)));
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Path("{taskId}/results/{bufferId}/{token}/acknowledge")
     public void acknowledgeResults(
@@ -307,6 +316,7 @@ public class TaskResource
         taskManager.acknowledgeTaskResults(taskId, bufferId, token);
     }
 
+    @ResourceSecurity(INTERNAL_ONLY)
     @DELETE
     @Path("{taskId}/results/{bufferId}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
@@ -34,12 +34,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.prestosql.server.ThreadResource.Info.byName;
-import static io.prestosql.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 
 @Path("/v1/thread")
 public class ThreadResource
 {
-    @ResourceSecurity(INTERNAL_ONLY)
+    @ResourceSecurity(MANAGEMENT_READ)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<Info> getThreadInfo()

--- a/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ThreadResource.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -33,10 +34,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.prestosql.server.ThreadResource.Info.byName;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
 
 @Path("/v1/thread")
 public class ThreadResource
 {
+    @ResourceSecurity(INTERNAL_ONLY)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<Info> getThreadInfo()

--- a/presto-main/src/main/java/io/prestosql/server/WorkerModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/WorkerModule.java
@@ -22,8 +22,8 @@ import io.prestosql.execution.resourcegroups.NoOpResourceGroupManager;
 import io.prestosql.execution.resourcegroups.ResourceGroupManager;
 import io.prestosql.failuredetector.FailureDetector;
 import io.prestosql.failuredetector.NoOpFailureDetector;
-import io.prestosql.server.ui.NoWebUiAuthenticationManager;
-import io.prestosql.server.ui.WebUiAuthenticationManager;
+import io.prestosql.server.ui.NoWebUiAuthenticationFilter;
+import io.prestosql.server.ui.WebUiAuthenticationFilter;
 import io.prestosql.transaction.NoOpTransactionManager;
 import io.prestosql.transaction.TransactionManager;
 
@@ -54,7 +54,7 @@ public class WorkerModule
             throw new UnsupportedOperationException();
         }));
 
-        binder.bind(WebUiAuthenticationManager.class).to(NoWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
+        binder.bind(WebUiAuthenticationFilter.class).to(NoWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
@@ -27,6 +27,7 @@ import io.prestosql.memory.context.SimpleLocalMemoryContext;
 import io.prestosql.operator.ExchangeClient;
 import io.prestosql.operator.ExchangeClientSupplier;
 import io.prestosql.server.ForStatementResource;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.block.BlockEncodingSerde;
 
@@ -72,6 +73,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static io.prestosql.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.server.protocol.Slug.Context.EXECUTING_QUERY;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -141,6 +143,7 @@ public class ExecutingStatementResource
         queryPurger.shutdownNow();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("{queryId}/{slug}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -261,6 +264,7 @@ public class ExecutingStatementResource
         return response.build();
     }
 
+    @ResourceSecurity(PUBLIC)
     @DELETE
     @Path("{queryId}/{slug}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -291,6 +295,7 @@ public class ExecutingStatementResource
         }
     }
 
+    @ResourceSecurity(PUBLIC)
     @DELETE
     @Path("partialCancel/{queryId}/{stage}/{slug}/{token}")
     public void partialCancel(

--- a/presto-main/src/main/java/io/prestosql/server/security/AnnotatedResourceAccessTypeLoader.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/AnnotatedResourceAccessTypeLoader.java
@@ -11,21 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.server.ui;
+package io.prestosql.server.security;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.Scopes;
+import io.prestosql.server.security.ResourceSecurity.AccessType;
 
-import static io.airlift.configuration.ConfigBinder.configBinder;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
 
-public class FixedUiAuthenticatorModule
-        implements Module
+public class AnnotatedResourceAccessTypeLoader
+        implements ResourceAccessTypeLoader
 {
     @Override
-    public void configure(Binder binder)
+    public Optional<AccessType> getAccessType(AnnotatedElement element)
     {
-        binder.bind(WebUiAuthenticationFilter.class).to(FixedUserWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(FixedUserWebUiConfig.class);
+        return Optional.ofNullable(element.getAnnotation(ResourceSecurity.class))
+                .map(ResourceSecurity::value);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/Authenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/Authenticator.java
@@ -15,10 +15,10 @@ package io.prestosql.server.security;
 
 import io.prestosql.spi.security.Identity;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 public interface Authenticator
 {
-    Identity authenticate(HttpServletRequest request)
+    Identity authenticate(ContainerRequestContext request)
             throws AuthenticationException;
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/BasicAuthCredentials.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/BasicAuthCredentials.java
@@ -15,7 +15,7 @@ package io.prestosql.server.security;
 
 import com.google.common.base.Splitter;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.util.Base64;
 import java.util.List;
@@ -32,14 +32,14 @@ public class BasicAuthCredentials
     private final String user;
     private final Optional<String> password;
 
-    public static Optional<BasicAuthCredentials> extractBasicAuthCredentials(HttpServletRequest request)
+    public static Optional<BasicAuthCredentials> extractBasicAuthCredentials(ContainerRequestContext request)
             throws AuthenticationException
     {
         requireNonNull(request, "request is null");
 
         // This handles HTTP basic auth per RFC 7617. The header contains the
         // case-insensitive "Basic" scheme followed by a Base64 encoded "user:pass".
-        String header = nullToEmpty(request.getHeader(AUTHORIZATION));
+        String header = nullToEmpty(request.getHeaders().getFirst(AUTHORIZATION));
 
         return extractBasicAuthCredentials(header);
     }

--- a/presto-main/src/main/java/io/prestosql/server/security/BasicAuthCredentials.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/BasicAuthCredentials.java
@@ -29,6 +29,8 @@ import static java.util.Objects.requireNonNull;
 
 public class BasicAuthCredentials
 {
+    public static final String AUTHENTICATE_HEADER = "Basic realm=\"Presto\"";
+
     private final String user;
     private final Optional<String> password;
 

--- a/presto-main/src/main/java/io/prestosql/server/security/CertificateAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/CertificateAuthenticator.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.security.Identity;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.security.Principal;
 import java.security.cert.X509Certificate;
@@ -44,10 +44,10 @@ public class CertificateAuthenticator
     }
 
     @Override
-    public Identity authenticate(HttpServletRequest request)
+    public Identity authenticate(ContainerRequestContext request)
             throws AuthenticationException
     {
-        Object attribute = request.getAttribute(X509_ATTRIBUTE);
+        Object attribute = request.getProperty(X509_ATTRIBUTE);
         if (attribute == null) {
             throw new AuthenticationException(null);
         }

--- a/presto-main/src/main/java/io/prestosql/server/security/InsecureAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/InsecureAuthenticator.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import io.prestosql.spi.security.BasicPrincipal;
+import io.prestosql.spi.security.Identity;
+
+import javax.ws.rs.container.ContainerRequestContext;
+
+import java.util.Optional;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static io.prestosql.client.PrestoHeaders.PRESTO_USER;
+import static io.prestosql.server.security.BasicAuthCredentials.extractBasicAuthCredentials;
+
+public class InsecureAuthenticator
+        implements Authenticator
+{
+    @Override
+    public Identity authenticate(ContainerRequestContext request)
+            throws AuthenticationException
+    {
+        Optional<BasicAuthCredentials> basicAuthCredentials = extractBasicAuthCredentials(request);
+
+        String user;
+        if (basicAuthCredentials.isPresent()) {
+            if (basicAuthCredentials.get().getPassword().isPresent()) {
+                throw new AuthenticationException("Password not allowed for insecure authentication", BasicAuthCredentials.AUTHENTICATE_HEADER);
+            }
+            user = basicAuthCredentials.get().getUser();
+        }
+        else {
+            user = emptyToNull(request.getHeaders().getFirst(PRESTO_USER));
+        }
+
+        if (user == null) {
+            throw new AuthenticationException("Basic authentication or " + PRESTO_USER + " must be sent", BasicAuthCredentials.AUTHENTICATE_HEADER);
+        }
+
+        return Identity.forUser(user)
+                .withPrincipal(new BasicPrincipal(user))
+                .build();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/JsonWebTokenAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/JsonWebTokenAuthenticator.java
@@ -30,7 +30,7 @@ import io.prestosql.spi.security.Identity;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,10 +104,10 @@ public class JsonWebTokenAuthenticator
     }
 
     @Override
-    public Identity authenticate(HttpServletRequest request)
+    public Identity authenticate(ContainerRequestContext request)
             throws AuthenticationException
     {
-        String header = nullToEmpty(request.getHeader(AUTHORIZATION));
+        String header = nullToEmpty(request.getHeaders().getFirst(AUTHORIZATION));
 
         int space = header.indexOf(' ');
         if ((space < 0) || !header.substring(0, space).equalsIgnoreCase("bearer")) {

--- a/presto-main/src/main/java/io/prestosql/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/KerberosAuthenticator.java
@@ -31,7 +31,7 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -136,10 +136,10 @@ public class KerberosAuthenticator
     }
 
     @Override
-    public Identity authenticate(HttpServletRequest request)
+    public Identity authenticate(ContainerRequestContext request)
             throws AuthenticationException
     {
-        String header = request.getHeader(AUTHORIZATION);
+        String header = request.getHeaders().getFirst(AUTHORIZATION);
 
         String requestSpnegoToken = null;
 

--- a/presto-main/src/main/java/io/prestosql/server/security/PasswordAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/PasswordAuthenticator.java
@@ -67,6 +67,6 @@ public class PasswordAuthenticator
 
     private static AuthenticationException needAuthentication(String message)
     {
-        return new AuthenticationException(message, "Basic realm=\"Presto\"");
+        return new AuthenticationException(message, BasicAuthCredentials.AUTHENTICATE_HEADER);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/PasswordAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/PasswordAuthenticator.java
@@ -17,7 +17,7 @@ import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.Identity;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
 
 import java.security.Principal;
 
@@ -42,7 +42,7 @@ public class PasswordAuthenticator
     }
 
     @Override
-    public Identity authenticate(HttpServletRequest request)
+    public Identity authenticate(ContainerRequestContext request)
             throws AuthenticationException
     {
         BasicAuthCredentials basicAuthCredentials = extractBasicAuthCredentials(request)

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessType.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessType.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
-import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
 
 public class ResourceAccessType
 {
@@ -65,7 +65,7 @@ public class ResourceAccessType
         }
         // Presto resources are required to have a declared access control
         verifyNotPrestoResource(resourceInfo);
-        return PUBLIC;
+        return MANAGEMENT_READ;
     }
 
     private static void verifyNotPrestoResource(ResourceInfo resourceInfo)

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessType.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessType.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.server.security.ResourceSecurity.AccessType;
+import io.prestosql.server.security.ResourceSecurityBinder.StaticResourceAccessTypeLoader;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ResourceInfo;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+
+public class ResourceAccessType
+{
+    private final List<ResourceAccessTypeLoader> resourceAccessTypeLoaders;
+
+    @Inject
+    public ResourceAccessType(StaticResourceAccessTypeLoader staticResourceAccessTypeLoader)
+    {
+        this.resourceAccessTypeLoaders = ImmutableList.<ResourceAccessTypeLoader>builder()
+                .add(staticResourceAccessTypeLoader)
+                .add(new AnnotatedResourceAccessTypeLoader())
+                .build();
+    }
+
+    public AccessType getAccessType(ResourceInfo resourceInfo)
+    {
+        for (ResourceAccessTypeLoader resourceAccessTypeLoader : resourceAccessTypeLoaders) {
+            // check if the method has an access type declared
+            Optional<AccessType> accessType = resourceAccessTypeLoader.getAccessType(resourceInfo.getResourceMethod());
+            if (accessType.isPresent()) {
+                return accessType.get();
+            }
+            // check if the resource class has an access type declared for all methods
+            accessType = resourceAccessTypeLoader.getAccessType(resourceInfo.getResourceClass());
+            if (accessType.isPresent()) {
+                verifyNotPrestoResource(resourceInfo);
+                return accessType.get();
+            }
+            // in some cases there the resource is a nested class, so check the parent class
+            // we currently only check one level, but we could handle multiple nesting levels if necessary
+            if (resourceInfo.getResourceClass().getDeclaringClass() != null) {
+                accessType = resourceAccessTypeLoader.getAccessType(resourceInfo.getResourceClass().getDeclaringClass());
+                if (accessType.isPresent()) {
+                    verifyNotPrestoResource(resourceInfo);
+                    return accessType.get();
+                }
+            }
+        }
+        // Presto resources are required to have a declared access control
+        verifyNotPrestoResource(resourceInfo);
+        return PUBLIC;
+    }
+
+    private static void verifyNotPrestoResource(ResourceInfo resourceInfo)
+    {
+        Method resourceMethod = resourceInfo.getResourceMethod();
+        if (resourceMethod != null && resourceMethod.getDeclaringClass().getPackageName().startsWith("io.prestosql.")) {
+            throw new IllegalArgumentException("Presto resource is not annotated with @" + ResourceSecurity.class.getSimpleName() + ": " + resourceInfo.getResourceMethod());
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessTypeLoader.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceAccessTypeLoader.java
@@ -11,17 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.server.ui;
+package io.prestosql.server.security;
 
-import javax.ws.rs.container.ContainerRequestContext;
+import io.prestosql.server.security.ResourceSecurity.AccessType;
 
-public interface WebUiAuthenticationManager
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+public interface ResourceAccessTypeLoader
 {
-    static boolean isUiRequest(ContainerRequestContext request)
-    {
-        String path = request.getUriInfo().getRequestUri().getPath();
-        return path == null || path.equals("/") || path.startsWith("/ui");
-    }
-
-    void handleUiRequest(ContainerRequestContext request);
+    Optional<AccessType> getAccessType(AnnotatedElement element);
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurity.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurity.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines the authentication and authorization required to access a REST resource.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface ResourceSecurity
+{
+    enum AccessType
+    {
+        PUBLIC, WEB_UI, AUTHENTICATED_USER, INTERNAL_ONLY
+    }
+
+    AccessType value();
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurity.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurity.java
@@ -31,7 +31,7 @@ public @interface ResourceSecurity
 {
     enum AccessType
     {
-        PUBLIC, WEB_UI, AUTHENTICATED_USER, INTERNAL_ONLY
+        PUBLIC, WEB_UI, AUTHENTICATED_USER, MANAGEMENT_READ, MANAGEMENT_WRITE, INTERNAL_ONLY
     }
 
     AccessType value();

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityBinder.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityBinder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.MapBinder;
+import io.prestosql.server.security.ResourceSecurity.AccessType;
+
+import javax.inject.Inject;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceSecurityBinder
+{
+    private final MapBinder<AnnotatedElement, AccessType> accessTypeBinder;
+
+    public static ResourceSecurityBinder resourceSecurityBinder(Binder binder)
+    {
+        return new ResourceSecurityBinder(binder);
+    }
+
+    private ResourceSecurityBinder(Binder binder)
+    {
+        requireNonNull(binder, "binder is null");
+        binder.bind(ResourceAccessType.class).in(SINGLETON);
+        binder.bind(StaticResourceAccessTypeLoader.class).in(SINGLETON);
+        accessTypeBinder = MapBinder.newMapBinder(binder, AnnotatedElement.class, AccessType.class);
+    }
+
+    public ResourceSecurityBinder resourceSecurity(AnnotatedElement element, AccessType accessType)
+    {
+        accessTypeBinder.addBinding(element).toInstance(accessType);
+        return this;
+    }
+
+    public ResourceSecurityBinder publicResource(AnnotatedElement element)
+    {
+        return resourceSecurity(element, AccessType.PUBLIC);
+    }
+
+    public ResourceSecurityBinder anyUserResource(AnnotatedElement element)
+    {
+        return resourceSecurity(element, AccessType.AUTHENTICATED_USER);
+    }
+
+    public ResourceSecurityBinder internalOnlyResource(AnnotatedElement element)
+    {
+        return resourceSecurity(element, AccessType.INTERNAL_ONLY);
+    }
+
+    public static class StaticResourceAccessTypeLoader
+            implements ResourceAccessTypeLoader
+    {
+        private final Map<AnnotatedElement, AccessType> accessTypeMap;
+
+        @Inject
+        public StaticResourceAccessTypeLoader(Map<AnnotatedElement, AccessType> accessTypeMap)
+        {
+            this.accessTypeMap = ImmutableMap.copyOf(requireNonNull(accessTypeMap, "accessTypeMap is null"));
+        }
+
+        @Override
+        public Optional<AccessType> getAccessType(AnnotatedElement element)
+        {
+            return Optional.ofNullable(accessTypeMap.get(element));
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityBinder.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityBinder.java
@@ -60,6 +60,16 @@ public class ResourceSecurityBinder
         return resourceSecurity(element, AccessType.AUTHENTICATED_USER);
     }
 
+    public ResourceSecurityBinder managementReadResource(AnnotatedElement element)
+    {
+        return resourceSecurity(element, AccessType.MANAGEMENT_READ);
+    }
+
+    public ResourceSecurityBinder managementWriteResource(AnnotatedElement element)
+    {
+        return resourceSecurity(element, AccessType.MANAGEMENT_WRITE);
+    }
+
     public ResourceSecurityBinder internalOnlyResource(AnnotatedElement element)
     {
         return resourceSecurity(element, AccessType.INTERNAL_ONLY);

--- a/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityDynamicFeature.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ResourceSecurityDynamicFeature.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import io.prestosql.server.InternalAuthenticationManager;
+import io.prestosql.server.security.ResourceSecurity.AccessType;
+import io.prestosql.server.ui.WebUiAuthenticationFilter;
+import io.prestosql.spi.security.Identity;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+
+import java.util.Optional;
+
+import static io.prestosql.server.HttpRequestSessionContext.AUTHENTICATED_IDENTITY;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceSecurityDynamicFeature
+        implements DynamicFeature
+{
+    private final ResourceAccessType resourceAccessType;
+    private final AuthenticationFilter authenticationFilter;
+    private final WebUiAuthenticationFilter webUiAuthenticationFilter;
+    private final InternalAuthenticationManager internalAuthenticationManager;
+
+    @Inject
+    public ResourceSecurityDynamicFeature(
+            ResourceAccessType resourceAccessType,
+            AuthenticationFilter authenticationFilter,
+            WebUiAuthenticationFilter webUiAuthenticationFilter,
+            InternalAuthenticationManager internalAuthenticationManager)
+    {
+        this.resourceAccessType = requireNonNull(resourceAccessType, "resourceAccessType is null");
+        this.authenticationFilter = requireNonNull(authenticationFilter, "authenticationFilter is null");
+        this.webUiAuthenticationFilter = requireNonNull(webUiAuthenticationFilter, "webUiAuthenticationFilter is null");
+        this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
+    }
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context)
+    {
+        AccessType accessType = resourceAccessType.getAccessType(resourceInfo);
+        switch (accessType) {
+            case PUBLIC:
+                // no authentication or authorization
+                break;
+            case WEB_UI:
+                context.register(webUiAuthenticationFilter);
+                context.register(new DisposeIdentityResponseFilter());
+                break;
+            case AUTHENTICATED_USER:
+                context.register(authenticationFilter);
+                context.register(new DisposeIdentityResponseFilter());
+                break;
+            case INTERNAL_ONLY:
+                context.register(new InternalOnlyRequestFilter(internalAuthenticationManager));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown mode: " + accessType);
+        }
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    private static class InternalOnlyRequestFilter
+            implements ContainerRequestFilter
+    {
+        private final InternalAuthenticationManager internalAuthenticationManager;
+
+        @Inject
+        public InternalOnlyRequestFilter(InternalAuthenticationManager internalAuthenticationManager)
+        {
+            this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
+        }
+
+        @Override
+        public void filter(ContainerRequestContext request)
+        {
+            if (InternalAuthenticationManager.isInternalRequest(request)) {
+                internalAuthenticationManager.handleInternalRequest(request);
+                return;
+            }
+
+            throw new ForbiddenException("Internal only resource");
+        }
+    }
+
+    @Priority(Priorities.AUTHENTICATION)
+    private static class DisposeIdentityResponseFilter
+            implements ContainerResponseFilter
+    {
+        @Override
+        public void filter(ContainerRequestContext request, ContainerResponseContext response)
+        {
+            // destroy identity if identity is still attached to the request
+            Optional.ofNullable(request.getProperty(AUTHENTICATED_IDENTITY))
+                    .map(Identity.class::cast)
+                    .ifPresent(Identity::destroy);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
@@ -33,7 +33,21 @@ public class SecurityConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
+    private boolean insecureAuthenticationOverHttpAllowed = true;
     private List<String> authenticationTypes = ImmutableList.of("insecure");
+
+    public boolean isInsecureAuthenticationOverHttpAllowed()
+    {
+        return insecureAuthenticationOverHttpAllowed;
+    }
+
+    @Config("http-server.authentication.allow-insecure-over-http")
+    @ConfigDescription("Insecure authentication over HTTP (non-secure) enabled")
+    public SecurityConfig setInsecureAuthenticationOverHttpAllowed(boolean insecureAuthenticationOverHttpAllowed)
+    {
+        this.insecureAuthenticationOverHttpAllowed = insecureAuthenticationOverHttpAllowed;
+        return this;
+    }
 
     @NotNull
     @NotEmpty(message = "http-server.authentication.type cannot be empty")

--- a/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
@@ -32,9 +33,10 @@ public class SecurityConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    private List<String> authenticationTypes = ImmutableList.of();
+    private List<String> authenticationTypes = ImmutableList.of("insecure");
 
     @NotNull
+    @NotEmpty(message = "http-server.authentication.type cannot be empty")
     public List<String> getAuthenticationTypes()
     {
         return authenticationTypes;

--- a/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
@@ -35,6 +35,8 @@ public class SecurityConfig
 
     private boolean insecureAuthenticationOverHttpAllowed = true;
     private List<String> authenticationTypes = ImmutableList.of("insecure");
+    private Optional<String> fixedManagementUser = Optional.empty();
+    private boolean fixedManagementUserForHttps;
 
     public boolean isInsecureAuthenticationOverHttpAllowed()
     {
@@ -67,6 +69,32 @@ public class SecurityConfig
     public SecurityConfig setAuthenticationTypes(String types)
     {
         authenticationTypes = Optional.ofNullable(types).map(SPLITTER::splitToList).orElse(null);
+        return this;
+    }
+
+    public Optional<String> getFixedManagementUser()
+    {
+        return fixedManagementUser;
+    }
+
+    @Config("management.user")
+    @ConfigDescription("Optional fixed user for all requests to management endpoints")
+    public SecurityConfig setFixedManagementUser(String fixedManagementUser)
+    {
+        this.fixedManagementUser = Optional.ofNullable(fixedManagementUser);
+        return this;
+    }
+
+    public boolean isFixedManagementUserForHttps()
+    {
+        return fixedManagementUserForHttps;
+    }
+
+    @Config("management.user.https-enabled")
+    @ConfigDescription("Use fixed management user for secure HTTPS requests")
+    public SecurityConfig setFixedManagementUserForHttps(boolean fixedManagementUserForHttps)
+    {
+        this.fixedManagementUserForHttps = fixedManagementUserForHttps;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -20,6 +20,10 @@ import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.util.Modules;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.discovery.server.DynamicAnnouncementResource;
+import io.airlift.discovery.server.ServiceResource;
+import io.airlift.discovery.store.StoreResource;
+import io.airlift.jmx.MBeanResource;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +34,7 @@ import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static io.airlift.configuration.ConditionalModule.installModuleIf;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.prestosql.server.security.ResourceSecurityBinder.resourceSecurityBinder;
 import static java.util.Locale.ENGLISH;
 
 public class ServerSecurityModule
@@ -38,7 +43,14 @@ public class ServerSecurityModule
     @Override
     protected void setup(Binder binder)
     {
-        jaxrsBinder(binder).bind(AuthenticationFilter.class);
+        binder.bind(AuthenticationFilter.class);
+        jaxrsBinder(binder).bind(ResourceSecurityDynamicFeature.class);
+
+        resourceSecurityBinder(binder)
+                .publicResource(ServiceResource.class)
+                .publicResource(MBeanResource.class)
+                .internalOnlyResource(DynamicAnnouncementResource.class)
+                .internalOnlyResource(StoreResource.class);
 
         binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
         binder.bind(CertificateAuthenticatorManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -20,9 +20,6 @@ import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.util.Modules;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.http.server.TheServlet;
-
-import javax.servlet.Filter;
 
 import java.util.List;
 import java.util.Map;
@@ -30,9 +27,9 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
-import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConditionalModule.installModuleIf;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static java.util.Locale.ENGLISH;
 
 public class ServerSecurityModule
@@ -41,8 +38,7 @@ public class ServerSecurityModule
     @Override
     protected void setup(Binder binder)
     {
-        newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
-                .to(AuthenticationFilter.class).in(Scopes.SINGLETON);
+        jaxrsBinder(binder).bind(AuthenticationFilter.class);
 
         binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
         binder.bind(CertificateAuthenticatorManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -49,8 +49,8 @@ public class ServerSecurityModule
         jaxrsBinder(binder).bind(ResourceSecurityDynamicFeature.class);
 
         resourceSecurityBinder(binder)
-                .publicResource(ServiceResource.class)
-                .publicResource(MBeanResource.class)
+                .managementReadResource(ServiceResource.class)
+                .managementReadResource(MBeanResource.class)
                 .internalOnlyResource(DynamicAnnouncementResource.class)
                 .internalOnlyResource(StoreResource.class);
 

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -61,6 +61,8 @@ public class ServerSecurityModule
         installAuthenticator("kerberos", KerberosAuthenticator.class, KerberosConfig.class);
         installAuthenticator("password", PasswordAuthenticator.class, PasswordAuthenticatorConfig.class);
         installAuthenticator("jwt", JsonWebTokenAuthenticator.class, JsonWebTokenConfig.class);
+
+        install(authenticatorModule("insecure", InsecureAuthenticator.class, unused -> {}));
     }
 
     @Provides

--- a/presto-main/src/main/java/io/prestosql/server/ui/ClusterResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/ClusterResource.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.Duration;
 import io.prestosql.client.NodeVersion;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.annotation.concurrent.Immutable;
 import javax.inject.Inject;
@@ -25,6 +26,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import static io.airlift.units.Duration.nanosSince;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -42,6 +44,7 @@ public class ClusterResource
         this.environment = requireNonNull(nodeInfo, "nodeInfo is null").getEnvironment();
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Produces(APPLICATION_JSON)
     public ClusterInfo getInfo()

--- a/presto-main/src/main/java/io/prestosql/server/ui/ClusterStatsResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/ClusterStatsResource.java
@@ -22,6 +22,7 @@ import io.prestosql.memory.ClusterMemoryManager;
 import io.prestosql.metadata.InternalNodeManager;
 import io.prestosql.metadata.NodeState;
 import io.prestosql.server.BasicQueryInfo;
+import io.prestosql.server.security.ResourceSecurity;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -29,6 +30,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -49,6 +51,7 @@ public class ClusterStatsResource
         this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public ClusterStats getClusterStats()

--- a/presto-main/src/main/java/io/prestosql/server/ui/DisabledWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/DisabledWebUiAuthenticationFilter.java
@@ -16,15 +16,15 @@ package io.prestosql.server.ui;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.DISABLED_LOCATION_URI;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.isPublicUiResource;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION_URI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.isPublicUiResource;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
-public class DisabledWebUiAuthenticationManager
-        implements WebUiAuthenticationManager
+public class DisabledWebUiAuthenticationFilter
+        implements WebUiAuthenticationFilter
 {
     @Override
-    public void handleUiRequest(ContainerRequestContext request)
+    public void filter(ContainerRequestContext request)
     {
         String path = request.getUriInfo().getRequestUri().getPath();
         if (path.equals("/")) {

--- a/presto-main/src/main/java/io/prestosql/server/ui/FixedUserWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FixedUserWebUiAuthenticationFilter.java
@@ -20,27 +20,27 @@ import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 
 import static io.prestosql.server.ServletSecurityUtils.setAuthenticatedIdentity;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.redirectAllFormLoginToUi;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.redirectAllFormLoginToUi;
 import static java.util.Objects.requireNonNull;
 
-public class FixedUserWebUiAuthenticationManager
-        implements WebUiAuthenticationManager
+public class FixedUserWebUiAuthenticationFilter
+        implements WebUiAuthenticationFilter
 {
     private final Identity webUiIdentity;
 
     @Inject
-    public FixedUserWebUiAuthenticationManager(FixedUserWebUiConfig config)
+    public FixedUserWebUiAuthenticationFilter(FixedUserWebUiConfig config)
     {
         this(basicIdentity(requireNonNull(config, "config is null").getUsername()));
     }
 
-    public FixedUserWebUiAuthenticationManager(Identity webUiIdentity)
+    public FixedUserWebUiAuthenticationFilter(Identity webUiIdentity)
     {
         this.webUiIdentity = requireNonNull(webUiIdentity, "webUiIdentity is null");
     }
 
     @Override
-    public void handleUiRequest(ContainerRequestContext request)
+    public void filter(ContainerRequestContext request)
     {
         if (redirectAllFormLoginToUi(request)) {
             return;

--- a/presto-main/src/main/java/io/prestosql/server/ui/FixedUserWebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FixedUserWebUiAuthenticationManager.java
@@ -17,14 +17,9 @@ import io.prestosql.spi.security.BasicPrincipal;
 import io.prestosql.spi.security.Identity;
 
 import javax.inject.Inject;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ContainerRequestContext;
 
-import java.io.IOException;
-
-import static io.prestosql.server.ServletSecurityUtils.withAuthenticatedIdentity;
+import static io.prestosql.server.ServletSecurityUtils.setAuthenticatedIdentity;
 import static io.prestosql.server.ui.FormWebUiAuthenticationManager.redirectAllFormLoginToUi;
 import static java.util.Objects.requireNonNull;
 
@@ -45,14 +40,13 @@ public class FixedUserWebUiAuthenticationManager
     }
 
     @Override
-    public void handleUiRequest(HttpServletRequest request, HttpServletResponse response, FilterChain nextFilter)
-            throws IOException, ServletException
+    public void handleUiRequest(ContainerRequestContext request)
     {
-        if (redirectAllFormLoginToUi(request, response)) {
+        if (redirectAllFormLoginToUi(request)) {
             return;
         }
 
-        withAuthenticatedIdentity(nextFilter, request, response, webUiIdentity);
+        setAuthenticatedIdentity(request, webUiIdentity);
     }
 
     private static Identity basicIdentity(String username)

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormAuthenticator.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+public interface FormAuthenticator
+{
+    boolean isLoginEnabled(boolean secure);
+
+    boolean isPasswordAllowed(boolean secure);
+
+    boolean isValidCredential(String username, String password, boolean secure);
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
@@ -16,10 +16,10 @@ package io.prestosql.server.ui;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.Scopes;
 import io.prestosql.server.security.Authenticator;
 import io.prestosql.server.security.PasswordAuthenticatorManager;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
@@ -27,12 +27,25 @@ import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 public class FormUiAuthenticatorModule
         implements Module
 {
+    private final boolean usePasswordManager;
+
+    public FormUiAuthenticatorModule(boolean usePasswordManager)
+    {
+        this.usePasswordManager = usePasswordManager;
+    }
+
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
-        binder.bind(FormWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
-        binder.bind(WebUiAuthenticationFilter.class).to(FormWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
+        binder.bind(PasswordAuthenticatorManager.class).in(SINGLETON);
+        binder.bind(FormWebUiAuthenticationFilter.class).in(SINGLETON);
+        binder.bind(WebUiAuthenticationFilter.class).to(FormWebUiAuthenticationFilter.class).in(SINGLETON);
+        if (usePasswordManager) {
+            binder.bind(FormAuthenticator.class).to(PasswordManagerFormAuthenticator.class).in(SINGLETON);
+        }
+        else {
+            binder.bind(FormAuthenticator.class).to(InsecureFormAuthenticator.class).in(SINGLETON);
+        }
         configBinder(binder).bindConfig(FormWebUiConfig.class);
         jaxrsBinder(binder).bind(LoginResource.class);
         newOptionalBinder(binder, Key.get(Authenticator.class, ForWebUi.class));

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
@@ -22,6 +22,7 @@ import io.prestosql.server.security.PasswordAuthenticatorManager;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 
 public class FormUiAuthenticatorModule
         implements Module
@@ -30,8 +31,10 @@ public class FormUiAuthenticatorModule
     public void configure(Binder binder)
     {
         binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
+        binder.bind(FormWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
         binder.bind(WebUiAuthenticationManager.class).to(FormWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FormWebUiConfig.class);
+        jaxrsBinder(binder).bind(LoginResource.class);
         newOptionalBinder(binder, Key.get(Authenticator.class, ForWebUi.class));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormUiAuthenticatorModule.java
@@ -31,8 +31,8 @@ public class FormUiAuthenticatorModule
     public void configure(Binder binder)
     {
         binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
-        binder.bind(FormWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
-        binder.bind(WebUiAuthenticationManager.class).to(FormWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
+        binder.bind(FormWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
+        binder.bind(WebUiAuthenticationFilter.class).to(FormWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FormWebUiConfig.class);
         jaxrsBinder(binder).bind(LoginResource.class);
         newOptionalBinder(binder, Key.get(Authenticator.class, ForWebUi.class));

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
@@ -56,9 +56,9 @@ public class FormWebUiAuthenticationFilter
 {
     private static final String PRESTO_UI_AUDIENCE = "presto-ui";
     private static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
-    private static final String LOGIN_FORM = "/ui/login.html";
+    static final String LOGIN_FORM = "/ui/login.html";
     static final URI LOGIN_FORM_URI = URI.create(LOGIN_FORM);
-    private static final String DISABLED_LOCATION = "/ui/disabled.html";
+    static final String DISABLED_LOCATION = "/ui/disabled.html";
     static final URI DISABLED_LOCATION_URI = URI.create(DISABLED_LOCATION);
     private static final String UI_LOCATION = "/ui/";
     private static final URI UI_LOCATION_URI = URI.create(UI_LOCATION);
@@ -109,7 +109,7 @@ public class FormWebUiAuthenticationFilter
         }
 
         // login and logout resource is not visible to protocol authenticators
-        if (path.equals(UI_LOGIN) || path.equals(UI_LOGOUT)) {
+        if ((path.equals(UI_LOGIN) && request.getMethod().equals("POST")) || path.equals(UI_LOGOUT)) {
             return;
         }
 

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
@@ -51,8 +51,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
-public class FormWebUiAuthenticationManager
-        implements WebUiAuthenticationManager
+public class FormWebUiAuthenticationFilter
+        implements WebUiAuthenticationFilter
 {
     private static final String PRESTO_UI_AUDIENCE = "presto-ui";
     private static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
@@ -71,7 +71,7 @@ public class FormWebUiAuthenticationManager
     private final Optional<Authenticator> authenticator;
 
     @Inject
-    public FormWebUiAuthenticationManager(
+    public FormWebUiAuthenticationFilter(
             FormWebUiConfig config,
             PasswordAuthenticatorManager passwordAuthenticatorManager,
             @ForWebUi Optional<Authenticator> authenticator)
@@ -95,14 +95,9 @@ public class FormWebUiAuthenticationManager
     }
 
     @Override
-    public void handleUiRequest(ContainerRequestContext request)
+    public void filter(ContainerRequestContext request)
     {
         String path = request.getUriInfo().getRequestUri().getPath();
-        if (path.equals("/")) {
-            request.abortWith(Response.seeOther(UI_LOCATION_URI).build());
-            return;
-        }
-
         if (isPublicUiResource(path)) {
             return;
         }

--- a/presto-main/src/main/java/io/prestosql/server/ui/InsecureFormAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/InsecureFormAuthenticator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+import io.prestosql.server.security.SecurityConfig;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class InsecureFormAuthenticator
+        implements FormAuthenticator
+{
+    private final boolean insecureAuthenticationOverHttpAllowed;
+
+    @Inject
+    public InsecureFormAuthenticator(SecurityConfig securityConfig)
+    {
+        insecureAuthenticationOverHttpAllowed = requireNonNull(securityConfig, "securityConfig is null").isInsecureAuthenticationOverHttpAllowed();
+    }
+
+    @Override
+    public boolean isLoginEnabled(boolean secure)
+    {
+        return secure || insecureAuthenticationOverHttpAllowed;
+    }
+
+    @Override
+    public boolean isPasswordAllowed(boolean secure)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isValidCredential(String username, String password, boolean secure)
+    {
+        if (username == null) {
+            return false;
+        }
+
+        return isLoginEnabled(secure) && password == null;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
@@ -67,7 +67,8 @@ public class LoginResource
     @Path(LOGIN_FORM)
     public Response getFile(@Context SecurityContext securityContext)
     {
-        return Response.ok(loginHtml.replace(REPLACEMENT_TEXT, "var hidePassword = " + !securityContext.isSecure() + ";"))
+        boolean passwordAllowed = formWebUiAuthenticationManager.isPasswordAllowed(securityContext.isSecure());
+        return Response.ok(loginHtml.replace(REPLACEMENT_TEXT, "var hidePassword = " + !passwordAllowed + ";"))
                 .type(TEXT_HTML)
                 .build();
     }
@@ -85,7 +86,7 @@ public class LoginResource
         password = emptyToNull(password);
         redirectPath = emptyToNull(redirectPath);
 
-        if (!formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext)) {
+        if (!formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext.isSecure())) {
             return Response.seeOther(DISABLED_LOCATION_URI).build();
         }
 
@@ -106,7 +107,7 @@ public class LoginResource
     public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
     {
         URI redirectLocation;
-        if (formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext)) {
+        if (formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext.isSecure())) {
             redirectLocation = LOGIN_FORM_URI;
         }
         else {

--- a/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+import javax.inject.Inject;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.DISABLED_LOCATION_URI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.LOGIN_FORM_URI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGIN;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGOUT;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.getDeleteCookie;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.redirectFromSuccessfulLoginResponse;
+import static java.util.Objects.requireNonNull;
+
+@Path("")
+public class LoginResource
+{
+    private final FormWebUiAuthenticationManager formWebUiAuthenticationManager;
+
+    @Inject
+    public LoginResource(FormWebUiAuthenticationManager formWebUiAuthenticationManager)
+    {
+        this.formWebUiAuthenticationManager = requireNonNull(formWebUiAuthenticationManager, "formWebUiAuthenticationManager is null");
+    }
+
+    @POST
+    @Path(UI_LOGIN)
+    public Response login(
+            @FormParam("username") String username,
+            @FormParam("password") String password,
+            @FormParam("redirectPath") String redirectPath,
+            @Context SecurityContext securityContext)
+    {
+        username = emptyToNull(username);
+        password = emptyToNull(password);
+        redirectPath = emptyToNull(redirectPath);
+
+        if (!formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext)) {
+            return Response.seeOther(DISABLED_LOCATION_URI).build();
+        }
+
+        Optional<NewCookie> authenticationCookie = formWebUiAuthenticationManager.checkLoginCredentials(username, password, securityContext.isSecure());
+        if (!authenticationCookie.isPresent()) {
+            // authentication failed, redirect back to the login page
+            return Response.seeOther(LOGIN_FORM_URI).build();
+        }
+
+        return redirectFromSuccessfulLoginResponse(redirectPath)
+                .cookie(authenticationCookie.get())
+                .build();
+    }
+
+    @GET
+    @Path(UI_LOGOUT)
+    public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
+    {
+        URI redirectLocation;
+        if (formWebUiAuthenticationManager.isAuthenticationEnabled(securityContext)) {
+            redirectLocation = LOGIN_FORM_URI;
+        }
+        else {
+            redirectLocation = DISABLED_LOCATION_URI;
+        }
+        return Response.seeOther(redirectLocation)
+                .cookie(getDeleteCookie(securityContext.isSecure()))
+                .build();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/LoginResource.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.server.ui;
 
+import io.prestosql.server.security.ResourceSecurity;
+
 import javax.inject.Inject;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -29,25 +31,27 @@ import java.net.URI;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.emptyToNull;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.DISABLED_LOCATION_URI;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.LOGIN_FORM_URI;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGIN;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGOUT;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.getDeleteCookie;
-import static io.prestosql.server.ui.FormWebUiAuthenticationManager.redirectFromSuccessfulLoginResponse;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION_URI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.LOGIN_FORM_URI;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.UI_LOGIN;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.getDeleteCookie;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.redirectFromSuccessfulLoginResponse;
 import static java.util.Objects.requireNonNull;
 
 @Path("")
 public class LoginResource
 {
-    private final FormWebUiAuthenticationManager formWebUiAuthenticationManager;
+    private final FormWebUiAuthenticationFilter formWebUiAuthenticationManager;
 
     @Inject
-    public LoginResource(FormWebUiAuthenticationManager formWebUiAuthenticationManager)
+    public LoginResource(FormWebUiAuthenticationFilter formWebUiAuthenticationManager)
     {
         this.formWebUiAuthenticationManager = requireNonNull(formWebUiAuthenticationManager, "formWebUiAuthenticationManager is null");
     }
 
+    @ResourceSecurity(WEB_UI)
     @POST
     @Path(UI_LOGIN)
     public Response login(
@@ -75,6 +79,7 @@ public class LoginResource
                 .build();
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path(UI_LOGOUT)
     public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)

--- a/presto-main/src/main/java/io/prestosql/server/ui/NoWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/NoWebUiAuthenticationFilter.java
@@ -18,11 +18,11 @@ import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
-public class NoWebUiAuthenticationManager
-        implements WebUiAuthenticationManager
+public class NoWebUiAuthenticationFilter
+        implements WebUiAuthenticationFilter
 {
     @Override
-    public void handleUiRequest(ContainerRequestContext request)
+    public void filter(ContainerRequestContext request)
     {
         request.abortWith(Response.status(NOT_FOUND).build());
     }

--- a/presto-main/src/main/java/io/prestosql/server/ui/NoWebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/NoWebUiAuthenticationManager.java
@@ -13,21 +13,17 @@
  */
 package io.prestosql.server.ui;
 
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
 
-import java.io.IOException;
-
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 public class NoWebUiAuthenticationManager
         implements WebUiAuthenticationManager
 {
     @Override
-    public void handleUiRequest(HttpServletRequest request, HttpServletResponse response, FilterChain nextFilter)
-            throws IOException
+    public void handleUiRequest(ContainerRequestContext request)
     {
-        response.sendError(SC_NOT_FOUND);
+        request.abortWith(Response.status(NOT_FOUND).build());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/PasswordManagerFormAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/PasswordManagerFormAuthenticator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+import io.prestosql.server.security.PasswordAuthenticatorManager;
+import io.prestosql.server.security.SecurityConfig;
+import io.prestosql.spi.security.AccessDeniedException;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class PasswordManagerFormAuthenticator
+        implements FormAuthenticator
+{
+    private final PasswordAuthenticatorManager passwordAuthenticatorManager;
+    private final boolean insecureAuthenticationOverHttpAllowed;
+
+    @Inject
+    public PasswordManagerFormAuthenticator(PasswordAuthenticatorManager passwordAuthenticatorManager, SecurityConfig securityConfig)
+    {
+        this.passwordAuthenticatorManager = requireNonNull(passwordAuthenticatorManager, "passwordAuthenticatorManager is null");
+        passwordAuthenticatorManager.setRequired();
+        this.insecureAuthenticationOverHttpAllowed = requireNonNull(securityConfig, "securityConfig is null").isInsecureAuthenticationOverHttpAllowed();
+    }
+
+    @Override
+    public boolean isLoginEnabled(boolean secure)
+    {
+        // unsecured requests support username-only authentication (no password)
+        // secured requests require a password authenticator
+        if (secure) {
+            return true;
+        }
+        return insecureAuthenticationOverHttpAllowed;
+    }
+
+    @Override
+    public boolean isPasswordAllowed(boolean secure)
+    {
+        return secure;
+    }
+
+    @Override
+    public boolean isValidCredential(String username, String password, boolean secure)
+    {
+        if (username == null) {
+            return false;
+        }
+
+        if (!secure) {
+            return insecureAuthenticationOverHttpAllowed && password == null;
+        }
+
+        try {
+            passwordAuthenticatorManager.getAuthenticator().createAuthenticatedPrincipal(username, password);
+            return true;
+        }
+        catch (AccessDeniedException e) {
+            return false;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/UiQueryResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/UiQueryResource.java
@@ -19,6 +19,7 @@ import io.prestosql.execution.QueryInfo;
 import io.prestosql.execution.QueryState;
 import io.prestosql.security.AccessControl;
 import io.prestosql.server.BasicQueryInfo;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.security.AccessDeniedException;
@@ -48,6 +49,7 @@ import static io.prestosql.security.AccessControlUtil.checkCanKillQueryOwnedBy;
 import static io.prestosql.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.prestosql.security.AccessControlUtil.filterQueries;
 import static io.prestosql.server.HttpRequestSessionContext.extractAuthorizedIdentity;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
 
 @Path("/ui/api/query")
@@ -65,6 +67,7 @@ public class UiQueryResource
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     public List<BasicQueryInfo> getAllQueryInfo(@QueryParam("state") String stateFilter, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
     {
@@ -82,6 +85,7 @@ public class UiQueryResource
         return builder.build();
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path("{queryId}")
     public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -101,6 +105,7 @@ public class UiQueryResource
         return Response.status(Status.GONE).build();
     }
 
+    @ResourceSecurity(WEB_UI)
     @PUT
     @Path("{queryId}/killed")
     public Response killQuery(@PathParam("queryId") QueryId queryId, String message, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
@@ -108,6 +113,7 @@ public class UiQueryResource
         return failQuery(queryId, createKillQueryException(message), servletRequest, httpHeaders);
     }
 
+    @ResourceSecurity(WEB_UI)
     @PUT
     @Path("{queryId}/preempted")
     public Response preemptQuery(@PathParam("queryId") QueryId queryId, String message, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationFilter.java
@@ -13,19 +13,12 @@
  */
 package io.prestosql.server.ui;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.Scopes;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestFilter;
 
-import static io.airlift.configuration.ConfigBinder.configBinder;
-
-public class FixedUiAuthenticatorModule
-        implements Module
+@Priority(Priorities.AUTHENTICATION)
+public interface WebUiAuthenticationFilter
+        extends ContainerRequestFilter
 {
-    @Override
-    public void configure(Binder binder)
-    {
-        binder.bind(WebUiAuthenticationFilter.class).to(FixedUserWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(FixedUserWebUiConfig.class);
-    }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationManager.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationManager.java
@@ -13,21 +13,15 @@
  */
 package io.prestosql.server.ui;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
 
 public interface WebUiAuthenticationManager
 {
-    static boolean isUiRequest(HttpServletRequest request)
+    static boolean isUiRequest(ContainerRequestContext request)
     {
-        String pathInfo = request.getPathInfo();
-        return pathInfo == null || pathInfo.equals("/") || pathInfo.startsWith("/ui");
+        String path = request.getUriInfo().getRequestUri().getPath();
+        return path == null || path.equals("/") || path.startsWith("/ui");
     }
 
-    void handleUiRequest(HttpServletRequest request, HttpServletResponse response, FilterChain nextFilter)
-            throws IOException, ServletException;
+    void handleUiRequest(ContainerRequestContext request);
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
@@ -115,7 +115,11 @@ public class WebUiAuthenticationModule
             }
             // otherwise use the first authenticator, or if there are no authenticators
             // configured, use form for the UI since it handles this case
-            return authenticationTypes.stream().findFirst().orElse("form");
+            authentication = authenticationTypes.stream().findFirst().orElseThrow(() -> new IllegalArgumentException("authenticatorTypes is empty"));
+            if (authentication.equals("insecure")) {
+                return "form";
+            }
+            return authentication;
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
@@ -45,7 +45,8 @@ public class WebUiAuthenticationModule
     {
         configBinder(binder).bindConfig(WebUiAuthenticationConfig.class);
 
-        installWebUiAuthenticator("form", new FormUiAuthenticatorModule());
+        installWebUiAuthenticator("insecure", new FormUiAuthenticatorModule(false));
+        installWebUiAuthenticator("form", new FormUiAuthenticatorModule(true));
         installWebUiAuthenticator("fixed", new FixedUiAuthenticatorModule());
 
         installWebUiAuthenticator("certificate", CertificateAuthenticator.class, CertificateConfig.class);
@@ -72,7 +73,7 @@ public class WebUiAuthenticationModule
     {
         checkArgument(name.toLowerCase(ENGLISH).equals(name), "name is not lower case: %s", name);
         Module authModule = binder -> {
-            binder.install(new FormUiAuthenticatorModule());
+            binder.install(new FormUiAuthenticatorModule(false));
             newOptionalBinder(binder, Key.get(Authenticator.class, ForWebUi.class)).setBinding().to(clazz).in(SINGLETON);
         };
         return webUiAuthenticator(name, Modules.combine(module, authModule));
@@ -113,13 +114,8 @@ public class WebUiAuthenticationModule
             if (authenticationTypes.contains("password")) {
                 return "form";
             }
-            // otherwise use the first authenticator, or if there are no authenticators
-            // configured, use form for the UI since it handles this case
-            authentication = authenticationTypes.stream().findFirst().orElseThrow(() -> new IllegalArgumentException("authenticatorTypes is empty"));
-            if (authentication.equals("insecure")) {
-                return "form";
-            }
-            return authentication;
+            // otherwise use the first authenticator type
+            return authenticationTypes.stream().findFirst().orElseThrow(() -> new IllegalArgumentException("authenticatorTypes is empty"));
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiModule.java
@@ -18,7 +18,6 @@ import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 
 public class WebUiModule
@@ -27,7 +26,7 @@ public class WebUiModule
     @Override
     protected void setup(Binder binder)
     {
-        httpServerBinder(binder).bindResource("/ui", "webapp").withWelcomeFile("index.html");
+        jaxrsBinder(binder).bind(WebUiStaticResource.class);
 
         configBinder(binder).bindConfig(WebUiConfig.class);
 

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiModule.java
@@ -37,7 +37,7 @@ public class WebUiModule
             jaxrsBinder(binder).bind(UiQueryResource.class);
         }
         else {
-            binder.bind(WebUiAuthenticationManager.class).to(DisabledWebUiAuthenticationManager.class).in(Scopes.SINGLETON);
+            binder.bind(WebUiAuthenticationFilter.class).to(DisabledWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiStaticResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiStaticResource.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.server.ui;
 
+import io.prestosql.server.security.ResourceSecurity;
+
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -26,11 +28,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 @Path("")
 public class WebUiStaticResource
 {
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("/")
     public Response getRoot()
@@ -38,6 +43,7 @@ public class WebUiStaticResource
         return Response.seeOther(URI.create("/ui/")).build();
     }
 
+    @ResourceSecurity(PUBLIC)
     @GET
     @Path("/ui")
     public Response getUi()
@@ -45,6 +51,7 @@ public class WebUiStaticResource
         return Response.seeOther(URI.create("/ui/")).build();
     }
 
+    @ResourceSecurity(WEB_UI)
     @POST
     @Path("/ui/{path: .*}")
     public Response postFile(@PathParam("path") String path)
@@ -55,6 +62,7 @@ public class WebUiStaticResource
         return Response.status(NOT_FOUND).build();
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path("/ui/{path: .*}")
     public Response getFile(@PathParam("path") String path, @Context ServletContext servletContext)

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiStaticResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiStaticResource.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.ui;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("")
+public class WebUiStaticResource
+{
+    @GET
+    @Path("/")
+    public Response getRoot()
+    {
+        return Response.seeOther(URI.create("/ui/")).build();
+    }
+
+    @GET
+    @Path("/ui")
+    public Response getUi()
+    {
+        return Response.seeOther(URI.create("/ui/")).build();
+    }
+
+    @POST
+    @Path("/ui/{path: .*}")
+    public Response postFile(@PathParam("path") String path)
+    {
+        // The "getFile" resource method matches all GET requests, and without a
+        // resource for POST requests, a METHOD_NOT_ALLOWED error will be returned
+        // instead of a NOT_FOUND error
+        return Response.status(NOT_FOUND).build();
+    }
+
+    @GET
+    @Path("/ui/{path: .*}")
+    public Response getFile(@PathParam("path") String path, @Context ServletContext servletContext)
+            throws IOException
+    {
+        if (path.isEmpty()) {
+            path = "index.html";
+        }
+
+        String fullPath = "/webapp/" + path;
+        if (!isCanonical(fullPath)) {
+            // consider redirecting to the absolute path
+            return Response.status(NOT_FOUND).build();
+        }
+
+        URL resource = getClass().getResource(fullPath);
+        if (resource == null) {
+            return Response.status(NOT_FOUND).build();
+        }
+
+        return Response.ok(resource.openStream(), servletContext.getMimeType(resource.toString())).build();
+    }
+
+    private static boolean isCanonical(String fullPath)
+    {
+        try {
+            return new URI(fullPath).normalize().getPath().equals(fullPath);
+        }
+        catch (URISyntaxException e) {
+            return false;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ui/WorkerResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WorkerResource.java
@@ -24,6 +24,7 @@ import io.prestosql.metadata.InternalNodeManager;
 import io.prestosql.metadata.NodeState;
 import io.prestosql.security.AccessControl;
 import io.prestosql.server.ForWorkerInfo;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.GroupProvider;
@@ -50,6 +51,7 @@ import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.prestosql.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.prestosql.server.HttpRequestSessionContext.extractAuthorizedIdentity;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
@@ -79,6 +81,7 @@ public class WorkerResource
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path("{nodeId}/status")
     public Response getStatus(@PathParam("nodeId") String nodeId)
@@ -86,6 +89,7 @@ public class WorkerResource
         return proxyJsonResponse(nodeId, "v1/status");
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path("{nodeId}/thread")
     public Response getThreads(@PathParam("nodeId") String nodeId)
@@ -93,6 +97,7 @@ public class WorkerResource
         return proxyJsonResponse(nodeId, "v1/thread");
     }
 
+    @ResourceSecurity(WEB_UI)
     @GET
     @Path("{nodeId}/task/{taskId}")
     public Response getThreads(

--- a/presto-main/src/main/resources/webapp/login.html
+++ b/presto-main/src/main/resources/webapp/login.html
@@ -96,16 +96,18 @@
 </div>
 
 <script>
+    var hidePassword = false; // This value will be replaced
+
     var redirectPath = window.location.search.substring(1);
     if (redirectPath.indexOf('&') !== -1) {
         redirectPath = redirectPath.substring(0, redirectPath.indexOf('&'));
     }
     $("#redirectPath").val(redirectPath);
 
-    if (window.location.protocol !== 'https:') {
+    if (hidePassword) {
         $("#password")
                 .prop('required', false)
-                .prop('placeholder', 'Password not allowed over HTTP')
+                .prop('placeholder', 'Password not allowed')
                 .prop('readonly', true);
     }
     $("#login").show();

--- a/presto-main/src/test/java/io/prestosql/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/io/prestosql/security/TestFileBasedSystemAccessControl.java
@@ -175,6 +175,31 @@ public class TestFileBasedSystemAccessControl
     }
 
     @Test
+    public void testSystemInformation()
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "system_information.json");
+
+        accessControlManager.checkCanReadSystemInformation(admin);
+        accessControlManager.checkCanWriteSystemInformation(admin);
+
+        accessControlManager.checkCanReadSystemInformation(nonAsciiUser);
+        accessControlManager.checkCanWriteSystemInformation(nonAsciiUser);
+
+        accessControlManager.checkCanReadSystemInformation(admin);
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanWriteSystemInformation(alice);
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanReadSystemInformation(bob);
+        }));
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanWriteSystemInformation(bob);
+        }));
+    }
+
+    @Test
     public void testCatalogOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();

--- a/presto-main/src/test/java/io/prestosql/server/TestGenerateTokenFilter.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestGenerateTokenFilter.java
@@ -21,6 +21,7 @@ import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.client.jetty.JettyHttpClient;
+import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.server.testing.TestingPrestoServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -43,6 +44,7 @@ import static io.airlift.http.client.TraceTokenRequestFilter.TRACETOKEN_HEADER;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.Closeables.closeQuietly;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.testng.Assert.assertEquals;
@@ -93,6 +95,7 @@ public class TestGenerateTokenFilter
     @Path("/testing")
     public static class TestResource
     {
+        @ResourceSecurity(PUBLIC)
         @GET
         @Path("/echo_token")
         public String echoToken(@HeaderParam(TRACETOKEN_HEADER) String token)

--- a/presto-main/src/test/java/io/prestosql/server/TestNodeResource.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestNodeResource.java
@@ -26,6 +26,7 @@ import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandl
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.testing.Closeables.closeQuietly;
+import static io.prestosql.client.PrestoHeaders.PRESTO_USER;
 import static io.prestosql.failuredetector.HeartbeatFailureDetector.Stats;
 import static org.testng.Assert.assertTrue;
 
@@ -52,7 +53,10 @@ public class TestNodeResource
     public void testGetAllNodes()
     {
         List<Stats> nodes = client.execute(
-                prepareGet().setUri(server.resolve("/v1/node")).build(),
+                prepareGet()
+                        .setUri(server.resolve("/v1/node"))
+                        .setHeader(PRESTO_USER, "unknown")
+                        .build(),
                 createJsonResponseHandler(listJsonCodec(Stats.class)));
 
         // we only have one node and the list never contains the current node
@@ -63,7 +67,10 @@ public class TestNodeResource
     public void testGetFailedNodes()
     {
         List<Stats> nodes = client.execute(
-                prepareGet().setUri(server.resolve("/v1/node/failed")).build(),
+                prepareGet()
+                        .setUri(server.resolve("/v1/node/failed"))
+                        .setHeader(PRESTO_USER, "unknown")
+                        .build(),
                 createJsonResponseHandler(listJsonCodec(Stats.class)));
 
         assertTrue(nodes.isEmpty());

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfoResource.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfoResource.java
@@ -207,7 +207,10 @@ public class TestQueryStateInfoResource
     public void testGetQueryStateInfoNo()
     {
         client.execute(
-                prepareGet().setUri(server.resolve("/v1/queryState/123")).build(),
+                prepareGet()
+                        .setUri(server.resolve("/v1/queryState/123"))
+                        .setHeader(PRESTO_USER, "unknown")
+                        .build(),
                 createJsonResponseHandler(jsonCodec(QueryStateInfo.class)));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/server/TestServer.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServer.java
@@ -276,6 +276,7 @@ public class TestServer
     {
         Request request = prepareHead()
                 .setUri(uriFor("/v1/status"))
+                .setHeader(PRESTO_USER, "unknown")
                 .setFollowRedirects(false)
                 .build();
         StatusResponse response = client.execute(request, createStatusResponseHandler());

--- a/presto-main/src/test/java/io/prestosql/server/security/TestResourceSecurity.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestResourceSecurity.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.google.inject.Key;
+import io.airlift.http.server.HttpServerInfo;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.prestosql.plugin.base.security.AllowAllSystemAccessControl;
+import io.prestosql.security.AccessControlManager;
+import io.prestosql.server.testing.TestingPrestoServer;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.BasicPrincipal;
+import io.prestosql.spi.security.SystemSecurityContext;
+import okhttp3.Credentials;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.Principal;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.prestosql.client.OkHttpUtil.setupSsl;
+import static io.prestosql.client.PrestoHeaders.PRESTO_USER;
+import static io.prestosql.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
+import static io.prestosql.testing.assertions.Assert.assertEquals;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
+@Test
+public class TestResourceSecurity
+{
+    private static final String LOCALHOST_KEYSTORE = Resources.getResource("cert/localhost.pem").getPath();
+    private static final ImmutableMap<String, String> SECURE_PROPERTIES = ImmutableMap.<String, String>builder()
+            .put("http-server.https.enabled", "true")
+            .put("http-server.https.keystore.path", LOCALHOST_KEYSTORE)
+            .put("http-server.https.keystore.key", "")
+            .put("http-server.process-forwarded", "true")
+            .build();
+    private static final String TEST_USER = "test-user";
+    private static final String TEST_PASSWORD = "test-password";
+    private static final String MANAGEMENT_USER = "management-user";
+    private static final String MANAGEMENT_PASSWORD = "management-password";
+    private static final String HMAC_KEY = Resources.getResource("hmac_key.txt").getPath();
+
+    private OkHttpClient client;
+
+    @BeforeClass
+    public void setup()
+    {
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
+                .followRedirects(false);
+        setupSsl(
+                clientBuilder,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(LOCALHOST_KEYSTORE),
+                Optional.empty());
+        client = clientBuilder.build();
+    }
+
+    @Test
+    public void testInsecureAuthenticatorHttp()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertInsecureAuthentication(httpServerInfo.getHttpUri());
+        }
+    }
+
+    @Test
+    public void testInsecureAuthenticatorHttps()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(SECURE_PROPERTIES)
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertInsecureAuthentication(httpServerInfo.getHttpUri());
+            assertInsecureAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testInsecureAuthenticatorHttpsOnly()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.allow-insecure-over-http", "false")
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertAuthenticationDisabled(httpServerInfo.getHttpUri());
+            assertInsecureAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testPasswordAuthenticator()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "password")
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestResourceSecurity::authenticate);
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertAuthenticationDisabled(httpServerInfo.getHttpUri());
+            assertPasswordAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testPasswordAuthenticatorWithInsecureHttp()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.authentication.allow-insecure-over-http", "true")
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestResourceSecurity::authenticate);
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertInsecureAuthentication(httpServerInfo.getHttpUri());
+            assertPasswordAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testFixedManagerAuthenticatorHttpInsecureEnabledOnly()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.authentication.allow-insecure-over-http", "true")
+                        .put("management.user", MANAGEMENT_USER)
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestResourceSecurity::authenticate);
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertFixedManagementUser(httpServerInfo.getHttpUri(), true);
+            assertPasswordAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testFixedManagerAuthenticatorHttpInsecureDisabledOnly()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.authentication.allow-insecure-over-http", "false")
+                        .put("management.user", MANAGEMENT_USER)
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestResourceSecurity::authenticate);
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertResponseCode(client, getPublicLocation(httpServerInfo.getHttpUri()), SC_OK);
+            assertResponseCode(client, getAuthorizedUserLocation(httpServerInfo.getHttpUri()), SC_FORBIDDEN, TEST_USER, null);
+            assertResponseCode(client, getManagementLocation(httpServerInfo.getHttpUri()), SC_OK);
+            assertResponseCode(client, getManagementLocation(httpServerInfo.getHttpUri()), SC_OK, "unknown", "something");
+
+            assertPasswordAuthentication(httpServerInfo.getHttpsUri());
+        }
+    }
+
+    @Test
+    public void testFixedManagerAuthenticatorHttps()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.authentication.allow-insecure-over-http", "true")
+                        .put("management.user", MANAGEMENT_USER)
+                        .put("management.user.https-enabled", "true")
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestResourceSecurity::authenticate);
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertFixedManagementUser(httpServerInfo.getHttpUri(), true);
+            assertFixedManagementUser(httpServerInfo.getHttpsUri(), false);
+        }
+    }
+
+    @Test
+    public void testCertAuthenticator()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "certificate")
+                        .put("http-server.https.truststore.path", LOCALHOST_KEYSTORE)
+                        .put("http-server.https.truststore.key", "")
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+
+            assertAuthenticationDisabled(httpServerInfo.getHttpUri());
+
+            OkHttpClient.Builder clientBuilder = client.newBuilder();
+            setupSsl(
+                    clientBuilder,
+                    Optional.of(LOCALHOST_KEYSTORE),
+                    Optional.empty(),
+                    Optional.of(LOCALHOST_KEYSTORE),
+                    Optional.empty());
+            OkHttpClient clientWithCert = clientBuilder.build();
+            assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithCert);
+        }
+    }
+
+    @Test
+    public void testJwtAuthenticator()
+            throws Exception
+    {
+        try (TestingPrestoServer server = TestingPrestoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "jwt")
+                        .put("http-server.authentication.jwt.key-file", HMAC_KEY)
+                        .build())
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+
+            assertAuthenticationDisabled(httpServerInfo.getHttpUri());
+
+            String hmac = Files.readString(Paths.get(HMAC_KEY));
+            String token = Jwts.builder()
+                    .signWith(SignatureAlgorithm.HS256, hmac)
+                    .setSubject("test-user")
+                    .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .compact();
+
+            OkHttpClient clientWithJwt = client.newBuilder()
+                    .authenticator((route, response) -> response.request().newBuilder()
+                            .header(AUTHORIZATION, "Bearer " + token)
+                            .build())
+                    .build();
+            assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithJwt);
+        }
+    }
+
+    private void assertInsecureAuthentication(URI baseUri)
+            throws IOException
+    {
+        // public
+        assertOk(client, getPublicLocation(baseUri));
+        // authorized user
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_UNAUTHORIZED);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_OK, "unknown", null);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_UNAUTHORIZED, "unknown", "something");
+        // management
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN, "unknown", null);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, "unknown", "something");
+        assertResponseCode(client, getManagementLocation(baseUri), SC_OK, MANAGEMENT_USER, null);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, MANAGEMENT_USER, "something");
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, MANAGEMENT_USER, MANAGEMENT_PASSWORD);
+        // internal
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN, "unknown", null);
+    }
+
+    private void assertPasswordAuthentication(URI baseUri)
+            throws IOException
+    {
+        // public
+        assertOk(client, getPublicLocation(baseUri));
+        // authorized user
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_UNAUTHORIZED);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_UNAUTHORIZED, TEST_USER, null);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_UNAUTHORIZED, TEST_USER, "invalid");
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_OK, TEST_USER, TEST_PASSWORD);
+        // management
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, TEST_USER, null);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, TEST_USER, "invalid");
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN, TEST_USER, TEST_PASSWORD);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, MANAGEMENT_USER, null);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_UNAUTHORIZED, MANAGEMENT_USER, "invalid");
+        assertResponseCode(client, getManagementLocation(baseUri), SC_OK, MANAGEMENT_USER, MANAGEMENT_PASSWORD);
+        // internal
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN, TEST_USER, TEST_PASSWORD);
+    }
+
+    private static void assertAuthenticationAutomatic(URI baseUri, OkHttpClient authorizedClient)
+            throws IOException
+    {
+        // public
+        assertResponseCode(authorizedClient, getPublicLocation(baseUri), SC_OK);
+        // authorized user
+        assertResponseCode(authorizedClient, getAuthorizedUserLocation(baseUri), SC_OK);
+        // management
+        assertResponseCode(authorizedClient, getManagementLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(authorizedClient, getManagementLocation(baseUri), SC_OK, Headers.of(PRESTO_USER, MANAGEMENT_USER));
+        // internal
+        assertResponseCode(authorizedClient, getInternalLocation(baseUri), SC_FORBIDDEN);
+    }
+
+    private void assertAuthenticationDisabled(URI baseUri)
+            throws IOException
+    {
+        // public
+        assertOk(client, getPublicLocation(baseUri));
+        // authorized user
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_FORBIDDEN, "unknown", null);
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_FORBIDDEN, "unknown", "something");
+        assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_FORBIDDEN, TEST_USER, TEST_PASSWORD);
+        // management
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN, "unknown", null);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN, "unknown", "something");
+        assertResponseCode(client, getManagementLocation(baseUri), SC_FORBIDDEN, TEST_USER, TEST_PASSWORD);
+        // internal
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN);
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN, "unknown", null);
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN, "unknown", "something");
+        assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN, TEST_USER, TEST_PASSWORD);
+    }
+
+    private void assertFixedManagementUser(URI baseUri, boolean insecureAuthentication)
+            throws IOException
+    {
+        assertResponseCode(client, getPublicLocation(baseUri), SC_OK);
+        if (insecureAuthentication) {
+            assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_OK, TEST_USER, null);
+        }
+        else {
+            assertResponseCode(client, getAuthorizedUserLocation(baseUri), SC_OK, TEST_USER, TEST_PASSWORD);
+        }
+        assertResponseCode(client, getManagementLocation(baseUri), SC_OK);
+        assertResponseCode(client, getManagementLocation(baseUri), SC_OK, "unknown", "something");
+    }
+
+    private static void assertOk(OkHttpClient client, String url)
+            throws IOException
+    {
+        assertResponseCode(client, url, SC_OK, null, null);
+    }
+
+    private static void assertResponseCode(OkHttpClient client, String url, int expectedCode)
+            throws IOException
+    {
+        assertResponseCode(client, url, expectedCode, null, null);
+    }
+
+    private static void assertResponseCode(OkHttpClient client,
+            String url,
+            int expectedCode,
+            String userName,
+            String password)
+            throws IOException
+    {
+        assertResponseCode(client, url, expectedCode, Headers.of("Authorization", Credentials.basic(firstNonNull(userName, ""), firstNonNull(password, ""))));
+    }
+
+    private static void assertResponseCode(OkHttpClient client,
+            String url,
+            int expectedCode,
+            Headers headers)
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url(url)
+                .headers(headers)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(response.code(), expectedCode, url);
+        }
+    }
+
+    private static String getInternalLocation(URI baseUri)
+    {
+        return getLocation(baseUri, "/v1/task");
+    }
+
+    private static String getManagementLocation(URI baseUri)
+    {
+        return getLocation(baseUri, "/v1/node");
+    }
+
+    private static String getAuthorizedUserLocation(URI baseUri)
+    {
+        return getLocation(baseUri, "/v1/query");
+    }
+
+    private static String getPublicLocation(URI baseUri)
+    {
+        return getLocation(baseUri, "/v1/info");
+    }
+
+    private static String getLocation(URI baseUri, String path)
+    {
+        return uriBuilderFrom(baseUri).replacePath(path).toString();
+    }
+
+    private static Principal authenticate(String user, String password)
+    {
+        if ((TEST_USER.equals(user) && TEST_PASSWORD.equals(password)) || (MANAGEMENT_USER.equals(user) && MANAGEMENT_PASSWORD.equals(password))) {
+            return new BasicPrincipal(user);
+        }
+        throw new AccessDeniedException("Invalid credentials");
+    }
+
+    private static class TestSystemAccessControl
+            extends AllowAllSystemAccessControl
+    {
+        @Override
+        public void checkCanReadSystemInformation(SystemSecurityContext context)
+        {
+            if (!context.getIdentity().getUser().equals(MANAGEMENT_USER)) {
+                denyReadSystemInformationAccess();
+            }
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
@@ -29,7 +29,8 @@ public class TestSecurityConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SecurityConfig.class)
-                .setAuthenticationTypes("insecure"));
+                .setAuthenticationTypes("insecure")
+                .setInsecureAuthenticationOverHttpAllowed(true));
     }
 
     @Test
@@ -37,10 +38,12 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
+                .put("http-server.authentication.allow-insecure-over-http", "false")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
-                .setAuthenticationTypes(ImmutableList.of("KERBEROS", "PASSWORD"));
+                .setAuthenticationTypes(ImmutableList.of("KERBEROS", "PASSWORD"))
+                .setInsecureAuthenticationOverHttpAllowed(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
@@ -30,7 +30,9 @@ public class TestSecurityConfig
     {
         assertRecordedDefaults(recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("insecure")
-                .setInsecureAuthenticationOverHttpAllowed(true));
+                .setInsecureAuthenticationOverHttpAllowed(true)
+                .setFixedManagementUser(null)
+                .setFixedManagementUserForHttps(false));
     }
 
     @Test
@@ -39,11 +41,15 @@ public class TestSecurityConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
                 .put("http-server.authentication.allow-insecure-over-http", "false")
+                .put("management.user", "management-user")
+                .put("management.user.https-enabled", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of("KERBEROS", "PASSWORD"))
-                .setInsecureAuthenticationOverHttpAllowed(false);
+                .setInsecureAuthenticationOverHttpAllowed(false)
+                .setFixedManagementUser("management-user")
+                .setFixedManagementUserForHttps(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
@@ -29,7 +29,7 @@ public class TestSecurityConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SecurityConfig.class)
-                .setAuthenticationTypes(""));
+                .setAuthenticationTypes("insecure"));
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/server/ui/TestWebUi.java
+++ b/presto-main/src/test/java/io/prestosql/server/ui/TestWebUi.java
@@ -28,6 +28,7 @@ import okhttp3.FormBody;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -53,6 +54,8 @@ import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.testing.Closeables.closeQuietly;
 import static io.prestosql.client.OkHttpUtil.setupSsl;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGIN;
+import static io.prestosql.server.ui.FormWebUiAuthenticationManager.UI_LOGOUT;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
@@ -474,6 +477,13 @@ public class TestWebUi
         Request request = new Request.Builder()
                 .url(url)
                 .build();
+        if (url.endsWith(UI_LOGIN)) {
+            RequestBody formBody = new FormBody.Builder()
+                    .add("username", "test")
+                    .add("password", "test")
+                    .build();
+            request = request.newBuilder().post(formBody).build();
+        }
         try (Response response = client.newCall(request).execute()) {
             assertEquals(response.code(), SC_SEE_OTHER);
             assertEquals(response.header(LOCATION), redirectLocation);
@@ -591,6 +601,13 @@ public class TestWebUi
         Request request = new Request.Builder()
                 .url(url)
                 .build();
+        if (url.endsWith(UI_LOGIN)) {
+            RequestBody formBody = new FormBody.Builder()
+                    .add("username", "fake")
+                    .add("password", "bad")
+                    .build();
+            request = request.newBuilder().post(formBody).build();
+        }
         Response response = client.newCall(request).execute();
         assertEquals(response.code(), expectedCode);
         return response;
@@ -616,12 +633,12 @@ public class TestWebUi
 
     private static String getLoginLocation(URI httpsUrl)
     {
-        return getLocation(httpsUrl, "/ui/login");
+        return getLocation(httpsUrl, UI_LOGIN);
     }
 
     private static String getLogoutLocation(URI baseUri)
     {
-        return getLocation(baseUri, "/ui/logout");
+        return getLocation(baseUri, UI_LOGOUT);
     }
 
     private static String getDisabledLocation(URI baseUri)

--- a/presto-main/src/test/resources/system_information.json
+++ b/presto-main/src/test/resources/system_information.json
@@ -1,0 +1,21 @@
+{
+  "catalogs": [
+    {
+      "allow": true
+    }
+  ],
+  "system_information": [
+    {
+      "user": "admin",
+      "allow": ["read", "write"]
+    },
+    {
+      "user": "alice",
+      "allow": ["read"]
+    },
+    {
+      "user": "\u0194\u0194\u0194",
+      "allow": ["read", "write"]
+    }
+  ]
+}

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllSystemAccessControl.java
@@ -73,6 +73,16 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    {
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    {
+    }
+
+    @Override
     public void checkCanExecuteQuery(SystemSecurityContext context)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
@@ -302,6 +302,16 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
+    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    {
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    {
+    }
+
+    @Override
     public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControlRules.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControlRules.java
@@ -26,6 +26,7 @@ public class FileBasedSystemAccessControlRules
     private final Optional<List<QueryAccessRule>> queryAccessRules;
     private final Optional<List<ImpersonationRule>> impersonationRules;
     private final Optional<List<PrincipalUserMatchRule>> principalUserMatchRules;
+    private final Optional<List<SystemInformationRule>> systemInformationRules;
     private final Optional<List<SchemaAccessControlRule>> schemaRules;
     private final Optional<List<TableAccessControlRule>> tableRules;
 
@@ -35,6 +36,7 @@ public class FileBasedSystemAccessControlRules
             @JsonProperty("queries") Optional<List<QueryAccessRule>> queryAccessRules,
             @JsonProperty("impersonation") Optional<List<ImpersonationRule>> impersonationRules,
             @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules,
+            @JsonProperty("system_information") Optional<List<SystemInformationRule>> systemInformationRules,
             @JsonProperty("schemas") Optional<List<SchemaAccessControlRule>> schemaAccessControlRules,
             @JsonProperty("tables") Optional<List<TableAccessControlRule>> tableAccessControlRules)
     {
@@ -42,6 +44,7 @@ public class FileBasedSystemAccessControlRules
         this.queryAccessRules = queryAccessRules.map(ImmutableList::copyOf);
         this.principalUserMatchRules = principalUserMatchRules.map(ImmutableList::copyOf);
         this.impersonationRules = impersonationRules.map(ImmutableList::copyOf);
+        this.systemInformationRules = systemInformationRules.map(ImmutableList::copyOf);
         this.schemaRules = schemaAccessControlRules.map(ImmutableList::copyOf);
         this.tableRules = tableAccessControlRules.map(ImmutableList::copyOf);
     }
@@ -64,6 +67,11 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<PrincipalUserMatchRule>> getPrincipalUserMatchRules()
     {
         return principalUserMatchRules;
+    }
+
+    public Optional<List<SystemInformationRule>> getSystemInformationRules()
+    {
+        return systemInformationRules;
     }
 
     public Optional<List<SchemaAccessControlRule>> getSchemaRules()

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingSystemAccessControl.java
@@ -65,6 +65,18 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    {
+        delegate().checkCanReadSystemInformation(context);
+    }
+
+    @Override
+    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    {
+        delegate().checkCanWriteSystemInformation(context);
+    }
+
+    @Override
     public void checkCanExecuteQuery(SystemSecurityContext context)
     {
         delegate().checkCanExecuteQuery(context);

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/SystemInformationRule.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/SystemInformationRule.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class SystemInformationRule
+{
+    private final Set<AccessMode> allow;
+    private final Optional<Pattern> userRegex;
+
+    @JsonCreator
+    public SystemInformationRule(
+            @JsonProperty("allow") Set<AccessMode> allow,
+            @JsonProperty("user") Optional<Pattern> userRegex)
+    {
+        this.allow = ImmutableSet.copyOf(requireNonNull(allow, "allow is null"));
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+    }
+
+    public Optional<Set<AccessMode>> match(String user)
+    {
+        if (userRegex.map(regex -> regex.matcher(user).matches()).orElse(true)) {
+            return Optional.of(allow);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("allow", allow)
+                .add("userRegex", userRegex.orElse(null))
+                .toString();
+    }
+
+    public enum AccessMode
+    {
+        READ("read"),
+        WRITE("write");
+
+        private static final Map<String, AccessMode> modeByName = stream(values()).collect(toImmutableMap(AccessMode::toString, identity()));
+
+        private final String stringValue;
+
+        AccessMode(String stringValue)
+        {
+            this.stringValue = requireNonNull(stringValue, "stringValue is null");
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return stringValue;
+        }
+
+        @JsonCreator
+        public static AccessMode fromJson(Object value)
+        {
+            if (value instanceof String) {
+                AccessMode accessMode = modeByName.get(((String) value).toLowerCase(Locale.US));
+                if (accessMode != null) {
+                    return accessMode;
+                }
+            }
+
+            throw new IllegalArgumentException("Unknown " + AccessMode.class.getSimpleName() + ": " + value);
+        }
+    }
+}

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -406,7 +406,7 @@ public class TestFileBasedSystemAccessControl
     }
 
     @Test
-    public void testDocsExample()
+    public void testQueryDocsExample()
     {
         String rulesFile = new File("../presto-docs/src/main/sphinx/security/query-access.json").getAbsolutePath();
         SystemAccessControl accessControlManager = newFileBasedSystemAccessControl(ImmutableMap.of("security.config-file", rulesFile));
@@ -425,6 +425,49 @@ public class TestFileBasedSystemAccessControl
         assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(bob, queryId), "any"));
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(bob, queryId), ImmutableSet.of("a", "b")), ImmutableSet.of());
         assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(bob, queryId), "any"));
+    }
+
+    @Test
+    public void testSystemInformation()
+    {
+        SystemAccessControl accessControlManager = newFileBasedSystemAccessControl("system-information.json");
+
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, Optional.empty()));
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, Optional.empty())));
+
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
+
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(nonAsciiUser, Optional.empty()));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(nonAsciiUser, Optional.empty()));
+    }
+
+    @Test
+    public void testSystemInformationNotSet()
+    {
+        SystemAccessControl accessControlManager = newFileBasedSystemAccessControl("catalog.json");
+
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
+    }
+
+    @Test
+    public void testSystemInformationDocsExample()
+    {
+        String rulesFile = new File("../presto-docs/src/main/sphinx/security/system-information-access.json").getAbsolutePath();
+        SystemAccessControl accessControlManager = newFileBasedSystemAccessControl(ImmutableMap.of("security.config-file", rulesFile));
+
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, Optional.empty()));
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, Optional.empty())));
+
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
+        assertThrows(AccessDeniedException.class, () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())));
     }
 
     @Test

--- a/presto-plugin-toolkit/src/test/resources/system-information.json
+++ b/presto-plugin-toolkit/src/test/resources/system-information.json
@@ -1,0 +1,21 @@
+{
+  "catalogs": [
+    {
+      "allow": true
+    }
+  ],
+  "system_information": [
+    {
+      "user": "admin",
+      "allow": ["read", "write"]
+    },
+    {
+      "user": "alice",
+      "allow": ["read"]
+    },
+    {
+      "user": "\u0194\u0194\u0194",
+      "allow": ["read", "write"]
+    }
+  ]
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
@@ -51,6 +51,26 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Principal %s cannot become user %s%s", principal.orElse(null), userName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyReadSystemInformationAccess()
+    {
+        denyReadSystemInformationAccess(null);
+    }
+
+    public static void denyReadSystemInformationAccess(String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot read system information%s", formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyWriteSystemInformationAccess()
+    {
+        denyWriteSystemInformationAccess(null);
+    }
+
+    public static void denyWriteSystemInformationAccess(String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot write system information%s", formatExtraInfo(extraInfo)));
+    }
+
     public static void denyExecuteQuery()
     {
         denyExecuteQuery(null);

--- a/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
@@ -132,6 +132,29 @@ public interface SystemAccessControl
     }
 
     /**
+     * Check if identity is allowed to read system information such as statistics,
+     * service registry, thread stacks, etc.  This is typically allowed for administrators
+     * and management tools.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanReadSystemInformation(SystemSecurityContext context)
+    {
+        AccessDeniedException.denyReadSystemInformationAccess();
+    }
+
+    /**
+     * Check if identity is allowed to write system information such as marking nodes
+     * offline, or changing runtime flags.  This is typically allowed for administrators.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanWriteSystemInformation(SystemSecurityContext context)
+    {
+        AccessDeniedException.denyReadSystemInformationAccess();
+    }
+
+    /**
      * Check if identity is allowed to set the specified system property.
      *
      * @throws AccessDeniedException if not allowed


### PR DESCRIPTION
Unless configured for authentication, Presto allow user to connect with any username. In this PR, I make this mode explicit by introducing an "insecure" authenticator. This authenticator retains the existing behavior, any username is allowed, but no password can be sent. The default authenticator type is set to insecure so it is clear in the startup message that authentication is not secured.

In addition, the when secure authentication is configured, insecure authentication over HTTP is disabled by default. This can be reenabled with a configuration setting.