### PR TITLE
Salesforce authn

### DIFF
--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -29,6 +29,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 

--- a/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/PasswordAuthenticatorPlugin.java
+++ b/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/PasswordAuthenticatorPlugin.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.password;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.password.file.FileAuthenticatorFactory;
 import io.prestosql.plugin.password.ldap.LdapAuthenticatorFactory;
+import io.prestosql.plugin.password.salesforce.SalesforceAuthenticatorFactory;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.security.PasswordAuthenticatorFactory;
 
@@ -28,6 +29,7 @@ public class PasswordAuthenticatorPlugin
         return ImmutableList.<PasswordAuthenticatorFactory>builder()
                 .add(new FileAuthenticatorFactory())
                 .add(new LdapAuthenticatorFactory())
+                .add(new SalesforceAuthenticatorFactory())
                 .build();
     }
 }

--- a/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceAuthenticationClient.java
+++ b/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceAuthenticationClient.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface SalesforceAuthenticationClient
+{
+}

--- a/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceAuthenticatorFactory.java
+++ b/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceAuthenticatorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.prestosql.spi.security.PasswordAuthenticator;
+import io.prestosql.spi.security.PasswordAuthenticatorFactory;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+
+public class SalesforceAuthenticatorFactory
+        implements PasswordAuthenticatorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "salesforce";
+    }
+
+    @Override
+    public PasswordAuthenticator create(Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                binder -> {
+                    configBinder(binder).bindConfig(SalesforceConfig.class);
+                    binder.bind(SalesforceBasicAuthenticator.class).in(Scopes.SINGLETON);
+                    httpClientBinder(binder)
+                            .bindHttpClient("salesforce-authenticator", SalesforceAuthenticationClient.class);
+                });
+
+        Injector injector = app
+                .strictConfig()
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(SalesforceBasicAuthenticator.class);
+    }
+}

