### PR TITLE
Interpret JDBC ResultSet dates and timestamps in client JVM time zone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <dep.aws-sdk.version>1.11.749</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
+        <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>
         <dep.tempto.version>179</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>

--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
@@ -98,6 +98,7 @@ public class BenchmarkDriverOptions
                 schema,
                 null,
                 ZoneId.systemDefault(),
+                false,
                 Locale.getDefault(),
                 ImmutableMap.of(),
                 toProperties(this.sessionProperties),

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -182,6 +182,7 @@ public class ClientOptions
                 schema,
                 null,
                 ZoneId.of(timeZone),
+                false,
                 Locale.getDefault(),
                 toResourceEstimates(resourceEstimates),
                 toProperties(sessionProperties),

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -114,6 +114,7 @@ public class TestQueryRunner
                 "schema",
                 "path",
                 ZoneId.of("America/Los_Angeles"),
+                false,
                 Locale.ENGLISH,
                 ImmutableMap.of(),
                 ImmutableMap.of(),

--- a/presto-client/src/main/java/io/prestosql/client/ClientSession.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientSession.java
@@ -43,6 +43,7 @@ public class ClientSession
     private final String schema;
     private final String path;
     private final ZoneId timeZone;
+    private final boolean useSessionTimeZone;
     private final Locale locale;
     private final Map<String, String> resourceEstimates;
     private final Map<String, String> properties;
@@ -75,6 +76,7 @@ public class ClientSession
             String schema,
             String path,
             ZoneId timeZone,
+            boolean useSessionTimeZone,
             Locale locale,
             Map<String, String> resourceEstimates,
             Map<String, String> properties,
@@ -95,6 +97,7 @@ public class ClientSession
         this.path = path;
         this.locale = locale;
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
+        this.useSessionTimeZone = useSessionTimeZone;
         this.transactionId = transactionId;
         this.resourceEstimates = ImmutableMap.copyOf(requireNonNull(resourceEstimates, "resourceEstimates is null"));
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
@@ -182,6 +185,13 @@ public class ClientSession
         return timeZone;
     }
 
+    // TODO remove the fallback mechanism for JDBC temporal columns
+    @Deprecated
+    public boolean useSessionTimeZone()
+    {
+        return useSessionTimeZone;
+    }
+
     public Locale getLocale()
     {
         return locale;
@@ -243,6 +253,7 @@ public class ClientSession
                 .add("path", path)
                 .add("traceToken", traceToken.orElse(null))
                 .add("timeZone", timeZone)
+                .add("useSessionTimeZone", useSessionTimeZone)
                 .add("locale", locale)
                 .add("properties", properties)
                 .add("transactionId", transactionId)
@@ -262,6 +273,7 @@ public class ClientSession
         private String schema;
         private String path;
         private ZoneId timeZone;
+        private boolean useSessionTimeZone;
         private Locale locale;
         private Map<String, String> resourceEstimates;
         private Map<String, String> properties;
@@ -284,6 +296,7 @@ public class ClientSession
             schema = clientSession.getSchema();
             path = clientSession.getPath();
             timeZone = clientSession.getTimeZone();
+            useSessionTimeZone = clientSession.useSessionTimeZone();
             locale = clientSession.getLocale();
             resourceEstimates = clientSession.getResourceEstimates();
             properties = clientSession.getProperties();
@@ -348,6 +361,14 @@ public class ClientSession
             return this;
         }
 
