### PR TITLE
Run Iceberg smoke test with all file formats

### DIFF
--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -36,13 +36,13 @@ public final class IcebergQueryRunner
 
     private IcebergQueryRunner() {}
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties)
+    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraServerProperties)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, true);
+        return createIcebergQueryRunner(extraServerProperties, ImmutableMap.of(), true);
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, boolean createTpchTables)
+    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraServerProperties, Map<String, String> extraIcebergProperties, boolean createTpchTables)
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -51,7 +51,7 @@ public final class IcebergQueryRunner
                 .build();
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
-                .setExtraProperties(extraProperties)
+                .setExtraProperties(extraServerProperties)
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());
@@ -63,6 +63,7 @@ public final class IcebergQueryRunner
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", dataDir.toString())
+                .putAll(extraIcebergProperties)
                 .build();
 
         queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -15,10 +15,9 @@ package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.Session;
-import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.AbstractTestQueryFramework;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
-import io.prestosql.testing.assertions.Assert;
 import org.apache.iceberg.FileFormat;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
@@ -30,15 +29,13 @@ import java.util.regex.Pattern;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
-import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 public class TestIcebergSmoke
-        extends AbstractTestIntegrationSmokeTest
+        extends AbstractTestQueryFramework
 {
     private static final Pattern WITH_CLAUSE_EXTRACTER = Pattern.compile(".*(WITH\\s*\\([^)]*\\))\\s*$", Pattern.DOTALL);
 
@@ -58,45 +55,6 @@ public class TestIcebergSmoke
                         "WITH \\(\n" +
                         "   location = '.*/iceberg_data/tpch'\n" +
                         "\\)");
-    }
-
-    @Test
-    @Override
-    public void testDescribeTable()
-    {
-        MaterializedResult expectedColumns = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "", "")
-                .row("custkey", "bigint", "", "")
-                .row("orderstatus", "varchar", "", "")
-                .row("totalprice", "double", "", "")
-                .row("orderdate", "date", "", "")
-                .row("orderpriority", "varchar", "", "")
-                .row("clerk", "varchar", "", "")
-                .row("shippriority", "integer", "", "")
-                .row("comment", "varchar", "", "")
-                .build();
-        MaterializedResult actualColumns = computeActual("DESCRIBE orders");
-        Assert.assertEquals(actualColumns, expectedColumns);
-    }
-
-    @Override
-    public void testShowCreateTable()
-    {
-        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
-                .isEqualTo("CREATE TABLE iceberg.tpch.orders (\n" +
-                        "   orderkey bigint,\n" +
-                        "   custkey bigint,\n" +
-                        "   orderstatus varchar,\n" +
-                        "   totalprice double,\n" +
-                        "   orderdate date,\n" +
-                        "   orderpriority varchar,\n" +
-                        "   clerk varchar,\n" +
-                        "   shippriority integer,\n" +
-                        "   comment varchar\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'ORC'\n" +
-                        ")");
     }
 
     @Test

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/fileformat/TestIcebergOrcIntegrationSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/fileformat/TestIcebergOrcIntegrationSmoke.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg.fileformat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.MaterializedRow;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.assertions.Assert;
+
+import java.util.List;
+
+import static io.prestosql.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.testing.MaterializedResult.DEFAULT_PRECISION;
+import static io.prestosql.testing.MaterializedResult.resultBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergOrcIntegrationSmoke
+        extends AbstractTestIntegrationSmokeTest
+{
+    public static final List<MaterializedRow> ORDERS_COLUMNS = ImmutableList.<MaterializedRow>builder()
+            .add(new MaterializedRow(DEFAULT_PRECISION, "orderkey", "bigint", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "custkey", "bigint", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "orderstatus", "varchar", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "totalprice", "double", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "orderdate", "date", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "orderpriority", "varchar", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "clerk", "varchar", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "shippriority", "integer", "", ""))
+            .add(new MaterializedRow(DEFAULT_PRECISION, "comment", "varchar", "", ""))
+            .build();
+    public static final String SHOW_CREATE_TABLE_ORDERS_RESULT = "CREATE TABLE iceberg.tpch.orders (\n" +
+            "   orderkey bigint,\n" +
+            "   custkey bigint,\n" +
+            "   orderstatus varchar,\n" +
+            "   totalprice double,\n" +
+            "   orderdate date,\n" +
+            "   orderpriority varchar,\n" +
+            "   clerk varchar,\n" +
+            "   shippriority integer,\n" +
+            "   comment varchar\n" +
+            ")\n" +
+            "WITH (\n" +
+            "   format = 'ORC'\n" +
+            ")";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of("iceberg.file-format", "orc"), true);
+    }
+
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult expectedColumns = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .rows(ORDERS_COLUMNS)
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE orders");
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo(SHOW_CREATE_TABLE_ORDERS_RESULT);
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/fileformat/TestIcebergParquetIntegrationSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/fileformat/TestIcebergParquetIntegrationSmoke.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg.fileformat;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.assertions.Assert;
+
+import static io.prestosql.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.prestosql.plugin.iceberg.fileformat.TestIcebergOrcIntegrationSmoke.ORDERS_COLUMNS;
+import static io.prestosql.plugin.iceberg.fileformat.TestIcebergOrcIntegrationSmoke.SHOW_CREATE_TABLE_ORDERS_RESULT;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.testing.MaterializedResult.resultBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergParquetIntegrationSmoke
+        extends AbstractTestIntegrationSmokeTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of("iceberg.file-format", "parquet"), true);
+    }
+
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult expectedColumns = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .rows(ORDERS_COLUMNS)
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE orders");
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo(SHOW_CREATE_TABLE_ORDERS_RESULT.replace("format = 'ORC'", "format = 'PARQUET'"));
+    }
+}


### PR DESCRIPTION
With this change, the test suite inside `AbstractTestIntegrationSmokeTest` are run with both Orc and Parquet. 