### PR TITLE
Introduce SqlDialect to presto-base-jdbc

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -38,6 +38,8 @@ import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
 
+import javax.annotation.Nullable;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -467,7 +469,7 @@ public abstract class BaseJdbcClient
         }
     }
 
-    protected String createTableSql(String catalog, String remoteSchema, String tableName, List<String> columns)
+    protected String createTableSql(@Nullable String catalog, @Nullable String remoteSchema, String tableName, List<String> columns)
     {
         return format("CREATE TABLE %s (%s)", quoted(catalog, remoteSchema, tableName), join(", ", columns));
     }
@@ -919,7 +921,7 @@ public abstract class BaseJdbcClient
         return identifierQuote + name + identifierQuote;
     }
 
-    protected String quoted(String catalog, String schema, String table)
+    protected String quoted(@Nullable String catalog, @Nullable String schema, String table)
     {
         StringBuilder sb = new StringBuilder();
         if (!isNullOrEmpty(catalog)) {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseSqlDialect.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseSqlDialect.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import java.util.List;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Objects.requireNonNull;
+
+public class BaseSqlDialect
+        implements SqlDialect
+{
+    private static final String DEFAULT_IDENTIFIER_QUOTE = "\"";
+
+    private final String identifierQuote;
+
+    public BaseSqlDialect()
+    {
+        this(DEFAULT_IDENTIFIER_QUOTE);
+    }
+
+    public BaseSqlDialect(String identifierQuote)
+    {
+        this.identifierQuote = requireNonNull(identifierQuote, "identifierQuote is null");
+    }
+
+    @Override
+    public String quote(String identifier)
+    {
+        return identifierQuote + identifier.replace(identifierQuote, identifierQuote + identifierQuote) + identifierQuote;
+    }
+
+    @Override
+    public String getRelation(String catalog, String schema, String table)
+    {
+        StringBuilder sql = new StringBuilder();
+        if (!isNullOrEmpty(catalog)) {
+            sql.append(quote(catalog)).append('.');
+        }
+        if (!isNullOrEmpty(schema)) {
+            sql.append(quote(schema)).append('.');
+        }
+        return sql.append(quote(table)).toString();
+    }
+
+    @Override
+    public String getProjection(JdbcColumnHandle jdbcColumnHandle)
+    {
+        return format("%s AS %s", jdbcColumnHandle.toSqlExpression(name -> quote(name)), quote(jdbcColumnHandle.getColumnName()));
+    }
+
+    @Override
+    public String getPredicate(JdbcColumnHandle column, String operator)
+    {
+        return quote(column.getColumnName()) + " " + operator + " ?";
+    }
+
+    @Override
+    public String createTableSql(String catalog, String remoteSchema, String tableName, List<String> columns)
+    {
+        return format("CREATE TABLE %s (%s)", getRelation(catalog, remoteSchema, tableName), join(", ", columns));
+    }
+
+    @Override
+    public String renameTable(String catalogName, String schemaName, String tableName, String newSchemaName, String newTableName)
+    {
+        return format(
+                "ALTER TABLE %s RENAME TO %s",
+                getRelation(catalogName, schemaName, tableName),
+                getRelation(catalogName, newSchemaName, newTableName));
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -123,9 +123,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 newDomain,
                 Optional.empty(), // groupBy
                 handle.getLimit(),
@@ -154,9 +152,7 @@ public class JdbcMetadata
         return Optional.of(new ProjectionApplicationResult<>(
                 new JdbcTableHandle(
                         handle.getSchemaTableName(),
-                        handle.getCatalogName(),
-                        handle.getSchemaName(),
-                        handle.getTableName(),
+                        handle.getRemoteTableName(),
                         handle.getConstraint(),
                         handle.getGroupingSets(),
                         handle.getLimit(),
@@ -236,9 +232,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 handle.getConstraint(),
                 Optional.of(groupingSets.stream()
                         .map(groupingSet -> groupingSet.stream()
@@ -266,9 +260,7 @@ public class JdbcMetadata
 
         handle = new JdbcTableHandle(
                 handle.getSchemaTableName(),
-                handle.getCatalogName(),
-                handle.getSchemaName(),
-                handle.getTableName(),
+                handle.getRemoteTableName(),
                 handle.getConstraint(),
                 handle.getGroupingSets(),
                 OptionalLong.of(limit),

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
@@ -51,7 +50,7 @@ public class QueryBuilder
     private static final String ALWAYS_TRUE = "1=1";
     private static final String ALWAYS_FALSE = "1=0";
 
-    private final String identifierQuote;
+    private final SqlDialect dialect;
 
     private static class TypeAndValue
     {
@@ -82,9 +81,9 @@ public class QueryBuilder
         }
     }
 
-    public QueryBuilder(String identifierQuote)
+    public QueryBuilder(SqlDialect dialect)
     {
-        this.identifierQuote = requireNonNull(identifierQuote, "identifierQuote is null");
+        this.dialect = requireNonNull(dialect, "dialect is null");
     }
 
     public PreparedStatement buildSql(
@@ -102,7 +101,7 @@ public class QueryBuilder
             throws SQLException
     {
         String sql = "SELECT " + getProjection(columns);
-        sql += " FROM " + getRelation(catalog, schema, table);
+        sql += " FROM " + dialect.getRelation(catalog, schema, table);
 
         List<TypeAndValue> accumulator = new ArrayList<>();
 
@@ -152,26 +151,14 @@ public class QueryBuilder
         return statement;
     }
 
-    protected String getProjection(List<JdbcColumnHandle> columns)
+    private String getProjection(List<JdbcColumnHandle> columns)
     {
         if (columns.isEmpty()) {
             return "1";
         }
         return columns.stream()
-                .map(jdbcColumnHandle -> format("%s AS %s", jdbcColumnHandle.toSqlExpression(this::quote), quote(jdbcColumnHandle.getColumnName())))
+                .map(dialect::getProjection)
                 .collect(joining(", "));
-    }
-
-    protected String getRelation(String catalog, String schema, String table)
-    {
-        StringBuilder sql = new StringBuilder();
-        if (!isNullOrEmpty(catalog)) {
-            sql.append(quote(catalog)).append('.');
-        }
-        if (!isNullOrEmpty(schema)) {
-            sql.append(quote(schema)).append('.');
-        }
-        return sql.append(quote(table)).toString();
     }
 
     private static Domain pushDownDomain(JdbcClient client, ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain)
@@ -195,19 +182,20 @@ public class QueryBuilder
         for (Map.Entry<ColumnHandle, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
             JdbcColumnHandle column = ((JdbcColumnHandle) entry.getKey());
             Domain domain = pushDownDomain(client, session, connection, column, entry.getValue());
-            builder.add(toPredicate(column.getColumnName(), domain, column, accumulator));
+            builder.add(toPredicate(column, domain, accumulator));
         }
         return builder.build();
     }
 
-    private String toPredicate(String columnName, Domain domain, JdbcColumnHandle column, List<TypeAndValue> accumulator)
+    private String toPredicate(JdbcColumnHandle column, Domain domain, List<TypeAndValue> accumulator)
     {
+        String columnName = column.getColumnName();
         if (domain.getValues().isNone()) {
-            return domain.isNullAllowed() ? quote(columnName) + " IS NULL" : ALWAYS_FALSE;
+            return domain.isNullAllowed() ? dialect.quote(columnName) + " IS NULL" : ALWAYS_FALSE;
         }
 
         if (domain.getValues().isAll()) {
-            return domain.isNullAllowed() ? ALWAYS_TRUE : quote(columnName) + " IS NOT NULL";
+            return domain.isNullAllowed() ? ALWAYS_TRUE : dialect.quote(columnName) + " IS NOT NULL";
         }
 
         List<String> disjuncts = new ArrayList<>();
@@ -222,10 +210,10 @@ public class QueryBuilder
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
                         case ABOVE:
-                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), column, accumulator));
+                            rangeConjuncts.add(toPredicate(column, ">", range.getLow().getValue(), accumulator));
                             break;
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), column, accumulator));
+                            rangeConjuncts.add(toPredicate(column, ">=", range.getLow().getValue(), accumulator));
                             break;
                         case BELOW:
                             throw new IllegalArgumentException("Low marker should never use BELOW bound");
@@ -238,10 +226,10 @@ public class QueryBuilder
                         case ABOVE:
                             throw new IllegalArgumentException("High marker should never use ABOVE bound");
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), column, accumulator));
+                            rangeConjuncts.add(toPredicate(column, "<=", range.getHigh().getValue(), accumulator));
                             break;
                         case BELOW:
-                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), column, accumulator));
+                            rangeConjuncts.add(toPredicate(column, "<", range.getHigh().getValue(), accumulator));
                             break;
                         default:
                             throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
