### PR TITLE
Use session time zone for record decoder temporal types

### DIFF
--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSetProvider.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSetProvider.java
@@ -58,17 +58,17 @@ public class KafkaRecordSetProvider
                 .collect(ImmutableList.toImmutableList());
 
         RowDecoder keyDecoder = decoderFactory.create(
+                session,
                 kafkaSplit.getKeyDataFormat(),
-                getDecoderParameters(kafkaSplit.getKeyDataSchemaContents()),
-                kafkaColumns.stream()
+                getDecoderParameters(kafkaSplit.getKeyDataSchemaContents()), kafkaColumns.stream()
                         .filter(col -> !col.isInternal())
                         .filter(KafkaColumnHandle::isKeyCodec)
                         .collect(toImmutableSet()));
 
         RowDecoder messageDecoder = decoderFactory.create(
+                session,
                 kafkaSplit.getMessageDataFormat(),
-                getDecoderParameters(kafkaSplit.getMessageDataSchemaContents()),
-                kafkaColumns.stream()
+                getDecoderParameters(kafkaSplit.getMessageDataSchemaContents()), kafkaColumns.stream()
                         .filter(col -> !col.isInternal())
                         .filter(col -> !col.isKeyCodec())
                         .collect(toImmutableSet()));

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisRecordSetProvider.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisRecordSetProvider.java
@@ -63,9 +63,9 @@ public class KinesisRecordSetProvider
         ImmutableList.Builder<KinesisColumnHandle> handleBuilder = ImmutableList.builder();
 
         RowDecoder messageDecoder = decoderFactory.create(
+                session,
                 kinesisSplit.getMessageDataFormat(),
-                new HashMap<>(),
-                kinesisColumns.stream()
+                new HashMap<>(), kinesisColumns.stream()
                         .filter(column -> !column.isInternal())
                         .collect(toImmutableSet()));
 

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/DispatchingRowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/DispatchingRowDecoderFactory.java
@@ -14,6 +14,7 @@
 package io.prestosql.decoder;
 
 import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import javax.inject.Inject;
 
@@ -32,9 +33,9 @@ public class DispatchingRowDecoderFactory
         this.factories = ImmutableMap.copyOf(factories);
     }
 
-    public RowDecoder create(String dataFormat, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, String dataFormat, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         checkArgument(factories.containsKey(dataFormat), "unknown data format '%s'", dataFormat);
-        return factories.get(dataFormat).create(decoderParams, columns);
+        return factories.get(dataFormat).create(session, decoderParams, columns);
     }
 }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/RowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/RowDecoderFactory.java
@@ -13,10 +13,12 @@
  */
 package io.prestosql.decoder;
 
+import io.prestosql.spi.connector.ConnectorSession;
+
 import java.util.Map;
 import java.util.Set;
 
 public interface RowDecoderFactory
 {
-    RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns);
+    RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns);
 }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroRowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroRowDecoderFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.decoder.avro;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 
@@ -28,7 +29,7 @@ public class AvroRowDecoderFactory
         implements RowDecoderFactory
 {
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         String dataSchema = requireNonNull(decoderParams.get("dataSchema"), "dataSchema cannot be null");
         Schema parsedSchema = (new Schema.Parser()).parse(dataSchema);

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvRowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvRowDecoderFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.decoder.csv;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,7 @@ public class CsvRowDecoderFactory
         implements RowDecoderFactory
 {
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         return new CsvRowDecoder(columns);
     }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/dummy/DummyRowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/dummy/DummyRowDecoderFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.decoder.dummy;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +27,7 @@ public class DummyRowDecoderFactory
     private static final RowDecoder DECODER_INSTANCE = new DummyRowDecoder();
 
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         return DECODER_INSTANCE;
     }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
