### PR TITLE
Simplify product tests launching

### DIFF
--- a/presto-product-tests-launcher/bin/run-product-tests
+++ b/presto-product-tests-launcher/bin/run-product-tests
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+launcher="${BASH_SOURCE%/*}/run-launcher"
+
+# Script defaults
+RUNNER_ARGS=""
+TEMPTO_ARGS=""
+ENVIRONMENT=""
+SUITE="default"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        --environment) # environment name
+        RUNNER_ARGS="--environment=${2} ${RUNNER_ARGS}"
+        ENVIRONMENT="${2}"
+        shift
+        shift
+        ;;
+        --startup-timeout) # timeout for environment startup
+        RUNNER_ARGS="--startup-timeout=${2} ${RUNNER_ARGS}"
+        shift
+        shift
+        ;;
+        --suite) # suite name
+        SUITE="$2"
+        shift
+        shift
+        ;;
+        -g|--groups) # test groups to run
+        TEMPTO_ARGS="-g ${2} ${TEMPTO_ARGS}"
+        shift
+        shift
+        ;;
+        -x|--exclude-groups) # groups to exclude
+        TEMPTO_ARGS="-x ${2} ${TEMPTO_ARGS}"
+        shift
+        shift
+        ;;
+        -t|--tests) # specific tests to run
+        TEMPTO_ARGS="-t ${2} ${TEMPTO_ARGS}"
+        shift
+        shift
+        ;;
+        -e|--exclude-tests) # tests to exclude
+        TEMPTO_ARGS="-e ${2} ${TEMPTO_ARGS}"
+        shift
+        shift
+        ;;
+        -d|--debug) # open debug ports
+        RUNNER_ARGS="${RUNNER_ARGS} --debug"
+        shift
+        ;;
+        -b|--bind) # bind ports on localhost
+        RUNNER_ARGS="${RUNNER_ARGS} --bind"
+        shift
+        ;;
+        *)
+        POSITIONAL+=("$1")
+        shift
+        ;;
+    esac
+done
+
+set -- "${POSITIONAL[@]}"
+
+if [ "${ENVIRONMENT}" = "" ]; then
+    echo "Environment name is missing (use --environment)"
+    exit 1
+fi
+
+if [ "$TEMPTO_ARGS" = "" ]; then
+    echo "Tempto run configuration is missing (use combination of -g -x -t -e)";
+    exit 1
+fi
+
+REPORTS_DIR="${BASH_SOURCE%/*}/../../presto-product-tests/target/${SUITE}-${ENVIRONMENT}"
+RUNNER_ARGS="--reports-dir=${REPORTS_DIR} ${RUNNER_ARGS}"
+
+echo "[Suite: ${SUITE}, environment: ${ENVIRONMENT}] Starting products tests with Tempto configuration: '${TEMPTO_ARGS}'"
+${launcher} test run ${RUNNER_ARGS} -- ${TEMPTO_ARGS} @$
+echo "[Suite: ${SUITE}, environment: ${ENVIRONMENT}] Tests have finished. Test reports can be found in: '${REPORTS_DIR}'"

--- a/presto-product-tests/bin/product-tests-suite-1.sh
+++ b/presto-product-tests/bin/product-tests-suite-1.sh
@@ -7,10 +7,7 @@ DISTRO_SKIP_TEST="${DISTRO_SKIP_TEST:-}"
 
 suite_exit_code=0
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment multinode \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-1/multinode \
-    -- \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-1 --environment multinode \
     -x big_query,storage_formats,profile_specific_tests,tpcds,hive_compression,"${DISTRO_SKIP_GROUP}" \
     -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1

