### PR TITLE
Adding FLUSHING state to tasks and stages

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -998,7 +998,7 @@ public class QueryStateMachine
         }
         return getAllStages(rootStage).stream()
                 .map(StageInfo::getState)
-                .allMatch(state -> (state == StageState.RUNNING) || state.isDone());
+                .allMatch(state -> state == StageState.RUNNING || state == StageState.FLUSHING || state.isDone());
     }
 
     public Optional<ExecutionFailureInfo> getFailureInfo()

--- a/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
@@ -89,6 +89,8 @@ public final class SqlStageExecution
     @GuardedBy("this")
     private final Set<TaskId> finishedTasks = newConcurrentHashSet();
     @GuardedBy("this")
+    private final Set<TaskId> flushingTasks = newConcurrentHashSet();
+    @GuardedBy("this")
     private final Set<TaskId> tasksWithFinalInfo = newConcurrentHashSet();
     @GuardedBy("this")
     private final AtomicBoolean splitsScheduled = new AtomicBoolean();
@@ -224,6 +226,9 @@ public final class SqlStageExecution
 
         if (getAllTasks().stream().anyMatch(task -> getState() == StageState.RUNNING)) {
             stateMachine.transitionToRunning();
+        }
+        if (isFlushing()) {
+            stateMachine.transitionToFlushing();
         }
         if (finishedTasks.containsAll(allTasks)) {
             stateMachine.transitionToFinished();
@@ -505,13 +510,20 @@ public final class SqlStageExecution
                 // A task should only be in the aborted state if the STAGE is done (ABORTED or FAILED)
                 stateMachine.transitionToFailed(new PrestoException(GENERIC_INTERNAL_ERROR, "A task is in the ABORTED state but stage is " + stageState));
             }
+            else if (taskState == TaskState.FLUSHING) {
+                flushingTasks.add(taskStatus.getTaskId());
+            }
             else if (taskState == TaskState.FINISHED) {
                 finishedTasks.add(taskStatus.getTaskId());
+                flushingTasks.remove(taskStatus.getTaskId());
             }
 
