### PR TITLE
Change aggregation pushdown assertions to calculate expected results

### DIFF
--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -300,18 +300,16 @@ public class TestPostgreSqlIntegrationSmokeTest
         assertPushedDown("SELECT regionkey, min(nationkey) FROM nation GROUP BY regionkey");
         assertPushedDown("SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey");
         assertPushedDown("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey");
-        assertPushedDown(
-                "SELECT regionkey, avg(nationkey) FROM nation GROUP BY regionkey",
-                "SELECT regionkey, avg(CAST(nationkey AS double)) FROM nation GROUP BY regionkey");
+        assertPushedDown("SELECT regionkey, avg(nationkey) FROM nation GROUP BY regionkey");
 
         try (AutoCloseable ignoreTable = withTable("tpch.test_aggregation_pushdown", "(short_decimal decimal(9, 3), long_decimal decimal(30, 10))")) {
             execute("INSERT INTO tpch.test_aggregation_pushdown VALUES (100.000, 100000000.000000000)");
             execute("INSERT INTO tpch.test_aggregation_pushdown VALUES (123.321, 123456789.987654321)");
 
-            assertPushedDown("SELECT min(short_decimal), min(long_decimal) FROM test_aggregation_pushdown", "SELECT 100.000, 100000000.000000000");
-            assertPushedDown("SELECT max(short_decimal), max(long_decimal) FROM test_aggregation_pushdown", "SELECT 123.321, 123456789.987654321");
-            assertPushedDown("SELECT sum(short_decimal), sum(long_decimal) FROM test_aggregation_pushdown", "SELECT 223.321, 223456789.987654321");
-            assertPushedDown("SELECT avg(short_decimal), avg(long_decimal) FROM test_aggregation_pushdown", "SELECT 223.321 / 2, 223456789.987654321 / 2");
+            assertPushedDown("SELECT min(short_decimal), min(long_decimal) FROM test_aggregation_pushdown");
+            assertPushedDown("SELECT max(short_decimal), max(long_decimal) FROM test_aggregation_pushdown");
+            assertPushedDown("SELECT sum(short_decimal), sum(long_decimal) FROM test_aggregation_pushdown");
+            assertPushedDown("SELECT avg(short_decimal), avg(long_decimal) FROM test_aggregation_pushdown");
         }
     }
 

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -295,21 +295,21 @@ public class TestPostgreSqlIntegrationSmokeTest
         // TODO support aggregation pushdown with GROUPING SETS
         // TODO support aggregation over expressions
 
-        assertPushedDown("SELECT count(*) FROM nation");
-        assertPushedDown("SELECT count(nationkey) FROM nation");
-        assertPushedDown("SELECT regionkey, min(nationkey) FROM nation GROUP BY regionkey");
-        assertPushedDown("SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey");
-        assertPushedDown("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey");
-        assertPushedDown("SELECT regionkey, avg(nationkey) FROM nation GROUP BY regionkey");
+        assertAggregationPushedDown("SELECT count(*) FROM nation");
+        assertAggregationPushedDown("SELECT count(nationkey) FROM nation");
+        assertAggregationPushedDown("SELECT regionkey, min(nationkey) FROM nation GROUP BY regionkey");
+        assertAggregationPushedDown("SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey");
+        assertAggregationPushedDown("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey");
+        assertAggregationPushedDown("SELECT regionkey, avg(nationkey) FROM nation GROUP BY regionkey");
 
         try (AutoCloseable ignoreTable = withTable("tpch.test_aggregation_pushdown", "(short_decimal decimal(9, 3), long_decimal decimal(30, 10))")) {
             execute("INSERT INTO tpch.test_aggregation_pushdown VALUES (100.000, 100000000.000000000)");
             execute("INSERT INTO tpch.test_aggregation_pushdown VALUES (123.321, 123456789.987654321)");
 
-            assertPushedDown("SELECT min(short_decimal), min(long_decimal) FROM test_aggregation_pushdown");
-            assertPushedDown("SELECT max(short_decimal), max(long_decimal) FROM test_aggregation_pushdown");
-            assertPushedDown("SELECT sum(short_decimal), sum(long_decimal) FROM test_aggregation_pushdown");
-            assertPushedDown("SELECT avg(short_decimal), avg(long_decimal) FROM test_aggregation_pushdown");
+            assertAggregationPushedDown("SELECT min(short_decimal), min(long_decimal) FROM test_aggregation_pushdown");
+            assertAggregationPushedDown("SELECT max(short_decimal), max(long_decimal) FROM test_aggregation_pushdown");
+            assertAggregationPushedDown("SELECT sum(short_decimal), sum(long_decimal) FROM test_aggregation_pushdown");
+            assertAggregationPushedDown("SELECT avg(short_decimal), avg(long_decimal) FROM test_aggregation_pushdown");
         }
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -442,7 +442,7 @@ public abstract class AbstractTestIntegrationSmokeTest
                         "('views')");
     }
 
