### PR TITLE
Ensure to pushdown the aggregation for count(const)

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -427,7 +427,8 @@ public class PlanOptimizers
                                         new MergeLimitWithDistinct(),
                                         new PruneCountAggregationOverScalar(metadata),
                                         new PruneOrderByInAggregation(metadata),
-                                        new RewriteSpatialPartitioningAggregation(metadata)))
+                                        new RewriteSpatialPartitioningAggregation(metadata),
+                                        new SimplifyCountOverConstant(metadata)))
                                 .build()),
                 new IterativeOptimizer(
                         ruleStats,
@@ -552,11 +553,6 @@ public class PlanOptimizers
                 new UnaliasSymbolReferences(metadata), // Run again because predicate pushdown and projection pushdown might add more projections
                 columnPruningOptimizer, // Make sure to run this before index join. Filtered projections may not have all the columns.
                 new IndexJoinOptimizer(metadata), // Run this after projections and filters have been fully simplified and pushed down
-                new IterativeOptimizer(
-                        ruleStats,
-                        statsCalculator,
-                        estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new SimplifyCountOverConstant(metadata))),
                 new LimitPushDown(), // Run LimitPushDown before WindowFilterPushDown
                 new WindowFilterPushDown(metadata), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
                 new IterativeOptimizer(

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -297,6 +297,8 @@ public class TestPostgreSqlIntegrationSmokeTest
 
         assertAggregationPushedDown("SELECT count(*) FROM nation");
         assertAggregationPushedDown("SELECT count(nationkey) FROM nation");
+        assertAggregationPushedDown("SELECT count(1) FROM nation");
+        assertAggregationPushedDown("SELECT count() FROM nation");
         assertAggregationPushedDown("SELECT regionkey, min(nationkey) FROM nation GROUP BY regionkey");
         assertAggregationPushedDown("SELECT regionkey, max(nationkey) FROM nation GROUP BY regionkey");
         assertAggregationPushedDown("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey");


### PR DESCRIPTION
# Purpose
Aggregate pushdown should be enabled even with count(const) query. Since `SimplifyCountOverConstant` is applied after `PushAggregationIntoTableScan`, the aggregation pushdown does not treat count(*) and count(const) uniformally.

The logical plan of the following query with PostgreSQL connector is fixed.

```sql
create table test_table (c1 integer, c2 varchar);
```

## Before
```
> explain (type logical) select c2, count(1) from test_table group by 1;
                                                            Query Plan
-----------------------------------------------------------------------------------------------------------------------------------
 Output[c2, _col1]
 │   Layout: [c2:varchar, count:bigint]
 │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
 │   _col1 := count
 └─ RemoteExchange[GATHER]
    │   Layout: [c2:varchar, count:bigint]
    │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
    └─ Project[]
       │   Layout: [c2:varchar, count:bigint]
       │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
       └─ Aggregate(FINAL)[c2][$hashvalue]
          │   Layout: [c2:varchar, $hashvalue:bigint, count:bigint]
          │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
          │   count := count("count_0")
          └─ LocalExchange[HASH][$hashvalue] ("c2")
             │   Layout: [c2:varchar, count_0:bigint, $hashvalue:bigint]
             │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
             └─ RemoteExchange[REPARTITION][$hashvalue_1]
                │   Layout: [c2:varchar, count_0:bigint, $hashvalue_1:bigint]
                │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
                └─ Aggregate(PARTIAL)[c2][$hashvalue_2]
                   │   Layout: [c2:varchar, $hashvalue_2:bigint, count_0:bigint]
                   │   count_0 := count(*)
                   └─ ScanProject[table = postgresql:public.test_table public.test_table columns=[c2:varchar:varchar]]
                          Layout: [c2:varchar, $hashvalue_2:bigint]
                          Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B}
                          $hashvalue_2 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("c2"), 0))
                          c2 := c2:varchar:varchar
```

## After

The fix eliminates the aggregation node from the Presto side properly.

```
> explain (type logical) select c2, count(1) from test_table group by 1;
                                                                                  Query Plan
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output[c2, _col1]
 │   Layout: [c2_0:varchar, _presto_generated_1:bigint]
 │   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: ?}
 │   c2 := c2_0
 │   _col1 := _presto_generated_1
 └─ RemoteExchange[GATHER]
    │   Layout: [c2_0:varchar, _presto_generated_1:bigint]
    │   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: ?}
    └─ TableScan[postgresql:public.test_table public.test_table columns=[c2:varchar:varchar, count(*):_presto_generated_1:bigint:bigint] groupingSets=[[c2:varchar:varchar]]]
           Layout: [c2_0:varchar, _presto_generated_1:bigint]
           Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
           _presto_generated_1 := count(*):_presto_generated_1:bigint:bigint
           c2_0 := c2:varchar:varchar
```

It fixes https://github.com/prestosql/presto/issues/4362