### PR TITLE
Deprecate LocalQueryRunner

### DIFF
--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -216,6 +216,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
+@Deprecated
 public class LocalQueryRunner
         implements QueryRunner
 {


### PR DESCRIPTION
Deprecate LocalQueryRunner

LocalQueryRunner can be easily replaced with DistributedQueryRunner with
single node. Creation of such DistributedQueryRunner is not much longer
than LocalQueryRunner and it is more close to production Presto
installation.

LocalQueryRunner has following flaws:
 - does not require plugins to have serialization properly implemented
 - it does not support all task execution (GRANT, REVOKE)
 - it has different guice injection than the product code
 and so it complicates the understanding of test infra
 - there are places in the production code where we need to consider
 LocalQueryRunner usage (see disabled AddExchanges)
