### PR TITLE
Remove layouts from statistics docs

### DIFF
--- a/presto-docs/src/main/sphinx/optimizer/statistics.rst
+++ b/presto-docs/src/main/sphinx/optimizer/statistics.rst
@@ -9,22 +9,6 @@ the tables in that query.
 Table statistics are provided to the query planner by connectors.  Currently, the
 only connector that supports statistics is the :doc:`/connector/hive`.
 
-Table Layouts
--------------
-
-Statistics are exposed to the query planner by a table layout. A table layout
-represents a subset of a table's data, and contains information about the
-organizational properties of that data, like sort order and bucketing.
-
-The number of table layouts available for a table, and the details of those table
-layouts, are specific to each connector.  Using the Hive connector as an example:
-
-* Non-partitioned tables have just one table layout representing all data in the table
-* Partitioned tables have a family of table layouts. Each set of partitions to
-  be scanned represents one table layout.  Presto tries to pick a table
-  layout consisting of the smallest number of partitions, based on filtering
-  predicates from the query.
-
 Available Statistics
 --------------------
 
@@ -32,7 +16,7 @@ The following statistics are available in Presto:
 
 * For a table:
 
-  * **row count**: the total number of rows in the table layout
+  * **row count**: the total number of rows in the table
 
 * For each column in a table:
 
@@ -43,7 +27,7 @@ The following statistics are available in Presto:
   * **high value**: the largest value in the column
 
 The set of statistics available for a particular query depends on the connector
-being used and can also vary by table or even by table layout. For example, the
+being used and can also vary by table. For example, the
 Hive connector does not currently provide statistics on data size.
 
 Table statistics can be displayed via the Presto SQL interface using the


### PR DESCRIPTION
The statistics API, as eventually integrated in `master`, never used
layouts.