-            if (stageState == StageState.SCHEDULED || stageState == StageState.RUNNING) {
+            if (stageState == StageState.SCHEDULED || stageState == StageState.RUNNING || stageState == StageState.FLUSHING) {
                 if (taskState == TaskState.RUNNING) {
                     stateMachine.transitionToRunning();
+                }
+                if (isFlushing()) {
+                    stateMachine.transitionToFlushing();
                 }
                 if (finishedTasks.containsAll(allTasks)) {
                     stateMachine.transitionToFinished();
@@ -522,6 +534,13 @@ public final class SqlStageExecution
             // after updating state, check if all tasks have final status information
             checkAllTaskFinal();
         }
+    }
+
+    private synchronized boolean isFlushing()
+    {
+        // to transition to flushing, there must be at least one flushing task, and all others must be flushing or finished.
+        return !flushingTasks.isEmpty()
+                && allTasks.stream().allMatch(taskId -> finishedTasks.contains(taskId) || flushingTasks.contains(taskId));
     }
 
     private synchronized void updateFinalTaskInfo(TaskInfo finalTaskInfo)

--- a/presto-main/src/main/java/io/prestosql/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlTaskExecution.java
@@ -641,6 +641,7 @@ public class SqlTaskExecution
 
         // are there still pages in the output buffer
         if (!outputBuffer.isFinished()) {
+            taskStateMachine.transitionToFlushing();
             return;
         }
 

--- a/presto-main/src/main/java/io/prestosql/execution/StageState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/StageState.java
@@ -44,6 +44,11 @@ public enum StageState
      */
     RUNNING(false, false),
     /**
+     * Stage has finished executing and output being consumed.
+     * In this state, at-least one of the tasks is flushing and the non-flushing tasks are finished
+     */
+    FLUSHING(false, false),
+    /**
      * Stage has finished executing and all output has been consumed.
      */
     FINISHED(true, false),
@@ -99,6 +104,7 @@ public enum StageState
             case SCHEDULING_SPLITS:
             case SCHEDULED:
             case RUNNING:
+            case FLUSHING:
             case FINISHED:
             case CANCELED:
                 // no more workers will be added to the query

--- a/presto-main/src/main/java/io/prestosql/execution/StageStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/StageStats.java
@@ -32,6 +32,7 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.execution.StageState.FLUSHING;
 import static io.prestosql.execution.StageState.RUNNING;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -422,7 +423,7 @@ public class StageStats
 
     public BasicStageStats toBasicStageStats(StageState stageState)
     {
-        boolean isScheduled = (stageState == RUNNING) || stageState.isDone();
+        boolean isScheduled = stageState == RUNNING || stageState == FLUSHING || stageState.isDone();
 
         OptionalDouble progressPercentage = OptionalDouble.empty();
         if (isScheduled && totalDrivers != 0) {

--- a/presto-main/src/main/java/io/prestosql/execution/TaskState.java
+++ b/presto-main/src/main/java/io/prestosql/execution/TaskState.java
@@ -31,6 +31,12 @@ public enum TaskState
      */
     RUNNING(false),
     /**
+     * Task has finished executing and output is left to be consumed.
+     * In this state, there will be no new drivers, the existing drivers have finished
+     * and the output buffer of the task is at-least in a 'no-more-pages' state.
+     */
+    FLUSHING(false),
+    /**
      * Task has finished executing and all output has been consumed.
      */
     FINISHED(true),

--- a/presto-main/src/main/java/io/prestosql/execution/TaskStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/TaskStateMachine.java
@@ -26,6 +26,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.prestosql.execution.TaskState.FLUSHING;
+import static io.prestosql.execution.TaskState.RUNNING;
 import static io.prestosql.execution.TaskState.TERMINAL_TASK_STATES;
 import static java.util.Objects.requireNonNull;
 
@@ -78,6 +80,11 @@ public class TaskStateMachine
     public LinkedBlockingQueue<Throwable> getFailureCauses()
     {
         return failureCauses;
+    }
+
+    public void transitionToFlushing()
+    {
+        taskState.setIf(FLUSHING, currentState -> currentState == RUNNING);
     }
 
     public void finished()

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/AllAtOnceExecutionSchedule.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/AllAtOnceExecutionSchedule.java
@@ -43,6 +43,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.execution.StageState.FLUSHING;
 import static io.prestosql.execution.StageState.RUNNING;
 import static io.prestosql.execution.StageState.SCHEDULED;
 import static java.util.Objects.requireNonNull;
@@ -71,7 +72,7 @@ public class AllAtOnceExecutionSchedule
     {
         for (Iterator<SqlStageExecution> iterator = schedulingStages.iterator(); iterator.hasNext(); ) {
             StageState state = iterator.next().getState();
-            if (state == SCHEDULED || state == RUNNING || state.isDone()) {
+            if (state == SCHEDULED || state == RUNNING || state == FLUSHING || state.isDone()) {
                 iterator.remove();
             }
         }

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/PhasedExecutionSchedule.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/PhasedExecutionSchedule.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.execution.StageState.FLUSHING;
 import static io.prestosql.execution.StageState.RUNNING;
 import static io.prestosql.execution.StageState.SCHEDULED;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.LOCAL;
@@ -92,7 +93,7 @@ public class PhasedExecutionSchedule
     {
         for (Iterator<SqlStageExecution> stageIterator = activeSources.iterator(); stageIterator.hasNext(); ) {
             StageState state = stageIterator.next().getState();
-            if (state == SCHEDULED || state == RUNNING || state.isDone()) {
+            if (state == SCHEDULED || state == RUNNING || state == FLUSHING || state.isDone()) {
                 stageIterator.remove();
             }
         }

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
@@ -421,7 +421,7 @@ public class SqlQueryScheduler
         }
         Set<SqlStageExecution> childStages = childStagesBuilder.build();
         stage.addStateChangeListener(newState -> {
-            if (newState.isDone()) {
+            if (newState == FLUSHING || newState.isDone()) {
                 childStages.forEach(SqlStageExecution::cancel);
             }
         });

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
@@ -90,6 +90,7 @@ import static io.prestosql.execution.StageState.ABORTED;
 import static io.prestosql.execution.StageState.CANCELED;
 import static io.prestosql.execution.StageState.FAILED;
 import static io.prestosql.execution.StageState.FINISHED;
+import static io.prestosql.execution.StageState.FLUSHING;
 import static io.prestosql.execution.StageState.RUNNING;
 import static io.prestosql.execution.StageState.SCHEDULED;
 import static io.prestosql.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsStageScheduler;
@@ -595,7 +596,7 @@ public class SqlQueryScheduler
 
             for (SqlStageExecution stage : stages.values()) {
                 StageState state = stage.getState();
-                if (state != SCHEDULED && state != RUNNING && !state.isDone()) {
+                if (state != SCHEDULED && state != RUNNING && state != FLUSHING && !state.isDone()) {
                     throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Scheduling is complete, but stage %s is in state %s", stage.getStageId(), state));
                 }
             }

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -364,6 +364,11 @@ public class TestingPrestoServer
         return queryManager.getQueryPlan(queryId);
     }
 
+    public QueryInfo getFullQueryInfo(QueryId queryId)
+    {
+        return queryManager.getFullQueryInfo(queryId);
+    }
+
     public void addFinalQueryInfoListener(QueryId queryId, StateChangeListener<QueryInfo> stateChangeListener)
     {
         queryManager.addFinalQueryInfoListener(queryId, stateChangeListener);

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlTask.java
@@ -137,18 +137,18 @@ public class TestSqlTask
     {
         SqlTask sqlTask = createInitialTask();
 
-        TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
+        assertEquals(sqlTask.getTaskStatus().getState(), TaskState.RUNNING);
+        sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
                 OptionalInt.empty());
-        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
-        taskInfo = sqlTask.getTaskInfo();
-        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
+        TaskInfo taskInfo = sqlTask.getTaskInfo(TaskState.RUNNING).get(1, SECONDS);
+        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FLUSHING);
 
         BufferResult results = sqlTask.getTaskResults(OUT, 0, DataSize.of(1, MEGABYTE)).get();
-        assertEquals(results.isBufferComplete(), false);
+        assertFalse(results.isBufferComplete());
         assertEquals(results.getSerializedPages().size(), 1);
         assertEquals(results.getSerializedPages().get(0).getPositionCount(), 1);
 
@@ -202,15 +202,15 @@ public class TestSqlTask
     {
         SqlTask sqlTask = createInitialTask();
 
-        TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
+        assertEquals(sqlTask.getTaskStatus().getState(), TaskState.RUNNING);
+        sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
                 OptionalInt.empty());
-        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
-        taskInfo = sqlTask.getTaskInfo();
-        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
+        TaskInfo taskInfo = sqlTask.getTaskInfo(TaskState.RUNNING).get(1, SECONDS);
+        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FLUSHING);
 
         sqlTask.abortTaskResults(OUT);
 

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
@@ -277,8 +277,9 @@ public class TestSqlTaskExecution
                     throw new UnsupportedOperationException();
             }
 
+            assertEquals(taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS), TaskState.FLUSHING);
             outputBufferConsumer.abort(); // complete the task by calling abort on it
-            TaskState taskState = taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS);
+            TaskState taskState = taskStateMachine.getStateChange(TaskState.FLUSHING).get(10, SECONDS);
             assertEquals(taskState, TaskState.FINISHED);
         }
         finally {
@@ -579,8 +580,9 @@ public class TestSqlTaskExecution
                     throw new UnsupportedOperationException();
             }
 
+            assertEquals(taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS), TaskState.FLUSHING);
             outputBufferConsumer.abort(); // complete the task by calling abort on it
-            TaskState taskState = taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS);
+            TaskState taskState = taskStateMachine.getStateChange(TaskState.FLUSHING).get(10, SECONDS);
             assertEquals(taskState, TaskState.FINISHED);
         }
         finally {

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlTaskExecution.java
@@ -88,6 +88,9 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.block.BlockAssertions.createStringSequenceBlock;
 import static io.prestosql.block.BlockAssertions.createStringsBlock;
+import static io.prestosql.execution.TaskState.FINISHED;
+import static io.prestosql.execution.TaskState.FLUSHING;
+import static io.prestosql.execution.TaskState.RUNNING;
 import static io.prestosql.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static io.prestosql.execution.TaskTestUtils.createTestSplitMonitor;
 import static io.prestosql.execution.buffer.BufferState.OPEN;
@@ -177,7 +180,7 @@ public class TestSqlTaskExecution
 
             //
             // test body
-            assertEquals(taskStateMachine.getState(), TaskState.RUNNING);
+            assertEquals(taskStateMachine.getState(), RUNNING);
 
             switch (executionStrategy) {
                 case UNGROUPED_EXECUTION:
@@ -277,10 +280,9 @@ public class TestSqlTaskExecution
                     throw new UnsupportedOperationException();
             }
 
-            assertEquals(taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS), TaskState.FLUSHING);
+            assertEquals(taskStateMachine.getStateChange(RUNNING).get(10, SECONDS), FLUSHING);
             outputBufferConsumer.abort(); // complete the task by calling abort on it
