### PR TITLE
Extract assertPushedDown method

### DIFF
--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -449,8 +449,17 @@ public abstract class AbstractTestIntegrationSmokeTest
                 .setCatalogSessionProperty(catalog, "allow_aggregation_pushdown", "false")
                 .build();
 
+        assertPushDown(sql, computeActual(withoutPushdown, sql));
+    }
+
+    protected void assertPushedDown(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        assertPushDown(actual, computeActual(expected));
+    }
+
+    private void assertPushDown(@Language("SQL") String sql, MaterializedResult expectedResults)
+    {
         MaterializedResult actualResults = computeActual(sql);
-        MaterializedResult expectedResults = computeActual(withoutPushdown, sql);
         assertEqualsIgnoreOrder(actualResults.getMaterializedRows(), expectedResults.getMaterializedRows());
 
         transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())


### PR DESCRIPTION
Extract assertPushedDown method

This method could be used only for aggregtion pushdown.

Also in case of aggregation pushdown there are cases where
results may differ depending on where aggregation is calculated.
Notice that is also a case in Presto depending on execution distribution
and order on floating point numeric values.
