### PR TITLE
Remove unnecessary function references

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
@@ -471,7 +471,7 @@ class QueryPlanner
                             })
                             .collect(toImmutableList()),
                     function.isDistinct(),
-                    function.getFilter().map(coercions::apply),
+                    function.getFilter().map(coercions),
                     function.getOrderBy().map(orderBy -> translateOrderingScheme(orderBy.getSortItems(), coercions)),
                     Optional.empty());
 
@@ -527,7 +527,7 @@ class QueryPlanner
     {
         List<Symbol> symbols = items.stream()
                 .map(SortItem::getSortKey)
-                .map(coercions::apply)
+                .map(coercions)
                 .collect(toImmutableList());
 
         ImmutableMap.Builder<Symbol, SortOrder> orders = ImmutableMap.builder();


### PR DESCRIPTION
The variables are Functions, so they can be applied directly.
No need to reference apply explicitly.