--- a/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceBasicAuthenticator.java
+++ b/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceBasicAuthenticator.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StaticBodyGenerator;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.log.Logger;
+import io.prestosql.plugin.password.Credential;
+import io.prestosql.spi.classloader.ThreadContextClassLoader;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.BasicPrincipal;
+import io.prestosql.spi.security.PasswordAuthenticator;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.InputSource;
+
+import javax.inject.Inject;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.prestosql.plugin.password.salesforce.SalesforceConfig.APIVERSION;
+import static io.prestosql.plugin.password.salesforce.SalesforceConfig.LOGINURL;
+import static io.prestosql.plugin.password.salesforce.SalesforceConfig.LOGIN_SOAP_MESSAGE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Allows users to authenticate to Presto using their Salesforce username and password + security token concatenation.  You can learn about
+ * the Salesforce security token at https://help.salesforce.com/articleView?id=user_security_token.htm.
+ * <br><br>
+ * If your password is <code>foo</code> and token is <code>bar</code>, then your Presto password will be <code>foobar</code>.
+ * <br><br>
+ * Admins can configure one or more Salesforce Organization Ids (18 char) via <code>salesforce.org</code> in <code>password-authenticator.properties</code>
+ * to act as a single layer of authZ.  Essentially, if the user who logs in is not part of the configured org, their access will be denied.  Alternatively,
+ * the admin can specify "all", rather than actual orgs.  This will allow any authenticated Salesforce user access to Presto.
+ */
+public class SalesforceBasicAuthenticator
+        implements PasswordAuthenticator
+{
+    private static final Logger log = Logger.get(SalesforceBasicAuthenticator.class);
+
+    private Set<String> orgs;                                   // Set of Salesforce orgs, which users must belong to in order to authN.
+    private Map<String, String> responseMap = new HashMap<>();  // A flattened map of xml elements from the Salesforce login response.
+    private String key = "";                                    // Will hold the xml element tag, we can add to the map with its text attribute.
+    private final HttpClient httpClient;                        // An http client for posting to the Salesforce login endpoint.
+    private final LoadingCache<Credential, Principal> userCache;
+
+    private final Locale locale = Locale.US;                    // Tested API request and response for user with Japanese locale and language preference,
+    // and responses are English, and organization id is not in Japaneses characters (this is
+    // also true of the organization id in the UI, even with other text showing in Japanese).
+
+    @Inject
+    public SalesforceBasicAuthenticator(SalesforceConfig config, @SalesforceAuthenticationClient HttpClient httpClient)
+    {
+        this.orgs = config.getOrgSet();
+        this.httpClient = httpClient;
+
+        this.userCache = CacheBuilder.newBuilder()
+                .maximumSize(config.getCacheSize())
+                .expireAfterWrite(config.getCacheExpireSeconds(), TimeUnit.SECONDS)
+                .build(CacheLoader.from(this::doLogin));
+    }
+
+    @Override
+    public Principal createAuthenticatedPrincipal(String username, String password)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            return userCache.getUnchecked(new Credential(username, password));
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), AccessDeniedException.class);
+            throw e;
+        }
+    }
+
+    // This does the work of logging into Salesforce.
+    private Principal doLogin(Credential credential)
+    {
+        log.info("Logging into Salesforce.");
+        String username = credential.getUser();
+        String password = credential.getPassword();
+
+        // Login requests must be POSTs
+        Request request = new Request.Builder()
+                .setUri(URI.create(LOGINURL + APIVERSION))
+                .setHeader("Content-Type", "text/xml;charset=UTF-8")
+                .setHeader("SOAPAction", "login")
+                .setMethod("POST")
+                .setBodyGenerator(StaticBodyGenerator.createStaticBodyGenerator(String.format(LOGIN_SOAP_MESSAGE, username, password), UTF_8))
+                .build();
+
+        StringResponseHandler.StringResponse response = httpClient.execute(request, StringResponseHandler.createStringResponseHandler());
+
+        final int statusCode = response.getStatusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new AccessDeniedException(String.format("Invalid response for login [%s]: %s. %s",
+                    statusCode,
+                    response.getBody(),
+                    response.getHeaders()));
+        }
+
+        Document xmlResponse;
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder;
+        try {
+            builder = factory.newDocumentBuilder();
+            xmlResponse = builder.parse(new InputSource(new StringReader(
+                    response.getBody())));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(String.format("Error parsing response: %s\n\tReceived error message: %s",
+                    response.getBody(),
+                    e.getMessage()));
+        }
+
+        // Parse the response into a flattened map.
+        parse((Node) xmlResponse);
+        String sessionId = responseMap.get("sessionId");
+        if (sessionId == null || sessionId.length() == 0) {
+            throw new RuntimeException("Can't find accessToken in Salesforce login response.");
+        }
+
+        // We want the organizationId from the response to compare it to the configured org from password-authenticator.properties.
+        String returnedOrg = responseMap.get("organizationId");
+        if (returnedOrg == null || returnedOrg.length() == 0) {
+            throw new RuntimeException("Can't find organizationId in Salesforce login response.");
+        }
+        // If the only entry in the set is "all", don't bother to check, otherwise make sure the returned org is in the set.
+        if (!(orgs.size() == 1 && orgs.contains("all")) && !orgs.contains(returnedOrg.toLowerCase(locale))) {
+            throw new AccessDeniedException(String.format(
+                    "Login successful, but for wrong Salesforce org.  Got %s, but expected a different org.",
+                    returnedOrg));
+        }
+        return new BasicPrincipal(username);
+    }
+
+    // This simply finds elements in the xml response, and adds them and their text values to the flattened map
+    // We will use this to find the organizationId and approve the authenticated user.
+    private void parse(Node node)
+    {
+        switch (node.getNodeType()) {
+            case Node.ELEMENT_NODE:
+                key = ((Element) node).getTagName();
+                break;
+            case Node.TEXT_NODE:
+                if (key.length() > 0) {
+                    responseMap.put(key, ((Text) node).getData());
+                }
+                break;
+            default:
+                key = "";
+        }
+        NodeList list = node.getChildNodes();
+        for (int i = 0; i < list.getLength(); i++) {
+            parse(list.item(i));
+        }
+    }
+}

