### PR TITLE
Verify output type consistently

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/expression/ImplementCount.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/expression/ImplementCount.java
@@ -26,11 +26,11 @@ import io.prestosql.spi.type.BigintType;
 
 import java.util.Optional;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static io.prestosql.matching.Capture.newCapture;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.outputType;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -60,7 +60,6 @@ public class ImplementCount
     {
         return basicAggregation()
                 .with(functionName().equalTo("count"))
-                .with(outputType().equalTo(BIGINT))
                 .with(singleInput().matching(variable().capturedAs(INPUT)));
     }
 
@@ -70,6 +69,7 @@ public class ImplementCount
         Variable input = captures.get(INPUT);
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignments().get(input.getName());
         verifyNotNull(columnHandle, "Unbound variable: %s", input);
+        verify(aggregateFunction.getOutputType() == BIGINT);
 
         return Optional.of(new JdbcExpression(
                 format("count(%s)", columnHandle.toSqlExpression(context.getIdentifierQuote())),

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/expression/ImplementCountAll.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/expression/ImplementCountAll.java
@@ -24,10 +24,10 @@ import io.prestosql.spi.type.BigintType;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Verify.verify;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
 import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.prestosql.plugin.jdbc.expression.AggregateFunctionPatterns.outputType;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -52,13 +52,13 @@ public class ImplementCountAll
     {
         return basicAggregation()
                 .with(functionName().equalTo("count"))
-                .with(outputType().equalTo(BIGINT))
                 .with(inputs().equalTo(List.of()));
     }
 
     @Override
     public Optional<JdbcExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext context)
     {
+        verify(aggregateFunction.getOutputType() == BIGINT);
         return Optional.of(new JdbcExpression("count(*)", bigintTypeHandle));
     }
 }


### PR DESCRIPTION
`AggregateFunctionRule` needs to utilize knowledge of aggregate function
signature in Presto. Some implementations `verify` and some some bail
out (checking within the pattern).

This makes the implementations consistent.