+        // TODO remove the fallback mechanism for JDBC temporal columns
+        @Deprecated
+        public Builder withUseSessionTimeZone(boolean useSessionTimeZone)
+        {
+            this.useSessionTimeZone = useSessionTimeZone;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -361,6 +382,7 @@ public class ClientSession
                     schema,
                     path,
                     timeZone,
+                    useSessionTimeZone,
                     locale,
                     resourceEstimates,
                     properties,

--- a/presto-client/src/main/java/io/prestosql/client/StatementClient.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClient.java
@@ -28,6 +28,10 @@ public interface StatementClient
 
     ZoneId getTimeZone();
 
+    // TODO remove the fallback mechanism for JDBC temporal columns
+    @Deprecated
+    boolean useSessionTimeZone();
+
     boolean isRunning();
 
     boolean isClientAborted();

--- a/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
@@ -108,6 +108,7 @@ class StatementClientV1
     private final AtomicReference<String> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
     private final ZoneId timeZone;
+    private final boolean useSessionTimeZone;
     private final Duration requestTimeoutNanos;
     private final String user;
     private final String clientCapabilities;
@@ -122,6 +123,7 @@ class StatementClientV1
 
         this.httpClient = httpClient;
         this.timeZone = session.getTimeZone();
+        this.useSessionTimeZone = session.useSessionTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout();
         this.user = session.getUser();
@@ -217,6 +219,12 @@ class StatementClientV1
     public ZoneId getTimeZone()
     {
         return timeZone;
+    }
+
+    @Override
+    public boolean useSessionTimeZone()
+    {
+        return useSessionTimeZone;
     }
 
     @Override

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -117,6 +117,9 @@ Name                                   Description
 ``KerberosConfigPath``                 Kerberos configuration file.
 ``KerberosKeytabPath``                 Kerberos keytab file.
 ``KerberosCredentialCachePath``        Kerberos credential cache.
+``useSessionTimeZone``                 Should dates and timestamps use the session time zone (default: false).
+                                       Note that this property only exists for backward compatibility with the
+                                       previous behavior and will be removed in the future.
 ``extraCredentials``                   Extra credentials for connecting to external services,
                                        specified as a list of key-value pairs. For example,
                                        ``foo:bar;abc:xyz`` creates the credential named ``abc``

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -35,6 +35,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>security</artifactId>
         </dependency>
 
@@ -128,6 +133,37 @@
         <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-blackhole</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${dep.oracle.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -116,7 +116,7 @@ abstract class AbstractPrestoResultSet
             .toFormatter()
             .withOffsetParsed();
 
-    private final DateTimeZone sessionTimeZone;
+    private final DateTimeZone resultTimeZone;
     protected final Iterator<List<Object>> results;
     private final Map<String, Integer> fieldMap;
     private final List<ColumnInfo> columnInfoList;
@@ -125,10 +125,9 @@ abstract class AbstractPrestoResultSet
     private final AtomicBoolean wasNull = new AtomicBoolean();
     protected final AtomicBoolean closed = new AtomicBoolean();
 
-    AbstractPrestoResultSet(ZoneId sessionTimeZone, List<Column> columns, Iterator<List<Object>> results)
+    AbstractPrestoResultSet(ZoneId resultTimeZone, List<Column> columns, Iterator<List<Object>> results)
     {
-        requireNonNull(sessionTimeZone, "sessionTimeZone is null");
-        this.sessionTimeZone = DateTimeZone.forID(requireNonNull(sessionTimeZone, "sessionTimeZone is null").getId());
+        this.resultTimeZone = DateTimeZone.forID(requireNonNull(resultTimeZone, "resultTimeZone is null").getId());
 
         requireNonNull(columns, "columns is null");
         this.fieldMap = getFieldMap(columns);
@@ -246,7 +245,7 @@ abstract class AbstractPrestoResultSet
     public Date getDate(int columnIndex)
             throws SQLException
     {
-        return getDate(columnIndex, sessionTimeZone);
+        return getDate(columnIndex, resultTimeZone);
     }
 
     private Date getDate(int columnIndex, DateTimeZone localTimeZone)
@@ -269,7 +268,7 @@ abstract class AbstractPrestoResultSet
     public Time getTime(int columnIndex)
             throws SQLException
     {
-        return getTime(columnIndex, sessionTimeZone);
+        return getTime(columnIndex, resultTimeZone);
     }
 
     private Time getTime(int columnIndex, DateTimeZone localTimeZone)
@@ -306,7 +305,7 @@ abstract class AbstractPrestoResultSet
     public Timestamp getTimestamp(int columnIndex)
             throws SQLException
     {
-        return getTimestamp(columnIndex, sessionTimeZone);
+        return getTimestamp(columnIndex, resultTimeZone);
     }
 
     private Timestamp getTimestamp(int columnIndex, DateTimeZone localTimeZone)

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
@@ -64,6 +64,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> CLIENT_INFO = new ClientInfo();
     public static final ConnectionProperty<String> CLIENT_TAGS = new ClientTags();
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
+    public static final ConnectionProperty<Boolean> USE_SESSION_TIMEZONE = new UseSessionTimeZone();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
@@ -90,6 +91,7 @@ final class ConnectionProperties
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
             .add(TRACE_TOKEN)
+            .add(USE_SESSION_TIMEZONE)
             .add(SESSION_PROPERTIES)
             .build();
 
@@ -364,6 +366,15 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class UseSessionTimeZone
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public UseSessionTimeZone()
+        {
+            super("useSessionTimeZone", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -81,6 +81,7 @@ public class PrestoConnection
     private final AtomicReference<String> schema = new AtomicReference<>();
     private final AtomicReference<String> path = new AtomicReference<>();
     private final AtomicReference<ZoneId> timeZoneId = new AtomicReference<>();
+    private final AtomicBoolean useSessionTimeZone = new AtomicBoolean();
     private final AtomicReference<Locale> locale = new AtomicReference<>();
     private final AtomicReference<Integer> networkTimeoutMillis = new AtomicReference<>(Ints.saturatedCast(MINUTES.toMillis(2)));
     private final AtomicReference<ServerInfo> serverInfo = new AtomicReference<>();
@@ -116,6 +117,7 @@ public class PrestoConnection
 
         roles.putAll(uri.getRoles());
         timeZoneId.set(ZoneId.systemDefault());
+        useSessionTimeZone.set(uri.useSessionTimezone().orElse(false));
         locale.set(Locale.getDefault());
         sessionProperties.putAll(uri.getSessionProperties());
     }
@@ -726,6 +728,7 @@ public class PrestoConnection
                 schema.get(),
                 path.get(),
                 timeZoneId.get(),
+                useSessionTimeZone.get(),
                 locale.get(),
                 ImmutableMap.of(),
                 ImmutableMap.copyOf(allProperties),

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -65,6 +65,7 @@ import static io.prestosql.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
 import static io.prestosql.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
 import static io.prestosql.jdbc.ConnectionProperties.TRACE_TOKEN;
 import static io.prestosql.jdbc.ConnectionProperties.USER;
+import static io.prestosql.jdbc.ConnectionProperties.USE_SESSION_TIMEZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -174,6 +175,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return TRACE_TOKEN.getValue(properties);
+    }
+
+    public Optional<Boolean> useSessionTimezone()
+            throws SQLException
+    {
+        return USE_SESSION_TIMEZONE.getValue(properties);
     }
 
     public Map<String, String> getSessionProperties()

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
@@ -20,6 +20,7 @@ import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.client.StatementClient;
 
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -56,7 +57,7 @@ public class PrestoResultSet
             throws SQLException
     {
         super(
-                requireNonNull(client, "client is null").getTimeZone(),
+                getResultTimeZone(requireNonNull(client, "client is null")),
                 columns,
                 new AsyncIterator<>(flatten(new ResultsPageIterator(client, progressCallback, warningsManager), maxRows), client));
 
@@ -64,6 +65,14 @@ public class PrestoResultSet
         requireNonNull(progressCallback, "progressCallback is null");
 
         this.queryId = client.currentStatusInfo().getId();
+    }
+
+    private static ZoneId getResultTimeZone(StatementClient client)
+    {
+        if (client.useSessionTimeZone()) {
+            return client.getTimeZone();
+        }
+        return ZoneId.systemDefault();
     }
 
     public String getQueryId()

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSetTimezone.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSetTimezone.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.jdbc;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.prestosql.server.testing.TestingPrestoServer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
+import static java.lang.String.format;
+import static java.sql.JDBCType.DATE;
+import static java.sql.JDBCType.TIME;
+import static java.sql.JDBCType.TIMESTAMP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Checks that JDBC dates and timestamps are interpreted in the client JVM timezone and should not
+ * be affected by the session timezone.  We also compare the behavior to reference JDBC drivers.
+ */
+@Test(singleThreaded = true)
+public class TestJdbcResultSetTimezone
+{
+    private static final String OTHER_TIMEZONE = "Asia/Kathmandu";
+
+    private Logger log;
+    private TestingPrestoServer server;
+    private List<ReferenceDriver> referenceDrivers;
+
+    private Connection connection;
+    private Statement statement;
+
+    @BeforeClass
+    public void setupServer()
+    {
+        assertNotEquals(OTHER_TIMEZONE, TimeZone.getDefault().getID(), "We need a timezone different from the default JVM one");
+        Logging.initialize();
+        log = Logger.get(TestJdbcResultSetTimezone.class);
+        server = TestingPrestoServer.create();
+        referenceDrivers = ImmutableList.of(new PostgresqlReferenceDriver(), new OracleReferenceDriver());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownServer()
+            throws Exception
+    {
+        try (Closer closer = Closer.create()) {
+            referenceDrivers.forEach(closer::register);
+            closer.register(server);
+        }
+    }
+
+    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        connection = DriverManager.getConnection("jdbc:presto://" + server.getAddress(), "test", null);
+        statement = connection.createStatement();
+        referenceDrivers.forEach(ReferenceDriver::setUp);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        statement.close();
+        connection.close();
+        for (ReferenceDriver driver : referenceDrivers) {
+            try {
+                driver.tearDown();
+            }
+            catch (Exception e) {
+                log.warn(e, "Failed to close reference JDBC driver %s; continuing", driver);
+            }
+        }
+    }
+
+    // test behavior with UTC and time zones to the east and west
+    @DataProvider
+    public Object[][] timeZoneIds()
+    {
+        return new Object[][] {
+                {"UTC"},
+                {"Europe/Warsaw"},
+                {"America/Denver"},
+                {ZoneId.systemDefault().getId()}
+        };
+    }
+
+    @Test(dataProvider = "timeZoneIds")
+    public void testDate(String sessionTimezoneId)
+            throws Exception
+    {
+        checkRepresentation("DATE '2018-02-13'", DATE, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getDate(column), reference.getDate(column));
+            assertEquals(rs.getDate(column), Date.valueOf(LocalDate.of(2018, 2, 13)));
+        });
+
+        checkRepresentation("DATE '2018-02-13'", DATE, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getDate(column, getCalendar()), reference.getDate(column, getCalendar()));
+            assertEquals(rs.getDate(column, getCalendar()), new Date(LocalDate.of(2018, 2, 13).atStartOfDay(getZoneId()).toInstant().toEpochMilli()));
+        });
+    }
+
+    @Test(dataProvider = "timeZoneIds")
+    public void testTimestamp(String sessionTimezoneId)
+            throws Exception
+    {
+        checkRepresentation("TIMESTAMP '2018-02-13 13:14:15.123'", TIMESTAMP, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getTimestamp(column), reference.getTimestamp(column));
+            assertEquals(
+                    rs.getTimestamp(column),
+                    Timestamp.valueOf(LocalDateTime.of(2018, 2, 13, 13, 14, 15, 123_000_000)));
+        });
+
+        checkRepresentation("TIMESTAMP '2018-02-13 13:14:15.123'", TIMESTAMP, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getTimestamp(column, getCalendar()), reference.getTimestamp(column, getCalendar()));
+            assertEquals(
+                    rs.getTimestamp(column, getCalendar()),
+                    new Timestamp(LocalDateTime.of(2018, 2, 13, 13, 14, 15, 123_000_000).atZone(getZoneId()).toInstant().toEpochMilli()));
+        });
+    }
+
+    @Test(dataProvider = "timeZoneIds")
+    public void testTime(String sessionTimezoneId)
+            throws Exception
+    {
+        checkRepresentation("TIME '09:39:05'", TIME, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getTime(column), reference.getTime(column));
+            assertEquals(rs.getTime(column), Time.valueOf(LocalTime.of(9, 39, 5)));
+        });
+
+        checkRepresentation("TIME '09:39:05'", TIME, sessionTimezoneId, (rs, reference, column) -> {
+            assertEquals(rs.getTime(column, getCalendar()), reference.getTime(column, getCalendar()));
+            assertEquals(rs.getTime(column, getCalendar()), new Time(LocalDate.of(1970, 1, 1).atTime(LocalTime.of(9, 39, 5)).atZone(getZoneId()).toInstant().toEpochMilli()));
+        });
+    }
+
+    @Test(dataProvider = "timeZoneIds")
+    public void testDateRoundTrip(String sessionTimezoneId)
+            throws SQLException
+    {
+        LocalDate date = LocalDate.of(2001, 5, 6);
+        Date sqlDate = Date.valueOf(date);
+        java.util.Date javaDate = new java.util.Date(sqlDate.getTime());
+        LocalDateTime dateTime = LocalDateTime.of(date, LocalTime.of(12, 34, 56));
+        Timestamp sqlTimestamp = Timestamp.valueOf(dateTime);
+
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setDate(i, sqlDate));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlDate));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlDate, Types.DATE));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTimestamp, Types.DATE));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, javaDate, Types.DATE));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, date, Types.DATE));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, dateTime, Types.DATE));
+        assertParameter(sqlDate, sessionTimezoneId, (ps, i) -> ps.setObject(i, "2001-05-06", Types.DATE));
+    }
+
+    @Test(dataProvider = "timeZoneIds")
+    public void testTimestampRoundTrip(String sessionTimezoneId)
+            throws SQLException
+    {
+        LocalDateTime dateTime = LocalDateTime.of(2001, 5, 6, 12, 34, 56);
+        Date sqlDate = Date.valueOf(dateTime.toLocalDate());
+        Time sqlTime = Time.valueOf(dateTime.toLocalTime());
+        Timestamp sqlTimestamp = Timestamp.valueOf(dateTime);
+        Timestamp sameInstantInWarsawZone = Timestamp.valueOf(dateTime.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneId.of("Europe/Warsaw")).toLocalDateTime());
+        java.util.Date javaDate = java.util.Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, null));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance()));
+        assertParameter(sameInstantInWarsawZone, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone("Europe/Warsaw"))));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTimestamp));
+        assertParameter(new Timestamp(sqlDate.getTime()), sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlDate, Types.TIMESTAMP));
+        assertParameter(new Timestamp(sqlTime.getTime()), sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTime, Types.TIMESTAMP));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTimestamp, Types.TIMESTAMP));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, javaDate, Types.TIMESTAMP));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, dateTime, Types.TIMESTAMP));
+        assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, "2001-05-06 12:34:56", Types.TIMESTAMP));
+    }
+
+    private void assertParameter(Object expectedValue, String sessionTimezoneId, Binder binder)
+            throws SQLException
+    {
+        connection.unwrap(PrestoConnection.class).setTimeZoneId(sessionTimezoneId);
+        try (PreparedStatement statement = connection.prepareStatement("SELECT ?")) {
+            binder.bind(statement, 1);
+
+            try (ResultSet rs = statement.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(expectedValue, rs.getObject(1));
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private void checkRepresentation(String expression, JDBCType type, String sessionTimezoneId, ResultAssertion assertion)
+            throws Exception
+    {
+        for (ReferenceDriver driver : referenceDrivers) {
+            if (driver.supports(type)) {
+                log.info("Checking behavior against %s", driver);
+                checkRepresentation(expression, sessionTimezoneId, driver, assertion);
+            }
+        }
+    }
+
+    private void checkRepresentation(String expression, String sessionTimezoneId, ReferenceDriver reference, ResultAssertion assertion)
+            throws Exception
+    {
+        try (ResultSet rs = prestoQuery(expression, sessionTimezoneId); ResultSet referenceResultSet = reference.query(expression, sessionTimezoneId)) {
+            assertTrue(rs.next());
+            assertTrue(referenceResultSet.next());
+            assertion.accept(rs, referenceResultSet, 1);
+            assertFalse(rs.next());
+            assertFalse(referenceResultSet.next());
+        }
+    }
+
+    private ResultSet prestoQuery(String expression, String timezoneId)
+            throws Exception
+    {
+        connection.unwrap(PrestoConnection.class).setTimeZoneId(timezoneId);
+        return statement.executeQuery("SELECT " + expression);
+    }
+
+    private Calendar getCalendar()
+    {
+        return Calendar.getInstance(TimeZone.getTimeZone(OTHER_TIMEZONE));
+    }
+
+    private ZoneId getZoneId()
+    {
+        return ZoneId.of(getCalendar().getTimeZone().getID());
+    }
+
+    private interface ReferenceDriver
+            extends Closeable
+    {
+        ResultSet query(String expression, String timezoneId) throws Exception;
+
+        boolean supports(JDBCType type);
+
+        void setUp();
+
+        void tearDown() throws Exception;
+
+        @Override
+        void close();
+    }
+
+    private static class OracleReferenceDriver
+            implements ReferenceDriver
+    {
+        private static final Set<JDBCType> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIMESTAMP);
+        private OracleContainer oracleServer;
+        private Connection connection;
+        private Statement statement;
+
+        OracleReferenceDriver()
+        {
+            oracleServer = new OracleContainer("wnameless/oracle-xe-11g-r2");
+            oracleServer.start();
+        }
+
+        @Override
+        public ResultSet query(String expression, String timezoneId)
+                throws Exception
+        {
+            statement.execute(format("ALTER SESSION SET TIME_ZONE='%s'", timezoneId));
+            return statement.executeQuery(format("SELECT %s FROM dual", expression));
+        }
+
+        @Override
+        public boolean supports(JDBCType type)
+        {
+            return SUPPORTED_TYPES.contains(type);
+        }
+
+        @Override
+        public void setUp()
+        {
+            try {
+                connection = DriverManager.getConnection(oracleServer.getJdbcUrl(), oracleServer.getUsername(), oracleServer.getPassword());
+                statement = connection.createStatement();
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void tearDown()
+                throws Exception
+        {
+            statement.close();
+            connection.close();
+        }
+
+        @Override
+        public void close()
+        {
+            oracleServer.stop();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[oracle]";
+        }
+    }
+
+    private static class PostgresqlReferenceDriver
+            implements ReferenceDriver
+    {
+        private static final Set<JDBCType> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIMESTAMP);
+        private PostgreSQLContainer<?> postgresqlContainer;
+        private Connection connection;
+        private Statement statement;
+
+        PostgresqlReferenceDriver()
+        {
+            postgresqlContainer = new PostgreSQLContainer<>("postgres:10.3");
+            postgresqlContainer.start();
+        }
+
+        @Override
+        public ResultSet query(String expression, String timezoneId)
+                throws Exception
+        {
+            statement.execute(format("SET SESSION TIME ZONE '%s'", timezoneId));
+            return statement.executeQuery(format("SELECT %s", expression));
+        }
+
+        @Override
+        public boolean supports(JDBCType type)
+        {
+            return SUPPORTED_TYPES.contains(type);
+        }
+
+        @Override
+        public void setUp()
+        {
+            try {
+                connection = postgresqlContainer.createConnection("");
+                statement = connection.createStatement();
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void tearDown()
+                throws Exception
+        {
+            statement.close();
+            connection.close();
+        }
+
+        @Override
+        public void close()
+        {
+            postgresqlContainer.stop();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[postgresql]";
+        }
+    }
+
+    @FunctionalInterface
+    private interface ResultAssertion
+    {
+        void accept(ResultSet rs, ResultSet reference, int column)
+                throws Exception;
+    }
+
+    private interface Binder
+    {
+        void bind(PreparedStatement ps, int i)
+                throws SQLException;
+    }
+}

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
@@ -598,6 +598,26 @@ public class TestPrestoDriver
                     ResultSet rs = statement.executeQuery(sql)) {
                 assertTrue(rs.next());
                 assertEquals(rs.getString("zone"), "UTC");
+                // setting the session timezone has no effect on the interpretation of timestamps in the JDBC driver
+                assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, defaultZone).getMillis()));
+            }
+        }
+
+        // legacy mode
+        try (Connection connection = DriverManager.getConnection(format("jdbc:presto://%s?useSessionTimeZone=true", server.getAddress()), "test", null)) {
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery(sql)) {
+                assertTrue(rs.next());
+                assertEquals(rs.getString("zone"), defaultZoneKey.getId());
+                assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, defaultZone).getMillis()));
+            }
+
+            connection.unwrap(PrestoConnection.class).setTimeZoneId("UTC");
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery(sql)) {
+                assertTrue(rs.next());
+                assertEquals(rs.getString("zone"), "UTC");
+                // the session timezone is used
                 assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, DateTimeZone.UTC).getMillis()));
             }
         }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 
 import static io.prestosql.jdbc.ConnectionProperties.CLIENT_TAGS;
