### PR TITLE
Describe 'deterministic' flag for @ScalarFunction

### DIFF
--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -46,7 +46,7 @@ types. Below is a sample function which implements ``is_null``:
 
     public class ExampleNullFunction
     {
-        @ScalarFunction("is_null")
+        @ScalarFunction("is_null", deterministic = true)
         @Description("Returns TRUE if the argument is NULL")
         @SqlType(StandardTypes.BOOLEAN)
         public static boolean isNull(
@@ -60,6 +60,23 @@ The function ``is_null`` takes a single ``VARCHAR`` argument and returns a
 ``BOOLEAN`` indicating if the argument was ``NULL``. Note that the argument to
 the function is of type ``Slice``. ``VARCHAR`` uses ``Slice``, which is essentially
 a wrapper around ``byte[]``, rather than ``String`` for its native container type.
+
+The ``deterministic`` argument indicates that a function has no side effects and,
+for subsequent calls with the same argument(s), the function returns the exact
+same value(s).
+
+In Presto, deterministic functions don't rely on any changing state
+and don't modify any state. The ``deterministic`` flag is optional and defaults
+to ``true``.
+
+For example, the function :func:`shuffle` is non-deterministic, since it uses random
+values. On the other hand, :func:`now` is deterministic, because subsequent calls in a
+single query return the same timestamp.
+
+Any function with non-deterministic behavior is required to set ``deterministic = false``
+to avoid unexpected results.
+
+
 
 * ``@SqlType``:
 


### PR DESCRIPTION
Documentation added for the `deterministic` argument of `@ScalarFunction` annotation.