### PR TITLE
Add physicalInputDataSize to BasicQueryStats.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -354,6 +354,7 @@ public class QueryStateMachine
 
                 stageStats.getRawInputDataSize(),
                 stageStats.getRawInputPositions(),
+                stageStats.getPhysicalInputDataSize(),
 
                 stageStats.getCumulativeUserMemory(),
                 stageStats.getUserMemoryReservation(),

--- a/presto-main/src/main/java/io/prestosql/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/server/BasicQueryStats.java
@@ -52,6 +52,7 @@ public class BasicQueryStats
 
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
+    private final DataSize physicalInputDataSize;
 
     private final double cumulativeUserMemory;
     private final DataSize userMemoryReservation;
@@ -79,6 +80,7 @@ public class BasicQueryStats
             @JsonProperty("completedDrivers") int completedDrivers,
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
+            @JsonProperty("physicalInputDataSize") DataSize physicalInputDataSize,
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
@@ -108,6 +110,7 @@ public class BasicQueryStats
 
         this.rawInputDataSize = requireNonNull(rawInputDataSize);
         this.rawInputPositions = rawInputPositions;
+        this.physicalInputDataSize = physicalInputDataSize;
 
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.userMemoryReservation = userMemoryReservation;
@@ -136,6 +139,7 @@ public class BasicQueryStats
                 queryStats.getCompletedDrivers(),
                 queryStats.getRawInputDataSize(),
                 queryStats.getRawInputPositions(),
+                queryStats.getPhysicalInputDataSize(),
                 queryStats.getCumulativeUserMemory(),
                 queryStats.getUserMemoryReservation(),
                 queryStats.getTotalMemoryReservation(),
@@ -163,6 +167,7 @@ public class BasicQueryStats
                 0,
                 DataSize.ofBytes(0),
                 0,
+                DataSize.ofBytes(0),
                 0,
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
@@ -239,6 +244,12 @@ public class BasicQueryStats
     public long getRawInputPositions()
     {
         return rawInputPositions;
+    }
+
+    @JsonProperty
+    public DataSize getPhysicalInputDataSize()
+    {
+        return physicalInputDataSize;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -130,6 +130,7 @@ public class MockManagedQueryExecution
                         9,
                         DataSize.ofBytes(14),
                         15,
+                        DataSize.ofBytes(13),
                         16.0,
                         memoryUsage,
                         memoryUsage,

--- a/presto-tests/src/test/java/io/prestosql/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/io/prestosql/memory/TestClusterMemoryLeakDetector.java
@@ -91,6 +91,7 @@ public class TestClusterMemoryLeakDetector
                         100,
                         DataSize.valueOf("21GB"),
                         22,
+                        DataSize.valueOf("20GB"),
                         23,
                         DataSize.valueOf("23GB"),
                         DataSize.valueOf("24GB"),


### PR DESCRIPTION
As mention in https://github.com/prestosql/presto/pull/4076, split the change into two part, this is the first commit add physicalInputDataSize to basic query stats 