@@ -255,29 +243,29 @@ public class QueryBuilder
 
         // Add back all of the possible single values either as an equality or an IN predicate
         if (singleValues.size() == 1) {
-            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues), column, accumulator));
+            disjuncts.add(toPredicate(column, "=", getOnlyElement(singleValues), accumulator));
         }
         else if (singleValues.size() > 1) {
             for (Object value : singleValues) {
                 bindValue(value, column, accumulator);
             }
             String values = Joiner.on(",").join(nCopies(singleValues.size(), "?"));
-            disjuncts.add(quote(columnName) + " IN (" + values + ")");
+            disjuncts.add(dialect.quote(columnName) + " IN (" + values + ")");
         }
 
         // Add nullability disjuncts
         checkState(!disjuncts.isEmpty());
         if (domain.isNullAllowed()) {
-            disjuncts.add(quote(columnName) + " IS NULL");
+            disjuncts.add(dialect.quote(columnName) + " IS NULL");
         }
 
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
 
-    private String toPredicate(String columnName, String operator, Object value, JdbcColumnHandle column, List<TypeAndValue> accumulator)
+    private String toPredicate(JdbcColumnHandle column, String operator, Object value, List<TypeAndValue> accumulator)
     {
         bindValue(value, column, accumulator);
-        return quote(columnName) + " " + operator + " ?";
+        return dialect.getPredicate(column, operator);
     }
 
     private String getGroupBy(Optional<List<List<JdbcColumnHandle>>> groupingSets)
