### PR TITLE
Allow decimal datatypes to be returned as numeric values rather than strings

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/io/prestosql/client/FixJsonDataUtils.java
@@ -167,6 +167,10 @@ final class FixJsonDataUtils
             case IPADDRESS:
             case UUID:
             case DECIMAL:
+                if (value instanceof String) {
+                    return new java.math.BigDecimal((String) value);
+                }
+                return new java.math.BigDecimal(((Number) value).toString());
             case CHAR:
             case GEOMETRY:
                 return String.class.cast(value);


### PR DESCRIPTION
At the moment, if a value is of type Decimal or Timestamp, it is returned in the JSON response as a string. This PR was made to fix the former.