### PR TITLE
Add support for Iceberg metadata delete

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -49,6 +49,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
@@ -57,6 +58,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -77,10 +79,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.prestosql.plugin.iceberg.ExpressionConverter.toIcebergExpression;
@@ -104,6 +109,7 @@ import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
+import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -374,7 +380,7 @@ public class IcebergMetadata
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
         }
 
-        TableMetadata metadata = newTableMetadata(operations, schema, partitionSpec, targetPath, propertiesBuilder.build());
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, propertiesBuilder.build());
 
         transaction = createTableTransaction(tableName, operations, metadata);
 
@@ -451,6 +457,12 @@ public class IcebergMetadata
         return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
                 .map(CommitTaskData::getPath)
                 .collect(toImmutableList())));
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return new IcebergColumnHandle(0, "$row_id", BIGINT, Optional.empty());
     }
 
     @Override
@@ -599,22 +611,46 @@ public class IcebergMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
+
         // TODO: Remove TupleDomain#simplify once Iceberg supports IN expression
         TupleDomain<IcebergColumnHandle> newDomain = constraint.getSummary()
                 .transform(IcebergColumnHandle.class::cast)
-                .simplify()
                 .intersect(table.getPredicate());
+
+        if (newDomain.isNone()) {
+            return Optional.empty();
+        }
 
         if (newDomain.equals(table.getPredicate())) {
             return Optional.empty();
         }
+
+        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+
+        List<PartitionField> fields = icebergTable.spec().fields().stream()
+                .filter(field -> field.transform().isIdentity())
+                .collect(toImmutableList());
+
+        // Ensure partition specs in all manifests contain the identity fields from the predicate
+        if (!icebergTable.specs().values().stream().allMatch(spec -> spec.fields().containsAll(fields))) {
+            return Optional.empty();
+        }
+
+        Set<Integer> partitionSourceIds = icebergTable.spec().fields().stream()
+                .filter(field -> field.transform().isIdentity())
+                .map(PartitionField::sourceId)
+                .collect(toImmutableSet());
+
+        BiPredicate<IcebergColumnHandle, Domain> contains = (column, domain) -> partitionSourceIds.contains(column.getId());
+        TupleDomain<ColumnHandle> remainingTupleDomain = newDomain.filter(contains.negate()).transform(ColumnHandle.class::cast);
+        TupleDomain<IcebergColumnHandle> enforcedTupleDomain = newDomain.filter(contains);
 
         return Optional.of(new ConstraintApplicationResult<>(
                 new IcebergTableHandle(table.getSchemaName(),
                         table.getTableName(),
                         table.getTableType(),
                         table.getSnapshotId(),
-                        newDomain),
-                constraint.getSummary()));
+                        enforcedTupleDomain),
+                remainingTupleDomain));
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSmoke.java
@@ -33,6 +33,8 @@ import static io.prestosql.plugin.iceberg.IcebergQueryRunner.createIcebergQueryR
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -198,6 +200,12 @@ public class TestIcebergSmoke
     public void testCreatePartitionedTable()
     {
         testWithAllFileFormats(this::testCreatePartitionedTable);
+    }
+
+    @Test
+    public void testOnePartitionCase()
+    {
+        testCreatePartitionedTable(getSession(), FileFormat.ORC);
     }
 
     private void testCreatePartitionedTable(Session session, FileFormat fileFormat)
@@ -796,16 +804,90 @@ public class TestIcebergSmoke
         dropTable(session, "test_bucket_transform");
     }
 
-    private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
+    @Test
+    public void testMetadataDeleteSimple()
     {
-        test.accept(getSession(), FileFormat.PARQUET);
-        test.accept(getSession(), FileFormat.ORC);
+        testWithAllFileFormats(this::testMetadataDeleteSimpleForFormat);
     }
 
