### PR TITLE
Fix old client compatibility with parametric timestamp type

### DIFF
--- a/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
@@ -41,6 +41,7 @@ public class FullConnectorSession
     private final String catalog;
     private final SessionPropertyManager sessionPropertyManager;
     private final boolean isLegacyTimestamp;
+    private final boolean omitDatetimeTypePrecision;
 
     public FullConnectorSession(Session session, ConnectorIdentity identity)
     {
@@ -51,6 +52,7 @@ public class FullConnectorSession
         this.catalog = null;
         this.sessionPropertyManager = null;
         this.isLegacyTimestamp = SystemSessionProperties.isLegacyTimestamp(session);
+        this.omitDatetimeTypePrecision = SystemSessionProperties.isOmitDateTimeTypePrecision(session);
     }
 
     public FullConnectorSession(
@@ -68,6 +70,7 @@ public class FullConnectorSession
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.isLegacyTimestamp = SystemSessionProperties.isLegacyTimestamp(session);
+        this.omitDatetimeTypePrecision = SystemSessionProperties.isOmitDateTimeTypePrecision(session);
     }
 
     public Session getSession()
@@ -121,6 +124,12 @@ public class FullConnectorSession
     public boolean isLegacyTimestamp()
     {
         return isLegacyTimestamp;
+    }
+
+    @Override
+    public boolean isOmitDatetimeTypePrecision()
+    {
+        return omitDatetimeTypePrecision;
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -128,6 +128,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_COUNT = "required_workers_count";
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
+    public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -558,7 +559,12 @@ public final class SystemSessionProperties
                         COST_ESTIMATION_WORKER_COUNT,
                         "Set the estimate count of workers while planning",
                         null,
-                        true));
+                        true),
+                booleanProperty(
+                        OMIT_DATETIME_TYPE_PRECISION,
+                        "Omit precision when rendering datetime type names with default precision",
+                        featuresConfig.isOmitDateTimeTypePrecision(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1002,5 +1008,10 @@ public final class SystemSessionProperties
     public static Integer getCostEstimationWorkerCount(Session session)
     {
         return session.getSystemProperty(COST_ESTIMATION_WORKER_COUNT, Integer.class);
+    }
+
+    public static boolean isOmitDateTimeTypePrecision(Session session)
+    {
+        return session.getSystemProperty(OMIT_DATETIME_TYPE_PRECISION, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -92,6 +92,7 @@ public class FeaturesConfig
     private boolean forceSingleNodeOutput = true;
     private boolean pagesIndexEagerCompactionEnabled;
     private boolean distributedSort = true;
+    private boolean omitDateTimeTypePrecision;
 
     private boolean dictionaryAggregation;
 
@@ -212,6 +213,18 @@ public class FeaturesConfig
     public FeaturesConfig setDistributedIndexJoinsEnabled(boolean distributedIndexJoinsEnabled)
     {
         this.distributedIndexJoinsEnabled = distributedIndexJoinsEnabled;
+        return this;
+    }
+
+    public boolean isOmitDateTimeTypePrecision()
+    {
+        return omitDateTimeTypePrecision;
+    }
+
+    @Config("deprecated.omit-datetime-type-precision")
+    public FeaturesConfig setOmitDateTimeTypePrecision(boolean value)
+    {
+        this.omitDateTimeTypePrecision = value;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
@@ -53,6 +53,7 @@ public class TestingConnectorSession
     private final Map<String, PropertyMetadata<?>> properties;
     private final Map<String, Object> propertyValues;
     private final boolean isLegacyTimestamp;
+    private final boolean omitTimestampPrecision;
 
     private TestingConnectorSession(
             ConnectorIdentity identity,
@@ -63,7 +64,8 @@ public class TestingConnectorSession
             Instant start,
             List<PropertyMetadata<?>> propertyMetadatas,
             Map<String, Object> propertyValues,
-            boolean isLegacyTimestamp)
+            boolean isLegacyTimestamp,
+            boolean omitTimestampPrecision)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.source = requireNonNull(source, "source is null");
@@ -74,6 +76,7 @@ public class TestingConnectorSession
         this.properties = Maps.uniqueIndex(propertyMetadatas, PropertyMetadata::getName);
         this.propertyValues = ImmutableMap.copyOf(propertyValues);
         this.isLegacyTimestamp = isLegacyTimestamp;
+        this.omitTimestampPrecision = omitTimestampPrecision;
     }
 
     @Override
@@ -125,6 +128,12 @@ public class TestingConnectorSession
     }
 
     @Override
+    public boolean isOmitDatetimeTypePrecision()
+    {
+        return omitTimestampPrecision;
+    }
+
+    @Override
     public <T> T getProperty(String name, Class<T> type)
     {
         PropertyMetadata<?> metadata = properties.get(name);
@@ -169,6 +178,7 @@ public class TestingConnectorSession
         private List<PropertyMetadata<?>> propertyMetadatas = ImmutableList.of();
         private Map<String, Object> propertyValues = ImmutableMap.of();
         private boolean isLegacyTimestamp = new FeaturesConfig().isLegacyTimestamp();
+        private boolean omitTimestampPrecision = new FeaturesConfig().isOmitDateTimeTypePrecision();
 
         public Builder setIdentity(ConnectorIdentity identity)
         {
@@ -208,6 +218,12 @@ public class TestingConnectorSession
             return this;
         }
 
+        public Builder setOmitTimestampPrecision(boolean value)
+        {
+            this.omitTimestampPrecision = value;
+            return this;
+        }
+
         public TestingConnectorSession build()
         {
             return new TestingConnectorSession(
@@ -219,7 +235,8 @@ public class TestingConnectorSession
                     start.orElse(Instant.now()),
                     propertyMetadatas,
                     propertyValues,
-                    isLegacyTimestamp);
+                    isLegacyTimestamp,
+                    omitTimestampPrecision);
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsBase.java
@@ -49,6 +49,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static io.prestosql.SystemSessionProperties.isLegacyTimestamp;
+import static io.prestosql.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.prestosql.operator.scalar.DateTimeFunctions.currentDate;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -171,6 +172,7 @@ public abstract class TestDateTimeFunctionsBase
                 .setStart(instant)
                 .setTimeZoneKey(timeZoneKey)
                 .setLegacyTimestamp(isLegacyTimestamp(session))
+                .setOmitTimestampPrecision(isOmitDateTimeTypePrecision(session))
                 .build();
         long dateTimeCalculation = currentDate(connectorSession);
         assertEquals(dateTimeCalculation, expectedDays);

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -112,7 +112,8 @@ public class TestFeaturesConfig
                 .setEnableDynamicFiltering(true)
                 .setDynamicFilteringMaxPerDriverRowCount(100)
                 .setDynamicFilteringMaxPerDriverSize(DataSize.of(10, KILOBYTE))
-                .setIgnoreDownstreamPreferences(false));
+                .setIgnoreDownstreamPreferences(false)
+                .setOmitDateTimeTypePrecision(false));
     }
 
     @Test
