### PR TITLE
Update docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,9 @@ LABEL maintainer="Presto community <https://prestosql.io/community.html>"
 ENV JAVA_HOME /usr/lib/jvm/java-11
 RUN \
     set -xeu && \
+    yum -y -q install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
     yum -y -q update && \
-    yum -y -q install java-11-openjdk-devel less && \
+    yum -y -q install zulu11 less && \
     yum -q clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /tmp/* /var/tmp/* && \

--- a/docker/build-local.sh
+++ b/docker/build-local.sh
@@ -19,7 +19,7 @@ cp -R bin default ${WORK_DIR}/presto-server-${PRESTO_VERSION}
 
 cp ../presto-cli/target/presto-cli-${PRESTO_VERSION}-executable.jar ${WORK_DIR}
 
-docker build ${WORK_DIR} -f Dockerfile --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}"
+docker build ${WORK_DIR} --pull -f Dockerfile --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}"
 
 rm -r ${WORK_DIR}
 

--- a/docker/build-remote.sh
+++ b/docker/build-remote.sh
@@ -25,7 +25,7 @@ cp -R bin default ${WORK_DIR}/presto-server-${PRESTO_VERSION}
 curl -o ${WORK_DIR}/presto-cli-${PRESTO_VERSION}-executable.jar ${CLIENT_LOCATION}
 chmod +x ${WORK_DIR}/presto-cli-${PRESTO_VERSION}-executable.jar
 
-docker build ${WORK_DIR} -f Dockerfile -t "presto:${PRESTO_VERSION}" --build-arg "PRESTO_VERSION=${PRESTO_VERSION}"
+docker build ${WORK_DIR} --pull -f Dockerfile -t "presto:${PRESTO_VERSION}" --build-arg "PRESTO_VERSION=${PRESTO_VERSION}"
 
 rm -r ${WORK_DIR}
 


### PR DESCRIPTION
This would make two main changes:

1. Set docker build scripts to pull the latest base image
2. Since JDK 11.0.8 is not available in CentOS 7, update to 11.0.8 via the Zulu JDK

These changes were suggested in discussion with security@prestosql.io.