### PR TITLE
System Table for Optimizer Rule Stats

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/system/RuleStatsSystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/RuleStatsSystemTable.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.connector.system;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.connector.FixedPageSource;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.RuleStatsRecorder;
+import io.prestosql.sql.planner.iterative.RuleStats;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static io.prestosql.spi.connector.SystemTable.Distribution.SINGLE_COORDINATOR;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.TypeSignature.mapType;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class RuleStatsSystemTable
+        implements SystemTable
+{
+    private static final SchemaTableName TABLE_NAME = new SchemaTableName("runtime", "optimizer_rule_stats");
+    private final ConnectorTableMetadata ruleStatsTable;
+    private final Optional<RuleStatsRecorder> ruleStatsRecorder;
+
+    @Inject
+    public RuleStatsSystemTable(Optional<RuleStatsRecorder> ruleStatsRecorder, Metadata metadata)
+    {
+        this.ruleStatsRecorder = requireNonNull(ruleStatsRecorder, "ruleStatsRecorder is null");
+        requireNonNull(metadata, "metadata is null");
+
+        this.ruleStatsTable = tableMetadataBuilder(TABLE_NAME)
+                .column("rule_name", VARCHAR)
+                .column("invocations", BIGINT)
+                .column("matches", BIGINT)
+                .column("failures", BIGINT)
+                .column("average_time", DOUBLE)
+                .column("time_distribution_percentiles", metadata.getType(mapType(DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())))
+                .build();
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return ruleStatsTable;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        checkState(ruleStatsRecorder.isPresent(), "Rule stats system table can return results only on coordinator");
+        Map<Class<?>, RuleStats> ruleStats = ruleStatsRecorder.get().getStats();
+
+        int positionCount = ruleStats.size();
+        Map<String, BlockBuilder> blockBuilders = ruleStatsTable.getColumns().stream()
+                .collect(toImmutableMap(ColumnMetadata::getName, column -> column.getType().createBlockBuilder(null, positionCount)));
+
+        for (Map.Entry<Class<?>, RuleStats> entry : ruleStats.entrySet()) {
+            RuleStats stats = entry.getValue();
+
+            VARCHAR.writeString(blockBuilders.get("rule_name"), entry.getKey().getSimpleName());
+            BIGINT.writeLong(blockBuilders.get("invocations"), stats.getInvocations());
+            BIGINT.writeLong(blockBuilders.get("matches"), stats.getHits());
+            BIGINT.writeLong(blockBuilders.get("failures"), stats.getFailures());
+            DOUBLE.writeDouble(blockBuilders.get("average_time"), stats.getTime().getAvg());
+
+            BlockBuilder mapWriter = blockBuilders.get("time_distribution_percentiles").beginBlockEntry();
+            for (Map.Entry<Double, Double> percentile : stats.getTime().getPercentiles().entrySet()) {
+                DOUBLE.writeDouble(mapWriter, percentile.getKey());
+                DOUBLE.writeDouble(mapWriter, percentile.getValue());
+            }
+            blockBuilders.get("time_distribution_percentiles").closeEntry();
+        }
+
+        Block[] blocks = ruleStatsTable.getColumns().stream()
+                .map(column -> blockBuilders.get(column.getName()).build())
+                .toArray(Block[]::new);
+
+        return new FixedPageSource(ImmutableList.of(new Page(positionCount, blocks)));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/SystemConnectorModule.java
@@ -55,6 +55,7 @@ public class SystemConnectorModule
         globalTableBinder.addBinding().to(ColumnPropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(AnalyzePropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TransactionsSystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(RuleStatsSystemTable.class).in(Scopes.SINGLETON);
 
         globalTableBinder.addBinding().to(AttributeJdbcTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(CatalogJdbcTable.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/CoordinatorModule.java
@@ -82,6 +82,7 @@ import io.prestosql.spi.security.SelectedRole;
 import io.prestosql.sql.analyzer.QueryExplainer;
 import io.prestosql.sql.planner.PlanFragmenter;
 import io.prestosql.sql.planner.PlanOptimizers;
+import io.prestosql.sql.planner.RuleStatsRecorder;
 import io.prestosql.transaction.ForTransactionManager;
 import io.prestosql.transaction.InMemoryTransactionManager;
 import io.prestosql.transaction.TransactionManager;
@@ -209,6 +210,9 @@ public class CoordinatorModule
         // planner
         binder.bind(PlanFragmenter.class).in(Scopes.SINGLETON);
         binder.bind(PlanOptimizers.class).in(Scopes.SINGLETON);
+
+        // Rule Stats Recorder
+        binder.bind(RuleStatsRecorder.class).in(Scopes.SINGLETON);
 
         // query explainer
         binder.bind(QueryExplainer.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -124,6 +124,7 @@ import io.prestosql.sql.parser.SqlParserOptions;
 import io.prestosql.sql.planner.CompilerConfig;
 import io.prestosql.sql.planner.LocalExecutionPlanner;
 import io.prestosql.sql.planner.NodePartitioningManager;
+import io.prestosql.sql.planner.RuleStatsRecorder;
 import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.transaction.TransactionManagerConfig;
@@ -432,6 +433,10 @@ public class ServerMainModule
         // dispatcher
         // TODO remove dispatcher fromm ServerMainModule, and bind dependent components only on coordinators
         OptionalBinder.newOptionalBinder(binder, DispatchManager.class);
+
+        // Added for RuleStatsSystemTable
+        // TODO: remove this when system tables are bound separately for coordinator and worker
+        OptionalBinder.newOptionalBinder(binder, RuleStatsRecorder.class);
 
         // cleanup
         binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -207,7 +207,7 @@ import java.util.Set;
 public class PlanOptimizers
 {
     private final List<PlanOptimizer> optimizers;
-    private final RuleStatsRecorder ruleStats = new RuleStatsRecorder();
+    private final RuleStatsRecorder ruleStats;
     private final OptimizerStatsRecorder optimizerStats = new OptimizerStatsRecorder();
     private final MBeanExporter exporter;
 
@@ -223,7 +223,8 @@ public class PlanOptimizers
             CostCalculator costCalculator,
             @EstimatedExchanges CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
-            TaskCountEstimator taskCountEstimator)
+            TaskCountEstimator taskCountEstimator,
+            RuleStatsRecorder ruleStats)
     {
         this(metadata,
                 typeAnalyzer,
@@ -236,7 +237,8 @@ public class PlanOptimizers
                 costCalculator,
                 estimatedExchangesCostCalculator,
                 costComparator,
-                taskCountEstimator);
+                taskCountEstimator,
+                ruleStats);
     }
 
     @PostConstruct
@@ -265,8 +267,10 @@ public class PlanOptimizers
             CostCalculator costCalculator,
             CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
-            TaskCountEstimator taskCountEstimator)
+            TaskCountEstimator taskCountEstimator,
+            RuleStatsRecorder ruleStats)
     {
+        this.ruleStats = ruleStats;
         this.exporter = exporter;
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RuleStatsRecorder.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RuleStatsRecorder.java
@@ -82,4 +82,9 @@ public class RuleStatsRecorder
         }
         mbeanExports.clear();
     }
+
+    public Map<Class<?>, RuleStats> getStats()
+    {
+        return ImmutableMap.copyOf(stats);
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/RuleStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/RuleStats.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class RuleStats
 {
+    private final AtomicLong invocations = new AtomicLong();
     private final AtomicLong hits = new AtomicLong();
     private final TimeDistribution time = new TimeDistribution(TimeUnit.MICROSECONDS);
     private final AtomicLong failures = new AtomicLong();
@@ -32,12 +33,19 @@ public class RuleStats
             hits.incrementAndGet();
         }
 
+        invocations.incrementAndGet();
         time.add(nanos);
     }
 
     public void recordFailure()
     {
         failures.incrementAndGet();
+    }
+
+    @Managed
+    public long getInvocations()
+    {
+        return invocations.get();
     }
 
     @Managed

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -143,6 +143,7 @@ import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.PlanFragmenter;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
 import io.prestosql.sql.planner.PlanOptimizers;
+import io.prestosql.sql.planner.RuleStatsRecorder;
 import io.prestosql.sql.planner.SubPlan;
 import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
@@ -833,7 +834,8 @@ public class LocalQueryRunner
                 costCalculator,
                 estimatedExchangesCostCalculator,
                 new CostComparator(featuresConfig),
-                taskCountEstimator).get();
+                taskCountEstimator,
+                new RuleStatsRecorder()).get();
     }
 
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, WarningCollector warningCollector)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -70,6 +70,12 @@ system| runtime| nodes| http_uri| varchar| YES| null| null|
 system| runtime| nodes| node_version| varchar| YES| null| null|
 system| runtime| nodes| coordinator| boolean| YES| null| null|
 system| runtime| nodes| state| varchar| YES| null| null|