@@ -187,6 +188,7 @@ public class TestFeaturesConfig
                 .put("dynamic-filtering-max-per-driver-row-count", "256")
                 .put("dynamic-filtering-max-per-driver-size", "64kB")
                 .put("optimizer.ignore-downstream-preferences", "true")
+                .put("deprecated.omit-datetime-type-precision", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -257,7 +259,8 @@ public class TestFeaturesConfig
                 .setEnableDynamicFiltering(false)
                 .setDynamicFilteringMaxPerDriverRowCount(256)
                 .setDynamicFilteringMaxPerDriverSize(DataSize.of(64, KILOBYTE))
-                .setIgnoreDownstreamPreferences(true);
+                .setIgnoreDownstreamPreferences(true)
+                .setOmitDateTimeTypePrecision(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
+++ b/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
@@ -122,6 +122,7 @@ public class TestPinotSplitManager
                         .put(PinotSessionProperties.FORBID_SEGMENT_QUERIES, forbidSegmentQueries)
                         .build())
                 .setLegacyTimestamp(new FeaturesConfig().isLegacyTimestamp())
+                .setOmitTimestampPrecision(new FeaturesConfig().isOmitDateTimeTypePrecision())
                 .build();
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
@@ -52,5 +52,7 @@ public interface ConnectorSession
 
     boolean isLegacyTimestamp();
 
+    boolean isOmitDatetimeTypePrecision();
+
     <T> T getProperty(String name, Class<T> type);
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampType.java
@@ -30,7 +30,7 @@ public abstract class TimestampType
     public static final int MAX_PRECISION = 12;
 
     public static final int MAX_SHORT_PRECISION = 6;
-    private static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
 
     @Deprecated
     public static final TimestampType TIMESTAMP = new ShortTimestampType(DEFAULT_PRECISION);

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampWithTimeZoneType.java
@@ -25,7 +25,7 @@ public abstract class TimestampWithTimeZoneType
     public static final int MAX_PRECISION = 12;
 
     public static final int MAX_SHORT_PRECISION = 3;
-    private static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
 
     @Deprecated
     public static final TimestampWithTimeZoneType TIMESTAMP_WITH_TIME_ZONE = new ShortTimestampWithTimeZoneType(DEFAULT_PRECISION);

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
@@ -79,6 +79,12 @@ public final class TestingSession
         }
 
         @Override
+        public boolean isOmitDatetimeTypePrecision()
+        {
+            return false;
+        }
+
+        @Override
         public <T> T getProperty(String name, Class<T> type)
         {
             throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);


### PR DESCRIPTION
Fixes #4036 

Tools like PowerBI and Tableau use ODBC interface to interact with Presto. With the recent enhancements in Presto to support parametric timestamp type (timestamp with different precision), the old ODBC interfaces are not working. The code changes in this PR will convert data type for the following cases.

timestamp(3)                          =>   timestamp
timestamp(3) with time zone =>   timestamp with time zone

Since Presto used to support timestamps with three digit precision (up to milliseconds) in the past, we are doing the above conversion to maintain compatibility with previous interpretation of "timestamp" types by clients. Any other timestamp with a different precision (say timestamp(9)) will remain as is.

@martint @tooptoop4