### PR TITLE
Make skip.header.line.count=1 files splittable

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
@@ -490,7 +490,8 @@ public class BackgroundHiveSplitLoader
 
         // S3 Select pushdown works at the granularity of individual S3 objects,
         // therefore we must not split files when it is enabled.
-        boolean splittable = getHeaderCount(schema) == 0 && getFooterCount(schema) == 0 && !s3SelectPushdownEnabled;
+        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
+        boolean splittable = !s3SelectPushdownEnabled && getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
 
         // Bucketed partitions are fully loaded immediately since all files must be loaded to determine the file to bucket mapping
         if (tableBucketInfo.isPresent()) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -256,7 +256,8 @@ public final class HiveUtil
             RecordReader<WritableComparable, Writable> recordReader = (RecordReader<WritableComparable, Writable>) inputFormat.getRecordReader(fileSplit, jobConf, Reporter.NULL);
 
             int headerCount = getHeaderCount(schema);
-            if (headerCount > 0) {
+            //  Only skip header rows when the split is at the beginning of the file
+            if (start == 0 && headerCount > 0) {
                 Utilities.skipHeader(recordReader, headerCount, recordReader.createKey(), recordReader.createValue());
             }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -157,7 +157,8 @@ public class TestBackgroundHiveSplitLoader
             throws Exception
     {
         assertSplitCount(CSV, ImmutableMap.of(), 33);
-        assertSplitCount(CSV, ImmutableMap.of("skip.header.line.count", "1"), 1);
+        assertSplitCount(CSV, ImmutableMap.of("skip.header.line.count", "1"), 33);
+        assertSplitCount(CSV, ImmutableMap.of("skip.header.line.count", "2"), 1);
         assertSplitCount(CSV, ImmutableMap.of("skip.footer.line.count", "1"), 1);
         assertSplitCount(CSV, ImmutableMap.of("skip.header.line.count", "1", "skip.footer.line.count", "1"), 1);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static io.prestosql.plugin.hive.HiveTestUtils.SESSION;
 import static io.prestosql.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static java.lang.Math.toIntExact;
@@ -75,6 +76,34 @@ public class TestHiveSplitSource
         // try to remove 20 splits, and verify we only got 5
         assertEquals(getSplits(hiveSplitSource, 20).size(), 5);
         assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 0);
+    }
+
+    @Test
+    public void testEvenlySizedSplitRemainder()
+    {
+        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION);
+        HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
+                SESSION,
+                "database",
+                "table",
+                10,
+                10,
+                DataSize.of(1, MEGABYTE),
+                Integer.MAX_VALUE,
+                new TestingHiveSplitLoader(),
+                Executors.newSingleThreadExecutor(),
+                new CounterStat());
+
+        // One byte larger than the initial split max size
+        DataSize fileSize = DataSize.ofBytes(initialSplitSize.toBytes() + 1);
+        long halfOfSize = fileSize.toBytes() / 2;
+        hiveSplitSource.addToQueue(new TestSplit(1, OptionalInt.empty(), fileSize));
+
+        HiveSplit first = (HiveSplit) getSplits(hiveSplitSource, 1).get(0);
+        assertEquals(first.getLength(), halfOfSize);
+
+        HiveSplit second = (HiveSplit) getSplits(hiveSplitSource, 1).get(0);
+        assertEquals(second.getLength(), fileSize.toBytes() - halfOfSize);
     }
 
     @Test
@@ -287,16 +316,21 @@ public class TestHiveSplitSource
 
         private TestSplit(int id, OptionalInt bucketNumber)
         {
+            this(id, bucketNumber, DataSize.ofBytes(100));
+        }
+
+        private TestSplit(int id, OptionalInt bucketNumber, DataSize fileSize)
+        {
             super(
                     "partition-name",
                     "path",
                     0,
-                    100,
-                    100,
+                    fileSize.toBytes(),
+                    fileSize.toBytes(),
                     Instant.now().toEpochMilli(),
                     properties("id", String.valueOf(id)),
                     ImmutableList.of(),
-                    ImmutableList.of(new InternalHiveBlock(0, 100, ImmutableList.of())),
+                    ImmutableList.of(new InternalHiveBlock(0, fileSize.toBytes(), ImmutableList.of())),
                     bucketNumber,
                     true,
                     false,


### PR DESCRIPTION
Cross contribution of https://github.com/prestodb/presto/pull/14866

In general, files with arbitrarily many header lines are not currently considered splittable because the hive record reading logic does not work when rows might span over multiple splits. However, the relatively common case of having a single header row to skip is actually safe and can be considered splittable.
Observe:
- when skip.header.line.count = 1, the hive split boundary handling works even if the header line extends into the subsequent split because the reader of the next split will only process rows that start within the boundary of the split, not rows that extend into the split from the previous one. No additional logic required.
- when skip.header.line.count > 1 and the header rows extend past the first split end boundary, it becomes impossible for a reader to know which rows should be skipped without reading from the beginning. This is still considered unsplittable.

Also includes a separate commit to port a unit test added in https://github.com/prestodb/presto/pull/14855 after https://github.com/prestosql/presto/pull/4485 had already merged.
