### PR TITLE
Eliminate the redundant control flow

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/Symbol.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/Symbol.java
@@ -68,11 +68,7 @@ public class Symbol
 
         Symbol symbol = (Symbol) o;
 
-        if (!name.equals(symbol.name)) {
-            return false;
-        }
-
-        return true;
+        return name.equals(symbol.name);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -311,11 +311,7 @@ public class PushPredicateIntoTableScan
             Object optimized = TryFunction.evaluate(() -> evaluator.optimize(inputs), true);
 
             // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned
-            if (Boolean.FALSE.equals(optimized) || optimized == null || optimized instanceof NullLiteral) {
-                return false;
-            }
-
-            return true;
+            return !(Boolean.FALSE.equals(optimized) || optimized == null || optimized instanceof NullLiteral);
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -300,11 +300,7 @@ public class OptimizeMixedDistinctAggregations
                 }
             }
 
-            if (!symbolAllocator.getTypes().get(aggregateInfo.getMask()).isComparable()) {
-                return false;
-            }
-
-            return true;
+            return symbolAllocator.getTypes().get(aggregateInfo.getMask()).isComparable();
         }
 
         /*

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanFragmentId.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanFragmentId.java
@@ -51,11 +51,7 @@ public class PlanFragmentId
 
         PlanFragmentId that = (PlanFragmentId) o;
 
-        if (!id.equals(that.id)) {
-            return false;
-        }
-
-        return true;
+        return id.equals(that.id);
     }
 
     @Override


### PR DESCRIPTION
The optimizer module has several unnecessary `if` statements inside. We can simplify such control flows by eliminating them.

It relates to https://github.com/prestosql/presto/pull/4300.