### PR TITLE
Support the TIME type in the Iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
@@ -43,9 +43,11 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.plugin.iceberg.TypeConverter.TIME_MICROS;
 import static io.prestosql.spi.predicate.Marker.Bound.ABOVE;
 import static io.prestosql.spi.predicate.Marker.Bound.BELOW;
 import static io.prestosql.spi.predicate.Marker.Bound.EXACTLY;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -179,6 +181,10 @@ public final class ExpressionConverter
         // TODO: Remove this conversion once we move to next iceberg version
         if (type instanceof DateType) {
             return toIntExact(((Long) marker.getValue()));
+        }
+
+        if (type.equals(TIME_MICROS)) {
+            return ((long) marker.getValue()) / PICOSECONDS_PER_MICROSECOND;
         }
 
         if (type instanceof VarcharType) {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSink.java
@@ -64,8 +64,10 @@ import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.toJobConf;
 import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_TOO_MANY_OPEN_PARTITIONS;
 import static io.prestosql.plugin.iceberg.PartitionTransforms.getColumnTransform;
+import static io.prestosql.plugin.iceberg.TypeConverter.TIME_MICROS;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.Decimals.readBigDecimal;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -360,6 +362,9 @@ public class IcebergPageSink
         }
         if (type instanceof DoubleType) {
             return type.getDouble(block, position);
+        }
+        if (type.equals(TIME_MICROS)) {
+            return type.getLong(block, position) / PICOSECONDS_PER_MICROSECOND;
         }
         if (type instanceof TimestampType) {
             return MILLISECONDS.toMicros(type.getLong(block, position));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
@@ -39,6 +39,7 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
+import static io.prestosql.plugin.iceberg.TypeConverter.TIME_MICROS;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
@@ -49,10 +50,9 @@ import static io.prestosql.spi.type.Decimals.isShortDecimal;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
-import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.floatToRawIntBits;
@@ -213,8 +213,8 @@ public class IcebergPageSource
             if (type.equals(DATE)) {
                 return parseLong(valueString);
             }
-            if (type.equals(TIME)) {
-                return parseLong(valueString) * PICOSECONDS_PER_MILLISECOND;
+            if (type.equals(TIME_MICROS)) {
+                return parseLong(valueString) * PICOSECONDS_PER_MICROSECOND;
             }
             if (type.equals(TIMESTAMP)) {
                 return MICROSECONDS.toMillis(parseLong(valueString));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionData.java
@@ -133,6 +133,7 @@ public class PartitionData
                 return partitionValue.asInt();
             case LONG:
             case TIMESTAMP:
+            case TIME:
                 return partitionValue.asLong();
             case FLOAT:
                 return partitionValue.floatValue();

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTable.java
@@ -59,6 +59,7 @@ import static io.prestosql.plugin.iceberg.IcebergUtil.getTableScan;
 import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
@@ -292,6 +293,9 @@ public class PartitionTable
                 return packDateTimeWithZone(utcMillis, TimeZoneKey.UTC_KEY);
             }
             return utcMillis;
+        }
+        if (type instanceof Types.TimeType) {
+            return ((Long) value) * PICOSECONDS_PER_MICROSECOND;
         }
         if (type instanceof Types.FloatType) {
             return Float.floatToIntBits((Float) value);

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -27,7 +27,9 @@ import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.Timestamps;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
 import io.prestosql.spi.type.VarcharType;
@@ -189,6 +191,10 @@ public class TupleDomainOrcPredicate
 
         boolean hasNullValue = columnStatistics.getNumberOfValues() != rowCount;
 
+        if (type instanceof TimeType && columnStatistics.getIntegerStatistics() != null) {
+            // This is the representation of TIME used by Iceberg
+            return createDomain(type, hasNullValue, columnStatistics.getIntegerStatistics(), value -> ((long) value) * Timestamps.PICOSECONDS_PER_MICROSECOND);
+        }
         if (type.getJavaType() == boolean.class && columnStatistics.getBooleanStatistics() != null) {
             BooleanStatistics booleanStatistics = columnStatistics.getBooleanStatistics();
 

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/LongColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/LongColumnReader.java
@@ -31,6 +31,7 @@ import io.prestosql.spi.type.BigintType;
 import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.SmallintType;
+import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -85,7 +86,7 @@ public class LongColumnReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(column, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        verifyStreamType(column, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType || t instanceof TimeType);
         this.type = type;
 
         this.column = requireNonNull(column, "column is null");
@@ -161,6 +162,12 @@ public class LongColumnReader
             dataStream.next(values, nextBatchSize);
             return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
         }
+        if (type instanceof TimeType) {
+            long[] values = new long[nextBatchSize];
+            dataStream.next(values, nextBatchSize);
+            maybeTransformValues(values, nextBatchSize);
+            return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
+        }
         if (type instanceof IntegerType || type instanceof DateType) {
             int[] values = new int[nextBatchSize];
             dataStream.next(values, nextBatchSize);
@@ -173,6 +180,8 @@ public class LongColumnReader
         }
         throw new VerifyError("Unsupported type " + type);
     }
+
+    protected void maybeTransformValues(long[] values, int nextBatchSize) {}
 
     private Block readNullBlock(boolean[] isNull, int nonNullCount)
             throws IOException

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/TimeColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/TimeColumnReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.reader;
+
+import io.prestosql.memory.context.LocalMemoryContext;
+import io.prestosql.orc.OrcColumn;
+import io.prestosql.orc.OrcCorruptionException;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+
+public class TimeColumnReader
+        extends LongColumnReader
+{
+    public TimeColumnReader(Type type, OrcColumn column, LocalMemoryContext systemMemoryContext)
+            throws OrcCorruptionException
+    {
+        super(type, column, systemMemoryContext);
+    }
+
+    @Override
+    protected void maybeTransformValues(long[] values, int nextBatchSize)
+    {
+        for (int i = 0; i < nextBatchSize; i++) {
+            values[i] *= PICOSECONDS_PER_MICROSECOND;
+        }
+    }
+}

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/LongColumnWriter.java
@@ -109,11 +109,16 @@ public class LongColumnWriter
         // record values
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                long value = type.getLong(block, position);
+                long value = transformValue(type.getLong(block, position));
                 dataStream.writeLong(value);
                 statisticsBuilder.addValue(value);
             }
         }
