### PR TITLE
Mark the fields of ROW Type optional for Iceberg schema

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TypeConverter.java
@@ -198,7 +198,7 @@ public final class TypeConverter
         for (RowType.Field field : type.getFields()) {
             String name = field.getName().orElseThrow(() ->
                     new PrestoException(NOT_SUPPORTED, "Row type field does not have a name: " + type.getDisplayName()));
-            fields.add(Types.NestedField.required(fields.size() + 1, name, toIcebergType(field.getType())));
+            fields.add(Types.NestedField.optional(fields.size() + 1, name, toIcebergType(field.getType())));
         }
         return Types.StructType.of(fields);
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
@@ -44,6 +44,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -250,7 +251,8 @@ public class TestingPrestoClient
         }
         else if (type instanceof RowType) {
             List<Type> fieldTypes = type.getTypeParameters();
-            List<Object> fieldValues = ImmutableList.copyOf(((Map<?, ?>) value).values());
+            Collection<?> values = ((Map<?, ?>) value).values();
+            List<Object> fieldValues = new ArrayList(values);
             return dataToRow(fieldTypes).apply(fieldValues);
         }
         else if (type instanceof DecimalType) {


### PR DESCRIPTION
Currently the fields of ROW type in Iceberg schema are marked as 'required'.
In reality, if the fields are optional, the writer may write a null value for
those fields. In such a case, the parquet file can not be read by parquet
reader or Presto. Since Presto doesn't have a way to specify required/optional
designation for ROW fields, this commit marks the fields as 'optional'.