### PR TITLE
Add data_block_encoding parameter to Phoenix connector.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/phoenix.rst
+++ b/presto-docs/src/main/sphinx/connector/phoenix.rst
@@ -2,8 +2,8 @@
 Phoenix Connector
 =================
 
-The Phoenix connector allows querying data stored in 
-`Apache HBase <https://hbase.apache.org/>`_ using 
+The Phoenix connector allows querying data stored in
+`Apache HBase <https://hbase.apache.org/>`_ using
 `Apache Phoenix <https://phoenix.apache.org/>`_.
 
 Compatibility
@@ -156,7 +156,10 @@ Property Name               Default Value    Description
 
 ``compression``             ``NONE``         Compression algorithm to use.  Valid values are ``NONE`` (default), ``SNAPPY``, ``LZO``, ``LZ4``, or ``GZ``.
 
+``data_block_encoding``     ``FAST_DIFF``    Block encoding algorithm to use. Valid values are: ``NONE``, ``PREFIX``, ``DIFF``, ``FAST_DIFF`` (default), or ``ROW_INDEX_V1``.
+
 ``ttl``                     ``FOREVER``      Time To Live for each cell.
+
 ``bloomfilter``             ``ROW``          Bloomfilter to use. Valid values are ``NONE``, ``ROW`` (default), or ``ROWCOL``.
 =========================== ================ ==============================================================================================================
 

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
@@ -179,6 +179,9 @@ public class PhoenixMetadata
                     if (columnFamily.getTimeToLive() < FOREVER) {
                         properties.put(PhoenixTableProperties.TTL, columnFamily.getTimeToLive());
                     }
+                    if (!columnFamily.getDataBlockEncoding().toString().equals("NONE")) {
+                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding().toString());
+                    }
                     break;
                 }
             }
@@ -367,6 +370,7 @@ public class PhoenixMetadata
             PhoenixTableProperties.getMinVersions(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.MIN_VERSIONS + "=" + value));
             PhoenixTableProperties.getCompression(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.COMPRESSION + "='" + value + "'"));
             PhoenixTableProperties.getTimeToLive(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.TTL + "=" + value));
+            PhoenixTableProperties.getDataBlockEncoding(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.DATA_BLOCK_ENCODING + "='" + value + "'"));
 
             String sql = format(
                     "CREATE %s TABLE %s (%s , CONSTRAINT PK PRIMARY KEY (%s)) %s",

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
@@ -48,6 +48,7 @@ public final class PhoenixTableProperties
     public static final String MIN_VERSIONS = "min_versions";
     public static final String COMPRESSION = "compression";
     public static final String TTL = "ttl";
+    public static final String DATA_BLOCK_ENCODING = "data_block_encoding";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -108,6 +109,11 @@ public final class PhoenixTableProperties
                 integerProperty(
                         TTL,
                         "Number of seconds for cell TTL.  HBase will automatically delete rows once the expiration time is reached.",
+                        null,
+                        false),
+                stringProperty(
+                        DATA_BLOCK_ENCODING,
+                        "The block encoding algorithm to use for Cells in HBase blocks. Options are: NONE, PREFIX, DIFF, FAST_DIFF, ROW_INDEX_V1, and others.",
                         null,
                         false));
     }
@@ -230,6 +236,14 @@ public final class PhoenixTableProperties
             return Optional.empty();
         }
         return Optional.of(value);
+    }
+
+    public static Optional<String> getDataBlockEncoding(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        String value = (String) tableProperties.get(DATA_BLOCK_ENCODING);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<Integer> getTimeToLive(Map<String, Object> tableProperties)

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
@@ -67,6 +67,7 @@ public class TestPhoenixIntegrationSmokeTest
                         "   comment varchar(79)\n" +
                         ")\n" +
                         "WITH (\n" +
+                        "   data_block_encoding = 'FAST_DIFF',\n" +
                         "   rowkeys = 'ROWKEY',\n" +
                         "   salt_buckets = 10\n" +
                         ")");
@@ -140,6 +141,7 @@ public class TestPhoenixIntegrationSmokeTest
                            "   d varchar(10)\n" +
                            ")\n" +
                            "WITH (\n" +
+                           "   data_block_encoding = 'FAST_DIFF',\n" +
                            "   rowkeys = 'A,B,C',\n" +
                            "   salt_buckets = 10\n" +
                            ")");


### PR DESCRIPTION
DATA_BLOCK_ENCODING is a common parameter that Phoenix users might want to set (along with Compression), so we should add this.

(There are in fact a bunch of more HBase column family level options that Phoenix also supports, but most of them are not common, and should be probably set directly within Phoenix)