### PR TITLE
Handle nulls for timestamp columns

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/QueryResultRows.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/QueryResultRows.java
@@ -163,15 +163,16 @@ public class QueryResultRows
             Block block = currentPage.getBlock(channel);
 
             try {
-                if (type instanceof TimestampType && !supportsParametricDateTime) {
-                    row.add(channel, ((SqlTimestamp) type.getObjectValue(session, block, inPageIndex)).roundTo(3));
+                Object value = type.getObjectValue(session, block, inPageIndex);
+                if (value != null && !supportsParametricDateTime) {
+                    if (type instanceof TimestampType) {
+                        value = ((SqlTimestamp) value).roundTo(3);
+                    }
+                    else if (type instanceof TimestampWithTimeZoneType) {
+                        value = ((SqlTimestampWithTimeZone) value).roundTo(3);
+                    }
                 }
-                else if (type instanceof TimestampWithTimeZoneType && !supportsParametricDateTime) {
-                    row.add(channel, ((SqlTimestampWithTimeZone) type.getObjectValue(session, block, inPageIndex)).roundTo(3));
-                }
-                else {
-                    row.add(channel, type.getObjectValue(session, block, inPageIndex));
-                }
+                row.add(channel, value);
             }
             catch (Throwable throwable) {
                 propagateException(rowPosition, column, throwable);


### PR DESCRIPTION
Handle nulls for timestamp columns

Otherwise, the query may fail the following message due to
a `NullPointerException` when `PARAMETRIC_DATETIME` is not supported
by the client:

    Could not serialize column '_col0' of type 'timestamp(3)'
