### PR TITLE
Minor page optimizations

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/GroupedTopNBuilder.java
+++ b/presto-main/src/main/java/io/prestosql/operator/GroupedTopNBuilder.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Ordering;
 import io.prestosql.array.ObjectBigArray;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
 import it.unimi.dsi.fastutil.ints.IntIterator;
@@ -324,11 +323,7 @@ public class GroupedTopNBuilder
             verify(index == usedPositionCount);
 
             // compact page
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int i = 0; i < page.getChannelCount(); i++) {
-                Block block = page.getBlock(i);
-                blocks[i] = block.copyPositions(positions, 0, usedPositionCount);
-            }
+            Page newPage = page.copyPositions(positions, 0, usedPositionCount);
 
             // update all the elements in the heaps that reference the current page
             for (int i = 0; i < usedPositionCount; i++) {
@@ -336,7 +331,7 @@ public class GroupedTopNBuilder
                 // it only updates the value of the elements; while keeping the same order
                 newReference[i].reset(i);
             }
-            page = new Page(usedPositionCount, blocks);
+            page = newPage;
             reference = newReference;
         }
 

--- a/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
@@ -39,16 +39,18 @@ public final class JoinUtils
 
     public static List<Page> channelsToPages(List<List<Block>> channels)
     {
-        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builder();
-        if (!channels.isEmpty()) {
-            int pagesCount = channels.get(0).size();
-            for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
-                Block[] blocks = new Block[channels.size()];
-                for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-                    blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
-                }
-                pagesBuilder.add(new Page(blocks));
+        if (channels.isEmpty()) {
+            return ImmutableList.of();
+        }
+
+        int pagesCount = channels.get(0).size();
+        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builderWithExpectedSize(pagesCount);
+        for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
+            Block[] blocks = new Block[channels.size()];
+            for (int channelIndex = 0; channelIndex < blocks.length; ++channelIndex) {
+                blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
             }
+            pagesBuilder.add(new Page(blocks));
         }
         return pagesBuilder.build();
     }

--- a/presto-main/src/main/java/io/prestosql/operator/LimitOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LimitOperator.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator;
 
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -106,12 +105,7 @@ public class LimitOperator
             nextPage = page;
         }
         else {
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                Block block = page.getBlock(channel);
-                blocks[channel] = block.getRegion(0, (int) remainingLimit);
-            }
-            nextPage = new Page((int) remainingLimit, blocks);
+            nextPage = page.getRegion(0, (int) remainingLimit);
             remainingLimit = 0;
         }
     }

--- a/presto-main/src/main/java/io/prestosql/operator/NestedLoopJoinPagesBuilder.java
+++ b/presto-main/src/main/java/io/prestosql/operator/NestedLoopJoinPagesBuilder.java
@@ -60,11 +60,12 @@ public class NestedLoopJoinPagesBuilder
     {
         checkState(!finished, "NestedLoopJoinPagesBuilder is finished");
 
-        pages.stream()
-                .forEach(Page::compact);
-        estimatedSize = pages.stream()
-                .mapToLong(Page::getRetainedSizeInBytes)
-                .sum();
+        long estimatedSize = 0L;
+        for (Page page : pages) {
+            page.compact();
+            estimatedSize += page.getRetainedSizeInBytes();
+        }
+        this.estimatedSize = estimatedSize;
     }
 
     public NestedLoopJoinPages build()

