### PR TITLE
Remove omitDatetimeTypePrecision from SPI

### DIFF
--- a/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
@@ -41,7 +41,6 @@ public class FullConnectorSession
     private final String catalog;
     private final SessionPropertyManager sessionPropertyManager;
     private final boolean isLegacyTimestamp;
-    private final boolean omitDatetimeTypePrecision;
 
     public FullConnectorSession(Session session, ConnectorIdentity identity)
     {
@@ -52,7 +51,6 @@ public class FullConnectorSession
         this.catalog = null;
         this.sessionPropertyManager = null;
         this.isLegacyTimestamp = SystemSessionProperties.isLegacyTimestamp(session);
-        this.omitDatetimeTypePrecision = SystemSessionProperties.isOmitDateTimeTypePrecision(session);
     }
 
     public FullConnectorSession(
@@ -70,7 +68,6 @@ public class FullConnectorSession
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.isLegacyTimestamp = SystemSessionProperties.isLegacyTimestamp(session);
-        this.omitDatetimeTypePrecision = SystemSessionProperties.isOmitDateTimeTypePrecision(session);
     }
 
     public Session getSession()
@@ -124,12 +121,6 @@ public class FullConnectorSession
     public boolean isLegacyTimestamp()
     {
         return isLegacyTimestamp;
-    }
-
-    @Override
-    public boolean isOmitDatetimeTypePrecision()
-    {
-        return omitDatetimeTypePrecision;
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/jdbc/ColumnJdbcTable.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.prestosql.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.prestosql.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.prestosql.metadata.MetadataListing.listCatalogs;
@@ -239,6 +240,7 @@ public class ColumnJdbcTable
         }
 
         Session session = ((FullConnectorSession) connectorSession).getSession();
+        boolean omitDateTimeTypePrecision = isOmitDateTimeTypePrecision(session);
         Optional<String> catalogFilter = tryGetSingleVarcharValue(constraint, 0);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(constraint, 1);
         Optional<String> tableFilter = tryGetSingleVarcharValue(constraint, 2);
@@ -255,7 +257,7 @@ public class ColumnJdbcTable
             if ((schemaDomain.isAll() && tableDomain.isAll()) || (schemaFilter.isPresent() && tableFilter.isPresent())) {
                 QualifiedTablePrefix tablePrefix = tablePrefix(catalog, schemaFilter, tableFilter);
                 Map<SchemaTableName, List<ColumnMetadata>> tableColumns = listTableColumns(session, metadata, accessControl, tablePrefix);
-                addColumnsRow(table, catalog, tableColumns, connectorSession.isOmitDatetimeTypePrecision());
+                addColumnsRow(table, catalog, tableColumns, omitDateTimeTypePrecision);
             }
             else {
                 Collection<String> schemas = listSchemas(session, metadata, accessControl, catalog, schemaFilter);
@@ -275,7 +277,7 @@ public class ColumnJdbcTable
                         }
 
                         Map<SchemaTableName, List<ColumnMetadata>> tableColumns = listTableColumns(session, metadata, accessControl, new QualifiedTablePrefix(catalog, schema, tableName));
-                        addColumnsRow(table, catalog, tableColumns, connectorSession.isOmitDatetimeTypePrecision());
+                        addColumnsRow(table, catalog, tableColumns, omitDateTimeTypePrecision);
                     }
                 }
             }

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
@@ -128,12 +128,6 @@ public class TestingConnectorSession
     }
 
     @Override
-    public boolean isOmitDatetimeTypePrecision()
-    {
-        return omitTimestampPrecision;
-    }
-
-    @Override
     public <T> T getProperty(String name, Class<T> type)
     {
         PropertyMetadata<?> metadata = properties.get(name);

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
@@ -52,7 +52,5 @@ public interface ConnectorSession
 
     boolean isLegacyTimestamp();
 
-    boolean isOmitDatetimeTypePrecision();
-
     <T> T getProperty(String name, Class<T> type);
 }

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
@@ -79,12 +79,6 @@ public final class TestingSession
         }
 
         @Override
-        public boolean isOmitDatetimeTypePrecision()
-        {
-            return false;
-        }
-
-        @Override
         public <T> T getProperty(String name, Class<T> type)
         {
             throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);


### PR DESCRIPTION
This is only for internal usage in the engine.
