### PR TITLE
Limit for segment queries

### DIFF
--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -243,10 +243,6 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
-                <!--exclusion>
-                    <groupId>org.apache.thrift</groupId>
-                    <artifactId>libthrift</artifactId>
-                </exclusion-->
             </exclusions>
         </dependency>
 

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotConfig.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotConfig.java
@@ -49,6 +49,7 @@ public class PinotConfig
     private int segmentsPerSplit = 1;
     private int fetchRetryCount = 2;
     private int nonAggregateLimitForBrokerQueries = 25_000;
+    private int maxRowsPerSplitForSegmentQueries = 50_000;
 
     @NotNull
     public List<String> getControllerUrls()
@@ -242,6 +243,18 @@ public class PinotConfig
     public PinotConfig setNonAggregateLimitForBrokerQueries(int nonAggregateLimitForBrokerQueries)
     {
         this.nonAggregateLimitForBrokerQueries = nonAggregateLimitForBrokerQueries;
+        return this;
+    }
+
+    public int getMaxRowsPerSplitForSegmentQueries()
+    {
+        return maxRowsPerSplitForSegmentQueries;
+    }
+
+    @Config("pinot.max-rows-per-split-for-segment-queries")
+    public PinotConfig setMaxRowsPerSplitForSegmentQueries(int maxRowsPerSplitForSegmentQueries)
+    {
+        this.maxRowsPerSplitForSegmentQueries = maxRowsPerSplitForSegmentQueries;
         return this;
     }
 }

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotMetadata.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotMetadata.java
@@ -70,7 +70,6 @@ public class PinotMetadata
 
     private final LoadingCache<String, List<PinotColumn>> pinotTableColumnCache;
     private final LoadingCache<Object, List<String>> allTablesCache;