-            TaskState taskState = taskStateMachine.getStateChange(TaskState.FLUSHING).get(10, SECONDS);
-            assertEquals(taskState, TaskState.FINISHED);
+            assertEquals(taskStateMachine.getStateChange(FLUSHING).get(10, SECONDS), FINISHED);
         }
         finally {
             taskExecutor.stop();
@@ -429,7 +431,7 @@ public class TestSqlTaskExecution
 
             //
             // test body
-            assertEquals(taskStateMachine.getState(), TaskState.RUNNING);
+            assertEquals(taskStateMachine.getState(), RUNNING);
 
             switch (executionStrategy) {
                 case UNGROUPED_EXECUTION:
@@ -580,10 +582,9 @@ public class TestSqlTaskExecution
                     throw new UnsupportedOperationException();
             }
 
-            assertEquals(taskStateMachine.getStateChange(TaskState.RUNNING).get(10, SECONDS), TaskState.FLUSHING);
+            assertEquals(taskStateMachine.getStateChange(RUNNING).get(10, SECONDS), FLUSHING);
             outputBufferConsumer.abort(); // complete the task by calling abort on it
-            TaskState taskState = taskStateMachine.getStateChange(TaskState.FLUSHING).get(10, SECONDS);
-            assertEquals(taskState, TaskState.FINISHED);
+            assertEquals(taskStateMachine.getStateChange(FLUSHING).get(10, SECONDS), FINISHED);
         }
         finally {
             taskExecutor.stop();

--- a/presto-main/src/test/java/io/prestosql/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestStageStateMachine.java
@@ -81,6 +81,9 @@ public class TestStageStateMachine
         assertTrue(stateMachine.transitionToRunning());
         assertState(stateMachine, StageState.RUNNING);
 
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
+
         assertTrue(stateMachine.transitionToFinished());
         assertState(stateMachine, StageState.FINISHED);
     }
