### PR TITLE
Remove unused declaration

### DIFF
--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
@@ -832,7 +832,6 @@ public class TestPrestoDriver
             throws Exception
     {
         CountDownLatch queryFinished = new CountDownLatch(1);
-        AtomicReference<String> queryId = new AtomicReference<>();
         AtomicReference<Throwable> queryFailure = new AtomicReference<>();
         String queryUuid = "/* " + UUID.randomUUID().toString() + " */";
 


### PR DESCRIPTION
AtomicReference for queryId is not used in PrestoDriver test.