### PR TITLE
Support missingColumnsOnInsert in the Phoenix Connector.

### DIFF
--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixOutputTableHandle.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixOutputTableHandle.java
@@ -22,10 +22,12 @@ import io.prestosql.spi.type.Type;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 public class PhoenixOutputTableHandle
         extends JdbcOutputTableHandle
 {
-    private final boolean hasUuidRowKey;
+    private final Optional<String> rowkeyColumn;
 
     @JsonCreator
     public PhoenixOutputTableHandle(
@@ -34,15 +36,15 @@ public class PhoenixOutputTableHandle
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
-            @JsonProperty("hadUUIDRowkey") boolean hasUUIDRowkey)
+            @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
         super("", schemaName.orElse(null), tableName, columnNames, columnTypes, jdbcColumnTypes, "");
-        this.hasUuidRowKey = hasUUIDRowkey;
+        this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
     }
 
     @JsonProperty
-    public boolean hasUUIDRowkey()
+    public Optional<String> rowkeyColumn()
     {
-        return hasUuidRowKey;
+        return rowkeyColumn;
     }
 }

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
@@ -180,6 +180,16 @@ public class TestPhoenixIntegrationSmokeTest
         assertQuery("SELECT Val1 FROM testcaseinsensitive where Val1 < 1.2", "SELECT 1.1");
     }
 
+    @Test
+    public void testMissingColumnsOnInsert()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.test_col_insert(pk VARCHAR NOT NULL PRIMARY KEY, col1 VARCHAR, col2 VARCHAR)");
+        assertUpdate("INSERT INTO test_col_insert(pk, col1) VALUES('1', 'val1')", 1);
+        assertUpdate("INSERT INTO test_col_insert(pk, col2) VALUES('1', 'val2')", 1);
+        assertQuery("SELECT * FROM test_col_insert", "SELECT 1, 'val1', 'val2'");
+    }
+
     private void executeInPhoenix(String sql)
             throws SQLException
     {


### PR DESCRIPTION
See #4562

This is needed to provide for expected Phoenix INSERT semantics, specifically when inserting using an existing row key. Without this previous values of columns would be incorrectly overwritten.

Phoenix indicates NULL columns by not storing them. When an existing row is updated whatever the old value of a non-specified column was, should be retained.

~~This adds the functionality, still need to think about tests.~~
