### PR TITLE
Fix loading of PartitionFieldSummary in ManifestsTable

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ManifestsTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ManifestsTable.java
@@ -27,6 +27,7 @@ import io.prestosql.spi.connector.FixedPageSource;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.RowType;
 import org.apache.iceberg.ManifestFile.PartitionFieldSummary;
 import org.apache.iceberg.PartitionField;
@@ -69,10 +70,10 @@ public class ManifestsTable
                         .add(new ColumnMetadata("added_data_files_count", INTEGER))
                         .add(new ColumnMetadata("existing_data_files_count", INTEGER))
                         .add(new ColumnMetadata("deleted_data_files_count", INTEGER))
-                        .add(new ColumnMetadata("partitions", RowType.rowType(
+                        .add(new ColumnMetadata("partitions", new ArrayType(RowType.rowType(
                                 RowType.field("contains_null", BOOLEAN),
                                 RowType.field("lower_bound", VARCHAR),
-                                RowType.field("upper_bound", VARCHAR))))
+                                RowType.field("upper_bound", VARCHAR)))))
                         .build());
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
     }
@@ -125,20 +126,22 @@ public class ManifestsTable
         return pagesBuilder.build();
     }
 
-    private static void writePartitionSummaries(BlockBuilder blockBuilder, List<PartitionFieldSummary> summaries, PartitionSpec partitionSpec)
+    private static void writePartitionSummaries(BlockBuilder arrayBlockBuilder, List<PartitionFieldSummary> summaries, PartitionSpec partitionSpec)
     {
+        BlockBuilder singleArrayWriter = arrayBlockBuilder.beginBlockEntry();
         for (int i = 0; i < summaries.size(); i++) {
             PartitionFieldSummary summary = summaries.get(i);
             PartitionField field = partitionSpec.fields().get(i);
             Type nestedType = partitionSpec.partitionType().fields().get(i).type();
 
-            BlockBuilder rowBuilder = blockBuilder.beginBlockEntry();
+            BlockBuilder rowBuilder = singleArrayWriter.beginBlockEntry();
             BOOLEAN.writeBoolean(rowBuilder, summary.containsNull());
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(
                     Conversions.fromByteBuffer(nestedType, summary.lowerBound())));
             VARCHAR.writeString(rowBuilder, field.transform().toHumanString(
                     Conversions.fromByteBuffer(nestedType, summary.upperBound())));
-            blockBuilder.closeEntry();
+            singleArrayWriter.closeEntry();
         }
+        arrayBlockBuilder.closeEntry();
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -75,6 +75,10 @@ public class TestIcebergSystemTables
         assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
         assertUpdate("INSERT INTO test_schema.test_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
         assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");
+
+        assertUpdate("CREATE TABLE test_schema.test_table_multilevel_partitions (_varchar VARCHAR, _bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_bigint', '_date'])");
+        assertUpdate("INSERT INTO test_schema.test_table_multilevel_partitions VALUES ('a', 0, CAST('2019-09-08' AS DATE)), ('a', 1, CAST('2019-09-08' AS DATE)), ('a', 0, CAST('2019-09-09' AS DATE))", 3);
+        assertQuery("SELECT count(*) FROM test_schema.test_table_multilevel_partitions", "VALUES 3");
     }
 
     @Test
@@ -144,8 +148,10 @@ public class TestIcebergSystemTables
                         "('added_data_files_count', 'integer', '', '')," +
                         "('existing_data_files_count', 'integer', '', '')," +
                         "('deleted_data_files_count', 'integer', '', '')," +
-                        "('partitions', 'row(contains_null boolean, lower_bound varchar, upper_bound varchar)', '', '')");
+                        "('partitions', 'array(row(contains_null boolean, lower_bound varchar, upper_bound varchar))', '', '')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$manifests\"");
+
+        assertQuerySucceeds("SELECT * FROM test_schema.\"test_table_multilevel_partitions$manifests\"");
     }
 
     @Test
@@ -170,6 +176,7 @@ public class TestIcebergSystemTables
     public void tearDown()
     {
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table");
+        assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_multilevel_partitions");
         assertUpdate("DROP SCHEMA IF EXISTS test_schema");
     }
 }


### PR DESCRIPTION
Manifests table can have multiple or zero entries in `PartitionFieldSummary`. Added a test that fails without the change.