### PR TITLE
Order GHA job exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,12 @@ jobs:
           - suite-tpcds
         exclude:
           - config: config-hdp3
-            suite: suite-tpcds
-          - config: config-hdp3
             suite: suite-6-non-generic
           - config: config-hdp3
             suite: suite-7-non-generic
           - config: config-hdp3
             suite: suite-8-non-generic
-          - config: config-cdh5
+          - config: config-hdp3
             suite: suite-tpcds
           - config: config-cdh5
             suite: suite-6-non-generic
@@ -209,6 +207,8 @@ jobs:
             suite: suite-7-non-generic
           - config: config-cdh5
             suite: suite-8-non-generic
+          - config: config-cdh5
+            suite: suite-tpcds
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Order GHA job exclusions

Order GHA job exclusions so they are in the same order as suites.
