### PR TITLE
Fix Iceberg large DECIMAL partition values

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionData.java
@@ -26,6 +26,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -34,7 +35,7 @@ public class PartitionData
 {
     private static final String PARTITION_VALUES_FIELD = "partitionValues";
     private static final JsonFactory FACTORY = new JsonFactory();
-    private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
+    private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY).configure(USE_BIG_DECIMAL_FOR_FLOATS, true);
 
     private final Object[] partitionValues;
 


### PR DESCRIPTION
This commit fixes a bug that caused DECIMAL partition
values to get truncated if they don't fit in a Double,
and adds a smoke test to verify the fix.