@@ -29,6 +30,7 @@ import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestPrestoDriverUri
@@ -244,6 +246,14 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?clientTags=" + clientTags);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(CLIENT_TAGS.getKey()), clientTags);
+    }
+
+    @Test
+    public void testUriWithUseSessionTimeZone()
+            throws SQLException
+    {
+        Optional<Boolean> property = createDriverUri("presto://localhost:8080?useSessionTimeZone=true").useSessionTimezone();
+        assertTrue(property.isPresent() && property.get());
     }
 
     private static void assertUriPortScheme(PrestoDriverUri parameters, int port, String scheme)

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.oracle.version>19.3.0.0</dep.oracle.version>
     </properties>
 
     <dependencies>

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
@@ -148,6 +148,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getSchema().orElse(null),
                 session.getPath().toString(),
                 ZoneId.of(session.getTimeZoneKey().getId()),
+                false,
                 session.getLocale(),
                 resourceEstimates.build(),
                 properties.build(),

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
@@ -74,6 +74,7 @@ public class TestFinalQueryInfo
                     null,
                     null,
                     ZoneId.of("America/Los_Angeles"),
+                    false,
                     Locale.ENGLISH,
                     ImmutableMap.of(),
                     ImmutableMap.of(),


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/4017.

Dates, times and timestamps in result sets are no longer interpreted as local to the session time zone, but to the client JVM time zone.  This is consistent with other drivers' behavior (e.g. PostgreSQL, Oracle).

A toggle was added to fall back to the previous behavior.