### PR TITLE
Suppress NotFoundException when pruning docker networks

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
@@ -57,8 +57,13 @@ public final class ContainerUtil
         ListNetworksCmd listNetworksCmd = filter.apply(dockerClient.listNetworksCmd());
         List<Network> networks = listNetworksCmd.exec();
         for (Network network : networks) {
-            dockerClient.removeNetworkCmd(network.getId())
-                    .exec();
+            try {
+                dockerClient.removeNetworkCmd(network.getId())
+                        .exec();
+            }
+            catch (NotFoundException ignore) {
+                // Possible when previous tests invocation leaves a network behind and it is being garbage collected by Ryuk in the background.
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/4359