### PR TITLE
Add Kafka Json encoder

### DIFF
--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -105,6 +105,11 @@
 
         <!-- used by tests but also needed transitively -->
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/EncoderModule.java
@@ -20,6 +20,8 @@ import io.prestosql.plugin.kafka.encoder.avro.AvroRowEncoder;
 import io.prestosql.plugin.kafka.encoder.avro.AvroRowEncoderFactory;
 import io.prestosql.plugin.kafka.encoder.csv.CsvRowEncoder;
 import io.prestosql.plugin.kafka.encoder.csv.CsvRowEncoderFactory;
+import io.prestosql.plugin.kafka.encoder.json.JsonRowEncoder;
+import io.prestosql.plugin.kafka.encoder.json.JsonRowEncoderFactory;
 import io.prestosql.plugin.kafka.encoder.raw.RawRowEncoder;
 import io.prestosql.plugin.kafka.encoder.raw.RawRowEncoderFactory;
 
@@ -36,6 +38,7 @@ public class EncoderModule
         encoderFactoriesByName.addBinding(AvroRowEncoder.NAME).to(AvroRowEncoderFactory.class).in(SINGLETON);
         encoderFactoriesByName.addBinding(CsvRowEncoder.NAME).to(CsvRowEncoderFactory.class).in(SINGLETON);
         encoderFactoriesByName.addBinding(RawRowEncoder.NAME).to(RawRowEncoderFactory.class).in(SINGLETON);
