### PR TITLE
Add iterative rules for pruning correlation list

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -66,6 +66,7 @@ import io.prestosql.sql.planner.iterative.rule.MultipleDistinctAggregationToMark
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneApplyColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneApplyCorrelation;
 import io.prestosql.sql.planner.iterative.rule.PruneApplySourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAssignUniqueIdColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
@@ -276,6 +277,7 @@ public class PlanOptimizers
                 new PruneAggregationColumns(),
                 new PruneAggregationSourceColumns(),
                 new PruneApplyColumns(),
+                new PruneApplyCorrelation(),
                 new PruneApplySourceColumns(),
                 new PruneAssignUniqueIdColumns(),
                 new PruneCorrelatedJoinColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -70,6 +70,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneApplyCorrelation;
 import io.prestosql.sql.planner.iterative.rule.PruneApplySourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneAssignUniqueIdColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneCorrelatedJoinCorrelation;
 import io.prestosql.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import io.prestosql.sql.planner.iterative.rule.PruneDeleteSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneDistinctAggregation;
@@ -281,6 +282,7 @@ public class PlanOptimizers
                 new PruneApplySourceColumns(),
                 new PruneAssignUniqueIdColumns(),
                 new PruneCorrelatedJoinColumns(),
+                new PruneCorrelatedJoinCorrelation(),
                 new PruneDeleteSourceColumns(),
                 new PruneDistinctLimitSourceColumns(),
                 new PruneEnforceSingleRowColumns(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneApplyCorrelation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneApplyCorrelation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.ApplyNode;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.sql.planner.SymbolsExtractor.extractUnique;
+import static io.prestosql.sql.planner.plan.Patterns.applyNode;
+
+/**
+ * This rule updates ApplyNode's correlation list.
+ * A symbol can be removed from the correlation list if it is not referenced by the subquery node.
+ * Note: This rule does not restrict ApplyNode's children outputs. It requires additional information
+ * about context (symbols required by the outer plan) and is done in PruneApplyColumns rule.
+ */
+public class PruneApplyCorrelation
+        implements Rule<ApplyNode>
+{
+    private static final Pattern<ApplyNode> PATTERN = applyNode();
+
+    @Override
+    public Pattern<ApplyNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ApplyNode applyNode, Captures captures, Context context)
+    {
+        Set<Symbol> subquerySymbols = extractUnique(applyNode.getSubquery(), context.getLookup());
+        List<Symbol> newCorrelation = applyNode.getCorrelation().stream()
+                .filter(subquerySymbols::contains)
+                .collect(toImmutableList());
+
+        if (newCorrelation.size() < applyNode.getCorrelation().size()) {
+            return Result.ofPlanNode(new ApplyNode(
+                    applyNode.getId(),
+                    applyNode.getInput(),
+                    applyNode.getSubquery(),
+                    applyNode.getSubqueryAssignments(),
+                    newCorrelation,
+                    applyNode.getOriginSubquery()));
+        }
+
+        return Result.empty();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCorrelatedJoinCorrelation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCorrelatedJoinCorrelation.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.sql.planner.SymbolsExtractor.extractUnique;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
+
+/**
+ * This rule updates CorrelatedJoinNode's correlation list.
+ * A symbol can be removed from the correlation list if it is not referenced by the subquery node.
+ * Note: This rule does not restrict CorrelatedJoinNode's children outputs. It requires additional information
+ * about context (symbols required by the outer plan) and is done in PruneCorrelatedJoinColumns rule.
+ */
+
+public class PruneCorrelatedJoinCorrelation
+        implements Rule<CorrelatedJoinNode>
+{
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin();
+
+    @Override
+    public Pattern<CorrelatedJoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
+    {
+        Set<Symbol> subquerySymbols = extractUnique(correlatedJoinNode.getSubquery(), context.getLookup());
+        List<Symbol> newCorrelation = correlatedJoinNode.getCorrelation().stream()
+                .filter(subquerySymbols::contains)
+                .collect(toImmutableList());
+
+        if (newCorrelation.size() < correlatedJoinNode.getCorrelation().size()) {
+            return Result.ofPlanNode(new CorrelatedJoinNode(
+                    correlatedJoinNode.getId(),
+                    correlatedJoinNode.getInput(),
+                    correlatedJoinNode.getSubquery(),
+                    newCorrelation,
+                    correlatedJoinNode.getType(),
+                    correlatedJoinNode.getFilter(),
+                    correlatedJoinNode.getOriginSubquery()));
+        }
+
+        return Result.empty();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneApplyColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneApplyColumns.java
@@ -223,7 +223,7 @@ public class TestPruneApplyColumns
     }
 
     @Test
-    public void testPruneUnreferencedCorrelationSymbol()
+    public void testDoNotPruneUnreferencedCorrelationSymbol()
     {
         tester().assertThat(new PruneApplyColumns())
                 .on(p -> {
@@ -239,16 +239,7 @@ public class TestPruneApplyColumns
                                     p.values(a, correlationSymbol),
                                     p.values(subquerySymbol)));
                 })
-                .matches(
-                        project(
-                                ImmutableMap.of("a", PlanMatchPattern.expression("a"), "in_result", PlanMatchPattern.expression("in_result")),
-                                apply(
-                                        ImmutableList.of(),
-                                        ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
-                                        project(
-                                                ImmutableMap.of("a", PlanMatchPattern.expression("a")),
-                                                values("a", "correlation_symbol")),
-                                        values("subquery_symbol"))));
+                .doesNotFire();
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneApplyCorrelation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneApplyCorrelation.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.assertions.ExpressionMatcher;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.tree.ComparisonExpression;
+import io.prestosql.sql.tree.InPredicate;
+import io.prestosql.sql.tree.SymbolReference;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.apply;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
+
+public class TestPruneApplyCorrelation
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneCorrelationSymbolNotReferencedInSubquery()
+    {
+        tester().assertThat(new PruneApplyCorrelation())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol inputSymbol = p.symbol("input_symbol");
+                    Symbol subquerySymbol = p.symbol("subquery_symbol");
+                    Symbol inResult = p.symbol("in_result");
+                    return p.apply(
+                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                            ImmutableList.of(inputSymbol),
+                            p.values(a, inputSymbol),
+                            p.values(subquerySymbol));
+                })
+                .matches(
+                        apply(
+                                ImmutableList.of(),
+                                ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
+                                values("a", "input_symbol"),
+                                values("subquery_symbol")));
+    }
+
+    @Test
+    public void testAllCorrelationSymbolsReferencedInSubquery()
+    {
+        tester().assertThat(new PruneApplyCorrelation())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol inputSymbol = p.symbol("input_symbol");
+                    Symbol subquerySymbol = p.symbol("subquery_symbol");
+                    Symbol inResult = p.symbol("in_result");
+                    return p.apply(
+                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                            ImmutableList.of(inputSymbol),
+                            p.values(a, inputSymbol),
+                            p.filter(
+                                    new ComparisonExpression(GREATER_THAN, subquerySymbol.toSymbolReference(), inputSymbol.toSymbolReference()),
+                                    p.values(subquerySymbol)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneCorrelatedJoinCorrelation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneCorrelatedJoinCorrelation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.tree.ComparisonExpression;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.correlatedJoin;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
+
+public class TestPruneCorrelatedJoinCorrelation
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneCorrelationSymbolNotReferencedInSubquery()
+    {
+        tester().assertThat(new PruneCorrelatedJoinCorrelation())
+                .on(p -> {
+                    Symbol inputSymbol = p.symbol("input_symbol");
+                    Symbol subquerySymbol = p.symbol("subquery_symbol");
+                    return p.correlatedJoin(
+                            ImmutableList.of(inputSymbol),
+                            p.values(inputSymbol),
+                            p.values(subquerySymbol));
+                })
+                .matches(
+                        correlatedJoin(
+                                ImmutableList.of(),
+                                values("input_symbol"),
+                                values("subquery_symbol")));
+    }
+
+    @Test
+    public void testAllCorrelationSymbolsReferencedInSubquery()
+    {
+        tester().assertThat(new PruneCorrelatedJoinCorrelation())
+                .on(p -> {
+                    Symbol inputSymbol = p.symbol("input_symbol");
+                    Symbol subquerySymbol = p.symbol("subquery_symbol");
+                    return p.correlatedJoin(
+                            ImmutableList.of(inputSymbol),
+                            p.values(inputSymbol),
+                            p.filter(
+                                    new ComparisonExpression(GREATER_THAN, subquerySymbol.toSymbolReference(), inputSymbol.toSymbolReference()),
+                                    p.values(subquerySymbol)));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Adds rules for pruning correlation lists of `ApplyNode` and `CorrelatedJoinNode`.
Removes pruning of correlation list from project-off rules.