@@ -295,21 +283,16 @@ public class QueryBuilder
             }
             return " GROUP BY " + groupingSet.stream()
                     .map(JdbcColumnHandle::getColumnName)
-                    .map(this::quote)
+                    .map(dialect::quote)
                     .collect(joining(", "));
         }
         return " GROUP BY GROUPING SETS " +
                 groupingSets.get().stream()
                         .map(groupingSet -> groupingSet.stream()
                                 .map(JdbcColumnHandle::getColumnName)
-                                .map(this::quote)
+                                .map(dialect::quote)
                                 .collect(joining(", ", "(", ")")))
                         .collect(joining(", ", "(", ")"));
-    }
-
-    protected String quote(String name)
-    {
-        return identifierQuote + name.replace(identifierQuote, identifierQuote + identifierQuote) + identifierQuote;
     }
 
     private static void bindValue(Object value, JdbcColumnHandle column, List<TypeAndValue> accumulator)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableName.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RemoteTableName.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Qualified table name reported by the remote database.
+ */
+public final class RemoteTableName
+{
+    private final Optional<String> catalogName;
+    private final Optional<String> schemaName;
+    private final String tableName;
+
+    @JsonCreator
+    public RemoteTableName(Optional<String> catalogName, Optional<String> schemaName, String tableName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    @JsonProperty
+    public Optional<String> getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @JsonProperty
+    public Optional<String> getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RemoteTableName that = (RemoteTableName) o;
+        return catalogName.equals(that.catalogName) &&
+                schemaName.equals(that.schemaName) &&
+                tableName.equals(that.tableName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(catalogName, schemaName, tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return Joiner.on(".").skipNulls().join(catalogName.orElse(null), schemaName.orElse(null), tableName);
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SqlDialect.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SqlDialect.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+public interface SqlDialect
+{
+    String quote(String identifier);
+
+    String getRelation(@Nullable String catalog, @Nullable String schema, String table);
+
+    String getProjection(JdbcColumnHandle jdbcColumnHandle);
+
+    String getPredicate(JdbcColumnHandle column, String operator);
+
+    String createTableSql(String catalog, String remoteSchema, String tableName, List<String> columns);
+
+    String renameTable(String catalogName, String schemaName, String tableName, String newSchemaName, String newTableName);
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -88,6 +88,8 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class TestJdbcQueryBuilder
 {
+    private final SqlDialect dialect = new BaseSqlDialect();
+
     private TestingDatabase database;
     private JdbcClient jdbcClient;
 
@@ -233,7 +235,7 @@ public class TestJdbcQueryBuilder
                 .build());
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -256,7 +258,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Long> longBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<Float> floatBuilder = ImmutableSet.builder();
@@ -282,7 +284,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<String> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -310,7 +312,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<String> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -343,7 +345,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Date> dateBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<Time> timeBuilder = ImmutableSet.builder();
@@ -376,7 +378,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             ImmutableSet.Builder<Timestamp> builder = ImmutableSet.builder();
             while (resultSet.next()) {
@@ -400,7 +402,7 @@ public class TestJdbcQueryBuilder
     {
         Connection connection = database.getConnection();
         Function<String, String> function = sql -> sql + " LIMIT 10";
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, TupleDomain.all(), Optional.empty(), function);
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, TupleDomain.all(), Optional.empty(), function);
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             long count = 0;
             while (resultSet.next()) {
@@ -419,7 +421,7 @@ public class TestJdbcQueryBuilder
                 columns.get(1), Domain.onlyNull(DOUBLE)));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(jdbcClient, SESSION, connection, "", "", "test_table", Optional.empty(), columns, tupleDomain, Optional.empty(), identity());
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             assertEquals(resultSet.next(), false);
         }
@@ -440,7 +442,7 @@ public class TestJdbcQueryBuilder
                         Optional.empty()));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(
                 jdbcClient,
                 SESSION,
                 connection,
@@ -486,7 +488,7 @@ public class TestJdbcQueryBuilder
                         Optional.empty()));
 
         Connection connection = database.getConnection();
