### PR TITLE
Simplify negative anyMatch usage

### DIFF
--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/AccumuloClient.java
@@ -573,7 +573,7 @@ public class AccumuloClient
 
     public void renameColumn(AccumuloTable table, String source, String target)
     {
-        if (!table.getColumns().stream().anyMatch(columnHandle -> columnHandle.getName().equalsIgnoreCase(source))) {
+        if (table.getColumns().stream().noneMatch(columnHandle -> columnHandle.getName().equalsIgnoreCase(source))) {
             throw new PrestoException(NOT_FOUND, format("Failed to find source column %s to rename to %s", source, target));
         }
 

--- a/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/StaticSelector.java
+++ b/presto-resource-group-managers/src/main/java/io/prestosql/plugin/resourcegroups/StaticSelector.java
@@ -90,7 +90,7 @@ public class StaticSelector
             addVariableValues(userRegex.get(), criteria.getUser(), variables);
         }
 
-        if (userGroupRegex.isPresent() && !criteria.getUserGroups().stream().anyMatch(group -> userGroupRegex.get().matcher(group).matches())) {
+        if (userGroupRegex.isPresent() && criteria.getUserGroups().stream().noneMatch(group -> userGroupRegex.get().matcher(group).matches())) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
We can replace negative `anyMatch` with `noneMatch`.