+system| runtime| optimizer_rule_stats| rule_name| varchar| YES| null| null|
+system| runtime| optimizer_rule_stats| invocations| bigint| YES| null| null|
+system| runtime| optimizer_rule_stats| matches| bigint| YES| null| null|
+system| runtime| optimizer_rule_stats| failures| bigint| YES| null| null|
+system| runtime| optimizer_rule_stats| average_time| double| YES| null| null|
+system| runtime| optimizer_rule_stats| time_distribution_percentiles| map(double, double)| YES| null| null|
 system| runtime| queries| query_id| varchar| YES| null| null|
 system| runtime| queries| state| varchar| YES| null| null|
 system| runtime| queries| user| varchar| YES| null| null|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaTables.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaTables.result
@@ -1,4 +1,4 @@
--- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true; 
+-- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true;
 system | information_schema | columns  | BASE TABLE |
 system | information_schema | tables   | BASE TABLE |
 system | information_schema | views    | BASE TABLE |
@@ -7,3 +7,4 @@ system | runtime            | nodes    | BASE TABLE |
 system | metadata           | catalogs | BASE TABLE |
 system | runtime            | queries  | BASE TABLE |
 system | runtime            | tasks    | BASE TABLE |
+system | runtime            | optimizer_rule_stats | BASE TABLE |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemRuntime.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemRuntime.result
@@ -3,3 +3,4 @@ nodes|
 queries|
 tasks|
 transactions|
+optimizer_rule_stats|

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -34,6 +34,7 @@ import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.PlanFragmenter;
 import io.prestosql.sql.planner.PlanOptimizers;
+import io.prestosql.sql.planner.RuleStatsRecorder;
 import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
 import io.prestosql.sql.tree.ExplainType;
@@ -358,7 +359,8 @@ public abstract class AbstractTestQueryFramework
                 costCalculator,
                 new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator),
                 new CostComparator(featuresConfig),
-                taskCountEstimator).get();
+                taskCountEstimator,
+                new RuleStatsRecorder()).get();
         return new QueryExplainer(
                 optimizers,
                 new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig()),


### PR DESCRIPTION
#4504

I think a single-page pagesource would be okay, since the total size (from `page.getSizeInBytes()`) comes out to be `~389K`. (mainly from the map block for percentiles) 