### PR TITLE
Allow user mapping for empty principal name in access control rules

### DIFF
--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedSystemAccessControl.java
@@ -231,11 +231,7 @@ public class FileBasedSystemAccessControl
             return;
         }
 
-        if (principal.isEmpty()) {
-            denySetUser(principal, userName);
-        }
-
-        String principalName = principal.get().getName();
+        String principalName = (principal.isPresent()) ? principal.get().getName() : "";
 
         for (PrincipalUserMatchRule rule : principalUserMatchRules.get()) {
             Optional<Boolean> allowed = rule.match(principalName, userName);


### PR DESCRIPTION
Cluster running both HTTP and HTTPS (with password authentication) fails to use access control when principal name is empty, although it's required to limit it only to specific username.

for example `access_conrol.json`

```
{
  "catalogs": [
    {
      "allow": true
    }
  ],
  "principals": [
    {
      "principal": "()",
      "user": "etl_user[1-4]",
      "allow": true
    },
    {
      "principal": "(.*)",
      "principal_to_user": "$1",
      "allow": true
    }
  ]
}
```
