### PR TITLE
Invalidate predicates for reused symbols

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
@@ -60,6 +60,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.spi.type.TypeUtils.isFloatingPointNaN;
 import static io.prestosql.sql.ExpressionUtils.combineConjuncts;
 import static io.prestosql.sql.ExpressionUtils.expressionOrNullSymbols;
@@ -179,10 +180,27 @@ public class EffectivePredicateExtractor
         {
             // TODO: add simple algebraic solver for projection translation (right now only considers identity projections)
 
+            // Clear predicates involving symbols which are keys to non-identity assignments.
+            // Assignment such as `s -> x + 1` establishes new semantics for symbol `s`.
+            // If symbol `s` was present is the source plan and was included in underlying predicate, the predicate is no more valid.
+            // Also, if symbol `s` is present in a project assignment's value, e.g. `s1 -> s + 1`, this assignment should't be used to derive equality.
+
             Expression underlyingPredicate = node.getSource().accept(this, context);
 
-            List<Expression> projectionEqualities = node.getAssignments().entrySet().stream()
+            List<Map.Entry<Symbol, Expression>> nonIdentityAssignments = node.getAssignments().entrySet().stream()
                     .filter(SYMBOL_MATCHES_EXPRESSION.negate())
+                    .collect(toImmutableList());
+
+            Set<Symbol> newlyAssignedSymbols = nonIdentityAssignments.stream()
+                    .map(Map.Entry::getKey)
+                    .collect(toImmutableSet());
+
+            List<Expression> validUnderlyingEqualities = extractConjuncts(underlyingPredicate).stream()
+                    .filter(expression -> Sets.intersection(SymbolsExtractor.extractUnique(expression), newlyAssignedSymbols).isEmpty())
+                    .collect(toImmutableList());
+
+            List<Expression> projectionEqualities = nonIdentityAssignments.stream()
+                    .filter(assignment -> Sets.intersection(SymbolsExtractor.extractUnique(assignment.getValue()), newlyAssignedSymbols).isEmpty())
                     .map(ENTRY_TO_EQUALITY)
                     .collect(toImmutableList());
 
@@ -190,7 +208,7 @@ public class EffectivePredicateExtractor
                     metadata,
                     ImmutableList.<Expression>builder()
                             .addAll(projectionEqualities)
-                            .add(underlyingPredicate)
+                            .addAll(validUnderlyingEqualities)
                             .build()),
                     node.getOutputSymbols());
         }


### PR DESCRIPTION
Since symbols might be reused in the plan, some predicates that
hold in source plan may become invalid.
This change adds support for reused symbols in
EffectivePredicateExtractor.visitProject().
If a project assignment maps a symbol to some expression which is not
simply a reference to this symbol, such symbol is considered
'newly assigned'. Consequently, all predicates from source plan
involving this symbol become invalid and will not be passed.
Also, any project assignments using this symbol aren't eligible
for deriving equalities.

Note: The issue of reused symbols might occur in the future  when
extracting effective predicate is implemented for other PlanNodes
e.g. RowNumberNode.