### PR TITLE
Change name of Kafka createTopics to match parameter type

### DIFF
--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/KafkaQueryRunner.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/KafkaQueryRunner.java
@@ -133,7 +133,7 @@ public final class KafkaQueryRunner
             testingKafka.start();
 
             for (TpchTable<?> table : tables) {
-                testingKafka.createTopics(kafkaTopicName(table));
+                testingKafka.createTopic(kafkaTopicName(table));
             }
 
             Map<SchemaTableName, KafkaTopicDescription> tpchTopicDescriptions = createTpchTopicDescriptions(queryRunner.getCoordinator().getMetadata(), tables);
@@ -147,7 +147,7 @@ public final class KafkaQueryRunner
 
             ImmutableMap.Builder<SchemaTableName, KafkaTopicDescription> testTopicDescriptions = ImmutableMap.builder();
             for (String tableName : tableNames) {
-                testingKafka.createTopics("write_test." + tableName);
+                testingKafka.createTopic("write_test." + tableName);
                 SchemaTableName table = new SchemaTableName("write_test", tableName);
                 KafkaTopicDescription tableTemplate = topicDescriptionJsonCodec.fromJson(toByteArray(KafkaQueryRunner.class.getResourceAsStream(format("/write_test/%s.json", tableName))));
 

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationSmokeTest.java
@@ -85,7 +85,7 @@ public class TestKafkaIntegrationSmokeTest
                         .build())
                 .build();
 
-        testingKafka.createTopics(rawFormatTopic);
+        testingKafka.createTopic(rawFormatTopic);
         return queryRunner;
     }
 

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestMinimalFunctionality.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestMinimalFunctionality.java
@@ -50,7 +50,7 @@ public class TestMinimalFunctionality
                         .put("kafka.messages-per-split", "100")
                         .build())
                 .build();
-        testingKafka.createTopics(topicName);
+        testingKafka.createTopic(topicName);
         return queryRunner;
     }
 

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/TestingKafka.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/TestingKafka.java
@@ -48,12 +48,12 @@ public class TestingKafka
         container.close();
     }
 
-    public void createTopics(String topic)
+    public void createTopic(String topic)
     {
-        createTopics(2, 1, topic);
+        createTopic(2, 1, topic);
     }
 
-    private void createTopics(int partitions, int replication, String topic)
+    private void createTopic(int partitions, int replication, String topic)
     {
         try {
             List<String> command = new ArrayList<>();


### PR DESCRIPTION
I propose that we change the type of `io.prestosql.plugin.kafka.TestingKafka#createTopics` to reflect the name of the method