### PR TITLE
Fix ArbitraryOutputBuffer#isOverutilized

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/io/prestosql/execution/buffer/ArbitraryOutputBuffer.java
@@ -118,7 +118,7 @@ public class ArbitraryOutputBuffer
     @Override
     public boolean isOverutilized()
     {
-        return (memoryManager.getUtilization() >= 0.5) || !state.get().canAddPages();
+        return memoryManager.getUtilization() >= 0.5 && state.get().canAddPages();
     }
 
     @Override


### PR DESCRIPTION
In order for buffer to be utilized it has to
have certain utilization AND it must be in a state
where it can still accept pages. Buffer cannot be
overutilized (and blocked) in FLUSHING, FINISHED
or FAILED pages as no more pages can be added.