### PR TITLE
Remove useSessionTimeZone connection URL fallback mechanism

### DIFF
--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
@@ -107,7 +107,6 @@ public class BenchmarkDriverOptions
                 schema,
                 null,
                 ZoneId.systemDefault(),
-                false,
                 Locale.getDefault(),
                 ImmutableMap.of(),
                 toProperties(this.sessionProperties),

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -188,7 +188,6 @@ public class ClientOptions
                 schema,
                 null,
                 timeZone,
-                false,
                 Locale.getDefault(),
                 toResourceEstimates(resourceEstimates),
                 toProperties(sessionProperties),

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -114,7 +114,6 @@ public class TestQueryRunner
                 "schema",
                 "path",
                 ZoneId.of("America/Los_Angeles"),
-                false,
                 Locale.ENGLISH,
                 ImmutableMap.of(),
                 ImmutableMap.of(),

--- a/presto-client/src/main/java/io/prestosql/client/ClientSession.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientSession.java
@@ -43,7 +43,6 @@ public class ClientSession
     private final String schema;
     private final String path;
     private final ZoneId timeZone;
-    private final boolean useSessionTimeZone;
     private final Locale locale;
     private final Map<String, String> resourceEstimates;
     private final Map<String, String> properties;
@@ -76,7 +75,6 @@ public class ClientSession
             String schema,
             String path,
             ZoneId timeZone,
-            boolean useSessionTimeZone,
             Locale locale,
             Map<String, String> resourceEstimates,
             Map<String, String> properties,
@@ -97,7 +95,6 @@ public class ClientSession
         this.path = path;
         this.locale = locale;
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
-        this.useSessionTimeZone = useSessionTimeZone;
         this.transactionId = transactionId;
         this.resourceEstimates = ImmutableMap.copyOf(requireNonNull(resourceEstimates, "resourceEstimates is null"));
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
@@ -185,13 +182,6 @@ public class ClientSession
         return timeZone;
     }
 
-    // TODO remove the fallback mechanism for JDBC temporal columns
-    @Deprecated
-    public boolean useSessionTimeZone()
-    {
-        return useSessionTimeZone;
-    }
-
     public Locale getLocale()
     {
         return locale;
@@ -253,7 +243,6 @@ public class ClientSession
                 .add("path", path)
                 .add("traceToken", traceToken.orElse(null))
                 .add("timeZone", timeZone)
-                .add("useSessionTimeZone", useSessionTimeZone)
                 .add("locale", locale)
                 .add("properties", properties)
                 .add("transactionId", transactionId)
@@ -273,7 +262,6 @@ public class ClientSession
         private String schema;
         private String path;
         private ZoneId timeZone;
-        private boolean useSessionTimeZone;
         private Locale locale;
         private Map<String, String> resourceEstimates;
         private Map<String, String> properties;
@@ -296,7 +284,6 @@ public class ClientSession
             schema = clientSession.getSchema();
             path = clientSession.getPath();
             timeZone = clientSession.getTimeZone();
-            useSessionTimeZone = clientSession.useSessionTimeZone();
             locale = clientSession.getLocale();
             resourceEstimates = clientSession.getResourceEstimates();
             properties = clientSession.getProperties();
@@ -361,14 +348,6 @@ public class ClientSession
             return this;
         }
 
