### PR TITLE
Add deterministic UUID function uuid3

### DIFF
--- a/presto-docs/src/main/sphinx/functions/uuid.rst
+++ b/presto-docs/src/main/sphinx/functions/uuid.rst
@@ -5,3 +5,7 @@ UUID Functions
 .. function:: uuid() -> uuid
 
     Returns a pseudo randomly generated :ref:`uuid_type` (type 4).
+
+.. function:: uuid3(name) -> uuid
+
+    Generates a :ref:`uuid_type` (type 3) in the given namespace using the specified input name.

--- a/presto-main/src/main/java/io/prestosql/type/UuidOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/UuidOperators.java
@@ -45,7 +45,9 @@ import static io.prestosql.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.prestosql.spi.function.OperatorType.NOT_EQUAL;
 import static io.prestosql.spi.function.OperatorType.XX_HASH_64;
 import static io.prestosql.type.UuidType.UUID;
+import static java.util.UUID.nameUUIDFromBytes;
 import static java.util.UUID.randomUUID;
+
 
 public final class UuidOperators
 {
@@ -57,6 +59,15 @@ public final class UuidOperators
     public static Slice uuid()
     {
         java.util.UUID uuid = randomUUID();
+        return wrappedLongArray(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    @Description("Generates a deterministic (type 3) UUID using the specified input name")
+    @ScalarFunction(deterministic = true)
+    @SqlType(StandardTypes.UUID)
+    public static Slice uuid3(@SqlType(StandardTypes.VARCHAR) Slice name)
+    {
+        java.util.UUID uuid = nameUUIDFromBytes(name.getBytes());
         return wrappedLongArray(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDeterminismEvaluator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDeterminismEvaluator.java
@@ -43,6 +43,7 @@ public class TestDeterminismEvaluator
         assertFalse(DeterminismEvaluator.isDeterministic(function("random"), metadata));
         assertFalse(DeterminismEvaluator.isDeterministic(function("shuffle", ImmutableList.of(new ArrayType(VARCHAR)), ImmutableList.of(new NullLiteral())), metadata));
         assertFalse(DeterminismEvaluator.isDeterministic(function("uuid"), metadata));
+        assertTrue(DeterminismEvaluator.isDeterministic(function("uuid3"), metadata));
         assertTrue(DeterminismEvaluator.isDeterministic(function("abs", ImmutableList.of(DOUBLE), ImmutableList.of(input("symbol"))), metadata));
         assertFalse(DeterminismEvaluator.isDeterministic(function("abs", ImmutableList.of(DOUBLE), ImmutableList.of(function("rand"))), metadata));
         assertTrue(DeterminismEvaluator.isDeterministic(

--- a/presto-main/src/test/java/io/prestosql/type/TestUuidOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestUuidOperators.java
@@ -132,4 +132,13 @@ public class TestUuidOperators
         Block block = blockBuilder.build();
         return UUID.hash(block, 0);
     }
+
+    @Test
+    public void testUuid3(String name)
+    {
+        assertFunction("UUID3('presto')", UUID, "1e954771-8132-30da-9673-f51da7e4394c");
+        assertFunction("UUID3('p')", UUID, "83878c91-1713-3890-ae0f-e0fb97a8c47a");
+        assertFunction("UUID3('1')", UUID, "c4ca4238-a0b9-3382-8dcc-509a6f75849b");
+        assertFunction("UUID3('')", UUID, "d41d8cd9-8f00-3204-a980-0998ecf8427e");
+    }
 }


### PR DESCRIPTION
Add uuid3 function which takes a `VARCHAR` as input and returns a deterministic UUID (Type 3 UUID). The input is MD5 hashed, and uuid3 function doesn't have any random or environment-dependent element, and thus, it's reproducible