### PR TITLE
Expose QueryType in QueryContext

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
@@ -235,7 +235,8 @@ public class FailedDispatchQuery
                 ImmutableList.of(),
                 ImmutableList.of(),
                 true,
-                resourceGroupId);
+                resourceGroupId,
+                Optional.empty());
 
         return queryInfo;
     }

--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQueryFactory.java
@@ -33,6 +33,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.sql.tree.Statement;
 import io.prestosql.transaction.TransactionManager;
+import io.prestosql.util.StatementUtils;
 
 import javax.inject.Inject;
 
@@ -107,7 +108,8 @@ public class LocalDispatchQueryFactory
                 accessControl,
                 executor,
                 metadata,
-                warningCollector);
+                warningCollector,
+                StatementUtils.getQueryType(preparedQuery.getStatement().getClass()));
 
         queryMonitor.queryCreatedEvent(stateMachine.getBasicQueryInfo(Optional.empty()));
 

--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -50,6 +50,7 @@ import io.prestosql.spi.eventlistener.QueryMetadata;
 import io.prestosql.spi.eventlistener.QueryOutputMetadata;
 import io.prestosql.spi.eventlistener.QueryStatistics;
 import io.prestosql.spi.eventlistener.StageCpuDistribution;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.sql.planner.planprinter.ValuePrinter;
 import io.prestosql.transaction.TransactionId;
@@ -118,7 +119,7 @@ public class QueryMonitor
         eventListenerManager.queryCreated(
                 new QueryCreatedEvent(
                         queryInfo.getQueryStats().getCreateTime().toDate().toInstant(),
-                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                         new QueryMetadata(
                                 queryInfo.getQueryId().toString(),
                                 queryInfo.getSession().getTransactionId().map(TransactionId::toString),
@@ -176,7 +177,7 @@ public class QueryMonitor
                         ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty()),
-                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
                 ImmutableList.of(),
@@ -194,7 +195,7 @@ public class QueryMonitor
                 new QueryCompletedEvent(
                         createQueryMetadata(queryInfo),
                         createQueryStatistics(queryInfo),
-                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                         getQueryIOMetadata(queryInfo),
                         createQueryFailureInfo(queryInfo.getFailureInfo(), queryInfo.getOutputStage()),
                         queryInfo.getWarnings(),
@@ -262,7 +263,7 @@ public class QueryMonitor
                 serializedPlanNodeStatsAndCosts);
     }
 
-    private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)
+    private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup, Optional<QueryType> queryType)
     {
         return new QueryContext(
                 session.getUser(),
@@ -281,7 +282,8 @@ public class QueryMonitor
                 session.getResourceEstimates(),
                 serverAddress,
                 serverVersion,
-                environment);
+                environment,
+                queryType);
     }
 
     private Optional<String> createTextQueryPlan(QueryInfo queryInfo)

--- a/presto-main/src/main/java/io/prestosql/execution/QueryInfo.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryInfo.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.QueryId;
 import io.prestosql.spi.eventlistener.RoutineInfo;
 import io.prestosql.spi.eventlistener.TableInfo;
 import io.prestosql.spi.memory.MemoryPoolId;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.security.SelectedRole;
 import io.prestosql.sql.analyzer.Output;
@@ -79,6 +80,7 @@ public class QueryInfo
     private final Optional<Output> output;
     private final boolean completeInfo;
     private final Optional<ResourceGroupId> resourceGroupId;
+    private final Optional<QueryType> queryType;
 
     @JsonCreator
     public QueryInfo(
@@ -112,7 +114,8 @@ public class QueryInfo
             @JsonProperty("referencedTables") List<TableInfo> referencedTables,
             @JsonProperty("routines") List<RoutineInfo> routines,
             @JsonProperty("completeInfo") boolean completeInfo,
-            @JsonProperty("resourceGroupId") Optional<ResourceGroupId> resourceGroupId)
+            @JsonProperty("resourceGroupId") Optional<ResourceGroupId> resourceGroupId,
+            @JsonProperty("queryType") Optional<QueryType> queryType)
     {
         requireNonNull(queryId, "queryId is null");
         requireNonNull(session, "session is null");
@@ -137,6 +140,7 @@ public class QueryInfo
         requireNonNull(routines, "routines is null");
         requireNonNull(resourceGroupId, "resourceGroupId is null");
         requireNonNull(warnings, "warnings is null");
+        requireNonNull(queryType, "queryType is null");
 
         this.queryId = queryId;
         this.session = session;
@@ -170,6 +174,7 @@ public class QueryInfo
         this.routines = ImmutableList.copyOf(routines);
         this.completeInfo = completeInfo;
         this.resourceGroupId = resourceGroupId;
+        this.queryType = queryType;
     }
 
     @JsonProperty