@@ -98,6 +101,10 @@ public class TestStageStateMachine
         stateMachine = createStageStateMachine();
         assertTrue(stateMachine.transitionToRunning());
         assertState(stateMachine, StageState.RUNNING);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
 
         stateMachine = createStageStateMachine();
         assertTrue(stateMachine.transitionToFinished());
@@ -136,6 +143,11 @@ public class TestStageStateMachine
 
         stateMachine = createStageStateMachine();
         stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
         assertTrue(stateMachine.transitionToFinished());
         assertState(stateMachine, StageState.FINISHED);
 
@@ -170,6 +182,9 @@ public class TestStageStateMachine
 
         assertTrue(stateMachine.transitionToRunning());
         assertState(stateMachine, StageState.RUNNING);
+
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
 
         stateMachine = createStageStateMachine();
         stateMachine.transitionToScheduled();
@@ -208,6 +223,11 @@ public class TestStageStateMachine
         assertFalse(stateMachine.transitionToRunning());
         assertState(stateMachine, StageState.RUNNING);
 
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToRunning();
         assertTrue(stateMachine.transitionToFinished());
         assertState(stateMachine, StageState.FINISHED);
 
@@ -223,6 +243,46 @@ public class TestStageStateMachine
 
         stateMachine = createStageStateMachine();
         stateMachine.transitionToRunning();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertState(stateMachine, StageState.CANCELED);