-        // TODO remove the fallback mechanism for JDBC temporal columns
-        @Deprecated
-        public Builder withUseSessionTimeZone(boolean useSessionTimeZone)
-        {
-            this.useSessionTimeZone = useSessionTimeZone;
-            return this;
-        }
-
         public ClientSession build()
         {
             return new ClientSession(
@@ -382,7 +361,6 @@ public class ClientSession
                     schema,
                     path,
                     timeZone,
-                    useSessionTimeZone,
                     locale,
                     resourceEstimates,
                     properties,

--- a/presto-client/src/main/java/io/prestosql/client/StatementClient.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClient.java
@@ -28,10 +28,6 @@ public interface StatementClient
 
     ZoneId getTimeZone();
 
-    // TODO remove the fallback mechanism for JDBC temporal columns
-    @Deprecated
-    boolean useSessionTimeZone();
-
     boolean isRunning();
 
     boolean isClientAborted();

--- a/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
+++ b/presto-client/src/main/java/io/prestosql/client/StatementClientV1.java
@@ -108,7 +108,6 @@ class StatementClientV1
     private final AtomicReference<String> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
     private final ZoneId timeZone;
-    private final boolean useSessionTimeZone;
     private final Duration requestTimeoutNanos;
     private final String user;
     private final String clientCapabilities;
@@ -123,7 +122,6 @@ class StatementClientV1
 
         this.httpClient = httpClient;
         this.timeZone = session.getTimeZone();
-        this.useSessionTimeZone = session.useSessionTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout();
         this.user = session.getUser();
@@ -219,12 +217,6 @@ class StatementClientV1
     public ZoneId getTimeZone()
     {
         return timeZone;
-    }
-
-    @Override
-    public boolean useSessionTimeZone()
-    {
-        return useSessionTimeZone;
     }
 
     @Override

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -147,9 +147,6 @@ Name                                   Description
 ``KerberosConfigPath``                 Kerberos configuration file.
 ``KerberosKeytabPath``                 Kerberos keytab file.
 ``KerberosCredentialCachePath``        Kerberos credential cache.
-``useSessionTimeZone``                 Should dates and timestamps use the session time zone (default: false).
-                                       Note that this property only exists for backward compatibility with the
-                                       previous behavior and will be removed in the future.
 ``extraCredentials``                   Extra credentials for connecting to external services,
                                        specified as a list of key-value pairs. For example,
                                        ``foo:bar;abc:xyz`` creates the credential named ``abc``

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -127,10 +127,10 @@ abstract class AbstractPrestoResultSet
     protected final AtomicBoolean closed = new AtomicBoolean();
     private final Optional<Statement> statement;
 
-    AbstractPrestoResultSet(Optional<Statement> statement, ZoneId resultTimeZone, List<Column> columns, Iterator<List<Object>> results)
+    AbstractPrestoResultSet(Optional<Statement> statement, List<Column> columns, Iterator<List<Object>> results)
     {
         this.statement = requireNonNull(statement, "statement is null");
-        this.resultTimeZone = DateTimeZone.forID(requireNonNull(resultTimeZone, "resultTimeZone is null").getId());
+        this.resultTimeZone = DateTimeZone.forID(ZoneId.systemDefault().getId());
 
         requireNonNull(columns, "columns is null");
         this.fieldMap = getFieldMap(columns);

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
@@ -66,7 +66,6 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> CLIENT_INFO = new ClientInfo();
     public static final ConnectionProperty<String> CLIENT_TAGS = new ClientTags();
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
-    public static final ConnectionProperty<Boolean> USE_SESSION_TIMEZONE = new UseSessionTimeZone();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String> SOURCE = new Source();
 
@@ -96,7 +95,6 @@ final class ConnectionProperties
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
             .add(TRACE_TOKEN)
-            .add(USE_SESSION_TIMEZONE)
             .add(SESSION_PROPERTIES)
             .add(SOURCE)
             .build();
@@ -396,15 +394,6 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
-        }
-    }
-
-    private static class UseSessionTimeZone
-            extends AbstractConnectionProperty<Boolean>
-    {
-        public UseSessionTimeZone()
-        {
-            super("useSessionTimeZone", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/InMemoryPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/InMemoryPrestoResultSet.java
@@ -16,7 +16,6 @@ package io.prestosql.jdbc;
 import io.prestosql.client.Column;
 
 import java.sql.SQLException;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,9 +24,9 @@ import static java.util.Objects.requireNonNull;
 class InMemoryPrestoResultSet
         extends AbstractPrestoResultSet
 {
-    public InMemoryPrestoResultSet(ZoneId sessionTimeZone, List<Column> columns, List<List<Object>> results)
+    public InMemoryPrestoResultSet(List<Column> columns, List<List<Object>> results)
     {
-        super(Optional.empty(), sessionTimeZone, columns, requireNonNull(results, "results is null").iterator());
+        super(Optional.empty(), columns, requireNonNull(results, "results is null").iterator());
     }
 
     @Override

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -81,7 +81,6 @@ public class PrestoConnection
     private final AtomicReference<String> schema = new AtomicReference<>();
     private final AtomicReference<String> path = new AtomicReference<>();
     private final AtomicReference<ZoneId> timeZoneId = new AtomicReference<>();
-    private final AtomicBoolean useSessionTimeZone = new AtomicBoolean();
     private final AtomicReference<Locale> locale = new AtomicReference<>();
     private final AtomicReference<Integer> networkTimeoutMillis = new AtomicReference<>(Ints.saturatedCast(MINUTES.toMillis(2)));
     private final AtomicReference<ServerInfo> serverInfo = new AtomicReference<>();
@@ -119,7 +118,6 @@ public class PrestoConnection
 
         roles.putAll(uri.getRoles());
         timeZoneId.set(ZoneId.systemDefault());
-        useSessionTimeZone.set(uri.useSessionTimezone().orElse(false));
         locale.set(Locale.getDefault());
         sessionProperties.putAll(uri.getSessionProperties());
     }
@@ -553,14 +551,9 @@ public class PrestoConnection
         return schema.get();
     }
 
-    ZoneId getTimeZone()
-    {
-        return timeZoneId.get();
-    }
-
     public String getTimeZoneId()
     {
-        return getTimeZone().getId();
+        return timeZoneId.get().getId();
     }
 
     public void setTimeZoneId(String timeZoneId)
@@ -720,7 +713,6 @@ public class PrestoConnection
                 schema.get(),
                 path.get(),
                 timeZoneId.get(),
-                useSessionTimeZone.get(),
                 locale.get(),
                 ImmutableMap.of(),
                 ImmutableMap.copyOf(allProperties),

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDatabaseMetaData.java
@@ -1381,7 +1381,7 @@ public class PrestoDatabaseMetaData
                             null));
                 });
 