+        encoderFactoriesByName.addBinding(JsonRowEncoder.NAME).to(JsonRowEncoderFactory.class).in(SINGLETON);
 
         binder.bind(DispatchingRowEncoderFactory.class).in(SINGLETON);
     }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoder.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.plugin.kafka.encoder.AbstractRowEncoder;
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.Type;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static io.prestosql.spi.type.Varchars.isVarcharType;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class JsonRowEncoder
+        extends AbstractRowEncoder
+{
+    private static final Set<Type> PRIMITIVE_SUPPORTED_TYPES = ImmutableSet.of(
+            BIGINT, INTEGER, SMALLINT, TINYINT, DOUBLE, BOOLEAN);
+
+    public static final String NAME = "json";
+
+    private final ObjectMapper objectMapper;
+    private final ObjectNode node;
+
+    JsonRowEncoder(ConnectorSession session, List<EncoderColumnHandle> columnHandles, ObjectMapper objectMapper)
+    {
+        super(session, columnHandles);
+
+        for (EncoderColumnHandle columnHandle : this.columnHandles) {
+            checkArgument(isSupportedType(columnHandle.getType()), "Unsupported column type '%s' for column '%s'", columnHandle.getType(), columnHandle.getName());
+            checkArgument(columnHandle.getFormatHint() == null, "Unexpected format hint '%s' defined for column '%s'", columnHandle.getFormatHint(), columnHandle.getName());
+            checkArgument(columnHandle.getDataFormat() == null, "Unexpected data format '%s' defined for column '%s'", columnHandle.getDataFormat(), columnHandle.getName());
+        }
+
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.node = objectMapper.createObjectNode();
+    }
+
+    private boolean isSupportedType(Type type)
+    {
+        return isVarcharType(type) ||
+                PRIMITIVE_SUPPORTED_TYPES.contains(type);
+    }
+
+    private String currentColumnName()
+    {
+        return columnHandles.get(currentColumnIndex).getName();
+    }
+
+    @Override
+    protected void appendNullValue()
+    {
+        node.putNull(currentColumnName());
+    }
+
+    @Override
+    protected void appendLong(long value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendInt(int value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendShort(short value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendByte(byte value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendDouble(double value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendFloat(float value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendBoolean(boolean value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendString(String value)
+    {
+        node.put(currentColumnName(), value);
+    }
+
+    @Override
+    protected void appendByteBuffer(ByteBuffer value)
+    {
+        node.put(currentColumnName(), value.array());
+    }
+
+    @Override
+    public byte[] toByteArray()
+    {
+        // make sure entire row has been updated with new values
+        checkArgument(currentColumnIndex == columnHandles.size(), format("Missing %d columns", columnHandles.size() - currentColumnIndex + 1));
+
+        try {
+            resetColumnIndex(); // reset currentColumnIndex to prepare for next row
+            return objectMapper.writeValueAsBytes(node);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoderFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoderFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
+import io.prestosql.plugin.kafka.encoder.RowEncoder;
+import io.prestosql.plugin.kafka.encoder.RowEncoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonRowEncoderFactory
+        implements RowEncoderFactory
+{
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public JsonRowEncoderFactory(ObjectMapper objectMapper)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @Override
+    public RowEncoder create(ConnectorSession session, Optional<String> dataSchema, List<EncoderColumnHandle> columnHandles)
+    {
+        return new JsonRowEncoder(session, columnHandles, objectMapper);
+    }
+}

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/KafkaQueryRunner.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/KafkaQueryRunner.java
@@ -142,6 +142,7 @@ public final class KafkaQueryRunner
             tableNames.add("all_datatypes_avro");
             tableNames.add("all_datatypes_csv");
             tableNames.add("all_datatypes_raw");
+            tableNames.add("all_datatypes_json");
 
             JsonCodec<KafkaTopicDescription> topicDescriptionJsonCodec = new CodecSupplier<>(KafkaTopicDescription.class, queryRunner.getMetadata()).get();
 

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
@@ -17,9 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.plugin.kafka.util.TestingKafka;
 import io.prestosql.spi.connector.SchemaTableName;
-import io.prestosql.spi.type.BigintType;
-import io.prestosql.spi.type.BooleanType;
-import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.QueryRunner;
@@ -41,6 +38,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.testing.TestngUtils.toDataProvider;
 import static java.util.Objects.requireNonNull;
@@ -65,17 +65,17 @@ public class TestKafkaIntegrationSmokeTest
                 .put(new SchemaTableName("default", rawFormatTopic),
                         createDescription(rawFormatTopic, "default", rawFormatTopic,
                                 createFieldGroup("raw", ImmutableList.of(
-                                        createOneFieldDescription("bigint_long", BigintType.BIGINT, "0", "LONG"),
-                                        createOneFieldDescription("bigint_int", BigintType.BIGINT, "8", "INT"),
-                                        createOneFieldDescription("bigint_short", BigintType.BIGINT, "12", "SHORT"),
-                                        createOneFieldDescription("bigint_byte", BigintType.BIGINT, "14", "BYTE"),
-                                        createOneFieldDescription("double_double", DoubleType.DOUBLE, "15", "DOUBLE"),
-                                        createOneFieldDescription("double_float", DoubleType.DOUBLE, "23", "FLOAT"),
+                                        createOneFieldDescription("bigint_long", BIGINT, "0", "LONG"),
+                                        createOneFieldDescription("bigint_int", BIGINT, "8", "INT"),
+                                        createOneFieldDescription("bigint_short", BIGINT, "12", "SHORT"),
+                                        createOneFieldDescription("bigint_byte", BIGINT, "14", "BYTE"),
+                                        createOneFieldDescription("double_double", DOUBLE, "15", "DOUBLE"),
+                                        createOneFieldDescription("double_float", DOUBLE, "23", "FLOAT"),
                                         createOneFieldDescription("varchar_byte", createVarcharType(6), "27:33", "BYTE"),
-                                        createOneFieldDescription("boolean_long", BooleanType.BOOLEAN, "33", "LONG"),
-                                        createOneFieldDescription("boolean_int", BooleanType.BOOLEAN, "41", "INT"),
-                                        createOneFieldDescription("boolean_short", BooleanType.BOOLEAN, "45", "SHORT"),
-                                        createOneFieldDescription("boolean_byte", BooleanType.BOOLEAN, "47", "BYTE")))))
+                                        createOneFieldDescription("boolean_long", BOOLEAN, "33", "LONG"),
+                                        createOneFieldDescription("boolean_int", BOOLEAN, "41", "INT"),
+                                        createOneFieldDescription("boolean_short", BOOLEAN, "45", "SHORT"),
+                                        createOneFieldDescription("boolean_byte", BOOLEAN, "47", "BYTE")))))
                 .build();
 
         QueryRunner queryRunner = KafkaQueryRunner.builder(testingKafka)
@@ -86,6 +86,7 @@ public class TestKafkaIntegrationSmokeTest
                 .build();
 
         testingKafka.createTopic(rawFormatTopic);
+
         return queryRunner;
     }
 
@@ -160,7 +161,7 @@ public class TestKafkaIntegrationSmokeTest
         return new KafkaTopicFieldDescription(name, type, mapping, null, dataFormat, null, false);
     }
 
-    @Test(dataProvider = "testRoundTripAllFormatsDataProvider")
+    @Test(dataProvider = "roundTripAllFormatsDataProvider")
     public void testRoundTripAllFormats(RoundTripTestCase testCase)
     {
         assertUpdate("INSERT into write_test." + testCase.getTableName() +
@@ -171,14 +172,14 @@ public class TestKafkaIntegrationSmokeTest
                 "VALUES " + testCase.getRowValues());
     }
 
-    @DataProvider(name = "testRoundTripAllFormatsDataProvider")
-    public final Object[][] testRoundTripAllFormatsDataProvider()
+    @DataProvider
+    public final Object[][] roundTripAllFormatsDataProvider()
     {
-        return testRoundTripAllFormatsData().stream()
+        return roundTripAllFormatsData().stream()
                 .collect(toDataProvider());
     }
 
-    private List<RoundTripTestCase> testRoundTripAllFormatsData()
+    private List<RoundTripTestCase> roundTripAllFormatsData()
     {
         return ImmutableList.<RoundTripTestCase>builder()
                 .add(new RoundTripTestCase(
@@ -199,10 +200,16 @@ public class TestKafkaIntegrationSmokeTest
                         ImmutableList.of(
                                 ImmutableList.of(1, "'test'", 100000, 1000, 100, 10, 1000.001, true),
                                 ImmutableList.of(1, "'abcd'", 123456, 1234, 123, 12, 12345.123, false))))
+                .add(new RoundTripTestCase(
+                        "all_datatypes_json",
+                        ImmutableList.of("f_bigint", "f_int", "f_smallint", "f_tinyint", "f_double", "f_boolean", "f_varchar"),
+                        ImmutableList.of(
+                                ImmutableList.of(100000, 1000, 100, 10, 1000.001, true, "'test'"),
+                                ImmutableList.of(123748, 1234, 123, 12, 12345.123, false, "'abcd'"))))
                 .build();
     }
 
-    protected static final class RoundTripTestCase
+    private static final class RoundTripTestCase
     {
         private final String tableName;
         private final List<String> fieldNames;

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/encoder/json/TestJsonEncoder.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/encoder/json/TestJsonEncoder.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka.encoder.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.kafka.KafkaColumnHandle;
+import io.prestosql.spi.type.Type;
+import io.prestosql.testing.TestingConnectorSession;
+import org.assertj.core.api.ThrowableAssert;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.DecimalType.createDecimalType;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
+import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestJsonEncoder
+{
+    private static final JsonRowEncoderFactory ENCODER_FACTORY = new JsonRowEncoderFactory(new ObjectMapper());
+
+    private void assertUnsupportedColumnTypeException(ThrowableAssert.ThrowingCallable callable)
+    {
+        assertThatThrownBy(callable)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageMatching("Unsupported column type .* for column .*");
+    }
+
+    private void singleColumnEncoder(Type type)
+    {
+        ENCODER_FACTORY.create(TestingConnectorSession.SESSION, Optional.empty(), ImmutableList.of(new KafkaColumnHandle("default", type, "default", null, null, false, false, false)));
+    }
+
+    @Test
+    public void testColumnValidation()
+    {
+        singleColumnEncoder(BIGINT);
+        singleColumnEncoder(INTEGER);
+        singleColumnEncoder(SMALLINT);
+        singleColumnEncoder(TINYINT);
+        singleColumnEncoder(DOUBLE);
+        singleColumnEncoder(BOOLEAN);
+        singleColumnEncoder(createVarcharType(20));
+        singleColumnEncoder(createUnboundedVarcharType());
+
+        assertUnsupportedColumnTypeException(() -> singleColumnEncoder(REAL));
+        assertUnsupportedColumnTypeException(() -> singleColumnEncoder(createDecimalType(10, 4)));
+        assertUnsupportedColumnTypeException(() -> singleColumnEncoder(VARBINARY));
+    }
+}

--- a/presto-kafka/src/test/resources/write_test/all_datatypes_json.json
+++ b/presto-kafka/src/test/resources/write_test/all_datatypes_json.json
@@ -1,0 +1,55 @@
+{
+    "tableName": "all_datatypes_json",
+    "schemaName": "write_test",
+    "topicName": "all_datatypes_json",
+    "key": {
+        "dataFormat": "json",
+        "fields": [
+            {
+                "name": "kafka_key",
+                "type": "BIGINT",
+                "mapping": "kafka_key"
+            }
+        ]
+    },
+    "message": {
+        "dataFormat": "json",
+        "fields": [
+            {
+                "name": "f_bigint",
+                "type": "BIGINT",
+                "mapping": "f_bigint"
+            },
+            {
+                "name": "f_int",
+                "type": "INTEGER",
+                "mapping": "f_int"
+            },
+            {
+                "name": "f_smallint",
+                "type": "SMALLINT",
+                "mapping": "f_smallint"
+            },
+            {
+                "name": "f_tinyint",
+                "type": "TINYINT",
+                "mapping": "f_tinyint"
+            },
+            {
+                "name": "f_double",
+                "type": "DOUBLE",
+                "mapping": "f_double"
+            },
+            {
+                "name": "f_boolean",
+                "type": "BOOLEAN",
+                "mapping": "f_boolean"
+            },
+            {
+                "name": "f_varchar",
+                "type": "VARCHAR",
+                "mapping": "f_varchar"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Add `JsonRowEncoder` and `JsonRowEncoderFactory`
Add test case in `io.prestosql.plugin.kafka.TestKafkaIntegrationSmokeTest#testRoundTripAllFormats`

Might it be better to have separate formatters for the date/time types rather than methods in `JsonRowEncoder`?

closes #3980 