-        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(
+        try (PreparedStatement preparedStatement = new QueryBuilder(dialect).buildSql(
                 jdbcClient,
                 SESSION,
                 connection,

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -180,9 +180,7 @@ public class TestJdbcRecordSetProvider
     {
         jdbcTableHandle = new JdbcTableHandle(
                 jdbcTableHandle.getSchemaTableName(),
-                jdbcTableHandle.getCatalogName(),
-                jdbcTableHandle.getSchemaName(),
-                jdbcTableHandle.getTableName(),
+                jdbcTableHandle.getRemoteTableName(),
                 domain,
                 Optional.empty(),
                 OptionalLong.empty(),

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRemoteTableName.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRemoteTableName.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestRemoteTableName
+{
+    @Test
+    public void testJsonRoundTrip()
+    {
+        JsonCodec<RemoteTableName> codec = JsonCodec.jsonCodec(RemoteTableName.class);
+        RemoteTableName table = new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table");
+        RemoteTableName roundTrip = codec.fromJson(codec.toJson(table));
+        assertEquals(table.getCatalogName(), roundTrip.getCatalogName());
+        assertEquals(table.getSchemaName(), roundTrip.getSchemaName());
+        assertEquals(table.getTableName(), roundTrip.getTableName());
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcClient.java
@@ -31,7 +31,7 @@ class TestingH2JdbcClient
 
     public TestingH2JdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
     }
 
     @Override
@@ -43,7 +43,7 @@ class TestingH2JdbcClient
     @Override
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
-        return new AggregateFunctionRewriter(this::quoted, ImmutableSet.of(new ImplementCountAll(BIGINT_TYPE_HANDLE)))
+        return new AggregateFunctionRewriter(name -> dialect.quote(name), ImmutableSet.of(new ImplementCountAll(BIGINT_TYPE_HANDLE)))
                 .rewrite(session, aggregate, assignments);
     }
 }

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
@@ -66,9 +66,8 @@ public class DruidJdbcClient
 
     @Inject
     public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
-            throws SQLException
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
     }
 
     @Override
@@ -155,7 +154,7 @@ public class DruidJdbcClient
     {
         String schemaName = table.getSchemaName();
         checkArgument("druid".equals(schemaName), "Only \"druid\" schema is supported");
-        return new QueryBuilder(identifierQuote)
+        return new QueryBuilder(dialect)
                 .buildSql(
                         this,
                         session,

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.memsql;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.BaseSqlDialect;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.spi.connector.ConnectorSession;
 
@@ -35,7 +36,7 @@ public class MemSqlClient
     @Inject
     public MemSqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
-        super(config, "`", connectionFactory);
+        super(config, new BaseSqlDialect("`"), connectionFactory);
     }
 
     @Override

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -24,6 +24,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.BaseSqlDialect;
 import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
@@ -103,7 +104,7 @@ public class MySqlClient
     @Inject
     public MySqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, TypeManager typeManager)
     {
-        super(config, "`", connectionFactory);
+        super(config, new BaseSqlDialect("`"), connectionFactory);
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
     }
 
@@ -270,9 +271,9 @@ public class MySqlClient
             }
             String sql = format(
                     "ALTER TABLE %s RENAME COLUMN %s TO %s",
-                    quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()),
-                    quoted(jdbcColumn.getColumnName()),
-                    quoted(newColumnName));
+                    dialect.getRelation(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName()),
+                    dialect.quote(jdbcColumn.getColumnName()),
+                    dialect.quote(newColumnName));
             execute(connection, sql);
         }
         catch (SQLException e) {
@@ -289,8 +290,8 @@ public class MySqlClient
     {
         String sql = format(
                 "CREATE TABLE %s LIKE %s",
-                quoted(catalogName, schemaName, newTableName),
-                quoted(catalogName, schemaName, tableName));
+                dialect.getRelation(catalogName, schemaName, newTableName),
+                dialect.getRelation(catalogName, schemaName, tableName));
         execute(connection, sql);
     }
 

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -155,7 +155,7 @@ public class OracleClient
             OracleConfig oracleConfig,
             ConnectionFactory connectionFactory)
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
 
         requireNonNull(oracleConfig, "oracle config is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
@@ -216,8 +216,8 @@ public class OracleClient
         String newTableName = newTable.getTableName().toUpperCase(ENGLISH);
         String sql = format(
                 "ALTER TABLE %s RENAME TO %s",
-                quoted(catalogName, schemaName, tableName),
-                quoted(newTableName));
+                dialect.getRelation(catalogName, schemaName, tableName),
+                dialect.quote(newTableName));
 
         try (Connection connection = connectionFactory.openConnection(identity)) {
             execute(connection, sql);

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
@@ -24,6 +24,7 @@ import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProv
 import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.prestosql.plugin.base.classloader.ForClassLoaderSafe;
 import io.prestosql.plugin.base.util.LoggingInvocationHandler;
+import io.prestosql.plugin.jdbc.BaseSqlDialect;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.ForwardingJdbcClient;
@@ -32,6 +33,7 @@ import io.prestosql.plugin.jdbc.JdbcMetadataConfig;
 import io.prestosql.plugin.jdbc.JdbcMetadataSessionProperties;
 import io.prestosql.plugin.jdbc.JdbcPageSinkProvider;
 import io.prestosql.plugin.jdbc.JdbcRecordSetProvider;
+import io.prestosql.plugin.jdbc.SqlDialect;
 import io.prestosql.plugin.jdbc.TypeHandlingJdbcConfig;
 import io.prestosql.plugin.jdbc.TypeHandlingJdbcSessionProperties;
 import io.prestosql.plugin.jdbc.credential.EmptyCredentialProvider;
@@ -59,6 +61,7 @@ import static io.prestosql.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.prestosql.plugin.phoenix.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.phoenix.util.SchemaUtil.ESCAPE_CHARACTER;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class PhoenixClientModule
@@ -90,8 +93,9 @@ public class PhoenixClientModule
         binder.bind(PhoenixClient.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorMetadata.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixMetadata.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorMetadata.class).to(ClassLoaderSafeConnectorMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(SqlDialect.class).toInstance(new BaseSqlDialect(ESCAPE_CHARACTER));
 
-        binder.bind(PhoenixTableProperties.class).in(Scopes.SINGLETON);
+                binder.bind(PhoenixTableProperties.class).in(Scopes.SINGLETON);
         binder.bind(PhoenixColumnProperties.class).in(Scopes.SINGLETON);
 
         binder.bind(PhoenixConnector.class).in(Scopes.SINGLETON);

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -181,7 +181,7 @@ public class PostgreSqlClient
             ConnectionFactory connectionFactory,
             TypeManager typeManager)
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
         this.jsonType = typeManager.getType(new TypeSignature(JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
@@ -195,7 +195,7 @@ public class PostgreSqlClient
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), 0, 0, Optional.empty(), Optional.empty());
         this.aggregateFunctionRewriter = new AggregateFunctionRewriter(
-                this::quoted,
+                name -> dialect.quote(name),
                 ImmutableSet.<AggregateFunctionRule>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
                         .add(new ImplementCount(bigintTypeHandle))
@@ -228,8 +228,8 @@ public class PostgreSqlClient
 
         String sql = format(
                 "ALTER TABLE %s RENAME TO %s",
-                quoted(catalogName, schemaName, tableName),
-                quoted(newTable.getTableName()));
+                dialect.getRelation(catalogName, schemaName, tableName),
+                dialect.quote(newTable.getTableName()));
         execute(identity, sql);
     }
 

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -38,7 +38,7 @@ public class RedshiftClient
     @Inject
     public RedshiftClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
     }
 
     @Override
