### PR TITLE
Trim white spaces for rowkey definition in Phoenix connector

### DIFF
--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
@@ -148,7 +149,10 @@ public final class PhoenixTableProperties
         if (rowkeysCsv == null) {
             return Optional.empty();
         }
-        return Optional.of(Arrays.asList(StringUtils.split(rowkeysCsv, ',')));
+
+        return Optional.of(Arrays.stream(StringUtils.split(rowkeysCsv, ','))
+                .map(String::trim)
+                .collect(toImmutableList()));
     }
 
     public static Optional<Boolean> getDisableWal(Map<String, Object> tableProperties)

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
@@ -128,9 +128,22 @@ public class TestPhoenixIntegrationSmokeTest
     @Test
     public void testCreateTableWithProperties()
     {
-        assertUpdate("CREATE TABLE test_create_table_with_properties (created_date date, a bigint, b double, c varchar(10), d varchar(10)) WITH(rowkeys = 'created_date row_timestamp,a,b,c', salt_buckets=10)");
+        assertUpdate("CREATE TABLE test_create_table_with_properties (created_date date, a bigint, b double, c varchar(10), d varchar(10)) WITH(rowkeys = 'created_date row_timestamp, a,b,c', salt_buckets=10)");
         assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_with_properties"));
         assertTableColumnNames("test_create_table_with_properties", "created_date", "a", "b", "c", "d");
+        assertThat(computeActual("SHOW CREATE TABLE test_create_table_with_properties").getOnlyValue())
+                .isEqualTo("CREATE TABLE phoenix.tpch.test_create_table_with_properties (\n" +
+                           "   created_date date,\n" +
+                           "   a bigint NOT NULL,\n" +
+                           "   b double NOT NULL,\n" +
+                           "   c varchar(10) NOT NULL,\n" +
+                           "   d varchar(10)\n" +
+                           ")\n" +
+                           "WITH (\n" +
+                           "   rowkeys = 'A,B,C',\n" +
+                           "   salt_buckets = 10\n" +
+                           ")");
+
         assertUpdate("DROP TABLE test_create_table_with_properties");
     }
 


### PR DESCRIPTION
Issue #3251. When spaces are given in rowkey definition, the columns which has space were ignored while creating table. Fixed this by using String trim operation on rowkeys.