--- a/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceConfig.java
+++ b/presto-password-authenticators/src/main/java/io/prestosql/plugin/password/salesforce/SalesforceConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.log.Logger;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public class SalesforceConfig
+{
+    private static final Logger log = Logger.get(SalesforceConfig.class);
+
+    protected static final String LOGINURL = "https://login.salesforce.com/services/Soap/u/";
+    protected static final String APIVERSION = "46.0";
+
+    protected static final String LOGIN_SOAP_MESSAGE = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+            "<env:Envelope xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n" +
+            "xmlns:urn=\"urn:enterprise.soap.sforce.com\"\n" +
+            "   xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "   xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+            " <env:Header>\n" +
+            "     <urn:CallOptions>\n" +
+            "       <urn:client>presto</urn:client>\n" +
+            "     </urn:CallOptions>\n" +
+            " </env:Header>\n" +
+            " <env:Body>\n" +
+            "   <n1:login xmlns:n1=\"urn:partner.soap.sforce.com\">\n" +
+            "     <n1:username>%s</n1:username>\n" +
+            "     <n1:password>%s</n1:password>\n" +
+            "   </n1:login>\n" +
+            " </env:Body>\n" +
+            "</env:Envelope>\n";
+
+    public static final int MAX_EXPIRE = 3600;
+    private int cacheSize = 4096;
+    private int cacheExpireSeconds = 120;
+    private String orgs;
+
+    private final Locale locale = Locale.US;    // Tested API request and response for user with Japanese locale and language preference,
+    // and responses are English, and organization id is not in Japaneses characters (this is
+    // also true of the organization id in the UI, even with other text showing in Japanese).
+
+    @NotNull(message = "Must set salesforce.org with one or more Salesforce 18 char OrgId's, or \"all\"")
+    public String getOrgs()
+    {
+        return orgs;
+    }
+
+    public Set<String> getOrgSet()
+    {
+        Set<String> tmp = new HashSet<>();
+        if (orgs == null) {
+            orgs = "";
+        }
+        String[] orgsSplit = orgs.split("[,;]");
+        for (String s : orgsSplit) {
+            tmp.add(s.toLowerCase(locale).trim());
+        }
+
+        return tmp;
+    }
+
+    @Config("salesforce.org")
+    @ConfigDescription("Comma separated list of Salesforce 18 Character OrgId.")
+    public SalesforceConfig setOrgs(String orgs)
+    {
+        this.orgs = orgs;
+        return this;
+    }
+
+    public int getCacheSize()
+    {
+        return cacheSize;
+    }
+
+    @Config("salesforce.cache-size")
+    @ConfigDescription("Maximum size of the cache that holds authenticated users.")
+    public SalesforceConfig setCacheSize(int cacheSize)
+    {
+        this.cacheSize = cacheSize;
+        return this;
+    }
+
+    @Max(value = MAX_EXPIRE, message = "The salesforce.cache-expire-seconds is set too high.  Maximum is " + MAX_EXPIRE + " seconds.")
+    public int getCacheExpireSeconds()
+    {
+        return cacheExpireSeconds;
+    }
+
+    @Config("salesforce.cache-expire-seconds")
+    @ConfigDescription("Expire time in seconds for an entry in cache since last write.  Max is " + MAX_EXPIRE + ".")
+    public SalesforceConfig setCacheExpireSeconds(int cacheExpireSeconds)
+    {
+        this.cacheExpireSeconds = cacheExpireSeconds;
+        return this;
+    }
+}

