### PR TITLE
Try compacting table multiple times if compaction has failed

### DIFF
--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -114,6 +114,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
Sometimes compaction can fail due to yarn container being killed. This prevents test from failing by retrying table compaction.