-        return new InMemoryPrestoResultSet(connection.getTimeZone(), columns.build(), results.build());
+        return new InMemoryPrestoResultSet(columns.build(), results.build());
     }
 
     @Override

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -68,7 +68,6 @@ import static io.prestosql.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
 import static io.prestosql.jdbc.ConnectionProperties.SSL_TRUST_STORE_TYPE;
 import static io.prestosql.jdbc.ConnectionProperties.TRACE_TOKEN;
 import static io.prestosql.jdbc.ConnectionProperties.USER;
-import static io.prestosql.jdbc.ConnectionProperties.USE_SESSION_TIMEZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -178,12 +177,6 @@ final class PrestoDriverUri
             throws SQLException
     {
         return TRACE_TOKEN.getValue(properties);
-    }
-
-    public Optional<Boolean> useSessionTimezone()
-            throws SQLException
-    {
-        return USE_SESSION_TIMEZONE.getValue(properties);
     }
 
     public Map<String, String> getSessionProperties()

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoResultSet.java
@@ -21,7 +21,6 @@ import io.prestosql.client.StatementClient;
 
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.time.ZoneId;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -60,22 +59,13 @@ public class PrestoResultSet
     {
         super(
                 Optional.of(requireNonNull(statement, "statement is null")),
-                getResultTimeZone(requireNonNull(client, "client is null")),
                 columns,
-                new AsyncIterator<>(flatten(new ResultsPageIterator(client, progressCallback, warningsManager), maxRows), client));
+                new AsyncIterator<>(flatten(new ResultsPageIterator(requireNonNull(client, "client is null"), progressCallback, warningsManager), maxRows), client));
 
         this.client = requireNonNull(client, "client is null");
         requireNonNull(progressCallback, "progressCallback is null");
 
         this.queryId = client.currentStatusInfo().getId();
-    }
-
-    private static ZoneId getResultTimeZone(StatementClient client)
-    {
-        if (client.useSessionTimeZone()) {
-            return client.getTimeZone();
-        }
-        return ZoneId.systemDefault();
     }
 
     public String getQueryId()

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
@@ -604,25 +604,6 @@ public class TestPrestoDriver
                 assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, defaultZone).getMillis()));
             }
         }
-
-        // legacy mode
-        try (Connection connection = DriverManager.getConnection(format("jdbc:presto://%s?useSessionTimeZone=true", server.getAddress()), "test", null)) {
-            try (Statement statement = connection.createStatement();
-                    ResultSet rs = statement.executeQuery(sql)) {
-                assertTrue(rs.next());
-                assertEquals(rs.getString("zone"), defaultZoneKey.getId());
-                assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, defaultZone).getMillis()));
-            }
-
-            connection.unwrap(PrestoConnection.class).setTimeZoneId("UTC");
-            try (Statement statement = connection.createStatement();
-                    ResultSet rs = statement.executeQuery(sql)) {
-                assertTrue(rs.next());
-                assertEquals(rs.getString("zone"), "UTC");
-                // the session timezone is used
-                assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, DateTimeZone.UTC).getMillis()));
-            }
-        }
     }
 
     @Test

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
@@ -17,7 +17,6 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.sql.SQLException;
-import java.util.Optional;
 import java.util.Properties;
 
 import static io.prestosql.jdbc.ConnectionProperties.CLIENT_TAGS;
@@ -30,7 +29,6 @@ import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestPrestoDriverUri
@@ -252,14 +250,6 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?clientTags=" + clientTags);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(CLIENT_TAGS.getKey()), clientTags);
-    }
-
-    @Test
-    public void testUriWithUseSessionTimeZone()
-            throws SQLException
-    {
-        Optional<Boolean> property = createDriverUri("presto://localhost:8080?useSessionTimeZone=true").useSessionTimezone();
-        assertTrue(property.isPresent() && property.get());
     }
 
     private static void assertUriPortScheme(PrestoDriverUri parameters, int port, String scheme)

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
@@ -154,7 +154,6 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getSchema().orElse(null),
                 session.getPath().toString(),
                 ZoneId.of(session.getTimeZoneKey().getId()),
-                false,
                 session.getLocale(),
                 resourceEstimates.build(),
                 properties.build(),

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
@@ -74,7 +74,6 @@ public class TestFinalQueryInfo
                     null,
                     null,
                     ZoneId.of("America/Los_Angeles"),
-                    false,
                     Locale.ENGLISH,
                     ImmutableMap.of(),
                     ImmutableMap.of(),


### PR DESCRIPTION
`useSessionTimeZone` was added as a fallback mechanism to temporarily
allow restoring previous behavior of reading date/time values.

See https://github.com/prestosql/presto/pull/4376, https://github.com/prestosql/presto/issues/4017 (339)