### PR TITLE
Implement base functionality for kafka connector inserts

### DIFF
--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.sf.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaColumnHandle.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaColumnHandle.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.kafka;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.prestosql.decoder.DecoderColumnHandle;
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.type.Type;
 
@@ -25,7 +26,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public final class KafkaColumnHandle
-        implements DecoderColumnHandle
+        implements EncoderColumnHandle, DecoderColumnHandle
 {
     /**
      * Column Name
@@ -38,24 +39,24 @@ public final class KafkaColumnHandle
     private final Type type;
 
     /**
-     * Mapping hint for the decoder. Can be null.
+     * Mapping hint for the codec. Can be null.
      */
     private final String mapping;
 
     /**
-     * Data format to use (selects the decoder). Can be null.
+     * Data format to use (selects the codec). Can be null.
      */
     private final String dataFormat;
 
     /**
-     * Additional format hint for the selected decoder. Selects a decoder subtype (e.g. which timestamp decoder).
+     * Additional format hint for the selected codec. Selects a codec subtype (e.g. which timestamp codec).
      */
     private final String formatHint;
 
     /**
-     * True if the key decoder should be used, false if the message decoder should be used.
+     * True if the key codec should be used, false if the message codec should be used.
      */
-    private final boolean keyDecoder;
+    private final boolean keyCodec;
 
     /**
      * True if the column should be hidden.
@@ -74,7 +75,7 @@ public final class KafkaColumnHandle
             @JsonProperty("mapping") String mapping,
             @JsonProperty("dataFormat") String dataFormat,
             @JsonProperty("formatHint") String formatHint,
-            @JsonProperty("keyDecoder") boolean keyDecoder,
+            @JsonProperty("keyCodec") boolean keyCodec,
             @JsonProperty("hidden") boolean hidden,
             @JsonProperty("internal") boolean internal)
     {
@@ -83,7 +84,7 @@ public final class KafkaColumnHandle
         this.mapping = mapping;
         this.dataFormat = dataFormat;
         this.formatHint = formatHint;
-        this.keyDecoder = keyDecoder;
+        this.keyCodec = keyCodec;
         this.hidden = hidden;
         this.internal = internal;
     }
@@ -124,9 +125,9 @@ public final class KafkaColumnHandle
     }
 
     @JsonProperty
-    public boolean isKeyDecoder()
+    public boolean isKeyCodec()
     {
-        return keyDecoder;
+        return keyCodec;
     }
 
     @JsonProperty
@@ -154,7 +155,7 @@ public final class KafkaColumnHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, mapping, dataFormat, formatHint, keyDecoder, hidden, internal);
+        return Objects.hash(name, type, mapping, dataFormat, formatHint, keyCodec, hidden, internal);
     }
 
     @Override
@@ -173,7 +174,7 @@ public final class KafkaColumnHandle
                 Objects.equals(this.mapping, other.mapping) &&
                 Objects.equals(this.dataFormat, other.dataFormat) &&
                 Objects.equals(this.formatHint, other.formatHint) &&
-                Objects.equals(this.keyDecoder, other.keyDecoder) &&
+                Objects.equals(this.keyCodec, other.keyCodec) &&
                 Objects.equals(this.hidden, other.hidden) &&
                 Objects.equals(this.internal, other.internal);
     }
@@ -187,7 +188,7 @@ public final class KafkaColumnHandle
                 .add("mapping", mapping)
                 .add("dataFormat", dataFormat)
                 .add("formatHint", formatHint)
-                .add("keyDecoder", keyDecoder)
+                .add("keyCodec", keyCodec)
                 .add("hidden", hidden)
                 .add("internal", internal)
                 .toString();

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnector.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnector.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.kafka;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorMetadata;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorRecordSetProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
@@ -34,18 +35,21 @@ public class KafkaConnector
     private final ConnectorMetadata metadata;
     private final ConnectorSplitManager splitManager;
     private final ConnectorRecordSetProvider recordSetProvider;
+    private final ConnectorPageSinkProvider pageSinkProvider;
 
     @Inject
     public KafkaConnector(
             LifeCycleManager lifeCycleManager,
             ConnectorMetadata metadata,
             ConnectorSplitManager splitManager,
-            ConnectorRecordSetProvider recordSetProvider)
+            ConnectorRecordSetProvider recordSetProvider,
+            ConnectorPageSinkProvider pageSinkProvider)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
     }
 
     @Override
@@ -71,6 +75,12 @@ public class KafkaConnector
     public ConnectorRecordSetProvider getRecordSetProvider()
     {
         return recordSetProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnectorModule.java
@@ -19,10 +19,13 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.prestosql.decoder.DecoderModule;
+import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
 import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorRecordSetProvider;
 import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.prestosql.plugin.base.classloader.ForClassLoaderSafe;
+import io.prestosql.plugin.kafka.encoder.EncoderModule;
 import io.prestosql.spi.connector.ConnectorMetadata;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorRecordSetProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.type.Type;
@@ -48,6 +51,8 @@ public class KafkaConnectorModule
         binder.bind(ConnectorSplitManager.class).to(ClassLoaderSafeConnectorSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorRecordSetProvider.class).annotatedWith(ForClassLoaderSafe.class).to(KafkaRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorRecordSetProvider.class).to(ClassLoaderSafeConnectorRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).annotatedWith(ForClassLoaderSafe.class).to(KafkaPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(KafkaConnector.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(KafkaConfig.class);
@@ -57,6 +62,8 @@ public class KafkaConnectorModule
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);
 
         binder.install(new DecoderModule());
+        binder.install(new EncoderModule());
+        binder.install(new KafkaProducerModule());
     }
 
     private static final class TypeDeserializer

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaErrorCode.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaErrorCode.java
@@ -18,11 +18,15 @@ import io.prestosql.spi.ErrorCodeSupplier;
 import io.prestosql.spi.ErrorType;
 
 import static io.prestosql.spi.ErrorType.EXTERNAL;
+import static io.prestosql.spi.ErrorType.INTERNAL_ERROR;
 
 public enum KafkaErrorCode
         implements ErrorCodeSupplier
 {
-    KAFKA_SPLIT_ERROR(0, EXTERNAL);
+    KAFKA_SPLIT_ERROR(0, EXTERNAL),
+    KAFKA_SCHEMA_ERROR(1, EXTERNAL),
+    KAFKA_PRODUCER_ERROR(2, INTERNAL_ERROR)
+    /**/;
 
     private final ErrorCode errorCode;
 

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaHandleResolver.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaHandleResolver.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.kafka;
 
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorHandleResolver;
+import io.prestosql.spi.connector.ConnectorInsertTableHandle;
 import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
@@ -35,6 +36,12 @@ public class KafkaHandleResolver
     public Class<? extends ColumnHandle> getColumnHandleClass()
     {
         return KafkaColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return KafkaTableHandle.class;
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
@@ -123,7 +123,6 @@ public class KafkaMetadata
         return getColumnHandles(kafkaTableHandle.toSchemaTableName());
     }
 
-    @SuppressWarnings("ValueOfIncrementOrDecrementUsed")
     private Map<String, ColumnHandle> getColumnHandles(SchemaTableName schemaTableName)
     {
         KafkaTopicDescription kafkaTopicDescription = getRequiredTopicDescription(schemaTableName);
@@ -190,7 +189,6 @@ public class KafkaMetadata
         return convertColumnHandle(columnHandle).getColumnMetadata();
     }
 
-    @SuppressWarnings("ValueOfIncrementOrDecrementUsed")
     private ConnectorTableMetadata getTableMetadata(SchemaTableName schemaTableName)
     {
         KafkaTopicDescription table = getRequiredTopicDescription(schemaTableName);

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
@@ -15,10 +15,13 @@ package io.prestosql.plugin.kafka;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import io.prestosql.decoder.dummy.DummyRowDecoder;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorInsertTableHandle;
 import io.prestosql.spi.connector.ConnectorMetadata;
+import io.prestosql.spi.connector.ConnectorOutputMetadata;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
@@ -26,15 +29,18 @@ import io.prestosql.spi.connector.ConnectorTableProperties;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.statistics.ComputedStatistics;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.kafka.KafkaHandleResolver.convertColumnHandle;
 import static io.prestosql.plugin.kafka.KafkaHandleResolver.convertTableHandle;
@@ -82,7 +88,10 @@ public class KafkaMetadata
                         getDataFormat(kafkaTopicDescription.getKey()),
                         getDataFormat(kafkaTopicDescription.getMessage()),
                         kafkaTopicDescription.getKey().flatMap(KafkaTopicFieldGroup::getDataSchema),
-                        kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getDataSchema)))
+                        kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getDataSchema),
+                        getColumnHandles(schemaTableName).values().stream()
+                                .map(KafkaColumnHandle.class::cast)
+                                .collect(toImmutableList())))
                 .orElse(null);
     }
 
