### PR TITLE
Add missing synchronize

### DIFF
--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorSplitManager.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorSplitManager.java
@@ -162,7 +162,7 @@ public class RaptorSplitManager
         }
 
         @Override
-        public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
+        public synchronized CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
         {
             checkState((future == null) || future.isDone(), "previous batch not completed");
             future = supplyAsync(batchSupplier(maxSize), executor);


### PR DESCRIPTION
RaptorSplitManager.RaptorSplitSource#future is
guarded by this, therefore it's access should
be synchronized