--- a/presto-password-authenticators/src/test/java/io/prestosql/plugin/password/salesforce/TestSalesforceBasicAuthenticator.java
+++ b/presto-password-authenticators/src/test/java/io/prestosql/plugin/password/salesforce/TestSalesforceBasicAuthenticator.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import com.google.common.net.MediaType;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.prestosql.spi.security.AccessDeniedException;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import java.security.Principal;
+
+import static io.airlift.http.client.testing.TestingResponse.mockResponse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestSalesforceBasicAuthenticator
+{
+    private HttpClient testHttpClient;
+    private String org;
+    private String username;
+    private String password;
+    private String successResponse;
+    private String failedResponse;
+    private SalesforceConfig config;
+    private boolean forReal;
+
+    @BeforeSuite
+    void initOnce()
+    {
+        successResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns=\"urn:partner.soap.sforce.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><loginResponse><result><metadataServerUrl>https://example.salesforce.com/services/Soap/m/46.0/example</metadataServerUrl><passwordExpired>false</passwordExpired><sandbox>false</sandbox><serverUrl>https://example.salesforce.com/services/Soap/u/46.0/example</serverUrl><sessionId>example</sessionId><userId>example</userId><userInfo><accessibilityMode>false</accessibilityMode><chatterExternal>false</chatterExternal><currencySymbol>$</currencySymbol><orgAttachmentFileSizeLimit>5242880</orgAttachmentFileSizeLimit><orgDefaultCurrencyIsoCode>USD</orgDefaultCurrencyIsoCode><orgDefaultCurrencyLocale>en_US</orgDefaultCurrencyLocale><orgDisallowHtmlAttachments>false</orgDisallowHtmlAttachments><orgHasPersonAccounts>true</orgHasPersonAccounts><organizationId>%s</organizationId><organizationMultiCurrency>false</organizationMultiCurrency><organizationName>example</organizationName><profileId>example</profileId><roleId>example</roleId><sessionSecondsValid>7200</sessionSecondsValid><userDefaultCurrencyIsoCode xsi:nil=\"true\"/><userEmail>user@salesforce.com</userEmail><userFullName>Vince Chase</userFullName><userId>example</userId><userLanguage>en_US</userLanguage><userLocale>en_US</userLocale><userName>%s</userName><userTimeZone>America/Chicago</userTimeZone><userType>Standard</userType><userUiSkin>Theme3</userUiSkin></userInfo></result></loginResponse></soapenv:Body></soapenv:Envelope>";
+        failedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:sf=\"urn:fault.partner.soap.sforce.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><soapenv:Fault><faultcode>sf:INVALID_LOGIN</faultcode><faultstring>INVALID_LOGIN: Invalid username, password, security token; or user locked out.</faultstring><detail><sf:LoginFault xsi:type=\"sf:LoginFault\"><sf:exceptionCode>INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid username, password, security token; or user locked out.</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>";
+        forReal = false;
+        String forRealEnvVar = System.getenv("SALESFORCE_TEST_FORREAL");
+        if (forRealEnvVar != null && forRealEnvVar.equalsIgnoreCase("TRUE")) {
+            forReal = true;
+        }
+    }
+
+    @Test
+    public void createAuthenticatedPrincipal_success()
+            throws InterruptedException
+    {
+        org = "my18CharOrgId";  // As if from salesforce.org property.
+        username = "user@salesforce.com";
+        password = "passtoken";
+
+        config = new SalesforceConfig()
+                .setOrgs(org)
+                .setCacheExpireSeconds(1); // Test cache timeout.
+
+        String xmlResponse = String.format(successResponse, org, username);
+
+        testHttpClient = new TestingHttpClient((request -> mockResponse(HttpStatus.OK, MediaType.ANY_TEXT_TYPE, xmlResponse)));
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test principal name.");
+
+        principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test principal name from cache.");
+
+        Thread.sleep(2000L);
+        principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test principal name from expired cache.");
+    }
+
+    @Test(expectedExceptions = AccessDeniedException.class)
+    public void createAuthenticatedPrincipal_wrongOrg()
+    {
+        org = "my18CharOrgId";  // As if from salesforce.org property.
+        username = "user@salesforce.com";
+        password = "passtoken";
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+
+        final String xmlResponse = String.format(successResponse, "NotMyOrg", username);
+
+        testHttpClient = new TestingHttpClient((request -> mockResponse(HttpStatus.OK, MediaType.ANY_TEXT_TYPE, xmlResponse)));
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+        authenticator.createAuthenticatedPrincipal(username, password);
+    }
+
+    @Test(expectedExceptions = AccessDeniedException.class)
+    public void createAuthenticatedPrincipal_badPass()
+    {
+        org = "my18CharOrgId";  // As if from salesforce.org property.
+        username = "user@salesforce.com";
+        password = "passtoken";
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+
+        final String xmlResponse = failedResponse;
+
+        testHttpClient = new TestingHttpClient((request -> mockResponse(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.ANY_TEXT_TYPE, xmlResponse)));
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+    }
+
+    @Test
+    public void createAuthenticatedPrincipalAllOrgs()
+    {
+        org = "all";  // As if from salesforce.org property.
+        username = "user@salesforce.com";
+        password = "passtoken";
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+
+        String xmlResponse = String.format(successResponse, "some18CharOrgId", username);
+
+        testHttpClient = new TestingHttpClient((request -> mockResponse(HttpStatus.OK, MediaType.ANY_TEXT_TYPE, xmlResponse)));
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test allowing all orgs.");
+    }
+
+    @Test
+    public void createAuthenticatedPrincipalFewOrgs()
+    {
+        org = "my18CharOrgId,your18CharOrgId, his18CharOrgId ,her18CharOrgId";  // As if from salesforce.org property.
+        username = "user@salesforce.com";
+        password = "passtoken";
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+
+        String xmlResponse = String.format(successResponse, "my18CharOrgId", username);
+
+        testHttpClient = new TestingHttpClient((request -> mockResponse(HttpStatus.OK, MediaType.ANY_TEXT_TYPE, xmlResponse)));
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test allowing a few orgs.");
+    }
+
+    /*
+     * Real tests that use Salesforce credentials and actually attempt to login.
+     * These should be disabled for automated builds and test runs.
+     *
+     * In order to run these, the following environment variables need to be set.
+     *
+     *   - SALESFORCE_TEST_ORG (this is the 18 character organization id)
+     *   - SALESFORCE_TEST_USERNAME
+     *   - SALESFORCE_TEST_PASSWORD (this must be password and security token concatenation)
+     *   - SALESFORCE_TEST_FORREAL must be TRUE
+     */
+
+    // Test a real login.
+    @Test(description = "Test principal name for real, yo!")
+    void createAuthenticatedPrincipal_realSuccess()
+    {
+        // Skip this test if SALESFORCE_TEST_FORREAL is not set to TRUE.
+        if (!forReal) {
+            throw new SkipException("Skipping real tests.");
+        }
+
+        org = System.getenv("SALESFORCE_TEST_ORG");
+        if (org == null || org.length() == 0) {
+            fail("Must set SALESFORCE_TEST_ORG environment variable.");
+        }
+        username = System.getenv("SALESFORCE_TEST_USERNAME");
+        password = System.getenv("SALESFORCE_TEST_PASSWORD");
+        if (username == null || username.length() == 0 || password == null || password.length() == 0) {
+            fail("Must set SALESFORCE_TEST_USERNAME and SALESFORCE_TEST_PASSWORD environment variables.");
+        }
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+        testHttpClient = new JettyHttpClient();
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test principal name for real, yo!");
+    }
+
+    // Test a real login for a different org.
+    @Test(expectedExceptions = AccessDeniedException.class, description = "Test got wrong org for real, yo!")
+    void createAuthenticatedPrincipal_realWrongOrg()
+    {
+        // Skip this test if SALESFORCE_TEST_FORREAL is not set to TRUE.
+        if (!forReal) {
+            throw new SkipException("Skipping real tests.");
+        }
+
+        username = System.getenv("SALESFORCE_TEST_USERNAME");
+        password = System.getenv("SALESFORCE_TEST_PASSWORD");
+        if (username == null || username.length() == 0 || password == null || password.length() == 0) {
+            fail("Must set SALESFORCE_TEST_USERNAME and SALESFORCE_TEST_PASSWORD environment variables.");
+        }
+
+        org = "NotMyOrg";
+        config = new SalesforceConfig()
+                .setOrgs(org);
+        testHttpClient = new JettyHttpClient();
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        authenticator.createAuthenticatedPrincipal(username, password);
+    }
+
+    // Test a real login for a different org.
+    @Test
+    void createAuthenticatedPrincipal_realAllOrgs()
+    {
+        // Skip this test if SALESFORCE_TEST_FORREAL is not set to TRUE.
+        if (!forReal) {
+            throw new SkipException("Skipping real tests.");
+        }
+
+        username = System.getenv("SALESFORCE_TEST_USERNAME");
+        password = System.getenv("SALESFORCE_TEST_PASSWORD");
+        if (username == null || username.length() == 0 || password == null || password.length() == 0) {
+            fail("Must set SALESFORCE_TEST_USERNAME and SALESFORCE_TEST_PASSWORD environment variables.");
+        }
+
+        config = new SalesforceConfig()
+                .setOrgs("all");
+
+        testHttpClient = new JettyHttpClient();
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+
+        Principal principal = authenticator.createAuthenticatedPrincipal(username, password);
+        assertEquals(principal.getName(), username, "Test no org check for real, yo!");
+    }
+
+    // Test a login with a bad password.
+    @Test(expectedExceptions = AccessDeniedException.class, description = "Test bad password for real, yo!")
+    void createAuthenticatedPrincipal_realBadPassword()
+    {
+        // Skip this test if SALESFORCE_TEST_FORREAL is not set to TRUE.
+        if (!forReal) {
+            throw new SkipException("Skipping real tests.");
+        }
+
+        org = System.getenv("SALESFORCE_TEST_ORG");
+        if (org == null || org.length() == 0) {
+            fail("Must set SALESFORCE_TEST_ORG environment variable.");
+        }
+        username = System.getenv("SALESFORCE_TEST_USERNAME");
+        password = System.getenv("SALESFORCE_TEST_PASSWORD");
+        if (username == null || username.length() == 0 || password == null || password.length() == 0) {
+            fail("Must set SALESFORCE_TEST_USERNAME and SALESFORCE_TEST_PASSWORD environment variables.");
+        }
+
+        config = new SalesforceConfig()
+                .setOrgs(org);
+        testHttpClient = new JettyHttpClient();
+        SalesforceBasicAuthenticator authenticator = new SalesforceBasicAuthenticator(config, testHttpClient);
+        authenticator.createAuthenticatedPrincipal(username, "NotMyPassword");
+    }
+}