@@ -366,6 +371,12 @@ public class QueryInfo
     public Optional<ResourceGroupId> getResourceGroupId()
     {
         return resourceGroupId;
+    }
+
+    @JsonProperty
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/server/BasicQueryInfo.java
+++ b/presto-main/src/main/java/io/prestosql/server/BasicQueryInfo.java
@@ -22,6 +22,7 @@ import io.prestosql.spi.ErrorCode;
 import io.prestosql.spi.ErrorType;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.memory.MemoryPoolId;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ public class BasicQueryInfo
     private final BasicQueryStats queryStats;
     private final ErrorType errorType;
     private final ErrorCode errorCode;
+    private final Optional<QueryType> queryType;
 
     @JsonCreator
     public BasicQueryInfo(
@@ -68,7 +70,8 @@ public class BasicQueryInfo
             @JsonProperty("preparedQuery") Optional<String> preparedQuery,
             @JsonProperty("queryStats") BasicQueryStats queryStats,
             @JsonProperty("errorType") ErrorType errorType,
-            @JsonProperty("errorCode") ErrorCode errorCode)
+            @JsonProperty("errorCode") ErrorCode errorCode,
+            @JsonProperty("queryType") Optional<QueryType> queryType)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.session = requireNonNull(session, "session is null");
@@ -83,6 +86,7 @@ public class BasicQueryInfo
         this.updateType = requireNonNull(updateType, "updateType is null");
         this.preparedQuery = requireNonNull(preparedQuery, "preparedQuery is null");
         this.queryStats = requireNonNull(queryStats, "queryStats is null");
+        this.queryType = requireNonNull(queryType, "queryType is null");
     }
 
     public BasicQueryInfo(QueryInfo queryInfo)
@@ -99,7 +103,8 @@ public class BasicQueryInfo
                 queryInfo.getPreparedQuery(),
                 new BasicQueryStats(queryInfo.getQueryStats()),
                 queryInfo.getErrorType(),
-                queryInfo.getErrorCode());
+                queryInfo.getErrorCode(),
+                queryInfo.getQueryType());
     }
 
     @JsonProperty
@@ -180,6 +185,12 @@ public class BasicQueryInfo
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    @JsonProperty
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -142,7 +142,8 @@ public class MockManagedQueryExecution
                         ImmutableSet.of(),
                         OptionalDouble.empty()),
                 null,
-                null);
+                null,
+                Optional.empty());
     }
 
     @Override
@@ -242,6 +243,7 @@ public class MockManagedQueryExecution
                 ImmutableList.of(),
                 ImmutableList.of(),
                 state.isDone(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/io/prestosql/execution/TestCallTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestCallTask.java
@@ -144,7 +144,8 @@ public class TestCallTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
     }
 
     private Session testSession(TransactionManager transactionManager)

--- a/presto-main/src/test/java/io/prestosql/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestCommitTask.java
@@ -131,7 +131,8 @@ public class TestCommitTask
                 new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig()),
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
     }
 
     private static SessionBuilder sessionBuilder()

--- a/presto-main/src/test/java/io/prestosql/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestDeallocateTask.java
@@ -89,7 +89,8 @@ public class TestDeallocateTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
         Deallocate deallocate = new Deallocate(new Identifier(statementName));
         new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());
         return stateMachine.getDeallocatedPreparedStatements();

