### PR TITLE
Disable JIT byte code recompilation cutoffs in default jvm.config

### DIFF
--- a/docker/default/etc/jvm.config
+++ b/docker/default/etc/jvm.config
@@ -8,5 +8,7 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=256M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -109,6 +109,8 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:+ExitOnOutOfMemoryError
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:ReservedCodeCacheSize=512M
+    -XX:PerMethodRecompilationCutoff=10000
+    -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
 

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -9,6 +9,8 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 # jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
 -Djdk.nio.maxCachedBufferSize=0

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -8,6 +8,8 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 # jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
 -Djdk.nio.maxCachedBufferSize=0

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -8,6 +8,8 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 # jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
 -Djdk.nio.maxCachedBufferSize=0

--- a/presto-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/presto-server-rpm/src/main/resources/dist/config/jvm.config
@@ -8,5 +8,7 @@
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=512M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000


### PR DESCRIPTION
Setting PerMethodRecompilationCutoff and PerBytecodeRecompilationCutoff to 10000
effectively disables these cutoff limits and JIT always recompiles code on hitting
"uncommon-trap". Without this, after hitting these cutoff limits JVM may enter a state
where it wastes CPU cycles in "uncommon-trap" handling but taking no action out of it.

This is based on [this work](https://docs.google.com/viewer?a=v&pid=forums&srcid=MTc4Njc1ODQ2NjUwMjMyMTg5MDgBMDI1NjY5NTA0OTU3NDE4MjA2MzABeVZ2NFEweGRCUUFKATAuMQEBdjI&authuser=0)) and we have seen this issue in java8 and these configs helped out. 