### PR TITLE
Update Rubix version to 0.3.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -990,7 +990,7 @@
             <dependency>
                 <groupId>com.qubole.rubix</groupId>
                 <artifactId>rubix-presto-shaded</artifactId>
-                <version>0.3.12</version>
+                <version>0.3.16</version>
             </dependency>
 
             <dependency>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-presto-shaded</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.prestosql.hadoop</groupId>

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveHadoop2Plugin.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveHadoop2Plugin.java
@@ -15,11 +15,14 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.qubole.rubix.core.CachingFileSystem;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.testing.TestingConnectorContext;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -47,6 +50,14 @@ public class TestHiveHadoop2Plugin
             throws IOException
     {
         deleteRecursively(tempDirectory, ALLOW_INSECURE);
+    }
+
+    @AfterMethod
+    @BeforeMethod
+    public void deinitializeRubix()
+    {
+        // revert static rubix initialization done by other tests
+        CachingFileSystem.deinitialize();
     }
 
     @Test

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/DummyBookKeeper.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/DummyBookKeeper.java
@@ -13,26 +13,27 @@
  */
 package io.prestosql.plugin.hive.rubix;
 
-import com.qubole.rubix.spi.thrift.BlockLocation;
 import com.qubole.rubix.spi.thrift.BookKeeperService;
 import com.qubole.rubix.spi.thrift.CacheStatusRequest;
+import com.qubole.rubix.spi.thrift.CacheStatusResponse;
 import com.qubole.rubix.spi.thrift.FileInfo;
 import com.qubole.rubix.spi.thrift.HeartbeatStatus;
+import com.qubole.rubix.spi.thrift.ReadResponse;
+import org.apache.thrift.shaded.TException;
 
-import java.util.List;
 import java.util.Map;
 
 public class DummyBookKeeper
         implements BookKeeperService.Iface
 {
     @Override
-    public List<BlockLocation> getCacheStatus(CacheStatusRequest cacheStatusRequest)
+    public CacheStatusResponse getCacheStatus(CacheStatusRequest cacheStatusRequest)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setAllCached(String remotePath, long fileLength, long lastModified, long startBlock, long endBlock)
+    public void setAllCached(String remotePath, long fileLength, long lastModified, long startBlock, long endBlock, int generationNumber)
     {
         throw new UnsupportedOperationException();
     }
@@ -44,7 +45,14 @@ public class DummyBookKeeper
     }
 
     @Override
-    public boolean readData(String remotePath, long offset, int length, long fileSize, long lastModified, int clusterType)
+    public Map<String, Long> getReadRequestChainStats()
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadResponse readData(String remotePath, long offset, int length, long fileSize, long lastModified, int clusterType)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rubix/RubixInitializer.java
@@ -243,7 +243,7 @@ public class RubixInitializer
         BookKeeper bookKeeper = bookKeeperServer.startServer(configuration, metricRegistry);
         LocalDataTransferServer.startServer(configuration, metricRegistry, bookKeeper);
 
-        CachingFileSystem.setLocalBookKeeper(bookKeeper, "catalog=" + catalogName);
+        CachingFileSystem.setLocalBookKeeper(configuration, bookKeeper, "catalog=" + catalogName);
         PrestoClusterManager.setNodeManager(nodeManager);
         log.info("Rubix initialized successfully");
         cacheReady = true;
@@ -253,7 +253,7 @@ public class RubixInitializer
     {
         Configuration configuration = getRubixServerConfiguration();
         new BookKeeperServer().setupServer(configuration, new MetricRegistry());
-        CachingFileSystem.setLocalBookKeeper(new DummyBookKeeper(), "catalog=" + catalogName);
+        CachingFileSystem.setLocalBookKeeper(configuration, new DummyBookKeeper(), "catalog=" + catalogName);
         PrestoClusterManager.setNodeManager(nodeManager);
     }
 

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCaching.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveCaching.java
@@ -121,8 +121,11 @@ public class TestHiveCaching
 
     private QueryResult getCacheStats()
     {
-        return query("SELECT sum(cachedreads) as cachedreads, sum(remotereads) as remotereads, sum(nonlocalreads) as nonlocalreads FROM " +
-                "jmx.current.\"rubix:catalog=hive,name=stats\"");
+        return query("SELECT " +
+                "  sum(Cached_rrc_requests) as cachedreads, " +
+                "  sum(Remote_rrc_requests + Direct_rrc_requests) as remotereads, " +
+                "  sum(Nonlocal_rrc_requests) as nonlocalreads " +
+                "FROM jmx.current.\"rubix:catalog=hive,type=detailed,name=stats\";");
     }
 
     private long getCachedReads(QueryResult queryResult)


### PR DESCRIPTION
Supersedes https://github.com/prestosql/presto/pull/4445 

New version is a bugfix release. Among other it includes fix for
https://github.com/prestosql/presto/issues/3580