### PR TITLE
Move column handle validation for Kafka encoders into constructor

### DIFF
--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -65,14 +65,8 @@ public abstract class AbstractRowEncoder
         this.session = requireNonNull(session, "session is null");
         requireNonNull(columnHandles, "columnHandles is null");
         this.columnHandles = ImmutableList.copyOf(columnHandles);
-        validateColumns(this.columnHandles);
         this.currentColumnIndex = 0;
     }
-
-    /**
-     * Performs any checks on the column handle field values
-     */
-    protected abstract void validateColumns(List<EncoderColumnHandle> columnHandles);
 
     @Override
     public RowEncoder appendColumnValue(Block block, int position)

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
@@ -52,18 +52,13 @@ public class CsvRowEncoder
     public CsvRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles)
     {
         super(session, columnHandles);
-        this.row = new String[columnHandles.size()];
-    }
+        for (EncoderColumnHandle columnHandle : this.columnHandles) {
+            checkArgument(columnHandle.getFormatHint() == null, "Unexpected format hint '%s' defined for column '%s'", columnHandle.getFormatHint(), columnHandle.getName());
+            checkArgument(columnHandle.getDataFormat() == null, "Unexpected data format '%s' defined for column '%s'", columnHandle.getDataFormat(), columnHandle.getName());
 
-    @Override
-    protected void validateColumns(List<EncoderColumnHandle> columnHandles)
-    {
-        for (EncoderColumnHandle columnHandle : columnHandles) {
-            checkArgument(columnHandle.getFormatHint() == null, "unexpected format hint '%s' defined for column '%s'", columnHandle.getFormatHint(), columnHandle.getName());
-            checkArgument(columnHandle.getDataFormat() == null, "unexpected data format '%s' defined for column '%s'", columnHandle.getDataFormat(), columnHandle.getName());
-
-            checkArgument(isSupportedType(columnHandle.getType()), "unsupported column type '%s' for column '%s'", columnHandle.getType(), columnHandle.getName());
+            checkArgument(isSupportedType(columnHandle.getType()), "Unsupported column type '%s' for column '%s'", columnHandle.getType(), columnHandle.getName());
         }
+        this.row = new String[this.columnHandles.size()];
     }
 
     private boolean isSupportedType(Type type)


### PR DESCRIPTION
`validateColumns` method was unnecessary, removed it and moved column validation into constructor. @losipiuk 