### PR TITLE
Update README for enable error prone check in IDEA

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Disable the following inspections:
 - ``Java | Performance | Call to 'Arrays.asList()' with too few arguments``,
 - ``Java | Abstraction issues | 'Optional' used as field or parameter type``.
 
+Enable errorprone ([Error Prone Installation#IDEA](https://errorprone.info/docs/installation#intellij-idea)):
+- Install ``Error Prone Compiler`` plugin from marketplace,
+- In ``Java Compiler`` tab, select ``Javac with error-prone`` as the compiler,
+- Update ``Additional command line parameters`` with ``-XepExcludedPaths:.*/target/generated-(|test-)sources/.* -XepDisableAllChecks -Xep:MissingOverride:ERROR ......`` (for current recommended list of command line parameters, see the top level ``pom.xml``, the definition of the ``errorprone-compiler-presto`` profile.
+
 ### Building the Web UI
 
 The Presto Web UI is composed of several React components and is written in JSX and ES6. This source code is compiled and packaged into browser-compatible Javascript, which is then checked in to the Presto source code (in the `dist` folder). You must have [Node.js](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/) installed to execute these commands. To update this folder after making changes, simply run:


### PR DESCRIPTION
Related to #4188

I guessed it will be easier to fix error-prone issues by enabling error-prone compiler in IDEA directly, so I update the README and everyone can enable it step-by-step.