-    private void dropTable(Session session, String table)
+    private void testMetadataDeleteSimpleForFormat(Session session, FileFormat format)
     {
-        assertUpdate(session, "DROP TABLE " + table);
-        assertFalse(getQueryRunner().tableExists(session, table));
+        assertUpdate(session, format("CREATE TABLE test_metadata_delete_simple (col1 BIGINT, col2 BIGINT) WITH (format = '%s', partitioning = ARRAY['col1'])", format.name()));
+        assertUpdate(session, "INSERT INTO test_metadata_delete_simple VALUES(1, 100), (1, 101), (1, 102), (2, 200), (2, 201), (3, 300)", 6);
+        assertQueryFails(
+                session,
+                "DELETE FROM test_metadata_delete_simple WHERE col1 = 1 AND col2 > 101",
+                "This connector only supports delete where one or more partitions are deleted entirely");
+        assertQuery(session, "SELECT sum(col2) FROM test_metadata_delete_simple", "SELECT 1004");
+        assertQuery(session, "SELECT count(*) FROM \"test_metadata_delete_simple$partitions\"", "SELECT 3");
+        assertUpdate(session, "DELETE FROM test_metadata_delete_simple WHERE col1 = 1");
+        assertQuery(session, "SELECT sum(col2) FROM test_metadata_delete_simple", "SELECT 701");
+        assertQuery(session, "SELECT count(*) FROM \"test_metadata_delete_simple$partitions\"", "SELECT 2");
+        dropTable(session, "test_metadata_delete_simple");
+    }
+
+    @Test
+    public void testMetadataDelete()
+    {
+        testWithAllFileFormats(this::testMetadataDeleteForFormat);
+    }
+
+    private void testMetadataDeleteForFormat(Session session, FileFormat format)
+    {
+        @Language("SQL") String createTable = "" +
+                "CREATE TABLE test_metadata_delete (" +
+                "  orderkey BIGINT," +
+                "  linenumber INTEGER," +
+                "  linestatus VARCHAR" +
+                ") " +
+                "WITH (" +
+                format(" format = '%s', partitioning = ARRAY[ 'linenumber', 'linestatus' ]", format.name()) +
+                ") ";
+
+        assertUpdate(session, createTable);
+
+        assertUpdate(session, "" +
+                        "INSERT INTO test_metadata_delete " +
+                        "SELECT orderkey, linenumber, linestatus " +
+                        "FROM tpch.tiny.lineitem",
+                "SELECT count(*) FROM lineitem");
+
+        assertQuery(session, "SELECT COUNT(*) FROM \"test_metadata_delete$partitions\"", "SELECT 14");
+
+        assertUpdate(session, "DELETE FROM test_metadata_delete WHERE linestatus = 'F' AND linenumber = 3");
+        assertQuery(session, "SELECT * FROM test_metadata_delete", "SELECT orderkey, linenumber, linestatus FROM lineitem WHERE linestatus <> 'F' or linenumber <> 3");
+        assertQuery(session, "SELECT count(*) FROM \"test_metadata_delete$partitions\"", "SELECT 13");
+
+        assertUpdate(session, "DELETE FROM test_metadata_delete WHERE linestatus='O'");
+        assertQuery(session, "SELECT count(*) FROM \"test_metadata_delete$partitions\"", "SELECT 6");
+        assertQuery(session, "SELECT * FROM test_metadata_delete", "SELECT orderkey, linenumber, linestatus FROM lineitem WHERE linestatus <> 'O' AND linenumber <> 3");
+
+        assertQueryFails("DELETE FROM test_metadata_delete WHERE orderkey=1", "This connector only supports delete where one or more partitions are deleted entirely");
+
+        dropTable(session, "test_metadata_delete");
+    }
+
+    @Test
+    public void testInSet()
+    {
+        testWithAllFileFormats((session, format) -> testInSetForFormat(session, format, 31));
+        testWithAllFileFormats((session, format) -> testInSetForFormat(session, format, 35));
+    }
+
+    private void testInSetForFormat(Session session, FileFormat format, int inCount)
+    {
+        String values = range(1, inCount + 1)
+                .mapToObj(n -> format("(%s, %s)", n, n + 10))
+                .collect(joining(", "));
+        String inList = range(1, inCount + 1)
+                .mapToObj(Integer::toString)
+                .collect(joining(", "));
+
+        assertUpdate(session, "CREATE TABLE test_in_set (col1 INTEGER, col2 BIGINT)");
+        assertUpdate(session, format("INSERT INTO test_in_set VALUES %s", values), inCount);
+        // This proves that SELECTs with large IN phrases work correctly
+        MaterializedResult result = computeActual(format("SELECT col1 FROM test_in_set WHERE col1 IN (%s)", inList));
+        dropTable(session, "test_in_set");
     }
 
     @Test
@@ -873,5 +955,17 @@ public class TestIcebergSmoke
 
         dropTable(session, "test_nested_table");
         dropTable(session, "test_nested_table2");
+    }
+
+    private void testWithAllFileFormats(BiConsumer<Session, FileFormat> test)
+    {
+        test.accept(getSession(), FileFormat.PARQUET);
+        test.accept(getSession(), FileFormat.ORC);
+    }
+
+    private void dropTable(Session session, String table)
+    {
+        assertUpdate(session, "DROP TABLE " + table);
+        assertFalse(getQueryRunner().tableExists(session, table));
     }
 }


### PR DESCRIPTION
This commit adds support for Iceberg metadata delete, as well as
a couple of smoke tests showing that it works correctly.

The changes required to support delete in IcebergMetadata.applyFilter()
included removal of a call to TupleDomain.simplify() on the constraint
summary domain, because otherwise the enforced and unenforced domains
don't equal the original set.  This is consistent with the Hive
treatment of TupleDomains.  It's mentioned here because it may result
in performance problems during query planning for queries of the form
SELECT ... FROM my_table WHERE x IN very_large_set, which was
apparently the reason the .simplify() call was added.