### PR TITLE
Make RowDecoder not require null map

### DIFF
--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
@@ -165,8 +165,8 @@ public class KafkaRecordSet
 
             Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
 
-            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData, null);
-            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData, null);
+            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
+            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData);
 
             for (DecoderColumnHandle columnHandle : columnHandles) {
                 if (columnHandle.isInternal()) {

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisRecordSet.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisRecordSet.java
@@ -307,7 +307,7 @@ public class KinesisRecordSet
 
             log.debug("Fetching %d bytes from current record. %d messages read so far", messageData.length, totalMessages);
 
-            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData, null);
+            Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = messageDecoder.decodeRow(messageData);
 
             Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
             for (DecoderColumnHandle columnHandle : columnHandles) {

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -62,6 +62,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/RowDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/RowDecoder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.decoder;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,13 +24,23 @@ import java.util.Optional;
 public interface RowDecoder
 {
     /**
-     * Decodes a given set of bytes into field values.
+     * Decodes a given sequence of bytes into field values.
+     *
+     * @param data The row data to decode.
+     * @return Returns mapping from column handle to decoded value. Unmapped columns will be reported as null. Optional.empty() signals decoding error.
+     */
+    default Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data)
+    {
+        return decodeRow(data, null);
+    }
+
+    /**
+     * Decodes a given sequence of bytes into field values.
      *
      * @param data The row data to decode.
      * @param dataMap The row data as fields map
      * @return Returns mapping from column handle to decoded value. Unmapped columns will be reported as null. Optional.empty() signals decoding error.
      */
-    Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(
-            byte[] data,
-            Map<String, String> dataMap);
+    // TODO This is Redis-specific, move to presto-redis
+    Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(byte[] data, @Nullable Map<String, String> dataMap);
 }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
@@ -166,7 +166,7 @@ public class TestAvroDecoder
     private static Map<DecoderColumnHandle, FieldValueProvider> decodeRow(byte[] avroData, Set<DecoderColumnHandle> columns, Map<String, String> dataParams)
     {
         RowDecoder rowDecoder = DECODER_FACTORY.create(dataParams, columns);
-        return rowDecoder.decodeRow(avroData, null)
+        return rowDecoder.decodeRow(avroData)
                 .orElseThrow(AssertionError::new);
     }
 

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/csv/TestCsvDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/csv/TestCsvDecoder.java
@@ -64,7 +64,7 @@ public class TestCsvDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5, row6, row7);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -95,7 +95,7 @@ public class TestCsvDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5, row6, row7, row8);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -123,7 +123,7 @@ public class TestCsvDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -149,7 +149,7 @@ public class TestCsvDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4, column5, column6);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -245,7 +245,7 @@ public class TestCsvDecoder
         DecoderTestColumnHandle column = new DecoderTestColumnHandle(0, "column", type, "0", null, null, false, false, false);
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
         return decodedRow.get(column);
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/JsonFieldDecoderTester.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/JsonFieldDecoderTester.java
@@ -131,7 +131,7 @@ public class JsonFieldDecoderTester
                 false);
 
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), ImmutableSet.of(columnHandle));
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json.getBytes(UTF_8), null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json.getBytes(UTF_8))
                 .orElseThrow(AssertionError::new);
         assertTrue(decodedRow.containsKey(columnHandle), format("column '%s' not found in decoded row", columnHandle.getName()));
         return decodedRow.get(columnHandle);

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
@@ -73,7 +73,7 @@ public class TestJsonDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4, column5);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -98,7 +98,7 @@ public class TestJsonDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -122,7 +122,7 @@ public class TestJsonDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(json, null);
+        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(json);
         assertTrue(decodedRow.isPresent());
 
         assertEquals(decodedRow.get().size(), columns.size());

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/raw/TestRawDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/raw/TestRawDecoder.java
@@ -60,7 +60,7 @@ public class TestRawDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(emptyRow, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(emptyRow)
                 .orElseThrow(AssertionError::new);
 
         checkIsNull(decodedRow, column);
@@ -88,7 +88,7 @@ public class TestRawDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -114,7 +114,7 @@ public class TestRawDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -144,7 +144,7 @@ public class TestRawDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -218,7 +218,7 @@ public class TestRawDecoder
                 row34);
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());
@@ -427,7 +427,7 @@ public class TestRawDecoder
 
         RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
 
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row, null)
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
 
         assertEquals(decodedRow.size(), columns.size());

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/RedisRecordCursor.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/RedisRecordCursor.java
@@ -154,9 +154,7 @@ public class RedisRecordCursor
         totalBytes += valueData.length;
         totalValues++;
 
-        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(
-                keyData,
-                null);
+        Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedKey = keyDecoder.decodeRow(keyData);
         Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedValue = valueDecoder.decodeRow(
                 valueData,
                 valueMap);


### PR DESCRIPTION
cc @charlesjmorgan @aalbu 

This relates to https://github.com/prestosql/presto/pull/4230#issuecomment-651726394