### PR TITLE
Update errorprone and enable NullOptional check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dep.drift.version>1.14</dep.drift.version>
         <dep.tempto.version>179</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
-        <dep.errorprone.version>2.3.4</dep.errorprone.version>
+        <dep.errorprone.version>2.4.0</dep.errorprone.version>
         <rubix.version>0.3.12</rubix.version>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1421,7 +1421,7 @@
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <!-- TODO enable more checks, i.e. remove "-XepDisableAllChecks" -->
-                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(|test-)sources/.* -XepDisableAllChecks -Xep:MissingOverride:ERROR -Xep:ClassCanBeStatic:ERROR -Xep:ArrayToString:ERROR -Xep:GetClassOnClass:ERROR -Xep:EqualsIncompatibleType:ERROR -Xep:BoxedPrimitiveConstructor:ERROR -Xep:BadInstanceof:ERROR -Xep:CompareToZero:ERROR -Xep:InconsistentHashCode:ERROR -Xep:ObjectToString:ERROR</arg>
+                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(|test-)sources/.* -XepDisableAllChecks -Xep:MissingOverride:ERROR -Xep:ClassCanBeStatic:ERROR -Xep:ArrayToString:ERROR -Xep:GetClassOnClass:ERROR -Xep:EqualsIncompatibleType:ERROR -Xep:BoxedPrimitiveConstructor:ERROR -Xep:BadInstanceof:ERROR -Xep:CompareToZero:ERROR -Xep:InconsistentHashCode:ERROR -Xep:ObjectToString:ERROR -Xep:NullOptional:ERROR</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/metadata/AccumuloTable.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/metadata/AccumuloTable.java
@@ -65,7 +65,7 @@ public class AccumuloTable
         this.table = requireNonNull(table, "table is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns are null"));
         this.serializerClassName = requireNonNull(serializerClassName, "serializerClassName is null");
-        this.scanAuthorizations = scanAuthorizations;
+        this.scanAuthorizations = requireNonNull(scanAuthorizations, "scanAuthorizations is null");
 
         boolean indexed = false;
         Optional<Integer> rowIdOrdinal = Optional.empty();

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/index/TestIndexer.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/index/TestIndexer.java
@@ -83,7 +83,7 @@ public class TestIndexer
         AccumuloColumnHandle c3 = new AccumuloColumnHandle("firstname", Optional.of("cf"), Optional.of("firstname"), VARCHAR, 2, "", true);
         AccumuloColumnHandle c4 = new AccumuloColumnHandle("arr", Optional.of("cf"), Optional.of("arr"), new ArrayType(VARCHAR), 3, "", true);
 
-        table = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", true, LexicoderRowSerializer.class.getCanonicalName(), null);
+        table = new AccumuloTable("default", "index_test_table", ImmutableList.of(c1, c2, c3, c4), "id", true, LexicoderRowSerializer.class.getCanonicalName(), Optional.empty());
 
         m1 = new Mutation(M1_ROWID);
         m1.put(CF, AGE, AGE_VALUE);

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisMetadata.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisMetadata.java
@@ -160,14 +160,12 @@ public class KinesisMetadata
             tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchema().get(), prefix.getTable().get()));
         }
         else {
-            tableNames = listTables(session, null);
+            tableNames = listTables(session, Optional.empty());
         }
 
         for (SchemaTableName tableName : tableNames) {
             ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
-            if (tableMetadata != null) {
-                columns.put(tableName, tableMetadata.getColumns());
-            }
+            columns.put(tableName, tableMetadata.getColumns());
         }
         return columns.build();
     }

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
@@ -67,7 +67,7 @@ public class ResourceGroupSpecBuilder
         this.jmxExport = requireNonNull(jmxExport, "jmxExport is null");
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null").map(Duration::valueOf);
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null").map(Duration::valueOf);
-        this.parentId = parentId;
+        this.parentId = requireNonNull(parentId, "parentId is null");
     }
 
     public long getId()

--- a/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -81,7 +81,7 @@ public class TestResourceGroupsDao
         dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
         List<ResourceGroupSpecBuilder> records = dao.getResourceGroups(ENVIRONMENT);
         assertEquals(records.size(), 2);
-        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), null));
+        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "50%", 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
         compareResourceGroups(map, records);
     }


### PR DESCRIPTION
This PR updates error-prone compiler to 2.4.0 and enabled `NullOptional` check which validates if `Optional.empty()` is passed instead of `null`.

See https://errorprone.info/bugpattern/NullOptional