### PR TITLE
Remove redundant Iceberg smoke test

### DIFF
--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -492,12 +492,6 @@ public class TestIcebergSmoke
         testWithAllFileFormats(this::testSchemaEvolution);
     }
 
-    @Test
-    public void testSchemaEvolutionParquet()
-    {
-        testSchemaEvolution(getSession(), FileFormat.PARQUET);
-    }
-
     private void testSchemaEvolution(Session session, FileFormat fileFormat)
     {
         assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (format = '" + fileFormat + "')");


### PR DESCRIPTION
This commit removes TestIcebergSmoke.testSchemaEvolutionParquet.
Parquet schema evolution is being tested in the adjacent test, and
because they both use the same table name, the existence of the
two tests can cause spurious test failures.