### PR TITLE
Ignore empty folder placeholder files on S3

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -575,6 +575,7 @@ public class PrestoS3FileSystem
         return objects.stream()
                 .filter(object -> !object.getKey().endsWith(PATH_SEPARATOR))
                 .filter(object -> !skipGlacierObjects || !isGlacierObject(object))
+                .filter(object -> !isHadoopFolderMarker(object))
                 .map(object -> new FileStatus(
                         object.getSize(),
                         false,
@@ -589,6 +590,11 @@ public class PrestoS3FileSystem
     private static boolean isGlacierObject(S3ObjectSummary object)
     {
         return Glacier.toString().equals(object.getStorageClass());
+    }
+
+    private static boolean isHadoopFolderMarker(S3ObjectSummary object)
+    {
+        return object.getKey().endsWith("_$folder$");
     }
 
     /**

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/MockAmazonS3.java
@@ -39,6 +39,7 @@ public class MockAmazonS3
     private GetObjectMetadataRequest getObjectMetadataRequest;
     private CannedAccessControlList acl;
     private boolean hasGlacierObjects;
+    private boolean hasHadoopFolderMarkerObjects;
 
     public void setGetObjectHttpErrorCode(int getObjectHttpErrorCode)
     {
@@ -58,6 +59,11 @@ public class MockAmazonS3
     public void setHasGlacierObjects(boolean hasGlacierObjects)
     {
         this.hasGlacierObjects = hasGlacierObjects;
+    }
+
+    public void setHasHadoopFolderMarkerObjects(boolean hasHadoopFolderMarkerObjects)
+    {
+        this.hasHadoopFolderMarkerObjects = hasHadoopFolderMarkerObjects;
     }
 
     public GetObjectMetadataRequest getGetObjectMetadataRequest()
@@ -125,6 +131,14 @@ public class MockAmazonS3
             listingV2.getObjectSummaries().add(standardOne);
             listingV2.setTruncated(true);
             listingV2.setNextContinuationToken(continuationToken);
+
+            if (hasHadoopFolderMarkerObjects) {
+                S3ObjectSummary hadoopFolderMarker = new S3ObjectSummary();
+                hadoopFolderMarker.setStorageClass(StorageClass.Standard.toString());
+                hadoopFolderMarker.setKey("test/test_$folder$");
+                hadoopFolderMarker.setLastModified(new Date());
+                listingV2.getObjectSummaries().add(hadoopFolderMarker);
+            }
         }
 
         return listingV2;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestPrestoS3FileSystem.java
@@ -570,6 +570,22 @@ public class TestPrestoS3FileSystem
         }
     }
 
+    @Test
+    public void testSkipHadoopFolderMarkerObjectsEnabled()
+            throws Exception
+    {
+        Configuration config = new Configuration(false);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            s3.setHasHadoopFolderMarkerObjects(true);
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+            fs.setS3Client(s3);
+            FileStatus[] statuses = fs.listStatus(new Path("s3n://test-bucket/test"));
+            assertEquals(statuses.length, 2);
+        }
+    }
+
     public static AWSCredentialsProvider getAwsCredentialsProvider(PrestoS3FileSystem fs)
     {
         return getFieldValue(fs.getS3Client(), "awsCredentialsProvider", AWSCredentialsProvider.class);


### PR DESCRIPTION
These files are created by the Hadoop file system to indicate empty folders.