--- a/presto-password-authenticators/src/test/java/io/prestosql/plugin/password/salesforce/TestSalesforceConfig.java
+++ b/presto-password-authenticators/src/test/java/io/prestosql/plugin/password/salesforce/TestSalesforceConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.password.salesforce;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.testng.Assert.assertEquals;
+
+public class TestSalesforceConfig
+{
+    private final int defaultCacheSize = 4096;
+    private final int defaultCacheExpireSeconds = 120;
+
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(SalesforceConfig.class)
+                .setOrgs(null)
+                .setCacheSize(defaultCacheSize)
+                .setCacheExpireSeconds(defaultCacheExpireSeconds));
+    }
+
+    // Test will only pass if config is created with properties that are different than the defaults.
+    @Test
+    public void testExplicitConfig()
+    {
+        String org = "my18CharOrgId";
+        String cacheSize = "128";
+        String cacheExpire = "3600";
+
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("salesforce.org", org)
+                .put("salesforce.cache-size", cacheSize)
+                .put("salesforce.cache-expire-seconds", cacheExpire)
+                .build();
+
+        SalesforceConfig expected = new SalesforceConfig()
+                .setOrgs(org)
+                .setCacheSize(Integer.valueOf(cacheSize))
+                .setCacheExpireSeconds(Integer.valueOf(cacheExpire));
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testGetOrgSet()
+    {
+        String orgs = "my18CharOrgId,your18CharOrgId, his18CharOrgId ,her18CharOrgId";
+        int expected = (int) orgs.chars().filter(sep -> sep == ',').count() + 1;
+        int actual = (new SalesforceConfig()
+                .setOrgs(orgs)).getOrgSet().size();
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This allows Presto admins to enable users to authenticate to Presto via Salesforce username and password/token. This is **not** a Salesforce connector, and does not allow users to query Salesforce data. It's simply a means by which users can authenticate to Presto, similar to LDAP or password file.

There is a single layer of security beyond simply providing username and password/token, which is that the admin can configure, via `salesforce.org` in `etc/password-authenticator.properties`, one or more 18 character Salesforce Organization Id's in a comma separated list. The user's successful login to Salesforce must return a matching Organization Id. Optionally, the admin can configure "all" to explicitly ignore this layer of security.

@lhofhansl