### PR TITLE
Create external table with no schema location

### DIFF
--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
@@ -155,6 +155,7 @@ public class TestExternalHiveTable
     public void testCreateExternalTableWithNoSchemaLocation()
     {
         String schema = "schema_without_location";
+        query(format("DROP SCHEMA IF EXISTS %s.%s", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema));
         query(format("CREATE SCHEMA %s.%s", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema));
 
         String table = "test_create_external";

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
@@ -139,7 +139,7 @@ public class TestExternalHiveTable
     @Test(groups = {HIVE_WITH_EXTERNAL_WRITES, PROFILE_SPECIFIC_TESTS})
     public void testCreateExternalTableWithInaccessibleSchemaLocation()
     {
-        String schema = "schema_without_location";
+        String schema = "schema_with_invalid_location";
         String schemaLocation = "/tmp/" + schema;
         hdfsClient.createDirectory(schemaLocation);
         query(format("CREATE SCHEMA %s.%s WITH (location='%s')", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, schemaLocation));

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
@@ -151,6 +151,17 @@ public class TestExternalHiveTable
         query(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, table, tableLocation));
     }
 
+    @Test(groups = {HIVE_WITH_EXTERNAL_WRITES, PROFILE_SPECIFIC_TESTS})
+    public void testCreateExternalTableWithNoSchemaLocation()
+    {
+        String schema = "schema_without_location";
+        query(format("CREATE SCHEMA %s.%s", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema));
+
+        String table = "test_create_external";
+        String tableLocation = "/tmp/" + table;
+        query(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, table, tableLocation));
+    }
+
     private void insertNationPartition(TableInstance<?> nation, int partition)
     {
         onHive().executeQuery(


### PR DESCRIPTION
Added test case for creating an external table where schema has no location.
This is to ensure compatibility with Athena's create external table 