--- a/presto-main/src/main/java/io/prestosql/operator/RowNumberOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/RowNumberOperator.java
@@ -26,7 +26,6 @@ import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -283,14 +282,12 @@ public class RowNumberOperator
 
     private Page getRowsWithRowNumber()
     {
-        Block rowNumberBlock = createRowNumberBlock();
-        Block[] sourceBlocks = new Block[inputPage.getChannelCount()];
+        Block[] outputBlocks = new Block[inputPage.getChannelCount() + 1]; // +1 for the row number column
         for (int i = 0; i < outputChannels.length; i++) {
-            sourceBlocks[i] = inputPage.getBlock(outputChannels[i]);
+            outputBlocks[i] = inputPage.getBlock(outputChannels[i]);
         }
 
-        Block[] outputBlocks = Arrays.copyOf(sourceBlocks, sourceBlocks.length + 1); // +1 for the row number column
-        outputBlocks[sourceBlocks.length] = rowNumberBlock;
+        outputBlocks[outputBlocks.length - 1] = createRowNumberBlock();
 
         return new Page(inputPage.getPositionCount(), outputBlocks);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/StreamingAggregationOperator.java
@@ -278,9 +278,9 @@ public class StreamingAggregationOperator
         {
             requireNonNull(page, "page is null");
 
-            Page groupByPage = extractColumns(page, groupByChannels);
+            Page groupByPage = page.getColumns(groupByChannels);
             if (currentGroup != null) {
-                if (!pagesHashStrategy.rowEqualsRow(0, extractColumns(currentGroup, groupByChannels), 0, groupByPage)) {
+                if (!pagesHashStrategy.rowEqualsRow(0, currentGroup.getColumns(groupByChannels), 0, groupByPage)) {
                     // page starts with new group, so flush it
                     evaluateAndFlushGroup(currentGroup, 0);
                 }
@@ -304,15 +304,6 @@ public class StreamingAggregationOperator
                     return;
                 }
             }
-        }
-
-        private static Page extractColumns(Page page, int[] channels)
-        {
-            Block[] newBlocks = new Block[channels.length];
-            for (int i = 0; i < channels.length; i++) {
-                newBlocks[i] = page.getBlock(channels[i]);
-            }
-            return new Page(page.getPositionCount(), newBlocks);
         }
 
         private void addRowsToAggregates(Page page, int startPosition, int endPosition)

--- a/presto-main/src/main/java/io/prestosql/operator/exchange/PageChannelSelector.java
+++ b/presto-main/src/main/java/io/prestosql/operator/exchange/PageChannelSelector.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.exchange;
 
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -29,20 +28,13 @@ public class PageChannelSelector
 
     public PageChannelSelector(int... channels)
     {
-        checkArgument(IntStream.of(channels).allMatch(channel -> channel >= 0), "channels must be positive");
         this.channels = requireNonNull(channels, "channels is null").clone();
+        checkArgument(IntStream.of(channels).allMatch(channel -> channel >= 0), "channels must be positive");
     }
 
     @Override
     public Page apply(Page page)
     {
-        requireNonNull(page, "page is null");
-
-        Block[] blocks = new Block[channels.length];
-        for (int i = 0; i < channels.length; i++) {
-            int channel = channels[i];
-            blocks[i] = page.getBlock(channel);
-        }
-        return new Page(page.getPositionCount(), blocks);
+        return requireNonNull(page, "page is null").getColumns(channels);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/exchange/PartitioningExchanger.java
+++ b/presto-main/src/main/java/io/prestosql/operator/exchange/PartitioningExchanger.java
@@ -20,7 +20,6 @@ import io.prestosql.operator.HashGenerator;
 import io.prestosql.operator.InterpretedHashGenerator;
 import io.prestosql.operator.PrecomputedHashGenerator;
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -83,15 +82,10 @@ class PartitioningExchanger
         }
 
         // build a page for each partition
-        Block[] outputBlocks = new Block[page.getChannelCount()];
         for (int partition = 0; partition < buffers.size(); partition++) {
             IntArrayList positions = partitionAssignments[partition];
             if (!positions.isEmpty()) {
-                for (int i = 0; i < page.getChannelCount(); i++) {
-                    outputBlocks[i] = page.getBlock(i).copyPositions(positions.elements(), 0, positions.size());
-                }
-
-                Page pageSplit = new Page(positions.size(), outputBlocks);
+                Page pageSplit = page.copyPositions(positions.elements(), 0, positions.size());
                 memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
                 buffers.get(partition).accept(new PageReference(pageSplit, 1, () -> memoryManager.updateMemoryUsage(-pageSplit.getRetainedSizeInBytes())));
             }

--- a/presto-main/src/main/java/io/prestosql/operator/project/InputChannels.java
+++ b/presto-main/src/main/java/io/prestosql/operator/project/InputChannels.java
@@ -15,7 +15,6 @@ package io.prestosql.operator.project;
 
 import com.google.common.primitives.Ints;
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,11 +48,7 @@ public class InputChannels
 
     public Page getInputChannels(Page page)
     {
-        Block[] blocks = new Block[inputChannels.length];
-        for (int i = 0; i < inputChannels.length; i++) {
-            blocks[i] = page.getBlock(inputChannels[i]);
-        }
-        return new Page(page.getPositionCount(), blocks);
+        return page.getColumns(inputChannels);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/split/MappedPageSource.java
+++ b/presto-main/src/main/java/io/prestosql/split/MappedPageSource.java
@@ -15,11 +15,9 @@ package io.prestosql.split;
 
 import com.google.common.primitives.Ints;
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSource;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -61,10 +59,7 @@ public class MappedPageSource
         if (nextPage == null) {
             return null;
         }
-        Block[] blocks = Arrays.stream(delegateFieldIndex)
-                .mapToObj(nextPage::getBlock)
-                .toArray(Block[]::new);
-        return new Page(nextPage.getPositionCount(), blocks);
+        return nextPage.getColumns(delegateFieldIndex);
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/Page.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/Page.java
@@ -318,6 +318,28 @@ public final class Page
         return wrapBlocksWithoutCopy(length, blocks);
     }
 
+    public Page copyPositions(int[] retainedPositions, int offset, int length)
+    {
+        requireNonNull(retainedPositions, "retainedPositions is null");
+
+        Block[] blocks = new Block[this.blocks.length];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = this.blocks[i].copyPositions(retainedPositions, offset, length);
+        }
+        return wrapBlocksWithoutCopy(length, blocks);
+    }
+
+    public Page getColumns(int... columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        Block[] blocks = new Block[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            blocks[i] = this.blocks[columns[i]];
+        }
+        return wrapBlocksWithoutCopy(positionCount, blocks);
+    }
+
     public Page prependColumn(Block column)
     {
         if (column.getPositionCount() != positionCount) {


### PR DESCRIPTION
Cross contribution of https://github.com/prestodb/presto/pull/14981

Adds two new utility methods to `Page`:

- `copyPositions(int[] retainedPositions, int offset, int length)` which mirrors getRegion
- `getColumns(int... columns)` which creates a new page with arbitrary column selection / reordering

The follow up commit then updates various operators and classes that explicitly created and manipulated Block arrays to use equivalent Page methods that avoid extra defensive copies.