--- a/presto-main/src/test/java/io/prestosql/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestPrepareTask.java
@@ -110,7 +110,8 @@ public class TestPrepareTask
                 new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig()),
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
         Prepare prepare = new Prepare(identifier(statementName), statement);
         new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());
         return stateMachine.getAddedPreparedStatements();

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
@@ -28,6 +28,7 @@ import io.prestosql.security.AccessControlConfig;
 import io.prestosql.security.AccessControlManager;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.memory.MemoryPoolId;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.analyzer.Output;
@@ -88,6 +89,7 @@ public class TestQueryStateMachine
             .put("drink", "coffee")
             .build();
     private static final List<String> RESET_SESSION_PROPERTIES = ImmutableList.of("candy");
+    private static final Optional<QueryType> QUERY_TYPE = Optional.of(QueryType.SELECT);
 
     private final ExecutorService executor = newCachedThreadPool();
 
@@ -439,6 +441,8 @@ public class TestQueryStateMachine
         assertEquals(queryInfo.getFieldNames(), OUTPUT_FIELD_NAMES);
         assertEquals(queryInfo.getUpdateType(), UPDATE_TYPE);
         assertEquals(queryInfo.getMemoryPool(), MEMORY_POOL.getId());
+        assertTrue(queryInfo.getQueryType().isPresent());
+        assertEquals(queryInfo.getQueryType().get(), QUERY_TYPE.get());
 
         QueryStats queryStats = queryInfo.getQueryStats();
         assertNotNull(queryStats.getElapsedTime());
@@ -509,7 +513,8 @@ public class TestQueryStateMachine
                 executor,
                 ticker,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                QUERY_TYPE);
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);
         stateMachine.setColumns(OUTPUT_FIELD_NAMES, OUTPUT_FIELD_TYPES);

--- a/presto-main/src/test/java/io/prestosql/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestResetSessionTask.java
@@ -102,7 +102,8 @@ public class TestResetSessionTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
 
         getFutureValue(new ResetSessionTask().execute(
                 new ResetSession(QualifiedName.of(CATALOG_NAME, "baz")),

--- a/presto-main/src/test/java/io/prestosql/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestRollbackTask.java
@@ -124,7 +124,8 @@ public class TestRollbackTask
                 new AllowAllAccessControl(),
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
     }
 
     private static SessionBuilder sessionBuilder()

--- a/presto-main/src/test/java/io/prestosql/execution/TestSetPathTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSetPathTask.java
@@ -101,7 +101,8 @@ public class TestSetPathTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
     }
 
     private void executeSetPathTask(PathSpecification pathSpecification, QueryStateMachine stateMachine)

--- a/presto-main/src/test/java/io/prestosql/execution/TestSetRoleTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSetRoleTask.java
@@ -120,7 +120,8 @@ public class TestSetRoleTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
         new SetRoleTask().execute(setRole, transactionManager, metadata, accessControl, stateMachine, ImmutableList.of());
         return stateMachine;
     }

--- a/presto-main/src/test/java/io/prestosql/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSetSessionTask.java
@@ -184,7 +184,8 @@ public class TestSetSessionTask
                 accessControl,
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
         getFutureValue(new SetSessionTask().execute(new SetSession(qualifiedPropName, expression), transactionManager, metadata, accessControl, stateMachine, parameters));
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();

--- a/presto-main/src/test/java/io/prestosql/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestStartTransactionTask.java
@@ -260,7 +260,8 @@ public class TestStartTransactionTask
                 new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig()),
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                Optional.empty());
     }
 
     private static SessionBuilder sessionBuilder()

--- a/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
@@ -25,6 +25,7 @@ import io.prestosql.spi.QueryId;
 import io.prestosql.spi.StandardErrorCode;
 import io.prestosql.spi.eventlistener.StageGcStatistics;
 import io.prestosql.spi.memory.MemoryPoolId;
+import io.prestosql.spi.resourcegroups.QueryType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
@@ -131,13 +132,15 @@ public class TestBasicQueryInfo
                         ImmutableList.of(),
                         ImmutableList.of(),
                         false,
-                        Optional.empty()));
+                        Optional.empty(),
+                        Optional.of(QueryType.SELECT)));
 
         assertEquals(basicInfo.getQueryId().getId(), "0");
         assertEquals(basicInfo.getState(), RUNNING);
         assertEquals(basicInfo.getMemoryPool().getId(), "reserved");
         assertEquals(basicInfo.isScheduled(), false);
         assertEquals(basicInfo.getQuery(), "SELECT 4");
