### PR TITLE
Explicitly disable transaction hive tables in TestTablePartitioningSelect

### DIFF
--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestTablePartitioningSelect.java
@@ -74,6 +74,7 @@ public class TestTablePartitioningSelect
             sb.append("ROW FORMAT ").append(rowFormat.get());
         }
         sb.append(" STORED AS " + fileFormat);
+        sb.append(" TBLPROPERTIES ('transactional'='false')");
         return sb.toString();
     }
 


### PR DESCRIPTION
Hive 3.1 enables transactional tables when ORC is used by default but the test does not work when run against transactional tables.

~Adding the test to the storage format group so that it runs against hdp3.1 as well.~