### PR TITLE
Fix ClassNotFoundException for benchto-benchmarks-executable.jar

### DIFF
--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -91,6 +91,21 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>1.2.5.RELEASE</version>


### PR DESCRIPTION
Now `benchto-benchmarks-executable.jar` returns `ClassNotFoundException`.

```
$ java -Xmx1g -jar target/presto-benchto-benchmarks-337-SNAPSHOT-executable.jar
java.lang.ClassNotFoundException: io.prestosql.benchto.driver.DriverApp
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at org.springframework.boot.loader.LaunchedURLClassLoader.doLoadClass(LaunchedURLClassLoader.java:170)
	at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:136)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:46)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

- Introduce maven-shade-plugin in presto-benchto-benchmarks sub project

context: https://prestosql.slack.com/archives/CFPVDC4G7/p1572449092001900