-    protected void assertPushedDown(@Language("SQL") String sql)
+    protected void assertAggregationPushedDown(@Language("SQL") String sql)
     {
         String catalog = getSession().getCatalog().orElseThrow();
         Session withoutPushdown = Session.builder(getSession())

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -26,6 +26,7 @@ import static io.prestosql.SystemSessionProperties.IGNORE_STATS_CALCULATOR_FAILU
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.sql.planner.assertions.PlanAssert.assertPlan;
 import static io.prestosql.testing.QueryAssertions.assertContains;
+import static io.prestosql.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
@@ -441,18 +442,20 @@ public abstract class AbstractTestIntegrationSmokeTest
                         "('views')");
     }
 
-    protected void assertPushedDown(String sql)
+    protected void assertPushedDown(@Language("SQL") String sql)
     {
-        assertPushedDown(sql, sql);
-    }
+        String catalog = getSession().getCatalog().orElseThrow();
+        Session withoutPushdown = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "allow_aggregation_pushdown", "false")
+                .build();
 
-    protected void assertPushedDown(String actual, String expectedOnH2)
-    {
-        assertQuery(actual, expectedOnH2);
+        MaterializedResult actualResults = computeActual(sql);
+        MaterializedResult expectedResults = computeActual(withoutPushdown, sql);
+        assertEqualsIgnoreOrder(actualResults.getMaterializedRows(), expectedResults.getMaterializedRows());
 
         transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
                 .execute(getSession(), session -> {
-                    Plan plan = getQueryRunner().createPlan(session, actual, WarningCollector.NOOP);
+                    Plan plan = getQueryRunner().createPlan(session, sql, WarningCollector.NOOP);
                     assertPlan(
                             session,
                             getQueryRunner().getMetadata(),

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
@@ -22,6 +22,7 @@ import io.prestosql.client.Column;
 import io.prestosql.client.QueryError;
 import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.client.StatementClient;
+import io.prestosql.connector.CatalogName;
 import io.prestosql.metadata.MetadataUtil;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.metadata.QualifiedTablePrefix;
@@ -126,6 +127,11 @@ public abstract class AbstractTestingPrestoClient<T>
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(session.getSystemProperties());
         for (Entry<String, Map<String, String>> connectorProperties : session.getUnprocessedCatalogProperties().entrySet()) {
+            for (Entry<String, String> entry : connectorProperties.getValue().entrySet()) {
+                properties.put(connectorProperties.getKey() + "." + entry.getKey(), entry.getValue());
+            }
+        }
+        for (Entry<CatalogName, Map<String, String>> connectorProperties : session.getConnectorProperties().entrySet()) {
             for (Entry<String, String> entry : connectorProperties.getValue().entrySet()) {
                 properties.put(connectorProperties.getKey() + "." + entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
Rather than supplying an expected result the method can run the query twice. Once with pushdown enabled, and once without.