--- a/presto-product-tests/bin/product-tests-suite-2.sh
+++ b/presto-product-tests/bin/product-tests-suite-2.sh
@@ -7,34 +7,24 @@ DISTRO_SKIP_TEST="${DISTRO_SKIP_TEST:-}"
 
 suite_exit_code=0
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-2/singlenode \
-    -- -g hdfs_no_impersonation,hive_compression -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-2 --environment singlenode \
+    -g hdfs_no_impersonation,hive_compression -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hdfs-no-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-2/singlenode-kerberos-hdfs-no-impersonation \
-    -- -g storage_formats,hdfs_no_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-2 --environment singlenode-kerberos-hdfs-no-impersonation \
+    -g storage_formats,hdfs_no_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-hdfs-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-2/singlenode-hdfs-impersonation \
-    -- -g storage_formats,cli,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-2 --environment singlenode-hdfs-impersonation \
+    -g storage_formats,cli,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hdfs-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-2/singlenode-kerberos-hdfs-impersonation \
-    -- -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-2 --environment singlenode-kerberos-hdfs-impersonation \
+    -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-2/singlenode \
-    -- -g hive_with_external_writes -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-2 --environment singlenode \
+    -g hive_with_external_writes -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-3.sh
+++ b/presto-product-tests/bin/product-tests-suite-3.sh
@@ -7,29 +7,21 @@ DISTRO_SKIP_TEST="${DISTRO_SKIP_TEST:-}"
 
 suite_exit_code=0
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment multinode-tls \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-3/multinode-tls \
-    -- -g smoke,cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-3 --environment multinode-tls \
+    -g smoke,cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment multinode-tls-kerberos \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-3/multinode-tls-kerberos \
-    -- -g cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-3 --environment multinode-tls-kerberos \
+    -g cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hdfs-impersonation-with-wire-encryption \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-3/singlenode-kerberos-hdfs-impersonation-with-wire-encryption \
-    -- -g storage_formats,cli,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-3 --environment singlenode-kerberos-hdfs-impersonation-with-wire-encryption \
+    -g storage_formats,cli,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
 # Smoke run af a few tests in environment with dfs.data.transfer.protection=true. Arbitrary tests which access HDFS data were chosen.
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hdfs-impersonation-with-data-protection \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-3/singlenode-kerberos-hdfs-impersonation-with-data-protection \
-    -- -t TestHiveStorageFormats.testOrcTableCreatedInPresto,TestHiveCreateTable.testCreateTable  -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-3 --environment singlenode-kerberos-hdfs-impersonation-with-data-protection \
+    -t TestHiveStorageFormats.testOrcTableCreatedInPresto,TestHiveCreateTable.testCreateTable -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-5.sh
+++ b/presto-product-tests/bin/product-tests-suite-5.sh
@@ -7,22 +7,16 @@ DISTRO_SKIP_TEST="${DISTRO_SKIP_TEST:-}"
 
 suite_exit_code=0
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-hive-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-5/singlenode-hive-impersonation \
-    -- -g storage_formats,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-5 --environment singlenode-hive-impersonation \
+    -g storage_formats,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hive-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-5/singlenode-kerberos-hive-impersonation \
-    -- -g storage_formats,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-5 --environment singlenode-kerberos-hive-impersonation \
+    -g storage_formats,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment multinode-hive-caching \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-5/multinode-hive-caching \
-    -- -g hive_caching,storage_formats -x iceberg,"${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-5 --environment multinode-hive-caching \
+    -g hive_caching,storage_formats -x iceberg,"${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-6-non-generic.sh
@@ -13,49 +13,35 @@ fi
 suite_exit_code=0
 
 # Uses hadoop, but it irrelevant from these tests' perspective.
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-ldap \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-ldap \
-    -- -g ldap \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-ldap \
+    -g ldap \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-ldap-insecure \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-ldap-insecure \
-    -- -g ldap \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-ldap-insecure \
+    -g ldap \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-ldap-referrals \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-ldap-referrals \
-    -- -g ldap \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-ldap-referrals \
+    -g ldap \
     || suite_exit_code=1
 
 # We have docker images with KMS on CDH only. TODO (https://github.com/prestosql/presto/issues/1652) create images with HDP and KMS
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-kms-hdfs-no-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-kerberos-kms-hdfs-no-impersonation \
-    -- -g storage_formats \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-kerberos-kms-hdfs-no-impersonation \
+    -g storage_formats \
     || suite_exit_code=1
 
 # We have docker images with KMS on CDH only. TODO (https://github.com/prestosql/presto/issues/1652) create images with HDP and KMS
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-kms-hdfs-impersonation \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-kerberos-kms-hdfs-impersonation \
-    -- -g storage_formats \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-kerberos-kms-hdfs-impersonation \
+    -g storage_formats \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-cassandra \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-cassandra \
-    -- -g cassandra \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-cassandra \
+    -g cassandra \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kafka \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-6-non-generic/singlenode-kafka \
-    -- -g kafka \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-6-non-generic --environment singlenode-kafka \
+    -g kafka \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-7-non-generic.sh
@@ -13,55 +13,39 @@ fi
 suite_exit_code=0
 
 # Does not use hadoop
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-mysql \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-mysql \
-    -- -g mysql \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-mysql \
+    -g mysql \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-postgresql \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-postgresql \
-    -- -g postgresql \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-postgresql \
+    -g postgresql \
     || suite_exit_code=1
 
 # Does not use hadoop
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-sqlserver \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-sqlserver \
-    -- -g sqlserver \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-sqlserver \
+    -g sqlserver \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-spark-iceberg \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-spark-iceberg \
-    -- -g iceberg -x storage_formats \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-spark-iceberg \
+    -g iceberg -x storage_formats \
     || suite_exit_code=1
 
 # Environment not set up on CDH. (TODO run on HDP 2.6 and HDP 3.1)
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-kerberos-hdfs-impersonation-cross-realm \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-kerberos-hdfs-impersonation-cross-realm \
-    -- -g storage_formats,cli,hdfs_impersonation \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-kerberos-hdfs-impersonation-cross-realm \
+    -g storage_formats,cli,hdfs_impersonation \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment two-mixed-hives \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/two-mixed-hives \
-    -- -g two_hives \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment two-mixed-hives \
+    -g two_hives \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment two-kerberos-hives \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/two-kerberos-hives \
-    -- -g two_hives \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment two-kerberos-hives \
+    -g two_hives \
     || suite_exit_code=1
 
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment singlenode-ldap-bind-dn \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-7-non-generic/singlenode-ldap-bind-dn \
-    -- -g ldap \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-7-non-generic --environment singlenode-ldap-bind-dn \
+    -g ldap \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-8-non-generic.sh
+++ b/presto-product-tests/bin/product-tests-suite-8-non-generic.sh
@@ -12,10 +12,8 @@ fi
 
 suite_exit_code=0
 
-presto-product-tests-launcher/bin/run-launcher test run \
-   --environment singlenode-hdp3 \
-   --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-8-non-generic/singlenode-hdp3 \
-    -- -g hdp3_only,hive_transactional \
+presto-product-tests-launcher/bin/run-product-tests --suite suite-8-non-generic --environment singlenode-hdp3 \
+    -g hdp3_only,hive_transactional \
     || suite_exit_code=1
 
 echo "$0: exiting with ${suite_exit_code}"

--- a/presto-product-tests/bin/product-tests-suite-tpcds.sh
+++ b/presto-product-tests/bin/product-tests-suite-tpcds.sh
@@ -8,12 +8,9 @@ DISTRO_SKIP_TEST="${DISTRO_SKIP_TEST:-}"
 suite_exit_code=0
 
 # TODO: Results for q72 need to be fixed. https://github.com/prestosql/presto/issues/4564
-presto-product-tests-launcher/bin/run-launcher test run \
-    --environment multinode \
-    --reports-dir="${BASH_SOURCE%/*}"/../../product-tests-reports/suite-tpcds/multinode \
-    -- -g tpcds -x "${DISTRO_SKIP_GROUP}" -e sql_tests.testcases.tpcds.q72,"${DISTRO_SKIP_TEST}" \
+presto-product-tests-launcher/bin/run-product-tests --suite tpcds --environment multinode \
+    -g tpcds -x "${DISTRO_SKIP_GROUP}" -e sql_tests.testcases.tpcds.q72,"${DISTRO_SKIP_TEST}" \
     || suite_exit_code=1
-
 
 echo "$0: exiting with ${suite_exit_code}"
 exit "${suite_exit_code}"


### PR DESCRIPTION
Follow-up to https://github.com/prestosql/presto/pull/4702

Make `product-tests-suite-*.sh` simpler by reducing boilerplate