### PR TITLE
Update log4j dependency version to 2.13.3

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.9.1</dep.log4j.version>
+        <dep.log4j.version>2.13.3</dep.log4j.version>
         <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
     </properties>
 


### PR DESCRIPTION
Vulnerability details: https://nvd.nist.gov/vuln/detail/CVE-2020-9488
Log4j version 2.13.2 fixes the vulnerability, updating the log4j version to 2.13.3
http://logging.apache.org/log4j/2.x/security.html