-    private final PinotConfig pinotConfig;
 
     @Inject
     public PinotMetadata(
@@ -78,8 +77,8 @@ public class PinotMetadata
             PinotConfig pinotConfig,
             @ForPinot Executor executor)
     {
-        this.pinotConfig = requireNonNull(pinotConfig, "pinot config");
-        long metadataCacheExpiryMillis = this.pinotConfig.getMetadataCacheExpiry().roundTo(TimeUnit.MILLISECONDS);
+        requireNonNull(pinotConfig, "pinot config");
+        long metadataCacheExpiryMillis = pinotConfig.getMetadataCacheExpiry().roundTo(TimeUnit.MILLISECONDS);
         this.allTablesCache = CacheBuilder.newBuilder()
                 .refreshAfterWrite(metadataCacheExpiryMillis, TimeUnit.MILLISECONDS)
                 .build(asyncReloading(CacheLoader.from(pinotClient::getAllTables), executor));

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotPageSourceProvider.java
@@ -37,10 +37,10 @@ import static java.util.Objects.requireNonNull;
 public class PinotPageSourceProvider
         implements ConnectorPageSourceProvider
 {
-    private final PinotConfig pinotConfig;
     private final PinotQueryClient pinotQueryClient;
     private final PinotClient clusterInfoFetcher;
     private final int limitForSegmentQueries;
+    private final int estimatedNonNumericColumnSize;
 
     @Inject
     public PinotPageSourceProvider(
@@ -48,10 +48,11 @@ public class PinotPageSourceProvider
             PinotClient clusterInfoFetcher,
             PinotQueryClient pinotQueryClient)
     {
-        this.pinotConfig = requireNonNull(pinotConfig, "pinotConfig is null");
+        requireNonNull(pinotConfig, "pinotConfig is null");
         this.pinotQueryClient = requireNonNull(pinotQueryClient, "pinotQueryClient is null");
         this.clusterInfoFetcher = requireNonNull(clusterInfoFetcher, "cluster info fetcher is null");
         this.limitForSegmentQueries = pinotConfig.getMaxRowsPerSplitForSegmentQueries();
+        estimatedNonNumericColumnSize = pinotConfig.getEstimatedSizeInBytesForNonNumericColumn();
     }
 
     @Override
@@ -77,7 +78,7 @@ public class PinotPageSourceProvider
             case SEGMENT:
                 return new PinotSegmentPageSource(
                         session,
-                        this.pinotConfig,
+                        estimatedNonNumericColumnSize,
                         limitForSegmentQueries,
                         this.pinotQueryClient,
                         pinotSplit,

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotSegmentPageSource.java
@@ -59,13 +59,13 @@ public class PinotSegmentPageSource
     private static final Logger LOG = Logger.get(PinotSegmentPageSource.class);
 
     private final List<PinotColumnHandle> columnHandles;
-    private final PinotConfig pinotConfig;
     private final PinotSplit split;
     private final PinotQueryClient pinotQueryClient;
     private final ConnectorSession session;
     private final String query;
     private final int limitForSegmentQueries;
     private final AtomicLong currentRowCount = new AtomicLong();
+    private final int estimatedNonNumericColumnSize;
 
     private List<Type> columnTypes;
     // dataTableList stores the dataTable returned from each server. Each dataTable is constructed to a Page, and then destroyed to save memory.
@@ -79,15 +79,15 @@ public class PinotSegmentPageSource
 
     public PinotSegmentPageSource(
             ConnectorSession session,
-            PinotConfig pinotConfig,
+            int estimatedNonNumericColumnSize,
             int limitForSegmentQueries,
             PinotQueryClient pinotQueryClient,
             PinotSplit split,
             List<PinotColumnHandle> columnHandles,
             String query)
     {
-        this.pinotConfig = requireNonNull(pinotConfig, "pinotConfig is null");
         this.limitForSegmentQueries = limitForSegmentQueries;
+        this.estimatedNonNumericColumnSize = estimatedNonNumericColumnSize;
         this.split = requireNonNull(split, "split is null");
         this.pinotQueryClient = requireNonNull(pinotQueryClient, "pinotQueryClient is null");
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
@@ -461,7 +461,7 @@ public class PinotSegmentPageSource
                     return Integer.BYTES;
             }
         }
-        return pinotConfig.getEstimatedSizeInBytesForNonNumericColumn();
+        return estimatedNonNumericColumnSize;
     }
 
     private static class PinotDataTableWithSize

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotSegmentPageSource.java
@@ -40,12 +40,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.prestosql.pinot.PinotErrorCode.PINOT_DECODE_ERROR;
+import static io.prestosql.pinot.PinotErrorCode.PINOT_EXCEPTION;
 import static io.prestosql.pinot.PinotErrorCode.PINOT_UNSUPPORTED_COLUMN_TYPE;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;
@@ -62,6 +64,8 @@ public class PinotSegmentPageSource
     private final PinotQueryClient pinotQueryClient;
     private final ConnectorSession session;
     private final String query;
+    private final int limitForSegmentQueries;
+    private final AtomicLong currentRowCount = new AtomicLong();
 
     private List<Type> columnTypes;
     // dataTableList stores the dataTable returned from each server. Each dataTable is constructed to a Page, and then destroyed to save memory.
@@ -76,12 +80,14 @@ public class PinotSegmentPageSource
     public PinotSegmentPageSource(
             ConnectorSession session,
             PinotConfig pinotConfig,
+            int limitForSegmentQueries,
             PinotQueryClient pinotQueryClient,
             PinotSplit split,
             List<PinotColumnHandle> columnHandles,
             String query)
     {
         this.pinotConfig = requireNonNull(pinotConfig, "pinotConfig is null");
+        this.limitForSegmentQueries = limitForSegmentQueries;
         this.split = requireNonNull(split, "split is null");
         this.pinotQueryClient = requireNonNull(pinotQueryClient, "pinotQueryClient is null");
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
@@ -180,6 +186,7 @@ public class PinotSegmentPageSource
                     .forEach(dataTable ->
                     {
                         checkExceptions(dataTable, split, query);
+                        checkTooManyRows(dataTable);
                         // Store each dataTable which will later be constructed into Pages.
                         // Also update estimatedMemoryUsage, mostly represented by the size of all dataTables, using numberOfRows and fieldTypes combined as an estimate
                         int estimatedTableSizeInBytes = IntStream.rangeClosed(0, dataTable.getDataSchema().size() - 1)
@@ -197,6 +204,13 @@ public class PinotSegmentPageSource
         }
         finally {
             readTimeNanos += System.nanoTime() - startTimeNanos;
+        }
+    }
+
+    private void checkTooManyRows(DataTable dataTable)
+    {
+        if (currentRowCount.addAndGet(dataTable.getNumberOfRows()) > limitForSegmentQueries) {
+            throw new PinotException(PINOT_EXCEPTION, Optional.of(query), format("Segment query returned '%s' rows per split, maximum allowed is '%s' rows.", currentRowCount.get(), limitForSegmentQueries));
         }
     }
 

--- a/presto-pinot/src/main/java/io/prestosql/pinot/client/PinotClient.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/client/PinotClient.java
@@ -310,9 +310,7 @@ public class PinotClient
 
     public Map<String, Map<String, List<String>>> getRoutingTableForTable(String tableName)
     {
-        LOG.info("Trying to get routingTable for %s from broker", tableName);
         Map<String, Map<String, List<String>>> routingTable = sendHttpGetToBrokerJson(tableName, format(ROUTING_TABLE_API_TEMPLATE, tableName), ROUTING_TABLE_CODEC);
-        LOG.info("Got routingTable for %s from broker: %s", tableName, routingTable);
         ImmutableMap.Builder<String, Map<String, List<String>>> routingTableMap = ImmutableMap.builder();
         for (Map.Entry<String, Map<String, List<String>>> entry : routingTable.entrySet()) {
             String tablenameWithType = entry.getKey();

--- a/presto-pinot/src/main/java/io/prestosql/pinot/decoders/ArrayDecoder.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/decoders/ArrayDecoder.java
@@ -38,24 +38,6 @@ public class ArrayDecoder
         this.elementDecoder = createDecoder(this.type.getElementType());
     }
 
-    /*
-    @Override
-    public void decode(Supplier<List<Serializable>> getter, BlockBuilder output)
-    {
-        List<Serializable> value = getter.get();
-        if (value == null) {
-            output.appendNull();
-        }
-        else {
-            BlockBuilder elementBlockBuilder = type.getElementType().createBlockBuilder(null, 1);
-            for (int i = 0; i < value.size(); i++) {
-                int index = i;
-                elementDecoder.decode(() -> value.get(index).toString(), elementBlockBuilder);
-            }
-            type.writeObject(output, elementBlockBuilder.build());
-        }
-    }
-     */
     @Override
     public void decode(Supplier<Object> getter, BlockBuilder output)
     {

--- a/presto-pinot/src/main/java/io/prestosql/pinot/query/PinotQueryBuilder.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/query/PinotQueryBuilder.java
@@ -15,9 +15,6 @@ package io.prestosql.pinot.query;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import io.airlift.json.JsonCodec;
-import io.airlift.json.JsonCodecFactory;
-import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
 import io.prestosql.pinot.PinotColumnHandle;
 import io.prestosql.pinot.PinotTableHandle;
@@ -31,8 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -42,10 +37,6 @@ import static java.util.stream.Collectors.joining;
 
 public final class PinotQueryBuilder
 {
-    public static final JsonCodec<DynamicTable> CODEC = new JsonCodecFactory(
-            () -> new ObjectMapperProvider().get().enable(FAIL_ON_UNKNOWN_PROPERTIES).disable(FAIL_ON_EMPTY_BEANS))
-            .jsonCodec(DynamicTable.class);
-
     private PinotQueryBuilder()
     {
     }

--- a/presto-pinot/src/main/java/io/prestosql/pinot/query/PinotQueryBuilder.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/query/PinotQueryBuilder.java
@@ -50,7 +50,7 @@ public final class PinotQueryBuilder
     {
     }
 
-    public static String generatePql(PinotTableHandle tableHandle, List<PinotColumnHandle> columnHandles, Optional<String> tableNameSuffix, Optional<String> timePredicate)
+    public static String generatePql(PinotTableHandle tableHandle, List<PinotColumnHandle> columnHandles, Optional<String> tableNameSuffix, Optional<String> timePredicate, int limitForSegmentQueries)
     {
         requireNonNull(tableHandle, "tableHandle is null");
         StringBuilder pqlBuilder = new StringBuilder();
@@ -71,15 +71,13 @@ public final class PinotQueryBuilder
                 .append(getTableName(tableHandle, tableNameSuffix))
                 .append(" ");
         generateFilterPql(pqlBuilder, tableHandle, timePredicate, columnHandles);
-        OptionalLong limit = tableHandle.getLimit();
-        if (limit.isPresent()) {
-            pqlBuilder.append(" LIMIT ")
-                    .append(limit.getAsLong());
+        OptionalLong appliedLimit = tableHandle.getLimit();
+        long limit = limitForSegmentQueries + 1;
+        if (appliedLimit.isPresent()) {
+            limit = Math.min(limit, appliedLimit.getAsLong());
         }
-        else {
-            pqlBuilder.append(" LIMIT ")
-                    .append(Integer.MAX_VALUE);
-        }
+        pqlBuilder.append(" LIMIT ")
+                .append(limit);
         return pqlBuilder.toString();
     }
 

--- a/presto-pinot/src/test/java/io/prestosql/pinot/TestMinimalFunctionality.java
+++ b/presto-pinot/src/test/java/io/prestosql/pinot/TestMinimalFunctionality.java
@@ -79,6 +79,7 @@ public class TestMinimalFunctionality
 
         Map<String, String> pinotProperties = ImmutableMap.<String, String>builder()
                 .put("pinot.controller-urls", pinot.getControllerConnectString())
+                .put("pinot.max-rows-per-split-for-segment-queries", "6")
                 .build();
 
         return PinotQueryRunner.createPinotQueryRunner(
@@ -177,6 +178,13 @@ public class TestMinimalFunctionality
                 "  FROM \"SELECT AVG(lucky_number) FROM my_table WHERE vendor in ('vendor2', 'vendor4')\"");
         assertEquals(getOnlyElement(result.getTypes()), DOUBLE);
         assertEquals(result.getOnlyValue(), 7.0);
+    }
+
+    @Test
+    public void testLimitForSegmentQueries()
+    {
+        assertQuerySucceeds("SELECT * FROM " + TOPIC_AND_TABLE + " WHERE vendor != 'vendor7'");
+        assertQueryFails("SELECT * FROM " + TOPIC_AND_TABLE, "Segment query returned.*");
     }
 
     private static Object createTestRecord(

--- a/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotConfig.java
+++ b/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotConfig.java
@@ -42,7 +42,8 @@ public class TestPinotConfig
                         .setFetchRetryCount(2)
                         .setForbidSegmentQueries(false)
                         .setNonAggregateLimitForBrokerQueries(25_000)
-                        .setRequestTimeout(new Duration(30, TimeUnit.SECONDS)));
+                        .setRequestTimeout(new Duration(30, TimeUnit.SECONDS))
+                        .setMaxRowsPerSplitForSegmentQueries(50_000));
     }
 
     @Test
@@ -64,6 +65,7 @@ public class TestPinotConfig
                 .put("pinot.non-aggregate-limit-for-broker-queries", "10")
                 .put("pinot.forbid-segment-queries", "true")
                 .put("pinot.request-timeout", "1m")
+                .put("pinot.max-rows-per-split-for-segment-queries", "10")
                 .build();
 
         PinotConfig expected = new PinotConfig()
@@ -81,7 +83,8 @@ public class TestPinotConfig
                 .setFetchRetryCount(3)
                 .setNonAggregateLimitForBrokerQueries(10)
                 .setForbidSegmentQueries(true)
-                .setRequestTimeout(new Duration(1, TimeUnit.MINUTES));
+                .setRequestTimeout(new Duration(1, TimeUnit.MINUTES))
+                .setMaxRowsPerSplitForSegmentQueries(10);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
+++ b/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
@@ -76,7 +76,6 @@ public class TestPinotSplitManager
 
     private void testSegmentSplitsHelperNoFilter(PinotTableHandle table, int segmentsPerSplit, int expectedNumSplits, boolean expectFilter)
     {
-        PinotConfig pinotConfig = new PinotConfig().setPreferBrokerQueries(false);
         PinotTableHandle pinotTableHandle = new PinotTableHandle(table.getSchemaName(), table.getTableName());
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, segmentsPerSplit, false);
         assertSplits(splits, expectedNumSplits, SEGMENT);
@@ -85,7 +84,6 @@ public class TestPinotSplitManager
 
     private void testSegmentSplitsHelperWithFilter(PinotTableHandle table, int segmentsPerSplit, int expectedNumSplits)
     {
-        PinotConfig pinotConfig = new PinotConfig().setPreferBrokerQueries(false);
         PinotTableHandle pinotTableHandle = new PinotTableHandle(table.getSchemaName(), table.getTableName());
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, segmentsPerSplit, false);
         assertSplits(splits, expectedNumSplits, SEGMENT);


### PR DESCRIPTION
Add limit for pinot server queries. Pinot servers can crash under load from heavy selects so add a limit for each pinot server query, which corresponds to a pinot segment split.