### PR TITLE
Remove support for Hive bucketing on timestamp

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -214,7 +214,7 @@ import static io.prestosql.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORM
 import static io.prestosql.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static io.prestosql.plugin.hive.util.CompressionConfigUtil.configureCompression;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.toJobConf;
-import static io.prestosql.plugin.hive.util.HiveBucketing.containsTimestampBucketedV2;
+import static io.prestosql.plugin.hive.util.HiveBucketing.bucketedOnTimestamp;
 import static io.prestosql.plugin.hive.util.HiveBucketing.getHiveBucketHandle;
 import static io.prestosql.plugin.hive.util.HiveUtil.PRESTO_VIEW_FLAG;
 import static io.prestosql.plugin.hive.util.HiveUtil.buildHiveViewConnectorDefinition;
@@ -2284,9 +2284,8 @@ public class HiveMetadata
                 .orElseThrow(() -> new TableNotFoundException(tableName));
 
         if (table.getStorage().getBucketProperty().isPresent()) {
-            // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
-            if (containsTimestampBucketedV2(table.getStorage().getBucketProperty().get(), table)) {
-                throw new PrestoException(NOT_SUPPORTED, "Table bucketing version not supported for writing when bucketing on timestamp type");
+            if (bucketedOnTimestamp(table.getStorage().getBucketProperty().get(), table)) {
+                throw new PrestoException(NOT_SUPPORTED, "Writing to tables bucketed on timestamp not supported");
             }
         }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
@@ -206,8 +206,7 @@ public final class HiveBucketing
             return Optional.empty();
         }
 
-        // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
-        if (containsTimestampBucketedV2(table.getStorage().getBucketProperty().get(), table)) {
+        if (bucketedOnTimestamp(table.getStorage().getBucketProperty().get(), table)) {
             return Optional.empty();
         }
 
@@ -304,36 +303,27 @@ public final class HiveBucketing
         }
     }
 
-    // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp and remove this method
-    public static boolean containsTimestampBucketedV2(HiveBucketProperty bucketProperty, Table table)
+    public static boolean bucketedOnTimestamp(HiveBucketProperty bucketProperty, Table table)
     {
-        switch (bucketProperty.getBucketingVersion()) {
-            case BUCKETING_V1:
-                return false;
-            case BUCKETING_V2:
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported bucketing version: " + bucketProperty.getBucketingVersion());
-        }
         return bucketProperty.getBucketedBy().stream()
                 .map(columnName -> table.getColumn(columnName)
                         .orElseThrow(() -> new IllegalArgumentException(format("Cannot find column '%s' in %s", columnName, table))))
                 .map(Column::getType)
                 .map(HiveType::getTypeInfo)
-                .anyMatch(HiveBucketing::containsTimestampBucketedV2);
+                .anyMatch(HiveBucketing::bucketedOnTimestamp);
     }
 
-    private static boolean containsTimestampBucketedV2(TypeInfo type)
+    private static boolean bucketedOnTimestamp(TypeInfo type)
     {
         switch (type.getCategory()) {
             case PRIMITIVE:
                 return ((PrimitiveTypeInfo) type).getPrimitiveCategory() == TIMESTAMP;
             case LIST:
-                return containsTimestampBucketedV2(((ListTypeInfo) type).getListElementTypeInfo());
+                return bucketedOnTimestamp(((ListTypeInfo) type).getListElementTypeInfo());
             case MAP:
                 MapTypeInfo mapTypeInfo = (MapTypeInfo) type;
-                // Note: we do not check map value type because HiveBucketingV2#hashOfMap hashes map values with v1
-                return containsTimestampBucketedV2(mapTypeInfo.getMapKeyTypeInfo());
+                return bucketedOnTimestamp(mapTypeInfo.getMapKeyTypeInfo()) ||
+                        bucketedOnTimestamp(mapTypeInfo.getMapValueTypeInfo());
             default:
                 // TODO: support more types, e.g. ROW
                 throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketingV1.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketingV1.java
@@ -101,8 +101,6 @@ final class HiveBucketingV1
                     case DATE:
                         // day offset from 1970-01-01
                         return toIntExact(prestoType.getLong(block, position));
-                    case TIMESTAMP:
-                        return hashTimestamp(prestoType.getLong(block, position));
                     default:
                         throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
                 }
@@ -151,8 +149,6 @@ final class HiveBucketingV1
                     case DATE:
                         // day offset from 1970-01-01
                         return toIntExact((long) value);
-                    case TIMESTAMP:
-                        return hashTimestamp((long) value);
                     default:
                         throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
                 }
@@ -164,15 +160,6 @@ final class HiveBucketingV1
                 // TODO: support more types, e.g. ROW
                 throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
         }
-    }
-
-    @SuppressWarnings("NumericCastThatLosesPrecision")
-    private static int hashTimestamp(long epochMillis)
-    {
-        long seconds = (Math.floorDiv(epochMillis, 1000L) << 30);
-        long nanos = Math.floorMod(epochMillis, 1000) * 1_000_000L;
-        long secondsAndNanos = seconds | nanos;
-        return (int) ((secondsAndNanos >>> 32) ^ secondsAndNanos);
     }
 
     private static int hashOfMap(MapTypeInfo type, Block singleMapBlock)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketingV2.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketingV2.java