@@ -107,13 +116,16 @@ public class KafkaMetadata
                 .collect(toImmutableList());
     }
 
-    @SuppressWarnings("ValueOfIncrementOrDecrementUsed")
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         KafkaTableHandle kafkaTableHandle = convertTableHandle(tableHandle);
+        return getColumnHandles(kafkaTableHandle.toSchemaTableName());
+    }
 
-        SchemaTableName schemaTableName = kafkaTableHandle.toSchemaTableName();
+    @SuppressWarnings("ValueOfIncrementOrDecrementUsed")
+    private Map<String, ColumnHandle> getColumnHandles(SchemaTableName schemaTableName)
+    {
         KafkaTopicDescription kafkaTopicDescription = getRequiredTopicDescription(schemaTableName);
 
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
@@ -234,5 +246,34 @@ public class KafkaMetadata
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst();
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
+    {
+        // TODO: support transactional inserts https://github.com/prestosql/presto/issues/4303
+        KafkaTableHandle table = (KafkaTableHandle) tableHandle;
+        List<KafkaColumnHandle> actualColumns = table.getColumns().stream()
+                .filter(col -> !col.isInternal())
+                .collect(toImmutableList());
+
+        checkArgument(columns.equals(actualColumns), "Unexpected columns!\nexpected: %s\ngot: %s", actualColumns, columns);
+
+        return new KafkaTableHandle(
+                table.getSchemaName(),
+                table.getTableName(),
+                table.getTopicName(),
+                table.getKeyDataFormat(),
+                table.getMessageDataFormat(),
+                table.getKeyDataSchemaLocation(),
+                table.getMessageDataSchemaLocation(),
+                actualColumns);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        // TODO: support transactional inserts https://github.com/prestosql/presto/issues/4303
+        return Optional.empty();
     }
 }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.prestosql.plugin.kafka.encoder.RowEncoder;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorPageSink;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.prestosql.plugin.kafka.KafkaErrorCode.KAFKA_PRODUCER_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class KafkaPageSink
