### PR TITLE
Fix flaky test in TestThrottledAsyncQueue

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestThrottledAsyncQueue.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestThrottledAsyncQueue.java
@@ -108,10 +108,9 @@ public class TestThrottledAsyncQueue
         assertFalse(future2.isDone());
 
         assertTrue(queue.offer(3).isDone());
-        assertTrue(queue.offer(4).isDone());
         queue.finish();
 
-        assertEquals(getFutureValue(future2), ImmutableList.of(3, 4));
+        assertEquals(getFutureValue(future2), ImmutableList.of(3));
 
         assertTrue(queue.isFinished());
     }


### PR DESCRIPTION
Reported in https://github.com/prestosql/presto/issues/2797, the
"testThrottleEmptyQueue" test can be flaky as the size of the batch
returned after the queue is throttled depends on the order of execution
of the offer() calls and the completion of the not-empty signal future.
Thus, the returned batch could have a size of either 1 or 2 depending on
whether the 2 offer() calls where executed before the not-empty signal
future completes or not.

Because this test only aims at checking that the queue is throttled, we
don't need to test that the batch returned is of more than one element.
Thus, we fix the flaky test by offering only one element, which
gurantees that the returned batch will always be of size 1.