### PR TITLE
Add push down documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -89,6 +89,18 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``postgresql`` in the above examples.
 
+Push down
+---------
+
+The connector supports :doc:`push down </optimizer/push-down>` for processing
+the following aggregate functions:
+
+* :func:`avg`
+* :func:`count`
+* :func:`max`
+* :func:`min`
+* :func:`sum`
+
 Limitations
 -----------
 

--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -89,11 +89,11 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``postgresql`` in the above examples.
 
-Push down
----------
+Pushdown
+--------
 
-The connector supports :doc:`push down </optimizer/push-down>` for processing
-the following aggregate functions:
+The connector supports :doc:`pushdown </optimizer/pushdown>` for processing the
+following aggregate functions:
 
 * :func:`avg`
 * :func:`count`

--- a/presto-docs/src/main/sphinx/optimizer.rst
+++ b/presto-docs/src/main/sphinx/optimizer.rst
@@ -8,4 +8,4 @@ Query Optimizer
     optimizer/statistics
     optimizer/cost-in-explain
     optimizer/cost-based-optimizations
-    optimizer/push-down
+    optimizer/pushdown

--- a/presto-docs/src/main/sphinx/optimizer.rst
+++ b/presto-docs/src/main/sphinx/optimizer.rst
@@ -8,3 +8,4 @@ Query Optimizer
     optimizer/statistics
     optimizer/cost-in-explain
     optimizer/cost-based-optimizations
+    optimizer/push-down