@@ -106,7 +106,6 @@ final class HiveBucketingV2
                     case DATE:
                         // day offset from 1970-01-01
                         return Murmur3.hash32(bytes(toIntExact(prestoType.getLong(block, position))));
-                    // case TIMESTAMP: // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
                     default:
                         throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
                 }
@@ -158,7 +157,6 @@ final class HiveBucketingV2
                     case DATE:
                         // day offset from 1970-01-01
                         return Murmur3.hash32(bytes(toIntExact((long) value)));
-                    // case TIMESTAMP: // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
                     default:
                         throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
                 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -140,7 +140,7 @@ import static io.prestosql.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.prestosql.plugin.hive.HiveType.toHiveTypes;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.copy;
 import static io.prestosql.plugin.hive.util.ConfigurationUtils.toJobConf;
-import static io.prestosql.plugin.hive.util.HiveBucketing.containsTimestampBucketedV2;
+import static io.prestosql.plugin.hive.util.HiveBucketing.bucketedOnTimestamp;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -900,8 +900,7 @@ public final class HiveUtil
         // add hidden columns
         columns.add(pathColumnHandle());
         if (table.getStorage().getBucketProperty().isPresent()) {
-            // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
-            if (!containsTimestampBucketedV2(table.getStorage().getBucketProperty().get(), table)) {
+            if (!bucketedOnTimestamp(table.getStorage().getBucketProperty().get(), table)) {
                 columns.add(bucketColumnHandle());
             }
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveBucketing.java
@@ -48,8 +48,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.testng.annotations.Test;
 
 import java.sql.Date;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,11 +60,13 @@ import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V2;
 import static io.prestosql.plugin.hive.util.HiveBucketing.getHiveBuckets;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Float.intBitsToFloat;
 import static java.util.Arrays.asList;
 import static java.util.Map.Entry;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.timestampTypeInfo;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
@@ -138,15 +138,20 @@ public class TestHiveBucketing
         assertBucketEquals("date", Date.valueOf("2015-11-19"), 16758, 8542395);
         assertBucketEquals("date", Date.valueOf("1950-11-19"), -6983, -431619185);
 
-        assertBucketEquals("timestamp", null, 0, 0);
-        assertBucketEquals("timestamp", Timestamp.valueOf("1970-01-01 00:00:00.000"), BUCKETING_V1, 7200);
-        assertBucketEquals("timestamp", Timestamp.valueOf("1969-12-31 23:59:59.999"), BUCKETING_V1, -74736673);
-        assertBucketEquals("timestamp", Timestamp.valueOf("1950-11-19 12:34:56.789"), BUCKETING_V1, -670699780);
-        assertBucketEquals("timestamp", Timestamp.valueOf("2015-11-19 07:06:05.432"), BUCKETING_V1, 1278000719);
-        // TODO (https://github.com/prestosql/presto/issues/1706): support bucketing v2 for timestamp
-        assertThatThrownBy(() -> assertBucketEquals("timestamp", Timestamp.valueOf("1970-01-01 00:00:00.000"), BUCKETING_V2, 0xDEAD_C0D3))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Computation of Hive bucket hashCode is not supported for Hive primitive category: TIMESTAMP");
+        for (BucketingVersion version : BucketingVersion.values()) {
+            List<TypeInfo> typeInfos = ImmutableList.of(timestampTypeInfo);
+
+            assertThatThrownBy(() -> version.getBucketHashCode(typeInfos, new Object[]{0}))
+                    .hasMessage("Computation of Hive bucket hashCode is not supported for Hive primitive category: TIMESTAMP");
+
+            TimestampType timestampType = createTimestampType(3);
+            BlockBuilder builder = timestampType.createBlockBuilder(null, 1);
+            timestampType.writeLong(builder, 0);
+            Page page = new Page(builder.build());
+
+            assertThatThrownBy(() -> version.getBucketHashCode(typeInfos, page, 0))
+                    .hasMessage("Computation of Hive bucket hashCode is not supported for Hive primitive category: TIMESTAMP");
+        }
 
         assertBucketEquals("array<double>", null, 0, 0);
         assertBucketEquals("array<boolean>", ImmutableList.of(), 0, 0);
@@ -423,15 +428,8 @@ public class TestHiveBucketing
             assertEquals(daysSinceEpochInLocalZone, DateWritable.dateToDays((Date) hiveValue));
             return daysSinceEpochInLocalZone;
         }
-        if (type instanceof TimestampType) {
-            Instant instant = ((Timestamp) hiveValue).toInstant();
-            long epochSecond = instant.getEpochSecond();
-            int nano = instant.getNano();
-            assertEquals(nano % 1_000_000, 0);
-            return epochSecond * 1000 + nano / 1_000_000;
-        }
 
-        throw new UnsupportedOperationException("unknown type");
+        throw new IllegalArgumentException("Unsupported bucketing type: " + type);
     }
 
     private static void appendToBlockBuilder(Type type, Object hiveValue, BlockBuilder blockBuilder)


### PR DESCRIPTION
Timestamps have various problems that makes supporting them
difficult, and bucketing on them is not useful thing to do anyway.

Fixes https://github.com/prestosql/presto/issues/1706