### PR TITLE
Upgrade mongo driver

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <mongo-java.version>3.6.0</mongo-java.version>
+        <mongo-java.version>3.8.0</mongo-java.version>
         <netty.version>4.0.32.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
While trying to query cosmos db from presto using mongo apis, the following error comes : ```Caused by: com.mongodb.MongoCommandException: Command failed with error 9: 'Cursor document in ListIndexes must be empty. Found batchSize' on server```
This error comes even if the `mongodb.cursor-batch-size` is not set. https://github.com/mongodb/mongo-java-driver/commit/80556b3a21325df1e3fcedb8045aca7281eaa3ea fixes the issue of sending batch size in request even if it is not set. 