--- a/presto-docs/src/main/sphinx/optimizer/push-down.rst
+++ b/presto-docs/src/main/sphinx/optimizer/push-down.rst
@@ -1,0 +1,143 @@
+=========
+Push down
+=========
+
+Presto can push down the processing of queries, or parts of queries, into the
+connected data source. This means that a specific function, or other operation,
+is passed through to the underlying database or storage system for processing.
+
+
+
+The results of this push down can include the following benefits:
+
+* improved overall query performance
+* reduced network traffic between Presto and the data source
+* reduced load on the remote data source
+
+Support for push down is specific to each connector and the relevant underlying
+database or storage system.
+
+Analysis and Confirmation
+-------------------------
+
+Push down depends on a number of factors:
+
+* generic support for push down for that function in Presto
+* function or operation specific support for push down in the connector
+* query that allows the detection of the function to push down
+* function needs to exist in the underlying system so it can process the push
+  down
+
+The best way to analyze if push down for a specific query is performed is to
+take a closer look at the :doc:`EXPLAIN plan </sql/explain>` of the query. If an
+operation such as an aggregate function is successfully pushed down to the
+connector, the explain plan does **not** show that operator. The explain plan
+only shows the operations that are performed by Presto.
+
+As an example, we loaded the TPCH data set into a PostgreSQL database and then
+queried it using the PostgreSQL connector::
+
+
+    SELECT regionkey, count(*)
+    FROM nation
+    GROUP BY regionkey;
+
+You can get the explain plan by prepending the above query with ``EXPLAIN``::
+
+    EXPLAIN
+    SELECT regionkey, count(*)
+    FROM nation
+    GROUP BY regionkey;
+
+The explain plan for this query does not show any ``Aggregate`` operator with
+the ``count`` function, as this operation is now performed by the connector. You
+can see the ``count(*)`` function as part of the PostgreSQL ``TableScan``
+operator. This shows you that the pushdown was successful.
+
+.. code-block:: none
+
+    Fragment 0 [SINGLE]
+        Output layout: [regionkey_0, _presto_generated_1]
+        Output partitioning: SINGLE []
+        Stage Execution Strategy: UNGROUPED_EXECUTION
+        Output[regionkey, _col1]
+        │   Layout: [regionkey_0:bigint, _presto_generated_1:bigint]
+        │   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: ?}
+        │   regionkey := regionkey_0
+        │   _col1 := _presto_generated_1
+        └─ RemoteSource[1]
+                Layout: [regionkey_0:bigint, _presto_generated_1:bigint]
+
+    Fragment 1 [SOURCE]
+        Output layout: [regionkey_0, _presto_generated_1]
+        Output partitioning: SINGLE []
+        Stage Execution Strategy: UNGROUPED_EXECUTION
+        TableScan[postgresql:tpch.nation tpch.nation columns=[regionkey:bigint:int8, count(*):_presto_generated_1:bigint:bigint] groupingSets=[[regionkey:bigint:int8]], gro
+            Layout: [regionkey_0:bigint, _presto_generated_1:bigint]
+            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
+            _presto_generated_1 := count(*):_presto_generated_1:bigint:bigint
+            regionkey_0 := regionkey:bigint:int8
+
+A number of factors can prevent a push down:
+
+* adding a condition to the query
+* using a different aggregate function without push down support in Presto
+* using a function that has no native equivalent in the underlying data source
+* using a connector without push down support for the specific function
+
+As a result, the explain plan shows the ``Aggregate`` operation being performed
+by Presto. This is a clear sign that now push down to the database is not
+performed, and instead Presto performs the aggregate processing.
+
+.. code-block:: none
+
+ Fragment 0 [SINGLE]
+     Output layout: [regionkey, count]
+     Output partitioning: SINGLE []
+     Stage Execution Strategy: UNGROUPED_EXECUTION
+     Output[regionkey, _col1]
+     │   Layout: [regionkey:bigint, count:bigint]
+     │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
+     │   _col1 := count
+     └─ RemoteSource[1]
+            Layout: [regionkey:bigint, count:bigint]
+
+ Fragment 1 [HASH]
+     Output layout: [regionkey, count]
+     Output partitioning: SINGLE []
+     Stage Execution Strategy: UNGROUPED_EXECUTION
+     Aggregate(FINAL)[regionkey]
+     │   Layout: [regionkey:bigint, count:bigint]
+     │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
+     │   count := count("count_0")
+     └─ LocalExchange[HASH][$hashvalue] ("regionkey")
+        │   Layout: [regionkey:bigint, count_0:bigint, $hashvalue:bigint]
+        │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
+        └─ RemoteSource[2]
+               Layout: [regionkey:bigint, count_0:bigint, $hashvalue_1:bigint]
+
+ Fragment 2 [SOURCE]
+     Output layout: [regionkey, count_0, $hashvalue_2]
+     Output partitioning: HASH [regionkey][$hashvalue_2]
+     Stage Execution Strategy: UNGROUPED_EXECUTION
+     Project[]
+     │   Layout: [regionkey:bigint, count_0:bigint, $hashvalue_2:bigint]
+     │   Estimates: {rows: ? (?), cpu: ?, memory: ?, network: ?}
+     │   $hashvalue_2 := combine_hash(bigint '0', COALESCE("$operator$hash_code"("regionkey"), 0))
+     └─ Aggregate(PARTIAL)[regionkey]
+        │   Layout: [regionkey:bigint, count_0:bigint]
+        │   count_0 := count(*)
+        └─ TableScan[tpch:nation:sf0.01, grouped = false]
+               Layout: [regionkey:bigint]
+               Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
+               regionkey := tpch:regionkey
+
+Limitations
+-----------
+
+Push down does not support a number of more complex statements:
+
+* complex grouping operations such as ``ROLLUP``, ``CUBE``, or ``GROUPING SETS``
+* expressions inside the aggregation function call: ``sum(a * b)``
+* coercions: ``sum(integer_column)``
+

--- a/presto-docs/src/main/sphinx/optimizer/pushdown.rst
+++ b/presto-docs/src/main/sphinx/optimizer/pushdown.rst
@@ -1,34 +1,32 @@
-=========
-Push down
-=========
+========
+Pushdown
+========
 
 Presto can push down the processing of queries, or parts of queries, into the
 connected data source. This means that a specific function, or other operation,
 is passed through to the underlying database or storage system for processing.
 
-
-
-The results of this push down can include the following benefits:
+The results of this pushdown can include the following benefits:
 
 * improved overall query performance
 * reduced network traffic between Presto and the data source
 * reduced load on the remote data source
 
-Support for push down is specific to each connector and the relevant underlying
+Support for pushdown is specific to each connector and the relevant underlying
 database or storage system.
 
 Analysis and Confirmation
 -------------------------
 
-Push down depends on a number of factors:
+Pushdown depends on a number of factors:
 
-* generic support for push down for that function in Presto
-* function or operation specific support for push down in the connector
+* generic support for pushdown for that function in Presto
+* function or operation specific support for pushdown in the connector
 * query that allows the detection of the function to push down
-* function needs to exist in the underlying system so it can process the push
-  down
+* function needs to exist in the underlying system so it can process the
+  pushdown
 
-The best way to analyze if push down for a specific query is performed is to
+The best way to analyze if pushdown for a specific query is performed is to
 take a closer look at the :doc:`EXPLAIN plan </sql/explain>` of the query. If an
 operation such as an aggregate function is successfully pushed down to the
 connector, the explain plan does **not** show that operator. The explain plan
@@ -36,7 +34,6 @@ only shows the operations that are performed by Presto.
 
 As an example, we loaded the TPCH data set into a PostgreSQL database and then
 queried it using the PostgreSQL connector::
-
 
     SELECT regionkey, count(*)
     FROM nation
@@ -81,12 +78,12 @@ operator. This shows you that the pushdown was successful.
 A number of factors can prevent a push down:
 
 * adding a condition to the query
-* using a different aggregate function without push down support in Presto
+* using a different aggregate function without pushdown support in Presto
 * using a function that has no native equivalent in the underlying data source
-* using a connector without push down support for the specific function
+* using a connector without pushdown support for the specific function
 
 As a result, the explain plan shows the ``Aggregate`` operation being performed
-by Presto. This is a clear sign that now push down to the database is not
+by Presto. This is a clear sign that now pushdown to the database is not
 performed, and instead Presto performs the aggregate processing.
 
 .. code-block:: none
@@ -135,7 +132,7 @@ performed, and instead Presto performs the aggregate processing.
 Limitations
 -----------
 
-Push down does not support a number of more complex statements:
+Pushdown does not support a number of more complex statements:
 
 * complex grouping operations such as ``ROLLUP``, ``CUBE``, or ``GROUPING SETS``
 * expressions inside the aggregation function call: ``sum(a * b)``


### PR DESCRIPTION
Replacement for https://github.com/prestosql/presto/pull/4369 since rebase confused github .. 

Can we please get this merged asap @electrum and @findepi ? We can reiterate further if necessary in terms of specific functions and coverage in other connectors or whatever. By the time we release 340 I want to make sure this is in and ideally up to date as well. In either case though .. this is better than not having anything since 338 when the feature started landing in 338.