+        assertEquals(basicInfo.getQueryType().get(), QueryType.SELECT);
 
         assertEquals(basicInfo.getQueryStats().getCreateTime(), DateTime.parse("1991-09-06T05:00-05:30"));
         assertEquals(basicInfo.getQueryStats().getEndTime(), DateTime.parse("1991-09-06T06:00-05:30"));

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
@@ -24,6 +24,7 @@ import io.prestosql.execution.QueryStats;
 import io.prestosql.execution.resourcegroups.InternalResourceGroup;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.memory.MemoryPoolId;
+import io.prestosql.spi.resourcegroups.QueryType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
@@ -175,6 +176,7 @@ public class TestQueryStateInfo
                 ImmutableList.of(),
                 ImmutableList.of(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                Optional.of(QueryType.SELECT));
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryContext.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryContext.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.session.ResourceEstimates;
 
@@ -47,6 +48,8 @@ public class QueryContext
     private final String serverVersion;
     private final String environment;
 
+    private final Optional<QueryType> queryType;
+
     public QueryContext(
             String user,
             Optional<String> principal,
@@ -64,7 +67,8 @@ public class QueryContext
             ResourceEstimates resourceEstimates,
             String serverAddress,
             String serverVersion,
-            String environment)
+            String environment,
+            Optional<QueryType> queryType)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
@@ -83,6 +87,7 @@ public class QueryContext
         this.serverAddress = requireNonNull(serverAddress, "serverAddress is null");
         this.serverVersion = requireNonNull(serverVersion, "serverVersion is null");
         this.environment = requireNonNull(environment, "environment is null");
+        this.queryType = requireNonNull(queryType, "queryType is null");
     }
 
     @JsonProperty
@@ -185,5 +190,11 @@ public class QueryContext
     public String getEnvironment()
     {
         return environment;
+    }
+
+    @JsonProperty
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListener.java
@@ -33,6 +33,7 @@ import io.prestosql.spi.eventlistener.QueryStatistics;
 import io.prestosql.spi.eventlistener.RoutineInfo;
 import io.prestosql.spi.eventlistener.SplitCompletedEvent;
 import io.prestosql.spi.eventlistener.TableInfo;
+import io.prestosql.spi.resourcegroups.QueryType;
 import io.prestosql.testing.DistributedQueryRunner;
 import io.prestosql.testing.MaterializedResult;
 import org.intellij.lang.annotations.Language;
@@ -127,6 +128,7 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getContext().getServerAddress(), "127.0.0.1");
         assertEquals(queryCreatedEvent.getContext().getEnvironment(), "testing");
         assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getContext().getQueryType().get(), QueryType.SELECT);
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), "SELECT 1");
         assertFalse(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
 
@@ -137,6 +139,7 @@ public class TestEventListener
         assertEquals(queryCompletedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
         assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryCompletedEvent.getMetadata().getQueryId());
         assertFalse(queryCompletedEvent.getMetadata().getPreparedQuery().isPresent());
+        assertEquals(queryCompletedEvent.getContext().getQueryType().get(), QueryType.SELECT);
 
         List<SplitCompletedEvent> splitCompletedEvents = generatedEvents.getSplitCompletedEvents();
         assertEquals(splitCompletedEvents.get(0).getQueryId(), queryCompletedEvent.getMetadata().getQueryId());

--- a/presto-tests/src/test/java/io/prestosql/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/io/prestosql/memory/TestClusterMemoryLeakDetector.java
@@ -103,6 +103,7 @@ public class TestClusterMemoryLeakDetector
                         ImmutableSet.of(WAITING_FOR_MEMORY),
                         OptionalDouble.of(20)),
                 null,
-                null);
+                null,
+                Optional.empty());
     }
 }


### PR DESCRIPTION
Having QueryType in QueryContext enables us to get the high-level query category (e.g. SELECT, DESCRIBE) in the logging of QueryCreatedEvent and QueryCompletedEvent. It is useful to analyze the metrics of workload by the category of query type.

It solves https://github.com/prestosql/presto/issues/3634