### PR TITLE
Fix incorrect column type for legacy clients

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -614,7 +614,7 @@ class Query
         if (type instanceof DateTimeDataType) {
             DateTimeDataType dataTimeType = (DateTimeDataType) type;
             if (dataTimeType.getType() == DateTimeDataType.Type.TIMESTAMP && !supportsParametricDateTime) {
-                if (!dataTimeType.isWithTimeZone()) {
+                if (dataTimeType.isWithTimeZone()) {
                     return TIMESTAMP_WITH_TIME_ZONE;
                 }
                 else {


### PR DESCRIPTION
The test was inverted, which results in the protocol incorrectly
describing timestamp columns as timestamp w/ tz and vice versa