### PR TITLE
Avoid creating tiny splits at the end of block boundaries

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
@@ -61,7 +61,6 @@ import static io.prestosql.plugin.hive.HiveSplitSource.StateKind.FAILED;
 import static io.prestosql.plugin.hive.HiveSplitSource.StateKind.INITIAL;
 import static io.prestosql.plugin.hive.HiveSplitSource.StateKind.NO_MORE_SPLITS;
 import static io.prestosql.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
-import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -347,7 +346,17 @@ class HiveSplitSource
                 InternalHiveBlock block = internalSplit.currentBlock();
                 long splitBytes;
                 if (internalSplit.isSplittable()) {
-                    splitBytes = min(maxSplitBytes, block.getEnd() - internalSplit.getStart());
+                    long remainingBlockBytes = block.getEnd() - internalSplit.getStart();
+                    if (remainingBlockBytes <= maxSplitBytes) {
+                        splitBytes = remainingBlockBytes;
+                    }
+                    else if (maxSplitBytes * 2 >= remainingBlockBytes) {
+                        //  Second to last split in this block, generate two evenly sized splits
+                        splitBytes = remainingBlockBytes / 2;
+                    }
+                    else {
+                        splitBytes = maxSplitBytes;
+                    }
                 }
                 else {
                     splitBytes = internalSplit.getEnd() - internalSplit.getStart();


### PR DESCRIPTION
Cross contribution of https://github.com/prestodb/presto/pull/14855

Previously, generating splits would carve out either the entire max split size or the remaining bytes in a block, whichever was smaller. This could create "tiny" last splits for unfortunate sized blocks. Eg: a max split size of 64MB would turn a 65MB block into one 64MB split and one 1MB split.

Now, the last two splits in a block are evenly apportioned. In the example above, the same block will now generate generate two 32.5MB splits.