### PR TITLE
Use "classpath" consistently

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -3,7 +3,7 @@ JDBC Driver
 ===========
 
 Presto can be accessed from Java using the JDBC driver.
-Download :maven_download:`jdbc` and add it to the class path of your Java application.
+Download :maven_download:`jdbc` and add it to the classpath of your Java application.
 
 The driver is also available from Maven Central:
 

--- a/presto-main/src/main/java/io/prestosql/metadata/ScalarFunctionAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/ScalarFunctionAdapter.java
@@ -423,7 +423,7 @@ public final class ScalarFunctionAdapter
 
         // caller will pass boolean true in the next argument for SQL null
         if (expectedArgumentConvention == BLOCK_POSITION) {
-            MethodHandle getBlockValue = getBlockValue(argumentType);
+            MethodHandle getBlockValue = getBlockValue(argumentType, methodHandle.type().parameterType(parameterIndex));
 
             if (actualArgumentConvention == NEVER_NULL) {
                 if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
@@ -487,7 +487,7 @@ public final class ScalarFunctionAdapter
         throw new IllegalArgumentException("Unsupported expected argument convention: " + expectedArgumentConvention);
     }
 
-    private static MethodHandle getBlockValue(Type argumentType)
+    private static MethodHandle getBlockValue(Type argumentType, Class<?> expectedType)
     {
         Class<?> methodArgumentType = argumentType.getJavaType();
         String getterName;
@@ -511,7 +511,7 @@ public final class ScalarFunctionAdapter
         try {
             MethodHandle getValue = lookup().findVirtual(Type.class, getterName, methodType(methodArgumentType, Block.class, int.class))
                     .bindTo(argumentType);
-            return explicitCastArguments(getValue, getValue.type().changeReturnType(argumentType.getJavaType()));
+            return explicitCastArguments(getValue, getValue.type().changeReturnType(expectedType));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);


### PR DESCRIPTION
Single-character change to change the one instance of "class path" in the doc set to "classpath" for consistency and standardization.

There is no consensus in the world on this. The Google Style Guide is silent. MMS, CMS, Merriam-Webster.com, and dictionary.com do not have entries for either term.

However, classic Java documentation, now in the questionable hands of Oracle, fairly consistently uses "classpath" based on the model of the CLASSPATH environment variable and the -classpath argument to the java executable itself. 

So we will standardize on "classpath". 