+    }
+
+    @Test
+    public void testFlushing()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        assertFalse(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        assertFalse(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        assertFalse(stateMachine.transitionToFlushing());
+        assertState(stateMachine, StageState.FLUSHING);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToFlushing();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToFlushing();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, StageState.FAILED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToFlushing();
+        assertTrue(stateMachine.transitionToAborted());
+        assertState(stateMachine, StageState.ABORTED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToFlushing();
         assertTrue(stateMachine.transitionToCanceled());
         assertState(stateMachine, StageState.CANCELED);
     }
@@ -276,6 +336,9 @@ public class TestStageStateMachine
         assertState(stateMachine, expectedState);
 
         assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToFlushing());
         assertState(stateMachine, expectedState);
 
         assertFalse(stateMachine.transitionToFinished());

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFlushingStageState.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFlushingStageState.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.prestosql.spi.QueryId;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.prestosql.SessionTestUtils.TEST_SESSION;
+import static io.prestosql.execution.QueryState.RUNNING;
+import static io.prestosql.execution.StageState.CANCELED;
+import static io.prestosql.execution.StageState.FLUSHING;
+import static io.prestosql.execution.TestQueryRunnerUtil.createQuery;
+import static io.prestosql.execution.TestQueryRunnerUtil.waitForQueryState;
+import static io.prestosql.testing.assertions.Assert.assertEventually;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+
+public class TestFlushingStageState
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        queryRunner = TpchQueryRunnerBuilder.builder().buildWithoutCatalogs();
+        queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", "10000"));
+    }
+
+    @Test(timeOut = 30_000)
+    public void testFlushingState()
+            throws Exception
+    {
+        QueryId queryId = createQuery(queryRunner, TEST_SESSION, "SELECT * FROM tpch.sf1000.lineitem limit 1");
+        waitForQueryState(queryRunner, queryId, RUNNING);
+
+        // wait for the query to finish producing results, but don't poll them
+        assertEventually(
+                new Duration(10, SECONDS),
+                () -> assertEquals(queryRunner.getCoordinator().getFullQueryInfo(queryId).getOutputStage().get().getState(), FLUSHING));
+
+        // wait for the sub stages to go to cancelled state
+        assertEventually(
+                new Duration(10, SECONDS),
+                () -> assertEquals(queryRunner.getCoordinator().getFullQueryInfo(queryId).getOutputStage().get().getSubStages().get(0).getState(), CANCELED));
+
+        QueryInfo queryInfo = queryRunner.getCoordinator().getFullQueryInfo(queryId);
+        assertEquals(queryInfo.getState(), RUNNING);
+        assertEquals(queryInfo.getOutputStage().get().getState(), FLUSHING);
+        assertEquals(queryInfo.getOutputStage().get().getSubStages().size(), 1);
+        assertEquals(queryInfo.getOutputStage().get().getSubStages().get(0).getState(), CANCELED);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+        }
+    }
+}


### PR DESCRIPTION
Adds a flushing state to tasks and stages.
This is useful in case of broadcast joins where if the build source stage is done processing and is just running to serving data from its output buffer to join tasks, its sub-stages can be shutdown by cancellation (since the new output produced by the sub stages will not be useful). The cancellation is helpful since the sub stages under build source can be complex and take significant memory (the output buffer size is configurable) and CPU (due to the processing) to get to a blocked state.

For tasks, flushing state signifies that there will be no new drivers, the existing drivers have finished and the output buffer of the task is at-least in a 'no-more-pages' state.
For stages, flushing state signifies that at-least one of its task is flushing and the non-flushing tasks are finished.
For both, once the state has started flushing it will never go back to 'RUNNING' state.