### PR TITLE
Run Iceberg product test once

### DIFF
--- a/presto-product-tests/conf/product-tests-config-cdh5.sh
+++ b/presto-product-tests/conf/product-tests-config-cdh5.sh
@@ -1,2 +1,2 @@
 export HADOOP_BASE_IMAGE="prestodev/cdh5.15-hive"
-export DISTRO_SKIP_GROUP=skip_on_cdh
+export DISTRO_SKIP_GROUP=skip_on_cdh,iceberg

--- a/presto-product-tests/conf/product-tests-config-hdp3.sh
+++ b/presto-product-tests/conf/product-tests-config-hdp3.sh
@@ -1,2 +1,3 @@
 export HADOOP_BASE_IMAGE="prestodev/hdp3.1-hive"
 export TEMPTO_ENVIRONMENT_CONFIG_FILE="/docker/presto-product-tests/conf/tempto/tempto-configuration-for-hive3.yaml"
+export DISTRO_SKIP_GROUP=iceberg


### PR DESCRIPTION
We do not need to run Iceberg product tests against HDP 3 and CDH 5
environments.

cc @MiguelWeezardo 