### PR TITLE
Add support for Iceberg snapshot rollback

### DIFF
--- a/presto-iceberg/README.md
+++ b/presto-iceberg/README.md
@@ -69,6 +69,23 @@ Iceberg supports `$snapshot_id` and `$snapshot_timestamp_ms` as hidden columns.
 These columns allow users to query an old version of the table. Think of this
 as a time travel feature which lets you query your table's snapshot at a given time.
 
+## Rolling back to a previous Snapshot
+
+The connector provides a system snapshots table for each Iceberg table.  Snapshots are
+identified by BIGINT snapshot ids.  You can find the latest snapshot id for table
+foo by incanting:
+
+``` sql
+SELECT snapshot_id FROM 'foo$snapshots' ORDER BY committed_at DESC LIMIT 1
+```
+
+An SQL procedure allows the caller to roll back the state of the table to
+a previous snapshot id, thusly:
+
+``` sql
+CALL system.rollback_to_snapshot(schema_name, table_name, snapshot_id)
+```
+
 ## TODO
 
 * Update the README to reflect the current status, and convert it to proper connector documentation

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConnector.java
@@ -30,6 +30,7 @@ import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.procedure.Procedure;
 import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
@@ -58,6 +59,7 @@ public class IcebergConnector
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
     private final ConnectorAccessControl accessControl;
+    private final Set<Procedure> procedures;
 
     public IcebergConnector(
             LifeCycleManager lifeCycleManager,
@@ -71,7 +73,8 @@ public class IcebergConnector
             List<PropertyMetadata<?>> sessionProperties,
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
-            ConnectorAccessControl accessControl)
+            ConnectorAccessControl accessControl,
+            Set<Procedure> procedures)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -85,6 +88,7 @@ public class IcebergConnector
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.procedures = requireNonNull(procedures, "procedures is null");
     }
 
     @Override
@@ -140,6 +144,12 @@ public class IcebergConnector
     public Set<SystemTable> getSystemTables()
     {
         return systemTables;
+    }
+
+    @Override
+    public Set<Procedure> getProcedures()
+    {
+        return procedures;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.iceberg;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HiveHdfsModule;
 import io.prestosql.plugin.hive.HiveNodePartitioningProvider;
@@ -27,7 +28,9 @@ import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.procedure.Procedure;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -67,5 +70,8 @@ public class IcebergModule
 
         binder.bind(IcebergFileWriterFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IcebergFileWriterFactory.class).withGeneratedName();
+
+        Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
+        procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -15,6 +15,8 @@ package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.util.Types;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
@@ -40,11 +42,13 @@ import io.prestosql.spi.connector.ConnectorNodePartitioningProvider;
 import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
+import io.prestosql.spi.procedure.Procedure;
 import io.prestosql.spi.type.TypeManager;
 import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public final class InternalIcebergConnectorFactory
 {
@@ -86,6 +90,7 @@ public final class InternalIcebergConnectorFactory
             ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
             IcebergSessionProperties icebergSessionProperties = injector.getInstance(IcebergSessionProperties.class);
             IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
+            Set<Procedure> procedures = injector.getInstance((Key<Set<Procedure>>) Key.get(Types.setOf(Procedure.class)));
 
             return new IcebergConnector(
                     lifeCycleManager,
@@ -99,7 +104,8 @@ public final class InternalIcebergConnectorFactory
                     icebergSessionProperties.getSessionProperties(),
                     IcebergSchemaProperties.SCHEMA_PROPERTIES,
                     icebergTableProperties.getTableProperties(),
-                    new AllowAllAccessControl());
+                    new AllowAllAccessControl(),
+                    procedures);
         }
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.procedure.Procedure;
+import org.apache.iceberg.Table;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.prestosql.plugin.iceberg.IcebergUtil.getIcebergTable;
+import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class RollbackToSnapshotProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle ROLLBACK_TO_SNAPSHOT = methodHandle(
+            RollbackToSnapshotProcedure.class,
+            "rollbackToSnapshot",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            Long.class);
+
+    private final IcebergMetadataFactory metadataFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public RollbackToSnapshotProcedure(IcebergMetadataFactory metadataFactory, HdfsEnvironment hdfsEnvironment)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "rollback_to_snapshot",
+                ImmutableList.of(
+                        new Procedure.Argument("schema", VARCHAR),
+                        new Procedure.Argument("table", VARCHAR),
+                        new Procedure.Argument("snapshot_id", BIGINT)),
+                ROLLBACK_TO_SNAPSHOT.bindTo(this));
+    }
+
+    public void rollbackToSnapshot(ConnectorSession clientSession, String schema, String table, Long snapshotId)
+    {
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        IcebergMetadata metadata = metadataFactory.create();
+        HiveMetastore metastore = metadata.getMetastore();
+        Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
+        icebergTable.rollback().toSnapshotId(snapshotId).commit();
+    }
+}


### PR DESCRIPTION
This commit provides support to roll back the state of an
Iceberg table to a previous snapshot id, and adds a unit test
to verify the rollback functionality.

The rollback is done using a new SQL procedure in schema system:
rollback_to_snapshot(schema, table, snapshot_id).

This commit also adds documentation for the procedure
in the README.md.

Since we are certain to need more SQL procedures in the
Iceberg connector, this commit includes a module and
a container class for Iceberg procedures.

#1324 