### PR TITLE
Fix Iceberg ORC DECIMAL types

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -386,7 +386,7 @@ public class IcebergMetadata
 
         for (NestedField column : icebergTable.schema().columns()) {
             io.prestosql.spi.type.Type type = toPrestoType(column.type(), typeManager);
-            if (type instanceof DecimalType) {
+            if (type instanceof DecimalType && !orcFormat) {
                 throw new PrestoException(NOT_SUPPORTED, "Writing to columns of type decimal not yet supported");
             }
             if (type instanceof TimestampType && !orcFormat) {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TypeConverter.java
@@ -335,8 +335,8 @@ public final class TypeConverter
             case BINARY:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.BINARY, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case DECIMAL:
-                DecimalType decimalType = (DecimalType) type;
-                return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.DECIMAL, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.of(decimalType.getPrecision()), Optional.of(decimalType.getScale()), attributes));
+                Types.DecimalType decimalType = (Types.DecimalType) type;
+                return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.DECIMAL, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.of(decimalType.precision()), Optional.of(decimalType.scale()), attributes));
             case STRUCT:
                 return toOrcStructType(nextFieldTypeIndex, (Types.StructType) type, attributes);
             case LIST:


### PR DESCRIPTION
This commit enables DECIMAL types in Iceberg ORC, and
fixes a couple of bugs in conversion from SPI DecimalType
and BigDecimal used by Iceberg ORC.  It adds some additional
DECIMAL tests in TestIcebergSmoke.  It also adds machinery
that allows the partitioned table unit tests to run with DECIMAL
and TIMESTAMP columns for FileFormat.ORC, and runs the same
tests without DECIMAL and TIMESTAMP for FileFormat.PARQUET,
where they are not yet supported.