@@ -50,8 +50,8 @@ public class RedshiftClient
 
         String sql = format(
                 "ALTER TABLE %s RENAME TO %s",
-                quoted(catalogName, schemaName, tableName),
-                quoted(newTable.getTableName()));
+                dialect.getRelation(catalogName, schemaName, tableName),
+                dialect.quote(newTable.getTableName()));
         execute(identity, sql);
     }
 

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -67,7 +67,7 @@ public class SqlServerClient
     @Inject
     public SqlServerClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
-        super(config, "\"", connectionFactory);
+        super(config, connectionFactory);
     }
 
     @Override
@@ -100,10 +100,10 @@ public class SqlServerClient
         String sql = format(
                 "SELECT %s INTO %s FROM %s WHERE 0 = 1",
                 columnNames.stream()
-                        .map(this::quoted)
+                        .map(name -> dialect.quote(name))
                         .collect(joining(", ")),
-                quoted(catalogName, schemaName, newTableName),
-                quoted(catalogName, schemaName, tableName));
+                dialect.getRelation(catalogName, schemaName, newTableName),
+                dialect.getRelation(catalogName, schemaName, tableName));
         execute(connection, sql);
     }
 


### PR DESCRIPTION
Introduce SqlDialect to presto-base-jdbc

Its goal is to capture SQL dialect differences between
SQL data sources.
