### PR TITLE
Refactor optimizer module tests

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestConnectorExpressionTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestConnectorExpressionTranslator.java
@@ -40,7 +40,6 @@ import static io.prestosql.spi.type.RowType.rowType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.sql.planner.ConnectorExpressionTranslator.translate;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestConnectorExpressionTranslator
 {
@@ -93,10 +92,10 @@ public class TestConnectorExpressionTranslator
     private void assertTranslationToConnectorExpression(Expression expression, Optional<ConnectorExpression> connectorExpression)
     {
         Optional<ConnectorExpression> translation = translate(TEST_SESSION, expression, TYPE_ANALYZER, TYPE_PROVIDER);
-        assertTrue(translation.isPresent() == connectorExpression.isPresent());
         if (translation.isPresent()) {
             assertEquals(translation.get(), connectorExpression.get());
         }
+        assertEquals(connectorExpression.isPresent(), translation.isPresent());
     }
 
     private void assertTranslationFromConnectorExpression(ConnectorExpression connectorExpression, Expression expected)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestConnectorExpressionTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestConnectorExpressionTranslator.java
@@ -92,10 +92,8 @@ public class TestConnectorExpressionTranslator
     private void assertTranslationToConnectorExpression(Expression expression, Optional<ConnectorExpression> connectorExpression)
     {
         Optional<ConnectorExpression> translation = translate(TEST_SESSION, expression, TYPE_ANALYZER, TYPE_PROVIDER);
-        if (translation.isPresent()) {
-            assertEquals(translation.get(), connectorExpression.get());
-        }
         assertEquals(connectorExpression.isPresent(), translation.isPresent());
+        translation.ifPresent(value -> assertEquals(value, connectorExpression.get()));
     }
 
     private void assertTranslationFromConnectorExpression(ConnectorExpression connectorExpression, Expression expected)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFilterConsumer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLocalDynamicFilterConsumer.java
@@ -29,7 +29,6 @@ import io.prestosql.sql.planner.plan.DynamicFilterId;
 import io.prestosql.sql.planner.plan.JoinNode;
 import org.testng.annotations.Test;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -257,7 +256,7 @@ public class TestLocalDynamicFilterConsumer
                 .getBuildChannels()
                 .entrySet()
                 .stream()
-                .sorted(Comparator.comparing(Map.Entry::getValue))
+                .sorted(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
                 .collect(toImmutableList());
         filter.getTupleDomainConsumer().accept(TupleDomain.withColumnDomains(ImmutableMap.of(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/AggregationMatcher.java
@@ -91,7 +91,7 @@ public class AggregationMatcher
         }
 
         for (Symbol symbol : aggregationsWithMask) {
-            if (!masks.keySet().contains(symbol)) {
+            if (!masks.containsKey(symbol)) {
                 return NO_MATCH;
             }
         }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ConnectorAwareTableScanMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ConnectorAwareTableScanMatcher.java
@@ -55,11 +55,10 @@ public class ConnectorAwareTableScanMatcher
         TableScanNode tableScanNode = (TableScanNode) node;
 
         TupleDomain<ColumnHandle> actual = tableScanNode.getEnforcedConstraint();
-        TupleDomain<Predicate<ColumnHandle>> expected = expectedEnforcedConstraint;
 
         boolean tableMatches = expectedTable.test(tableScanNode.getTable().getConnectorHandle());
 
-        return new MatchResult(tableMatches && domainsMatch(expected, actual));
+        return new MatchResult(tableMatches && domainsMatch(expectedEnforcedConstraint, actual));
     }
 
     public static PlanMatchPattern create(Predicate<ConnectorTableHandle> table, TupleDomain<Predicate<ColumnHandle>> constraints)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -983,9 +983,7 @@ public final class PlanMatchPattern
                 .map(PlanNodeMatcher.class::cast)
                 .findFirst();
 
-        if (planNodeMatcher.isPresent()) {
-            builder.append("(").append(planNodeMatcher.get().getNodeClass().getSimpleName()).append(")");
-        }
+        planNodeMatcher.ifPresent(nodeMatcher -> builder.append("(").append(nodeMatcher.getNodeClass().getSimpleName()).append(")"));
 
         builder.append("\n");
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TableScanMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TableScanMatcher.java
@@ -110,12 +110,11 @@ final class TableScanMatcher
 
         PlanMatchPattern build()
         {
-            PlanMatchPattern result = node(TableScanNode.class).with(
+            return node(TableScanNode.class).with(
                     new TableScanMatcher(
                             expectedTableName,
                             expectedConstraint,
                             hasTableLayout));
-            return result;
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleTester.java
@@ -78,7 +78,7 @@ public class RuleTester
         queryRunner.createCatalog(session.getCatalog().get(),
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
-        plugins.stream().forEach(queryRunner::installPlugin);
+        plugins.forEach(queryRunner::installPlugin);
 
         return new RuleTester(queryRunner);
     }


### PR DESCRIPTION
# Purpose
Refactor some code in the test for optimizer modules.

# Overview
- [x] : Use assertEquals is possible
- [x] : Prefer functional style over `isPresent` check
- [x] : Simplify comparator by `Map.Entry.comparingByValue`
- [x] : Prefer `containsKey` over `contains` for key set.
- [x] : Remove redundant variable declaration