+        implements ConnectorPageSink
+{
+    private final String topicName;
+    private final List<KafkaColumnHandle> columns;
+    private final RowEncoder keyEncoder;
+    private final RowEncoder messageEncoder;
+    private final KafkaProducer<byte[], byte[]> producer;
+    private final ErrorCountingCallback errorCounter;
+
+    public KafkaPageSink(
+            String topicName,
+            List<KafkaColumnHandle> columns,
+            RowEncoder keyEncoder,
+            RowEncoder messageEncoder,
+            PlainTextKafkaProducerFactory producerFactory)
+    {
+        this.topicName = requireNonNull(topicName, "topicName is null");
+        this.columns = requireNonNull(ImmutableList.copyOf(columns), "columns is null");
+        this.keyEncoder = requireNonNull(keyEncoder, "keyEncoder is null");
+        this.messageEncoder = requireNonNull(messageEncoder, "messageEncoder is null");
+        requireNonNull(producerFactory, "producerFactory is null");
+        this.producer = producerFactory.create();
+        this.errorCounter = new ErrorCountingCallback();
+    }
+
+    private static class ErrorCountingCallback
+            implements Callback
+    {
+        private final AtomicLong errorCounter;
+
+        public ErrorCountingCallback()
+        {
+            this.errorCounter = new AtomicLong(0);
+        }
+
+        @Override
+        public void onCompletion(RecordMetadata recordMetadata, Exception e)
+        {
+            if (e != null) {
+                errorCounter.incrementAndGet();
+            }
+        }
+
+        public long getErrorCount()
+        {
+            return errorCounter.get();
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                if (columns.get(channel).isKeyCodec()) {
+                    keyEncoder.appendColumnValue(page.getBlock(channel), position);
+                }
+                else {
+                    messageEncoder.appendColumnValue(page.getBlock(channel), position);
+                }
+            }
+            producer.send(new ProducerRecord<>(topicName, keyEncoder.toByteArray(), messageEncoder.toByteArray()), errorCounter);
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        producer.flush();
+        producer.close();
+        if (errorCounter.getErrorCount() > 0) {
+            throw new PrestoException(KAFKA_PRODUCER_ERROR, format("%d producer record('s) failed to send", errorCounter.getErrorCount()));
+        }
+        return completedFuture(ImmutableList.of());
+    }
+
+    @Override
+    public void abort()
+    {
+        producer.close();
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSinkProvider.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSinkProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.kafka.encoder.DispatchingRowEncoderFactory;
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
+import io.prestosql.plugin.kafka.encoder.RowEncoder;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorInsertTableHandle;
+import io.prestosql.spi.connector.ConnectorOutputTableHandle;
+import io.prestosql.spi.connector.ConnectorPageSink;
+import io.prestosql.spi.connector.ConnectorPageSinkProvider;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static io.prestosql.plugin.kafka.KafkaErrorCode.KAFKA_SCHEMA_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class KafkaPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final DispatchingRowEncoderFactory encoderFactory;
+    private final PlainTextKafkaProducerFactory producerFactory;
+
+    @Inject
+    public KafkaPageSinkProvider(DispatchingRowEncoderFactory encoderFactory, PlainTextKafkaProducerFactory producerFactory)
+    {
+        this.encoderFactory = requireNonNull(encoderFactory, "encoderFactory is null");
+        this.producerFactory = requireNonNull(producerFactory, "producerFactory is null");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException("Table creation is not supported by the kafka connector");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        KafkaTableHandle handle = (KafkaTableHandle) tableHandle;
+
+        ImmutableList.Builder<EncoderColumnHandle> keyColumns = ImmutableList.builder();
+        ImmutableList.Builder<EncoderColumnHandle> messageColumns = ImmutableList.builder();
+        handle.getColumns().forEach(col -> {
+            if (col.isInternal()) {
+                throw new IllegalArgumentException(format("unexpected internal column '%s'", col.getName()));
+            }
+            if (col.isKeyCodec()) {
+                keyColumns.add(col);
+            }
+            else {
+                messageColumns.add(col);
+            }
+        });
+
+        RowEncoder keyEncoder = encoderFactory.create(
+                session,
+                handle.getKeyDataFormat(),
+                getDataSchema(handle.getKeyDataSchemaLocation()),
+                keyColumns.build());
+
+        RowEncoder messageEncoder = encoderFactory.create(
+                session,
+                handle.getMessageDataFormat(),
+                getDataSchema(handle.getMessageDataSchemaLocation()),
+                messageColumns.build());
+
+        return new KafkaPageSink(
+                handle.getTopicName(),
+                handle.getColumns(),
+                keyEncoder,
+                messageEncoder,
+                producerFactory);
+    }
+
+    private Optional<String> getDataSchema(Optional<String> dataSchemaLocation)
+    {
+        return dataSchemaLocation.map(location -> {
+            try {
+                return Files.readString(Paths.get(location));
+            }
+            catch (IOException e) {
+                throw new PrestoException(KAFKA_SCHEMA_ERROR, format("Unable to read data schema at '%s'", dataSchemaLocation.get()), e);
+            }
+        });
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaProducerModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaProducerModule.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class KafkaProducerModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(PlainTextKafkaProducerFactory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSetProvider.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSetProvider.java
@@ -62,7 +62,7 @@ public class KafkaRecordSetProvider
                 getDecoderParameters(kafkaSplit.getKeyDataSchemaContents()),
                 kafkaColumns.stream()
                         .filter(col -> !col.isInternal())
-                        .filter(KafkaColumnHandle::isKeyDecoder)
+                        .filter(KafkaColumnHandle::isKeyCodec)
                         .collect(toImmutableSet()));
 
         RowDecoder messageDecoder = decoderFactory.create(
@@ -70,7 +70,7 @@ public class KafkaRecordSetProvider
                 getDecoderParameters(kafkaSplit.getMessageDataSchemaContents()),
                 kafkaColumns.stream()
                         .filter(col -> !col.isInternal())
-                        .filter(col -> !col.isKeyDecoder())
+                        .filter(col -> !col.isKeyCodec())
                         .collect(toImmutableSet()));
 
         return new KafkaRecordSet(kafkaSplit, consumerFactory, kafkaColumns, keyDecoder, messageDecoder);

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaTopicFieldDescription.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaTopicFieldDescription.java
@@ -101,7 +101,7 @@ public final class KafkaTopicFieldDescription
         return hidden;
     }
 
-    KafkaColumnHandle getColumnHandle(boolean keyDecoder, int index)
+    KafkaColumnHandle getColumnHandle(boolean keyCodec, int index)
     {
         return new KafkaColumnHandle(
                 getName(),
@@ -109,7 +109,7 @@ public final class KafkaTopicFieldDescription
                 getMapping(),
                 getDataFormat(),
                 getFormatHint(),
-                keyDecoder,
+                keyCodec,
                 isHidden(),
                 false);
     }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/PlainTextKafkaProducerFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/PlainTextKafkaProducerFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.spi.HostAddress;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG;
+
+public class PlainTextKafkaProducerFactory
+{
+    private final Map<String, Object> properties;
+
+    @Inject
+    public PlainTextKafkaProducerFactory(KafkaConfig kafkaConfig)
+    {
+        requireNonNull(kafkaConfig, "kafkaConfig is null");
+        Set<HostAddress> nodes = ImmutableSet.copyOf(kafkaConfig.getNodes());
+        properties = ImmutableMap.<String, Object>builder()
+                .put(BOOTSTRAP_SERVERS_CONFIG, nodes.stream()
+                        .map(HostAddress::toString)
+                        .collect(joining(",")))
+                .put(ACKS_CONFIG, "all")
+                .put(LINGER_MS_CONFIG, 5)
+                .build();
+    }
+
+    /**
+     * Creates a KafkaProducer with the properties set in the constructor.
+     */
+    public KafkaProducer<byte[], byte[]> create()
+    {
+        return new KafkaProducer<>(properties, new ByteArraySerializer(), new ByteArraySerializer());
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.SqlDate;
+import io.prestosql.spi.type.SqlTime;
+import io.prestosql.spi.type.SqlTimeWithTimeZone;
+import io.prestosql.spi.type.SqlTimestamp;
+import io.prestosql.spi.type.SqlTimestampWithTimeZone;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
+import io.prestosql.spi.type.Type;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DateType.DATE;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TimeType.TIME;
+import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static io.prestosql.spi.type.VarbinaryType.isVarbinaryType;
+import static io.prestosql.spi.type.Varchars.isVarcharType;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractRowEncoder
+        implements RowEncoder
+{
+    protected final ConnectorSession session;
+    protected final List<EncoderColumnHandle> columnHandles;
+
+    /**
+     * The current column index for appending values to the row encoder.
+     * Gets incremented by appendColumnValue and set back to zero when the encoder is reset.
+     */
+    protected int currentColumnIndex;
+
+    protected AbstractRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles)
+    {
+        this.session = requireNonNull(session, "session is null");
+        requireNonNull(columnHandles, "columnHandles is null");
+        this.columnHandles = ImmutableList.copyOf(columnHandles);
+        validateColumns(this.columnHandles);
+        this.currentColumnIndex = 0;
+    }
+
+    /**
+     * Performs any checks on the column handle field values
+     */
+    protected abstract void validateColumns(List<EncoderColumnHandle> columnHandles);
+
+    @Override
+    public RowEncoder appendColumnValue(Block block, int position)
+    {
+        checkArgument(currentColumnIndex < columnHandles.size(), format("currentColumnIndex '%d' is greater than number of columns '%d'", currentColumnIndex, columnHandles.size()));
+        Type type = columnHandles.get(currentColumnIndex).getType();
+        if (block.isNull(position)) {
+            appendNullValue();
+        }
+        else if (type == BOOLEAN) {
+            appendBoolean(type.getBoolean(block, position));
+        }
+        else if (type == BIGINT) {
+            appendLong(type.getLong(block, position));
+        }
+        else if (type == INTEGER) {
+            appendInt(toIntExact(type.getLong(block, position)));
+        }
+        else if (type == SMALLINT) {
+            appendShort(Shorts.checkedCast(type.getLong(block, position)));
+        }
+        else if (type == TINYINT) {
+            appendByte(SignedBytes.checkedCast(type.getLong(block, position)));
+        }
+        else if (type == DOUBLE) {
+            appendDouble(type.getDouble(block, position));
+        }
+        else if (type == REAL) {
+            appendFloat(intBitsToFloat(toIntExact(type.getLong(block, position))));
+        }
+        else if (isVarcharType(type)) {
+            appendString(type.getSlice(block, position).toStringUtf8());
+        }
+        else if (isVarbinaryType(type)) {
+            appendByteBuffer(type.getSlice(block, position).toByteBuffer());
+        }
+        else if (type == DATE) {
+            appendSqlDate((SqlDate) type.getObjectValue(session, block, position));
+        }
+        else if (type == TIME) {
+            appendSqlTime((SqlTime) type.getObjectValue(session, block, position));
+        }
+        else if (type == TIME_WITH_TIME_ZONE) {
+            appendSqlTimeWithTimeZone((SqlTimeWithTimeZone) type.getObjectValue(session, block, position));
+        }
+        else if (type instanceof TimestampType) {
+            appendSqlTimestamp((SqlTimestamp) type.getObjectValue(session, block, position));
+        }
+        else if (type instanceof TimestampWithTimeZoneType) {
+            appendSqlTimestampWithTimeZone((SqlTimestampWithTimeZone) type.getObjectValue(session, block, position));
+        }
+        else {
+            throw new UnsupportedOperationException(format("Column '%s' does not support 'null' value", columnHandles.get(currentColumnIndex).getName()));
+        }
+        currentColumnIndex++;
+        return this;
+    }
+
+    // these append value methods should be overridden for each row encoder
+    // only the methods with types supported by the data format should be overridden
+    protected void appendNullValue()
+    {
+        throw new UnsupportedOperationException(format("Column '%s' does not support 'null' value", columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendLong(long value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", long.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendInt(int value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", int.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendShort(short value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", short.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendByte(byte value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", byte.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendDouble(double value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", double.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendFloat(float value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", float.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendBoolean(boolean value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", boolean.class.getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendString(String value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendByteBuffer(ByteBuffer value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendSqlDate(SqlDate value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendSqlTime(SqlTime value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendSqlTimeWithTimeZone(SqlTimeWithTimeZone value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendSqlTimestamp(SqlTimestamp value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void appendSqlTimestampWithTimeZone(SqlTimestampWithTimeZone value)
+    {
+        throw new UnsupportedOperationException(format("Unsupported type '%s' for column '%s'", value.getClass().getName(), columnHandles.get(currentColumnIndex).getName()));
+    }
+
+    protected void resetColumnIndex()
+    {
+        currentColumnIndex = 0;
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/DispatchingRowEncoderFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/DispatchingRowEncoderFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class DispatchingRowEncoderFactory
+{
+    private final Map<String, RowEncoderFactory> factories;
+
+    @Inject
+    public DispatchingRowEncoderFactory(Map<String, RowEncoderFactory> factories)
+    {
+        this.factories = ImmutableMap.copyOf(requireNonNull(factories, "factories is null"));
+    }
+
+    public RowEncoder create(ConnectorSession session, String dataFormat, Optional<String> dataSchema, List<EncoderColumnHandle> columnHandles)
+    {
+        checkArgument(factories.containsKey(dataFormat), "unknown data format '%s'", dataFormat);
+        return factories.get(dataFormat).create(session, dataSchema, columnHandles);
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderColumnHandle.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderColumnHandle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.type.Type;
+
+public interface EncoderColumnHandle
+        extends ColumnHandle
+{
+    boolean isInternal();
+
+    String getFormatHint();
+
+    Type getType();
+
+    String getName();
+
+    String getMapping();
+
+    String getDataFormat();
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.multibindings.MapBinder;
+
+import static com.google.inject.Scopes.SINGLETON;
+
+public class EncoderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        MapBinder<String, RowEncoderFactory> encoderFactoriesByName = MapBinder.newMapBinder(binder, String.class, RowEncoderFactory.class);
+
+        binder.bind(DispatchingRowEncoderFactory.class).in(SINGLETON);
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
@@ -16,6 +16,8 @@ package io.prestosql.plugin.kafka.encoder;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.multibindings.MapBinder;
+import io.prestosql.plugin.kafka.encoder.csv.CsvRowEncoder;
+import io.prestosql.plugin.kafka.encoder.csv.CsvRowEncoderFactory;
 
 import static com.google.inject.Scopes.SINGLETON;
 
@@ -26,6 +28,8 @@ public class EncoderModule
     public void configure(Binder binder)
     {
         MapBinder<String, RowEncoderFactory> encoderFactoriesByName = MapBinder.newMapBinder(binder, String.class, RowEncoderFactory.class);
+
+        encoderFactoriesByName.addBinding(CsvRowEncoder.NAME).to(CsvRowEncoderFactory.class).in(SINGLETON);
 
         binder.bind(DispatchingRowEncoderFactory.class).in(SINGLETON);
     }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/RowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/RowEncoder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import io.prestosql.spi.block.Block;
+
+public interface RowEncoder
+{
+    /**
+     * Adds the value from the given block/position to the row being encoded
+     */
+    RowEncoder appendColumnValue(Block block, int position);
+
+    /**
+     * Returns the encoded values as a byte array, and resets any info needed to prepare for next row
+     */
+    byte[] toByteArray();
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/RowEncoderFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/RowEncoderFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder;
+
+import io.prestosql.spi.connector.ConnectorSession;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RowEncoderFactory
+{
+    RowEncoder create(ConnectorSession session, Optional<String> dataSchema, List<EncoderColumnHandle> columnHandles);
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder.csv;
+
+import au.com.bytecode.opencsv.CSVWriter;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.plugin.kafka.encoder.AbstractRowEncoder;
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.Type;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static io.prestosql.spi.type.Varchars.isVarcharType;
+import static java.lang.String.format;
+
+public class CsvRowEncoder
+        extends AbstractRowEncoder
+{
+    private static final Set<Type> SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(
+            BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, DOUBLE, REAL);
+
+    public static final String NAME = "csv";
+
+    private final String[] row;
+
+    public CsvRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles)
+    {
+        super(session, columnHandles);
+        this.row = new String[columnHandles.size()];
+    }
+
+    @Override
+    protected void validateColumns(List<EncoderColumnHandle> columnHandles)
+    {
+        for (EncoderColumnHandle columnHandle : columnHandles) {
+            checkArgument(columnHandle.getFormatHint() == null, "unexpected format hint '%s' defined for column '%s'", columnHandle.getFormatHint(), columnHandle.getName());
+            checkArgument(columnHandle.getDataFormat() == null, "unexpected data format '%s' defined for column '%s'", columnHandle.getDataFormat(), columnHandle.getName());
+
+            checkArgument(isSupportedType(columnHandle.getType()), "unsupported column type '%s' for column '%s'", columnHandle.getType(), columnHandle.getName());
+        }
+    }
+
+    private boolean isSupportedType(Type type)
+    {
+        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    @Override
+    protected void appendNullValue()
+    {
+        row[currentColumnIndex] = null;
+    }
+
+    @Override
+    protected void appendLong(long value)
+    {
+        row[currentColumnIndex] = Long.toString(value);
+    }
+
+    @Override
+    protected void appendInt(int value)
+    {
+        row[currentColumnIndex] = Integer.toString(value);
+    }
+
+    @Override
+    protected void appendShort(short value)
+    {
+        row[currentColumnIndex] = Short.toString(value);
+    }
+
+    @Override
+    protected void appendByte(byte value)
+    {
+        row[currentColumnIndex] = Byte.toString(value);
+    }
+
+    @Override
+    protected void appendDouble(double value)
+    {
+        row[currentColumnIndex] = Double.toString(value);
+    }
+
+    @Override
+    protected void appendFloat(float value)
+    {
+        row[currentColumnIndex] = Float.toString(value);
+    }
+
+    @Override
+    protected void appendBoolean(boolean value)
+    {
+        row[currentColumnIndex] = Boolean.toString(value);
+    }
+
+    @Override
+    protected void appendString(String value)
+    {
+        row[currentColumnIndex] = value;
+    }
+
+    @Override
+    public byte[] toByteArray()
+    {
+        // make sure entire row has been updated with new values
+        checkArgument(currentColumnIndex == columnHandles.size(), format("Missing %d columns", columnHandles.size() - currentColumnIndex + 1));
+
+        try (ByteArrayOutputStream byteArrayOuts = new ByteArrayOutputStream();
+                OutputStreamWriter outsWriter = new OutputStreamWriter(byteArrayOuts, StandardCharsets.UTF_8);
+                CSVWriter writer = new CSVWriter(outsWriter, ',', '"', "")) {
+            writer.writeNext(row);
+            writer.flush();
+
+            resetColumnIndex(); // reset currentColumnIndex to prepare for next row
+            return byteArrayOuts.toByteArray();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoderFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder.csv;
+
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
+import io.prestosql.plugin.kafka.encoder.RowEncoder;
+import io.prestosql.plugin.kafka.encoder.RowEncoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CsvRowEncoderFactory
+        implements RowEncoderFactory
+{
+    @Override
+    public RowEncoder create(ConnectorSession session, Optional<String> dataSchema, List<EncoderColumnHandle> columnHandles)
+    {
+        return new CsvRowEncoder(session, columnHandles);
+    }
+}

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
@@ -34,7 +35,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.testing.TestngUtils.toDataProvider;
+import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -44,18 +49,17 @@ public class TestKafkaIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
     private TestingKafka testingKafka;
-    private String topicName;
+    private String rawFormatTopic;
 
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
         testingKafka = new TestingKafka();
-        topicName = "test_raw_" + UUID.randomUUID().toString().replaceAll("-", "_");
-
+        rawFormatTopic = "test_raw_" + UUID.randomUUID().toString().replaceAll("-", "_");
         Map<SchemaTableName, KafkaTopicDescription> extraTopicDescriptions = ImmutableMap.<SchemaTableName, KafkaTopicDescription>builder()
-                .put(new SchemaTableName("default", topicName),
-                        createDescription(topicName, "default", topicName,
+                .put(new SchemaTableName("default", rawFormatTopic),
+                        createDescription(rawFormatTopic, "default", rawFormatTopic,
                                 createFieldGroup("raw", ImmutableList.of(
                                         createOneFieldDescription("id", BigintType.BIGINT, "0", "LONG")))))
                 .build();
@@ -67,7 +71,7 @@ public class TestKafkaIntegrationSmokeTest
                         .build())
                 .build();
 
-        testingKafka.createTopics(topicName);
+        testingKafka.createTopics(rawFormatTopic);
         return queryRunner;
     }
 
@@ -79,14 +83,14 @@ public class TestKafkaIntegrationSmokeTest
 
         insertData(buf.array());
 
-        assertQuery("SELECT id FROM default." + topicName + " WHERE id = 1", "VALUES (1)");
-        assertQuery("SELECT id FROM default." + topicName + " WHERE id < 2", "VALUES (1)");
+        assertQuery("SELECT id FROM default." + rawFormatTopic + " WHERE id = 1", "VALUES (1)");
+        assertQuery("SELECT id FROM default." + rawFormatTopic + " WHERE id < 2", "VALUES (1)");
     }
 
     private void insertData(byte[] data)
     {
         try (KafkaProducer<byte[], byte[]> producer = createProducer()) {
-            producer.send(new ProducerRecord<>(topicName, data));
+            producer.send(new ProducerRecord<>(rawFormatTopic, data));
         }
     }
 
@@ -114,6 +118,87 @@ public class TestKafkaIntegrationSmokeTest
     private KafkaTopicFieldDescription createOneFieldDescription(String name, Type type, String mapping, String dataFormat)
     {
         return new KafkaTopicFieldDescription(name, type, mapping, null, dataFormat, null, false);
+    }
+
+    @Test(dataProvider = "testRoundTripAllFormatsDataProvider")
+    public void testRoundTripAllFormats(RoundTripTestCase testCase)
+    {
+        assertUpdate("INSERT into write_test." + testCase.getTableName() +
+                " (" + testCase.getFieldNames() + ")" +
+                " VALUES (" + testCase.getFieldValues() + ")", 1);
+        assertQuery("SELECT " + testCase.getFieldNames() + " FROM write_test." + testCase.getTableName() +
+                " WHERE " + testCase.getFieldName("f_bigint") + " = " + testCase.getFieldValue("f_bigint"),
+                "VALUES (" + testCase.getFieldValues() + ")");
+    }
+
+    @DataProvider(name = "testRoundTripAllFormatsDataProvider")
+    public final Object[][] testRoundTripAllFormatsDataProvider()
+    {
+        return testRoundTripAllFormatsData().stream()
+                .collect(toDataProvider());
+    }
+
+    private List<RoundTripTestCase> testRoundTripAllFormatsData()
+    {
+        return ImmutableList.<RoundTripTestCase>builder()
+                .build();
+    }
+
+    protected static final class RoundTripTestCase
+    {
+        private final String tableName;
+        private final List<String> fieldNames;
+        private final List<Object> fieldValues;
+        private final int length;
+
+        public RoundTripTestCase(String tableName, List<String> fieldNames, List<Object> fieldValues)
+        {
+            checkArgument(fieldNames.size() == fieldValues.size(), "sizes of fieldNames and fieldValues are not equal");
+            this.tableName = requireNonNull(tableName, "tableName is null");
+            this.fieldNames = ImmutableList.copyOf(fieldNames);
+            this.fieldValues = ImmutableList.copyOf(fieldValues);
+            this.length = fieldNames.size();
+        }
+
+        public String getTableName()
+        {
+            return tableName;
+        }
+
+        private int getIndex(String fieldName)
+        {
+            return fieldNames.indexOf(fieldName);
+        }
+
+        public String getFieldName(String fieldName)
+        {
+            int index = getIndex(fieldName);
+            checkArgument(index >= 0 && index < length, "index out of bounds");
+            return fieldNames.get(index);
+        }
+
+        public String getFieldNames()
+        {
+            return String.join(", ", fieldNames);
+        }
+
+        public Object getFieldValue(String fieldName)
+        {
+            int index = getIndex(fieldName);
+            checkArgument(index >= 0 && index < length, "index out of bounds");
+            return fieldValues.get(index);
+        }
+
+        public String getFieldValues()
+        {
+            return fieldValues.stream().map(Object::toString).collect(Collectors.joining(", "));
+        }
+
+        @Override
+        public String toString()
+        {
+            return tableName; // for test case label in IDE
+        }
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
@@ -141,6 +141,10 @@ public class TestKafkaIntegrationSmokeTest
     private List<RoundTripTestCase> testRoundTripAllFormatsData()
     {
         return ImmutableList.<RoundTripTestCase>builder()
+                .add(new RoundTripTestCase(
+                        "all_datatypes_csv",
+                        ImmutableList.of("f_bigint", "f_int", "f_smallint", "f_tinyint", "f_double", "f_boolean", "f_varchar"),
+                        ImmutableList.of(100000, 1000, 100, 10, 1000.001, true, "'test'")))
                 .build();
     }
 

--- a/presto-kafka/src/test/resources/write_test/all_datatypes_csv.json
+++ b/presto-kafka/src/test/resources/write_test/all_datatypes_csv.json
@@ -1,0 +1,55 @@
+{
+    "tableName": "all_datatypes_csv",
+    "schemaName": "write_test",
+    "topicName": "all_datatypes_csv",
+    "key": {
+        "dataFormat": "csv",
+        "fields": [
+            {
+                "name": "kafka_key",
+                "type": "BIGINT",
+                "mapping": "0"
+            }
+        ]
+    },
+    "message": {
+        "dataFormat": "csv",
+        "fields": [
+            {
+                "name": "f_bigint",
+                "type": "BIGINT",
+                "mapping": "0"
+            },
+            {
+                "name": "f_int",
+                "type": "INTEGER",
+                "mapping": "1"
+            },
+            {
+                "name": "f_smallint",
+                "type": "SMALLINT",
+                "mapping": "2"
+            },
+            {
+                "name": "f_tinyint",
+                "type": "TINYINT",
+                "mapping": "3"
+            },
+            {
+                "name": "f_double",
+                "type": "DOUBLE",
+                "mapping": "4"
+            },
+            {
+                "name": "f_boolean",
+                "type": "BOOLEAN",
+                "mapping": "5"
+            },
+            {
+                "name": "f_varchar",
+                "type": "VARCHAR",
+                "mapping": "6"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This is the first of 5 PRs based on #4230 

This PR focuses on adding code to the kafka connector to support inserts. Something to note is that inserting won't actually work because none of the encoders are included. Each of the four encoders will have their own follow-up PRs after this one gets merged. This PR also lays out the base interfaces and classes for the encoder.

I have changed how the encoder works since #4230 . Each `RowEncoder` has a collection field that will store row data until requested as a `byte[]` by the `KafkaPageSink`. The page sink will call overloaded `put(EncoderColumnHandle, value)` methods to add values to the row. Then once the page sink gets the `byte[]` from the `RowEncoder` it calls a `clear()` method that clears the backing collection.

This PR is part of the implementation for #3980 

**edit**: I added the CSV encoder to a separate commit in this pr just to have an encoder that works

**edit**: Other encoders are blocked by this pr for now. They can be found at these links
- Json Encoder PR - [https://github.com/charlesjmorgan/presto/pull/4](url)
- Raw Encoder PR - [https://github.com/charlesjmorgan/presto/pull/3](url)
- Avro Encoder PR - [https://github.com/charlesjmorgan/presto/pull/5](url)