@@ -33,11 +34,13 @@ import static java.lang.String.format;
 public abstract class AbstractDateTimeJsonValueProvider
         extends FieldValueProvider
 {
+    protected final ConnectorSession session;
     protected final JsonNode value;
     protected final DecoderColumnHandle columnHandle;
 
-    protected AbstractDateTimeJsonValueProvider(JsonNode value, DecoderColumnHandle columnHandle)
+    protected AbstractDateTimeJsonValueProvider(ConnectorSession session, JsonNode value, DecoderColumnHandle columnHandle)
     {
+        this.session = session;
         this.value = value;
         this.columnHandle = columnHandle;
     }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 
 import java.util.concurrent.TimeUnit;
@@ -26,8 +28,6 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.String.format;
 
 public abstract class AbstractDateTimeJsonValueProvider
@@ -66,10 +66,10 @@ public abstract class AbstractDateTimeJsonValueProvider
         if (type.equals(DATE)) {
             return TimeUnit.MILLISECONDS.toDays(millis);
         }
-        if (type.equals(TIMESTAMP) || type.equals(TIME)) {
+        if (type instanceof TimestampType || type.equals(TIME)) {
             return millis;
         }
-        if (type.equals(TIMESTAMP_WITH_TIME_ZONE) || type.equals(TIME_WITH_TIME_ZONE)) {
+        if (type instanceof TimestampWithTimeZoneType || type.equals(TIME_WITH_TIME_ZONE)) {
             return packDateTimeWithZone(millis, 0);
         }
 

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
@@ -119,8 +119,14 @@ public class ISO8601JsonFieldDecoder
                 String textValue = value.asText();
                 if (columnType instanceof TimestampType) {
                     // Equivalent to: ISO_DATE_TIME.parse(textValue, LocalDateTime::from).toInstant(UTC).toEpochMilli();
-                    TemporalAccessor parseResult = ISO_DATE_TIME.parse(textValue);
-                    return TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY);
+                    try {
+                        TemporalAccessor parseResult = ISO_OFFSET_DATE_TIME.parse(textValue);
+                        return packDateTimeWithZone(TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY), getTimeZoneKey(ZoneId.from(parseResult).getId()));
+                    }
+                    catch (DateTimeParseException e) {
+                        TemporalAccessor parseResult = ISO_DATE_TIME.parse(textValue);
+                        return packDateTimeWithZone(TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY), session.getTimeZoneKey());
+                    }
                 }
                 if (columnType instanceof TimestampWithTimeZoneType) {
                     // Equivalent to:

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 
 import java.util.Set;
@@ -26,8 +28,6 @@ import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPO
 import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedColumnType;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -40,16 +40,23 @@ import static java.util.Objects.requireNonNull;
 public class MillisecondsSinceEpochJsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> NON_PARAMETRIC_SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
 
     public MillisecondsSinceEpochJsonFieldDecoder(DecoderColumnHandle columnHandle)
     {
         this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
-        if (!SUPPORTED_TYPES.contains(columnHandle.getType())) {
+        if (!isSupportedType(columnHandle.getType())) {
             throwUnsupportedColumnType(columnHandle);
         }
+    }
+
+    private boolean isSupportedType(Type type)
+    {
+        return NON_PARAMETRIC_SUPPORTED_TYPES.contains(type) ||
+                type instanceof TimestampType ||
+                type instanceof TimestampWithTimeZoneType;
     }
 
     @Override

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
@@ -19,6 +19,7 @@ import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
@@ -79,7 +80,7 @@ public class MillisecondsSinceEpochJsonFieldDecoder
         }
 
         @Override
-        protected long getMillis()
+        protected long getMillisUtc()
         {
             if (value.isIntegralNumber() && !value.isBigInteger()) {
                 return value.longValue();
@@ -97,6 +98,12 @@ public class MillisecondsSinceEpochJsonFieldDecoder
             throw new PrestoException(
                     DECODER_CONVERSION_NOT_SUPPORTED,
                     format("could not parse non-value node as '%s' for column '%s'", columnHandle.getType(), columnHandle.getName()));
+        }
+
+        @Override
+        protected TimeZoneKey getTimeZone()
+        {
+            return TimeZoneKey.UTC_KEY;
         }
     }
 }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/RFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/RFC2822JsonFieldDecoder.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -30,8 +32,6 @@ import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedCo
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
 public class RFC2822JsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> NON_PARAMETRIC_SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE);
 
     /**
      * Todo - configurable time zones and locales.
@@ -54,9 +54,16 @@ public class RFC2822JsonFieldDecoder
     public RFC2822JsonFieldDecoder(DecoderColumnHandle columnHandle)
     {
         this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
-        if (!SUPPORTED_TYPES.contains(columnHandle.getType())) {
+        if (!isSupportedType(columnHandle.getType())) {
             throwUnsupportedColumnType(columnHandle);
         }
+    }
+
+    private boolean isSupportedType(Type type)
+    {
+        return NON_PARAMETRIC_SUPPORTED_TYPES.contains(type) ||
+                type instanceof TimestampType ||
+                type instanceof TimestampWithTimeZoneType;
     }
 
     @Override

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 
 import java.util.Set;
@@ -26,8 +28,6 @@ import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPO
 import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedColumnType;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.Long.parseLong;
 import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
@@ -41,16 +41,23 @@ import static java.util.Objects.requireNonNull;
 public class SecondsSinceEpochJsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> NON_PARAMETRIC_SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
 
     public SecondsSinceEpochJsonFieldDecoder(DecoderColumnHandle columnHandle)
     {
         this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
-        if (!SUPPORTED_TYPES.contains(columnHandle.getType())) {
+        if (!isSupportedType(columnHandle.getType())) {
             throwUnsupportedColumnType(columnHandle);
         }
+    }
+
+    private boolean isSupportedType(Type type)
+    {
+        return NON_PARAMETRIC_SUPPORTED_TYPES.contains(type) ||
+                type instanceof TimestampType ||
+                type instanceof TimestampWithTimeZoneType;
     }
 
     @Override

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
@@ -19,6 +19,7 @@ import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
@@ -80,7 +81,7 @@ public class SecondsSinceEpochJsonFieldDecoder
         }
 
         @Override
-        protected long getMillis()
+        protected long getMillisUtc()
         {
             try {
                 if (value.isIntegralNumber()
@@ -99,6 +100,12 @@ public class SecondsSinceEpochJsonFieldDecoder
                         DECODER_CONVERSION_NOT_SUPPORTED,
                         format("could not parse value '%s' as '%s' for column '%s'", value.asText(), columnHandle.getType(), columnHandle.getName()));
             }
+        }
+
+        @Override
+        protected TimeZoneKey getTimeZone()
+        {
+            return TimeZoneKey.UTC_KEY;
         }
     }
 }

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
@@ -18,12 +18,14 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPORTED;
 import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedColumnType;
 import static io.prestosql.spi.type.TimeType.TIME;
@@ -43,10 +45,13 @@ public class SecondsSinceEpochJsonFieldDecoder
 {
     private static final Set<Type> NON_PARAMETRIC_SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE);
 
+    private final ConnectorSession session;
     private final DecoderColumnHandle columnHandle;
 
-    public SecondsSinceEpochJsonFieldDecoder(DecoderColumnHandle columnHandle)
+    public SecondsSinceEpochJsonFieldDecoder(ConnectorSession session, DecoderColumnHandle columnHandle)
     {
+        this.session = requireNonNull(session, "session is null");
+        checkArgument(this.session.isLegacyTimestamp(), "The seconds since epoch JSON field decoder only supports legacy timestamp semantics");
         this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
         if (!isSupportedType(columnHandle.getType())) {
             throwUnsupportedColumnType(columnHandle);
@@ -63,15 +68,15 @@ public class SecondsSinceEpochJsonFieldDecoder
     @Override
     public FieldValueProvider decode(JsonNode value)
     {
-        return new SecondsSinceEpochJsonValueProvider(value, columnHandle);
+        return new SecondsSinceEpochJsonValueProvider(session, value, columnHandle);
     }
 
     public static class SecondsSinceEpochJsonValueProvider
             extends AbstractDateTimeJsonValueProvider
     {
-        public SecondsSinceEpochJsonValueProvider(JsonNode value, DecoderColumnHandle columnHandle)
+        public SecondsSinceEpochJsonValueProvider(ConnectorSession session, JsonNode value, DecoderColumnHandle columnHandle)
         {
-            super(value, columnHandle);
+            super(session, value, columnHandle);
         }
 
         @Override

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/raw/RawRowDecoderFactory.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/raw/RawRowDecoderFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.decoder.raw;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,7 @@ public class RawRowDecoderFactory
         implements RowDecoderFactory
 {
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         return new RawRowDecoder(columns);
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/avro/TestAvroDecoder.java
@@ -76,6 +76,7 @@ import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -165,7 +166,7 @@ public class TestAvroDecoder
 
     private static Map<DecoderColumnHandle, FieldValueProvider> decodeRow(byte[] avroData, Set<DecoderColumnHandle> columns, Map<String, String> dataParams)
     {
-        RowDecoder rowDecoder = DECODER_FACTORY.create(dataParams, columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, dataParams, columns);
         return rowDecoder.decodeRow(avroData)
                 .orElseThrow(AssertionError::new);
     }
@@ -1212,7 +1213,7 @@ public class TestAvroDecoder
                 .name("dummy").type().longType().noDefault()
                 .endRecord()
                 .toString();
-        DECODER_FACTORY.create(ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, "0", null, null, false, false, false)));
+        DECODER_FACTORY.create(SESSION, ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, "0", null, null, false, false, false)));
     }
 
     private void singleColumnDecoder(Type columnType, String mapping, String dataFormat, String formatHint, boolean keyDecoder, boolean hidden, boolean internal)
@@ -1222,6 +1223,6 @@ public class TestAvroDecoder
                 .endRecord()
                 .toString();
 
-        DECODER_FACTORY.create(ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
+        DECODER_FACTORY.create(SESSION, ImmutableMap.of(DATA_SCHEMA, someSchema), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
     }
 }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/csv/TestCsvDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/csv/TestCsvDecoder.java
@@ -40,6 +40,7 @@ import static io.prestosql.decoder.util.DecoderTestUtil.checkIsNull;
 import static io.prestosql.decoder.util.DecoderTestUtil.checkValue;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -62,7 +63,7 @@ public class TestCsvDecoder
         DecoderTestColumnHandle row7 = new DecoderTestColumnHandle(6, "row7", DoubleType.DOUBLE, "6", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5, row6, row7);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
@@ -93,7 +94,7 @@ public class TestCsvDecoder
         DecoderTestColumnHandle row8 = new DecoderTestColumnHandle(7, "row8", BooleanType.BOOLEAN, "7", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5, row6, row7, row8);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
@@ -121,7 +122,7 @@ public class TestCsvDecoder
         DecoderTestColumnHandle row4 = new DecoderTestColumnHandle(3, "row4", BooleanType.BOOLEAN, "3", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
@@ -147,7 +148,7 @@ public class TestCsvDecoder
         DecoderTestColumnHandle column6 = new DecoderTestColumnHandle(0, "column6", BooleanType.BOOLEAN, "5", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4, column5, column6);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
@@ -231,7 +232,7 @@ public class TestCsvDecoder
 
     private void singleColumnDecoder(Type columnType, String mapping, String dataFormat, String formatHint, boolean keyDecoder, boolean hidden, boolean internal)
     {
-        DECODER_FACTORY.create(emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
+        DECODER_FACTORY.create(SESSION, emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
     }
 
     @Test
@@ -244,7 +245,7 @@ public class TestCsvDecoder
     {
         DecoderTestColumnHandle column = new DecoderTestColumnHandle(0, "column", type, "0", null, null, false, false, false);
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(csv.getBytes(StandardCharsets.UTF_8))
                 .orElseThrow(AssertionError::new);
         return decodedRow.get(column);

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/JsonFieldDecoderTester.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/JsonFieldDecoderTester.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.type.Type;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
@@ -130,7 +131,7 @@ public class JsonFieldDecoderTester
                 false,
                 false);
 
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), ImmutableSet.of(columnHandle));
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), ImmutableSet.of(columnHandle));
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json.getBytes(UTF_8))
                 .orElseThrow(AssertionError::new);
         assertTrue(decodedRow.containsKey(columnHandle), format("column '%s' not found in decoded row", columnHandle.getName()));

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
@@ -26,6 +26,7 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -93,7 +94,7 @@ public class TestCustomDateTimeJsonFieldDecoder
                 false,
                 false,
                 false);
-        assertThatThrownBy(() -> new JsonRowDecoderFactory(new ObjectMapperProvider().get()).create(emptyMap(), ImmutableSet.of(columnHandle)))
+        assertThatThrownBy(() -> new JsonRowDecoderFactory(new ObjectMapperProvider().get()).create(SESSION, emptyMap(), ImmutableSet.of(columnHandle)))
                 .isInstanceOf(PrestoException.class)
                 .hasMessageMatching("invalid joda pattern 'XXMM/yyyy/dd H:m:sXX' passed as format hint for column 'some_column'");
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
@@ -24,8 +24,8 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -40,10 +40,10 @@ public class TestCustomDateTimeJsonFieldDecoder
     @Test
     public void testDecode()
     {
-        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP, 1519032011000L);
-        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP, 1519032011000L);
-        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, UTC_KEY));
-        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, UTC_KEY)); // TODO: extract TZ from pattern
+        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", createTimestampType(0), 1519032011000L);
+        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", createTimestampType(0), 1519032011000L);
+        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032011000L, UTC_KEY));
+        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032011000L, UTC_KEY)); // TODO: extract TZ from pattern
         timeTester.assertDecodedAs("\"15:13:18\"", TIME, 47718000);
         timeJustHourTester.assertDecodedAs("\"15\"", TIME, 54000000);
         timeJustHourTester.assertDecodedAs("15", TIME, 54000000);
@@ -63,21 +63,21 @@ public class TestCustomDateTimeJsonFieldDecoder
         timeTester.assertDecodedAsNull("null", TIME_WITH_TIME_ZONE);
         timeTester.assertMissingDecodedAsNull(TIME_WITH_TIME_ZONE);
 
-        timestampTester.assertDecodedAsNull("null", TIMESTAMP);
-        timestampTester.assertMissingDecodedAsNull(TIMESTAMP);
+        timestampTester.assertDecodedAsNull("null", createTimestampType(0));
+        timestampTester.assertMissingDecodedAsNull(createTimestampType(0));
 
-        timestampTester.assertDecodedAsNull("null", TIMESTAMP_WITH_TIME_ZONE);
-        timestampTester.assertMissingDecodedAsNull(TIMESTAMP_WITH_TIME_ZONE);
+        timestampTester.assertDecodedAsNull("null", createTimestampWithTimeZoneType(0));
+        timestampTester.assertMissingDecodedAsNull(createTimestampWithTimeZoneType(0));
     }
 
     @Test
     public void testDecodeInvalid()
     {
-        timestampTester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"15:13:18\"", TIMESTAMP, "\\Qcould not parse value '15:13:18' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"02/2018/11\"", TIMESTAMP, "\\Qcould not parse value '02/2018/11' as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(0)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("{}", createTimestampType(0), "\\Qcould not parse non-value node as 'timestamp(0)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"a\"", createTimestampType(0), "\\Qcould not parse value 'a' as 'timestamp(0)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"15:13:18\"", createTimestampType(0), "\\Qcould not parse value '15:13:18' as 'timestamp(0)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"02/2018/11\"", createTimestampType(0), "\\Qcould not parse value '02/2018/11' as 'timestamp(0)' for column 'some_column'\\E");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class TestCustomDateTimeJsonFieldDecoder
         DecoderTestColumnHandle columnHandle = new DecoderTestColumnHandle(
                 0,
                 "some_column",
-                TIMESTAMP,
+                createTimestampType(0),
                 "mappedField",
                 "custom-date-time",
                 "XXMM/yyyy/dd H:m:sXX",

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
@@ -21,20 +21,20 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static java.util.Arrays.asList;
 
 public class TestISO8601JsonFieldDecoder
 {
-    private JsonFieldDecoderTester tester = new JsonFieldDecoderTester("iso8601");
+    private final JsonFieldDecoderTester tester = new JsonFieldDecoderTester("iso8601");
 
     @Test
     public void testDecode()
     {
-        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", TIMESTAMP, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", TIMESTAMP, 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", createTimestampType(0), 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", createTimestampType(0), 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", createTimestampType(0), 1519032011000L);
         tester.assertDecodedAs("\"13:15:18\"", TIME, 47718000);
         tester.assertDecodedAs("\"13:15\"", TIME, 47700000);
         tester.assertDecodedAs("\"13:15:18Z\"", TIME, 47718000);
@@ -42,8 +42,8 @@ public class TestISO8601JsonFieldDecoder
         tester.assertDecodedAs("\"13:15:18+10:00\"", TIME, 47718000);
         tester.assertDecodedAs("\"13:15+10:00\"", TIME, 47700000);
         tester.assertDecodedAs("\"2018-02-11\"", DATE, 17573);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, UTC_KEY));
-        tester.assertDecodedAs("\"2018-02-19T12:20:11+03:00\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, "+03:00"));
+        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032011000L, UTC_KEY));
+        tester.assertDecodedAs("\"2018-02-19T12:20:11+03:00\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032011000L, "+03:00"));
         tester.assertDecodedAs("\"13:15:18Z\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(47718000, UTC_KEY));
         tester.assertDecodedAs("\"13:15:18+10:00\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(47718000, "+10:00"));
     }
@@ -51,7 +51,7 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, createTimestampType(0), createTimestampWithTimeZoneType(0))) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -60,20 +60,20 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        tester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("{}", createTimestampType(0), "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"a\"", createTimestampType(0), "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
 
         tester.assertInvalidInput("\"2018-02-19T09:20:11\"", DATE, "could not parse value '2018-02-19T09:20:11' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"2018-02-19T09:20:11Z\"", DATE, "could not parse value '2018-02-19T09:20:11Z' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"09:20:11Z\"", DATE, "could not parse value '09:20:11Z' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"09:20:11\"", DATE, "could not parse value '09:20:11' as 'date' for column 'some_column'");
 
-        tester.assertInvalidInput("\"2018-02-19T09:20:11\"", TIMESTAMP_WITH_TIME_ZONE, "\\Qcould not parse value '2018-02-19T09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"09:20:11\"", TIMESTAMP_WITH_TIME_ZONE, "\\Qcould not parse value '09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"09:20:11Z\"", TIMESTAMP_WITH_TIME_ZONE, "\\Qcould not parse value '09:20:11Z' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"2018-02-19\"", TIMESTAMP_WITH_TIME_ZONE, "\\Qcould not parse value '2018-02-19' as 'timestamp(3) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"2018-02-19T09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19T09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"09:20:11Z\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11Z' as 'timestamp(3) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"2018-02-19\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19' as 'timestamp(3) with time zone' for column 'some_column'\\E");
 
         tester.assertInvalidInput("\"2018-02-19T09:20:11\"", TIME, "could not parse value '2018-02-19T09:20:11' as 'time' for column 'some_column'");
         tester.assertInvalidInput("\"2018-02-19T09:20:11Z\"", TIME, "could not parse value '2018-02-19T09:20:11Z' as 'time' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.decoder.json;
 
+import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
@@ -23,6 +24,7 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Arrays.asList;
 
 public class TestISO8601JsonFieldDecoder
@@ -32,9 +34,9 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecode()
     {
-        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", createTimestampType(0), 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", createTimestampType(0), 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", createTimestampType(0), 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", createTimestampType(0), packDateTimeWithZone(1519032011000L, SESSION.getTimeZoneKey()));
+        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", createTimestampType(0), packDateTimeWithZone(1519032011000L, UTC_KEY));
+        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", createTimestampType(0), packDateTimeWithZone(1519032011000L, TimeZoneKey.getTimeZoneKeyForOffset(600)));
         tester.assertDecodedAs("\"13:15:18\"", TIME, 47718000);
         tester.assertDecodedAs("\"13:15\"", TIME, 47700000);
         tester.assertDecodedAs("\"13:15:18Z\"", TIME, 47718000);
@@ -60,20 +62,20 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("{}", createTimestampType(0), "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"a\"", createTimestampType(0), "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("{}", createTimestampType(0), "\\Qcould not parse non-value node as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"a\"", createTimestampType(0), "\\Qcould not parse value 'a' as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", createTimestampType(0), "\\Qcould not parse value '1' as 'timestamp(0)' for column 'some_column'\\E");
 
         tester.assertInvalidInput("\"2018-02-19T09:20:11\"", DATE, "could not parse value '2018-02-19T09:20:11' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"2018-02-19T09:20:11Z\"", DATE, "could not parse value '2018-02-19T09:20:11Z' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"09:20:11Z\"", DATE, "could not parse value '09:20:11Z' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"09:20:11\"", DATE, "could not parse value '09:20:11' as 'date' for column 'some_column'");
 
-        tester.assertInvalidInput("\"2018-02-19T09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19T09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"09:20:11Z\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11Z' as 'timestamp(3) with time zone' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"2018-02-19\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19' as 'timestamp(3) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"2018-02-19T09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19T09:20:11' as 'timestamp(0) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"09:20:11\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11' as 'timestamp(0) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"09:20:11Z\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '09:20:11Z' as 'timestamp(0) with time zone' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"2018-02-19\"", createTimestampWithTimeZoneType(0), "\\Qcould not parse value '2018-02-19' as 'timestamp(0) with time zone' for column 'some_column'\\E");
 
         tester.assertInvalidInput("\"2018-02-19T09:20:11\"", TIME, "could not parse value '2018-02-19T09:20:11' as 'time' for column 'some_column'");
         tester.assertInvalidInput("\"2018-02-19T09:20:11Z\"", TIME, "could not parse value '2018-02-19T09:20:11Z' as 'time' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
@@ -48,6 +48,7 @@ import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -71,7 +72,7 @@ public class TestJsonDecoder
         DecoderTestColumnHandle column5 = new DecoderTestColumnHandle(4, "column5", BOOLEAN, "user/geo_enabled", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4, column5);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json)
                 .orElseThrow(AssertionError::new);
@@ -96,7 +97,7 @@ public class TestJsonDecoder
         DecoderTestColumnHandle column4 = new DecoderTestColumnHandle(3, "column4", BOOLEAN, "hello", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json)
                 .orElseThrow(AssertionError::new);
@@ -120,7 +121,7 @@ public class TestJsonDecoder
         DecoderTestColumnHandle column4 = new DecoderTestColumnHandle(3, "column4", BIGINT, "a_string", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column1, column2, column3, column4);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodedRow = rowDecoder.decodeRow(json);
         assertTrue(decodedRow.isPresent());
@@ -216,6 +217,6 @@ public class TestJsonDecoder
     private void singleColumnDecoder(Type columnType, String mapping, String dataFormat)
     {
         String formatHint = "custom-date-time".equals(dataFormat) ? "MM/yyyy/dd H:m:s" : null;
-        DECODER_FACTORY.create(emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, false, false, false)));
+        DECODER_FACTORY.create(SESSION, emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, false, false, false)));
     }
 }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
@@ -22,13 +22,13 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static java.util.Arrays.asList;
 
 public class TestMillisecondsSinceEpochJsonFieldDecoder
 {
-    private JsonFieldDecoderTester tester = new JsonFieldDecoderTester("milliseconds-since-epoch");
+    private final JsonFieldDecoderTester tester = new JsonFieldDecoderTester("milliseconds-since-epoch");
 
     @Test
     public void testDecode()
@@ -37,16 +37,16 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701000\"", TIME, 33701000);
         tester.assertDecodedAs("33701000", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
         tester.assertDecodedAs("\"33701000\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
-        tester.assertDecodedAs("1519032101123", TIMESTAMP, 1519032101123L);
-        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP, 1519032101123L);
-        tester.assertDecodedAs("1519032101123", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
-        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
+        tester.assertDecodedAs("1519032101123", createTimestampType(3), 1519032101123L);
+        tester.assertDecodedAs("\"1519032101123\"", createTimestampType(3), 1519032101123L);
+        tester.assertDecodedAs("1519032101123", createTimestampWithTimeZoneType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
+        tester.assertDecodedAs("\"1519032101123\"", createTimestampWithTimeZoneType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
     }
 
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, createTimestampType(3), createTimestampWithTimeZoneType(3))) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -55,7 +55,7 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, createTimestampType(3), createTimestampWithTimeZoneType(3))) {
             tester.assertInvalidInput("{}", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[]", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[10]", type, "could not parse non-value node as '.*' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
@@ -37,8 +37,8 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701000\"", TIME, 33701000);
         tester.assertDecodedAs("33701000", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
         tester.assertDecodedAs("\"33701000\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
-        tester.assertDecodedAs("1519032101123", createTimestampType(3), 1519032101123L);
-        tester.assertDecodedAs("\"1519032101123\"", createTimestampType(3), 1519032101123L);
+        tester.assertDecodedAs("1519032101123", createTimestampType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
+        tester.assertDecodedAs("\"1519032101123\"", createTimestampType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
         tester.assertDecodedAs("1519032101123", createTimestampWithTimeZoneType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101123\"", createTimestampWithTimeZoneType(3), packDateTimeWithZone(1519032101123L, UTC_KEY));
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.decoder.json;
 
+import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
@@ -23,6 +24,7 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Arrays.asList;
 
 public class TestRFC2822JsonFieldDecoder
@@ -35,10 +37,10 @@ public class TestRFC2822JsonFieldDecoder
         tester.assertDecodedAs("\"Mon Feb 12 13:15:16 Z 2018\"", DATE, 17574); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME, 47719000); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(47719000, UTC_KEY)); // TODO should it be supported really?
-        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", createTimestampType(0), 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", createTimestampType(0), packDateTimeWithZone(1518182119000L, SESSION.getTimeZoneKey()));
         tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1518182119000L, UTC_KEY));
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampType(0), 1518182119000L);
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1518182119000L, UTC_KEY));
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampType(0), packDateTimeWithZone(1518182119000L, SESSION.getTimeZoneKey()));
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1518182119000L, TimeZoneKey.getTimeZoneKeyForOffset(120)));
     }
 
     @Test

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
@@ -21,13 +21,13 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static java.util.Arrays.asList;
 
 public class TestRFC2822JsonFieldDecoder
 {
-    private JsonFieldDecoderTester tester = new JsonFieldDecoderTester("rfc2822");
+    private final JsonFieldDecoderTester tester = new JsonFieldDecoderTester("rfc2822");
 
     @Test
     public void testDecode()
@@ -35,16 +35,16 @@ public class TestRFC2822JsonFieldDecoder
         tester.assertDecodedAs("\"Mon Feb 12 13:15:16 Z 2018\"", DATE, 17574); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME, 47719000); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(47719000, UTC_KEY)); // TODO should it be supported really?
-        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP, 1518182119000L);
-        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, UTC_KEY));
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP, 1518182119000L);
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, UTC_KEY));
+        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", createTimestampType(0), 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1518182119000L, UTC_KEY));
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampType(0), 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1518182119000L, UTC_KEY));
     }
 
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, createTimestampType(0), createTimestampWithTimeZoneType(0))) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -53,16 +53,16 @@ public class TestRFC2822JsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        tester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("2018", TIMESTAMP, "\\Qcould not parse value '2018' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 Z\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 12 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon 12 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Feb 12 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 Europe/Warsaw 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 EST 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("{}", createTimestampType(0), "\\Qcould not parse non-value node as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"a\"", createTimestampType(0), "\\Qcould not parse value 'a' as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("2018", createTimestampType(0), "\\Qcould not parse value '2018' as 'timestamp(0)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 Z\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 12 Z 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 13:15:16 Z 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon 12 13:15:16 Z 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Feb 12 13:15:16 Z 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 Europe/Warsaw 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 EST 2018\"", createTimestampType(0), "could not parse value '.*' as 'timestamp\\(0\\)' for column 'some_column'");
     }
 }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
@@ -22,13 +22,13 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static java.util.Arrays.asList;
 
 public class TestSecondsSinceEpochJsonFieldDecoder
 {
-    private JsonFieldDecoderTester tester = new JsonFieldDecoderTester("seconds-since-epoch");
+    private final JsonFieldDecoderTester tester = new JsonFieldDecoderTester("seconds-since-epoch");
 
     @Test
     public void testDecode()
@@ -37,18 +37,18 @@ public class TestSecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701\"", TIME, 33701000);
         tester.assertDecodedAs("33701", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
         tester.assertDecodedAs("\"33701\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
-        tester.assertDecodedAs("1519032101", TIMESTAMP, 1519032101000L);
-        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP, 1519032101000L);
-        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), TIMESTAMP, Long.MAX_VALUE / 1000 * 1000);
-        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), TIMESTAMP, Long.MIN_VALUE / 1000 * 1000);
-        tester.assertDecodedAs("1519032101", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
-        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
+        tester.assertDecodedAs("1519032101", createTimestampType(0), 1519032101000L);
+        tester.assertDecodedAs("\"1519032101\"", createTimestampType(0), 1519032101000L);
+        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), createTimestampType(0), Long.MAX_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), createTimestampType(0), Long.MIN_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("1519032101", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
+        tester.assertDecodedAs("\"1519032101\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
     }
 
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, createTimestampType(0), createTimestampWithTimeZoneType(0))) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -57,7 +57,7 @@ public class TestSecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, createTimestampType(0), createTimestampWithTimeZoneType(0))) {
             tester.assertInvalidInput("{}", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[]", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[10]", type, "could not parse non-value node as '.*' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
@@ -37,10 +37,10 @@ public class TestSecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701\"", TIME, 33701000);
         tester.assertDecodedAs("33701", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
         tester.assertDecodedAs("\"33701\"", TIME_WITH_TIME_ZONE, packDateTimeWithZone(33701000, UTC_KEY));
-        tester.assertDecodedAs("1519032101", createTimestampType(0), 1519032101000L);
-        tester.assertDecodedAs("\"1519032101\"", createTimestampType(0), 1519032101000L);
-        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), createTimestampType(0), Long.MAX_VALUE / 1000 * 1000);
-        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), createTimestampType(0), Long.MIN_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("1519032101", createTimestampType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
+        tester.assertDecodedAs("\"1519032101\"", createTimestampType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
+        tester.assertDecodedAs("922337203", createTimestampType(0), packDateTimeWithZone(922337203000L, UTC_KEY));
+        tester.assertDecodedAs("\"922337203\"", createTimestampType(0), packDateTimeWithZone(922337203000L, UTC_KEY));
         tester.assertDecodedAs("1519032101", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101\"", createTimestampWithTimeZoneType(0), packDateTimeWithZone(1519032101000L, UTC_KEY));
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/raw/TestRawDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/raw/TestRawDecoder.java
@@ -43,6 +43,7 @@ import static io.prestosql.decoder.util.DecoderTestUtil.checkValue;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -58,7 +59,7 @@ public class TestRawDecoder
         byte[] emptyRow = new byte[0];
         DecoderTestColumnHandle column = new DecoderTestColumnHandle(0, "row1", createUnboundedVarcharType(), null, "BYTE", null, false, false, false);
         Set<DecoderColumnHandle> columns = ImmutableSet.of(column);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(emptyRow)
                 .orElseThrow(AssertionError::new);
@@ -86,7 +87,7 @@ public class TestRawDecoder
         DecoderTestColumnHandle row5 = new DecoderTestColumnHandle(4, "row5", createVarcharType(10), "15", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4, row5);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
@@ -112,7 +113,7 @@ public class TestRawDecoder
         DecoderTestColumnHandle row4 = new DecoderTestColumnHandle(3, "row4", createVarcharType(100), "5:8", null, null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2, row3, row4);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
@@ -142,7 +143,7 @@ public class TestRawDecoder
         DecoderTestColumnHandle row2 = new DecoderTestColumnHandle(1, "row2", DOUBLE, "8", "FLOAT", null, false, false, false);
 
         Set<DecoderColumnHandle> columns = ImmutableSet.of(row1, row2);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
@@ -216,7 +217,7 @@ public class TestRawDecoder
                 row32,
                 row33,
                 row34);
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
@@ -425,7 +426,7 @@ public class TestRawDecoder
         Set<DecoderColumnHandle> columns = ImmutableSet.of(
                 col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11);
 
-        RowDecoder rowDecoder = DECODER_FACTORY.create(emptyMap(), columns);
+        RowDecoder rowDecoder = DECODER_FACTORY.create(SESSION, emptyMap(), columns);
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(row)
                 .orElseThrow(AssertionError::new);
@@ -470,6 +471,6 @@ public class TestRawDecoder
 
     private void singleColumnDecoder(Type columnType, String mapping, String dataFormat, String formatHint, boolean keyDecoder, boolean hidden, boolean internal)
     {
-        DECODER_FACTORY.create(emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
+        DECODER_FACTORY.create(SESSION, emptyMap(), ImmutableSet.of(new DecoderTestColumnHandle(0, "some_column", columnType, mapping, dataFormat, formatHint, keyDecoder, hidden, internal)));
     }
 }

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/RedisRecordSetProvider.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/RedisRecordSetProvider.java
@@ -59,17 +59,17 @@ public class RedisRecordSetProvider
                 .collect(ImmutableList.toImmutableList());
 
         RowDecoder keyDecoder = decoderFactory.create(
+                session,
                 redisSplit.getKeyDataFormat(),
-                emptyMap(),
-                redisColumns.stream()
+                emptyMap(), redisColumns.stream()
                         .filter(col -> !col.isInternal())
                         .filter(RedisColumnHandle::isKeyDecoder)
                         .collect(toImmutableSet()));
 
         RowDecoder valueDecoder = decoderFactory.create(
+                session,
                 redisSplit.getValueDataFormat(),
-                emptyMap(),
-                redisColumns.stream()
+                emptyMap(), redisColumns.stream()
                         .filter(col -> !col.isInternal())
                         .filter(col -> !col.isKeyDecoder())
                         .collect(toImmutableSet()));

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/HashRedisRowDecoderFactory.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/HashRedisRowDecoderFactory.java
@@ -18,6 +18,7 @@ import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
 import io.prestosql.plugin.redis.RedisFieldDecoder;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +32,7 @@ public class HashRedisRowDecoderFactory
         implements RowDecoderFactory
 {
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         requireNonNull(columns, "columns is null");
         return new HashRedisRowDecoder(chooseFieldDecoders(columns));

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.redis.decoder.hash;
 
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
@@ -23,16 +24,26 @@ import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Locale;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class ISO8601HashRedisFieldDecoder
         extends HashRedisFieldDecoder
 {
     private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.dateTimeParser().withLocale(Locale.ENGLISH).withZoneUTC();
+
+    private final ConnectorSession session;
+
+    public ISO8601HashRedisFieldDecoder(ConnectorSession session)
+    {
+        this.session = requireNonNull(session, "session is null");
+        checkArgument(this.session.isLegacyTimestamp(), "The ISO8601HashRedisFieldDecoder does not support non-legacy timestamp semantics");
+    }
 
     @Override
     public FieldValueProvider decode(String value, DecoderColumnHandle columnHandle)

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
@@ -15,6 +15,8 @@ package io.prestosql.plugin.redis.decoder.hash;
 
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -25,8 +27,6 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
-import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class ISO8601HashRedisFieldDecoder
@@ -57,10 +57,10 @@ class ISO8601HashRedisFieldDecoder
             if (type.equals(DATE)) {
                 return MILLISECONDS.toDays(millis);
             }
-            if (type.equals(TIMESTAMP) || type.equals(TIME)) {
+            if (type instanceof TimestampType || type.equals(TIME)) {
                 return millis;
             }
-            if (type.equals(TIMESTAMP_WITH_TIME_ZONE) || type.equals(TIME_WITH_TIME_ZONE)) {
+            if (type instanceof TimestampWithTimeZoneType || type.equals(TIME_WITH_TIME_ZONE)) {
                 return packDateTimeWithZone(millis, 0);
             }
 

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.redis.decoder.zset;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.RowDecoder;
 import io.prestosql.decoder.RowDecoderFactory;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.util.Map;
 import java.util.Set;
@@ -29,7 +30,7 @@ public class ZsetRedisRowDecoderFactory
     private static final RowDecoder DECODER_INSTANCE = new ZsetRedisRowDecoder();
 
     @Override
-    public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
+    public RowDecoder create(ConnectorSession session, Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
         requireNonNull(columns, "columnHandles is null");
         checkArgument(columns.stream().noneMatch(DecoderColumnHandle::isInternal), "unexpected internal column");


### PR DESCRIPTION
- Update JSON record decoder to use parameterized timestamp semantics
- Add connector session field to temporal field decoders
- Use session time zone for timestamps
- Use parsed time zone for temporal "with time zone" types (no longer assume UTC)