### PR TITLE
Bump Iceberg version to 0.8.0-incubating

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.7.0-incubating</dep.iceberg.version>
+        <dep.iceberg.version>0.8.0-incubating</dep.iceberg.version>
     </properties>
 
     <dependencies>

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -70,6 +70,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 
 import java.io.IOException;
@@ -563,9 +564,10 @@ public class IcebergMetadata
                 icebergColumns.add(field);
             }
         }
-        Schema schema = new Schema(icebergColumns);
+        Type icebergSchema = Types.StructType.of(icebergColumns);
         AtomicInteger nextFieldId = new AtomicInteger(1);
-        return TypeUtil.assignFreshIds(schema, nextFieldId::getAndIncrement);
+        icebergSchema = TypeUtil.assignFreshIds(icebergSchema, nextFieldId::getAndIncrement);
+        return new Schema(icebergSchema.asStructType().fields());
     }
 
     @Override


### PR DESCRIPTION
The change in `IcebergMetadata::toIcebergSchema` is needed to avoid failures
with nested types. With 0.8.0-incubating, we need to assign fresh IDs (to
avoid duplicate IDs) before constructing an Iceberg schema.