### PR TITLE
Use global high memory split source counter

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -262,7 +262,7 @@ public class HiveSplitManager
                         maxSplitsPerSecond,
                         hiveSplitLoader,
                         executor,
-                        new CounterStat());
+                        highMemorySplitSourceCounter);
                 break;
             case GROUPED_SCHEDULING:
                 splitSource = HiveSplitSource.bucketed(
@@ -275,7 +275,7 @@ public class HiveSplitManager
                         maxSplitsPerSecond,
                         hiveSplitLoader,
                         executor,
-                        new CounterStat());
+                        highMemorySplitSourceCounter);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingStrategy);


### PR DESCRIPTION
The counter provided by `HiveSplitManager` was unused, and the corresponding mbean would not reflect high memory split sources.