### PR TITLE
Relax task locking in SourcePartitionedScheduler

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlStageExecution.java
@@ -559,6 +559,18 @@ public final class SqlStageExecution
         }
     }
 
+    public List<TaskStatus> getTaskStatuses()
+    {
+        return getAllTasks().stream()
+                .map(RemoteTask::getTaskStatus)
+                .collect(toImmutableList());
+    }
+
+    public boolean isAnyTaskBlocked()
+    {
+        return getTaskStatuses().stream().anyMatch(TaskStatus::isOutputBufferOverutilized);
+    }
+
     private ExecutionFailureInfo rewriteTransportFailure(ExecutionFailureInfo executionFailureInfo)
     {
         if (executionFailureInfo.getRemoteHost() == null || failureDetector.getState(executionFailureInfo.getRemoteHost()) != GONE) {

--- a/presto-main/src/main/java/io/prestosql/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/BroadcastOutputBuffer.java
@@ -104,7 +104,7 @@ public class BroadcastOutputBuffer
     @Override
     public boolean isOverutilized()
     {
-        return memoryManager.isOverutilized();
+        return (getUtilization() > 0.5) && state.get().canAddPages();
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -107,13 +107,16 @@ public class FixedSourcePartitionedScheduler
         for (PlanNodeId planNodeId : schedulingOrder) {
             SplitSource splitSource = splitSources.get(planNodeId);
             boolean groupedExecutionForScanNode = stageExecutionDescriptor.isScanGroupedExecution(planNodeId);
+            // TODO : change anySourceTaskBlocked to accommodate the correct blocked status of source tasks
+            //  (ref : https://github.com/prestosql/presto/issues/4713)
             SourceScheduler sourceScheduler = newSourcePartitionedSchedulerAsSourceScheduler(
                     stage,
                     planNodeId,
                     splitSource,
                     splitPlacementPolicy,
                     Math.max(splitBatchSize / concurrentLifespans, 1),
-                    groupedExecutionForScanNode);
+                    groupedExecutionForScanNode,
+                    () -> true);
 
             if (stageExecutionDescriptor.isStageGroupedExecution() && !groupedExecutionForScanNode) {
                 sourceScheduler = new AsGroupedSourceScheduler(sourceScheduler);

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
@@ -107,7 +107,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class SqlQueryScheduler
@@ -306,10 +305,37 @@ public class SqlQueryScheduler
                 queryExecutor,
                 failureDetector,
                 schedulerStats);
-
         stages.add(stage);
 
-        Optional<int[]> bucketToPartition;
+        // function to create child stages recursively by supplying the bucket partitioning (according to parent's partitioning)
+        Function<Optional<int[]>, Set<SqlStageExecution>> createChildStages = bucketToPartition -> {
+            ImmutableSet.Builder<SqlStageExecution> childStagesBuilder = ImmutableSet.builder();
+            for (StageExecutionPlan subStagePlan : plan.getSubStages()) {
+                List<SqlStageExecution> subTree = createStages(
+                        stage::addExchangeLocations,
+                        nextStageId,
+                        subStagePlan.withBucketToPartition(bucketToPartition),
+                        nodeScheduler,
+                        remoteTaskFactory,
+                        session,
+                        splitBatchSize,
+                        partitioningCache,
+                        nodePartitioningManager,
+                        queryExecutor,
+                        schedulerExecutor,
+                        failureDetector,
+                        nodeTaskMap,
+                        stageSchedulers,
+                        stageLinkages);
+                stages.addAll(subTree);
+
+                SqlStageExecution childStage = subTree.get(0);
+                childStagesBuilder.add(childStage);
+            }
+            return childStagesBuilder.build();
+        };
+
+        Set<SqlStageExecution> childStages;
         PartitioningHandle partitioningHandle = plan.getFragment().getPartitioning();
         if (partitioningHandle.equals(SOURCE_DISTRIBUTION)) {
             // nodes are selected dynamically based on the constraints of the splits and the system load
@@ -322,13 +348,37 @@ public class SqlQueryScheduler
             SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stage::getAllTasks);
 
             checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
-            stageSchedulers.put(stageId, newSourcePartitionedSchedulerAsStageScheduler(stage, planNodeId, splitSource, placementPolicy, splitBatchSize));
-            bucketToPartition = Optional.of(new int[1]);
+
+            childStages = createChildStages.apply(Optional.of(new int[1]));
+            stageSchedulers.put(stageId, newSourcePartitionedSchedulerAsStageScheduler(
+                    stage,
+                    planNodeId,
+                    splitSource,
+                    placementPolicy,
+                    splitBatchSize,
+                    () -> childStages.stream().anyMatch(SqlStageExecution::isAnyTaskBlocked)));
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
-            bucketToPartition = Optional.of(new int[1]);
+            childStages = createChildStages.apply(Optional.of(new int[1]));
+            Supplier<Collection<TaskStatus>> sourceTasksProvider = () -> childStages.stream()
+                    .map(SqlStageExecution::getTaskStatuses)
+                    .flatMap(List::stream)
+                    .collect(toImmutableList());
+            Supplier<Collection<TaskStatus>> writerTasksProvider = stage::getTaskStatuses;
+
+            ScaledWriterScheduler scheduler = new ScaledWriterScheduler(
+                    stage,
+                    sourceTasksProvider,
+                    writerTasksProvider,
+                    nodeScheduler.createNodeSelector(Optional.empty()),
+                    schedulerExecutor,
+                    getWriterMinSize(session));
+            whenAllStages(childStages, StageState::isDone)
+                    .addListener(scheduler::finish, directExecutor());
+            stageSchedulers.put(stageId, scheduler);
         }
         else {
+            Optional<int[]> bucketToPartition;
             Map<PlanNodeId, SplitSource> splitSources = plan.getSplitSources();
             if (!splitSources.isEmpty()) {
                 // contains local source
@@ -394,32 +444,9 @@ public class SqlQueryScheduler
                 stageSchedulers.put(stageId, new FixedCountScheduler(stage, partitionToNode));
                 bucketToPartition = Optional.of(nodePartitionMap.getBucketToPartition());
             }
+            childStages = createChildStages.apply(bucketToPartition);
         }
 
-        ImmutableSet.Builder<SqlStageExecution> childStagesBuilder = ImmutableSet.builder();
-        for (StageExecutionPlan subStagePlan : plan.getSubStages()) {
-            List<SqlStageExecution> subTree = createStages(
-                    stage::addExchangeLocations,
-                    nextStageId,
-                    subStagePlan.withBucketToPartition(bucketToPartition),
-                    nodeScheduler,
-                    remoteTaskFactory,
-                    session,
-                    splitBatchSize,
-                    partitioningCache,
-                    nodePartitioningManager,
-                    queryExecutor,
-                    schedulerExecutor,
-                    failureDetector,
-                    nodeTaskMap,
-                    stageSchedulers,
-                    stageLinkages);
-            stages.addAll(subTree);
-
-            SqlStageExecution childStage = subTree.get(0);
-            childStagesBuilder.add(childStage);
-        }
-        Set<SqlStageExecution> childStages = childStagesBuilder.build();
         stage.addStateChangeListener(newState -> {
             if (newState == FLUSHING || newState.isDone()) {
                 childStages.forEach(SqlStageExecution::cancel);
@@ -427,29 +454,6 @@ public class SqlQueryScheduler
         });
 
         stageLinkages.put(stageId, new StageLinkage(plan.getFragment().getId(), parent, childStages));
-
-        if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
-            Supplier<Collection<TaskStatus>> sourceTasksProvider = () -> childStages.stream()
-                    .map(SqlStageExecution::getAllTasks)
-                    .flatMap(Collection::stream)
-                    .map(RemoteTask::getTaskStatus)
-                    .collect(toList());
-
-            Supplier<Collection<TaskStatus>> writerTasksProvider = () -> stage.getAllTasks().stream()
-                    .map(RemoteTask::getTaskStatus)
-                    .collect(toList());
-
-            ScaledWriterScheduler scheduler = new ScaledWriterScheduler(
-                    stage,
-                    sourceTasksProvider,
-                    writerTasksProvider,
-                    nodeScheduler.createNodeSelector(Optional.empty()),
-                    schedulerExecutor,
-                    getWriterMinSize(session));
-            whenAllStages(childStages, StageState::isDone)
-                    .addListener(scheduler::finish, directExecutor());
-            stageSchedulers.put(stageId, scheduler);
-        }
 
         return stages.build();
     }

--- a/presto-main/src/test/java/io/prestosql/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockRemoteTaskFactory.java
@@ -167,6 +167,8 @@ public class MockRemoteTaskFactory
 
         private final PartitionedSplitCountTracker partitionedSplitCountTracker;
 
+        private boolean isOutputBufferOverUtilized;
+
         public MockRemoteTask(
                 TaskId taskId,
                 PlanFragment fragment,
@@ -242,7 +244,7 @@ public class MockRemoteTaskFactory
                             failures,
                             0,
                             0,
-                            false,
+                            isOutputBufferOverUtilized,
                             DataSize.ofBytes(0),
                             DataSize.ofBytes(0),
                             DataSize.ofBytes(0),
@@ -271,7 +273,7 @@ public class MockRemoteTaskFactory
                     ImmutableList.of(),
                     stats.getQueuedPartitionedDrivers(),
                     stats.getRunningPartitionedDrivers(),
-                    false,
+                    isOutputBufferOverUtilized,
                     stats.getPhysicalWrittenDataSize(),
                     stats.getUserMemoryReservation(),
                     stats.getSystemMemoryReservation(),
@@ -321,6 +323,11 @@ public class MockRemoteTaskFactory
             runningDrivers = splits.size();
             runningDrivers = Math.min(runningDrivers, maxRunning);
             updateSplitQueueSpace();
+        }
+
+        public synchronized void setOutputBufferOverUtilized(boolean isOutputBufferOverUtilized)
+        {
+            this.isOutputBufferOverUtilized = isOutputBufferOverUtilized;
         }
 
         @Override

--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.SettableFuture;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.cost.StatsAndCosts;
+import io.prestosql.execution.MockRemoteTaskFactory.MockRemoteTask;
 import io.prestosql.execution.scheduler.SplitSchedulerStats;
 import io.prestosql.failuredetector.NoOpFailureDetector;
 import io.prestosql.metadata.InternalNode;
@@ -153,6 +154,42 @@ public class TestSqlStageExecution
 
         // cancel the background thread adding tasks
         addTasksTask.cancel(true);
+    }
+
+    @Test
+    public void testIsAnyTaskBlocked()
+    {
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(new FinalizerService());
+
+        StageId stageId = new StageId(new QueryId("query"), 0);
+        SqlStageExecution stage = createSqlStageExecution(
+                stageId,
+                createExchangePlanFragment(),
+                ImmutableMap.of(),
+                new MockRemoteTaskFactory(executor, scheduledExecutor),
+                TEST_SESSION,
+                true,
+                nodeTaskMap,
+                executor,
+                new NoOpFailureDetector(),
+                new SplitSchedulerStats());
+        stage.setOutputBuffers(createInitialEmptyOutputBuffers(ARBITRARY));
+
+        InternalNode node1 = new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false);
+        InternalNode node2 = new InternalNode("other2", URI.create("http://127.0.0.2:12"), NodeVersion.UNKNOWN, false);
+        MockRemoteTask task1 = (MockRemoteTask) stage.scheduleTask(node1, 1, OptionalInt.empty()).get();
+        MockRemoteTask task2 = (MockRemoteTask) stage.scheduleTask(node2, 2, OptionalInt.empty()).get();
+
+        // both tasks' buffers are under utilized
+        assertFalse(stage.isAnyTaskBlocked());
+
+        // set one of the task's buffer to be over utilized
+        task1.setOutputBufferOverUtilized(true);
+        assertTrue(stage.isAnyTaskBlocked());
+
+        // set both the tasks' buffers to be over utilized
+        task2.setOutputBufferOverUtilized(true);
+        assertTrue(stage.isAnyTaskBlocked());
     }
 
     private static PlanFragment createExchangePlanFragment()


### PR DESCRIPTION
Currently, in a broadcast join - the join tasks are blocked as soon as split queues are full for the join stage tasks. The reason behind that is explained as below in the code in SourcePartitionedScheduler : 
>// In a broadcast join, output buffers of the tasks in build source stage have to
            // hold onto all data produced before probe side task scheduling finishes,
            // even if the data is acknowledged by all known consumers. This is because
            // new consumers may be added until the probe side task scheduling finishes.
            //
            // As a result, the following line is necessary to prevent deadlock
            // due to neither build nor probe can make any progress.
            // The build side blocks due to a full output buffer.
            // In the meantime the probe side split cannot be consumed since
            // builder side hash table construction has not finished.

This adds a check for the build stage's output buffer utilization as well. With this change, we'll lock the join tasks if the split queues are and the build output buffer is almost full. This allows improvement in scaling of broadcast joins to new workers incase of small builds.
This change only covers the case when SourcePartitionedScheduler is used as a stage scheduler.

Relates to #4290 