+    }
+
+    protected long transformValue(long value)
+    {
+        return value;
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimeColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimeColumnWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.orc.writer;
+
+import io.prestosql.orc.metadata.CompressionKind;
+import io.prestosql.orc.metadata.OrcColumnId;
+import io.prestosql.orc.metadata.statistics.LongValueStatisticsBuilder;
+import io.prestosql.spi.type.Type;
+
+import java.util.function.Supplier;
+
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+
+public class TimeColumnWriter
+        extends LongColumnWriter
+{
+    public TimeColumnWriter(OrcColumnId columnId, Type type, CompressionKind compression, int bufferSize, Supplier<LongValueStatisticsBuilder> statisticsBuilderSupplier)
+    {
+        super(columnId, type, compression, bufferSize, statisticsBuilderSupplier);
+    }
+
+    @Override
+    protected long transformValue(long value)
+    {
+        return value / PICOSECONDS_PER_MICROSECOND;
+    }
+}

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
@@ -86,6 +86,9 @@ public abstract class PrimitiveColumnReader
             case INT32:
                 return createDecimalColumnReader(descriptor).orElse(new IntColumnReader(descriptor));
             case INT64:
+                if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIME_MICROS) {
+                    return new TimeMicrosColumnReader(descriptor);
+                }
                 if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MICROS) {
                     return new TimestampMicrosColumnReader(descriptor);
                 }

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/TimeMicrosColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/TimeMicrosColumnReader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.parquet.reader;
+
+import io.prestosql.parquet.RichColumnDescriptor;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Timestamps;
+import io.prestosql.spi.type.Type;
+
+public class TimeMicrosColumnReader
+        extends PrimitiveColumnReader
+{
+    public TimeMicrosColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            long picos = valuesReader.readLong() * Timestamps.PICOSECONDS_PER_MICROSECOND;
+            type.writeLong(blockBuilder, picos);
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readLong();
+        }
+    }
+}

--- a/presto-parquet/src/main/java/io/prestosql/parquet/writer/MessageTypeConverter.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/writer/MessageTypeConverter.java
@@ -145,6 +145,8 @@ class MessageTypeConverter
                 return ConvertedType.DECIMAL;
             case DATE:
                 return ConvertedType.DATE;
+            case TIME_MICROS:
+                return ConvertedType.TIME_MICROS;
             case TIME_MILLIS:
                 return ConvertedType.TIME_MILLIS;
             case TIMESTAMP_MILLIS:

--- a/presto-parquet/src/main/java/io/prestosql/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/writer/ParquetWriters.java
@@ -23,6 +23,7 @@ import io.prestosql.parquet.writer.valuewriter.DoubleValueWriter;
 import io.prestosql.parquet.writer.valuewriter.IntegerValueWriter;
 import io.prestosql.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.prestosql.parquet.writer.valuewriter.RealValueWriter;
+import io.prestosql.parquet.writer.valuewriter.TimeMicrosValueWriter;
 import io.prestosql.parquet.writer.valuewriter.TimestampValueWriter;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.CharType;
@@ -54,6 +55,7 @@ import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
 
 class ParquetWriters
 {
@@ -154,6 +156,9 @@ class ParquetWriters
 
     private static PrimitiveValueWriter getValueWriter(ValuesWriter valuesWriter, io.prestosql.spi.type.Type type, PrimitiveType parquetType)
     {
+        if (parquetType.getOriginalType() != null && parquetType.getOriginalType() == TIME_MICROS) {
+            return new TimeMicrosValueWriter(valuesWriter, type, parquetType);
+        }
         if (BOOLEAN.equals(type)) {
             return new BooleanValueWriter(valuesWriter, parquetType);
         }

--- a/presto-parquet/src/main/java/io/prestosql/parquet/writer/valuewriter/TimeMicrosValueWriter.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/writer/valuewriter/TimeMicrosValueWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.parquet.writer.valuewriter;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.util.Objects.requireNonNull;
+
+public class TimeMicrosValueWriter
+        extends PrimitiveValueWriter
+{
+    private final Type type;
+
+    public TimeMicrosValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                long scaledValue = type.getLong(block, i) / PICOSECONDS_PER_MICROSECOND;
+                getValueWriter().writeLong(scaledValue);
+                getStatistics().updateStats(scaledValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds support for the TIME type in the Iceberg
connector.  The TIME type is stored as microsecond time since
midnight UTC in Parquet and ORC, so it occupies an int64.

The main change was adding Parquet and ORC column readers and writers
for TIME that convert between Presto engine picosecond time
and Iceberg connector native microsecond time.