### PR TITLE
getTableDefaultLocation should not called if external_location present

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -55,7 +55,7 @@ public class HiveLocationService
     public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation)
     {
         HdfsContext context = new HdfsContext(session, schemaName, tableName);
-        Path targetPath = externalLocation.orElse(getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName));
+        Path targetPath = externalLocation.orElseGet(() -> getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName));
 
         // verify the target directory for the table
         if (pathExists(context, hdfsEnvironment, targetPath)) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
@@ -33,6 +33,7 @@ public final class Hadoop
         implements EnvironmentExtender
 {
     public static final String CONTAINER_PRESTO_HIVE_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/hive.properties";
+    public static final String CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/hive_with_external_writes.properties";
     public static final String CONTAINER_PRESTO_ICEBERG_PROPERTIES = CONTAINER_PRESTO_ETC + "/catalog/iceberg.properties";
 
     private final DockerFiles dockerFiles;
@@ -62,6 +63,7 @@ public final class Hadoop
         builder.configureContainer("presto-master", container -> {
             container
                     .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
+                    .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_external_writes.properties")), CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES)
                     .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES);
 
             if (System.getenv("HADOOP_PRESTO_INIT_SCRIPT") != null) {

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
@@ -1,0 +1,16 @@
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+hive.allow-comment-table=true
+hive.allow-comment-column=true
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.allow-register-partition-procedure=true
+hive.metastore-cache-ttl=0s
+hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
+hive.translate-hive-views=true
+hive.non-managed-table-writes-enabled=true

--- a/presto-product-tests/bin/product-tests-suite-2.sh
+++ b/presto-product-tests/bin/product-tests-suite-2.sh
@@ -27,5 +27,10 @@ presto-product-tests-launcher/bin/run-launcher test run \
     -- -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header -x iceberg,"${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
+presto-product-tests-launcher/bin/run-launcher test run \
+    --environment singlenode \
+    -- -g hive_with_external_writes -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+    || suite_exit_code=1
+
 echo "$0: exiting with ${suite_exit_code}"
 exit "${suite_exit_code}"

--- a/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
@@ -42,6 +42,7 @@ public final class TestGroups
     public static final String HIVE_TRANSACTIONAL = "hive_transactional";
     public static final String HIVE_VIEWS = "hive_views";
     public static final String HIVE_CACHING = "hive_caching";
+    public static final String HIVE_WITH_EXTERNAL_WRITES = "hive_with_external_writes";
     public static final String AUTHORIZATION = "authorization";
     public static final String HIVE_COERCION = "hive_coercion";
     public static final String CASSANDRA = "cassandra";

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCreateExternalTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCreateExternalTable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import com.google.inject.Inject;
+import io.prestosql.tempto.ProductTest;
+import io.prestosql.tempto.hadoop.hdfs.HdfsClient;
+import org.testng.annotations.Test;
+
+import static io.prestosql.tempto.query.QueryExecutor.query;
+import static io.prestosql.tests.TestGroups.HIVE_WITH_EXTERNAL_WRITES;
+import static io.prestosql.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static java.lang.String.format;
+
+public class TestHiveCreateExternalTable
+        extends ProductTest
+{
+    private static final String HIVE_CATALOG_NAME = "hive_with_external_writes";
+
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @Test(groups = {HIVE_WITH_EXTERNAL_WRITES, PROFILE_SPECIFIC_TESTS})
+    public void testCreateExternalTableWithInaccessibleSchemaLocation()
+    {
+        String schema = "schema_without_location";
+        String schemaLocation = "/tmp/" + schema;
+        hdfsClient.createDirectory(schemaLocation);
+        query(format("CREATE SCHEMA %s.%s WITH (location='%s')",
+                HIVE_CATALOG_NAME, schema, schemaLocation));
+
+        hdfsClient.delete(schemaLocation);
+
+        String table = "test_create_external";
+        String tableLocation = "/tmp/" + table;
+        query(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                HIVE_CATALOG_NAME, schema, table, tableLocation));
+    }
+}


### PR DESCRIPTION
In
https://github.com/prestosql/presto/commit/66c360963e690a13b5a526060d7faac2110279ef
CTAS was fixed to use the external_location if provided but due to the
way Optional.orElse() works it still ended up calling
getTableDefaultLocation() which will throw errors if the location
defined in the schema cannot be accessed. This can be fixed by the user
by fixing the location defined in the schema - but Hive doesn't allow
that. So the other option is to not check the location defined in the
schema until absolutely needed.

Fixes #4069.