### PR TITLE
Various small Phoenix Connector fixes.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/phoenix.rst
+++ b/presto-docs/src/main/sphinx/connector/phoenix.rst
@@ -160,6 +160,6 @@ Property Name               Default Value    Description
 
 ``ttl``                     ``FOREVER``      Time To Live for each cell.
 
-``bloomfilter``             ``ROW``          Bloomfilter to use. Valid values are ``NONE``, ``ROW`` (default), or ``ROWCOL``.
+``bloomfilter``             ``NONE``         Bloomfilter to use. Valid values are ``NONE`` (default), ``ROW``, or ``ROWCOL``.
 =========================== ================ ==============================================================================================================
 

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
@@ -43,6 +43,9 @@ import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.query.QueryConstants;
@@ -164,8 +167,8 @@ public class PhoenixMetadata
             HColumnDescriptor[] columnFamilies = tableDesc.getColumnFamilies();
             for (HColumnDescriptor columnFamily : columnFamilies) {
                 if (columnFamily.getNameAsString().equals(defaultFamilyName)) {
-                    if (!"NONE".equals(columnFamily.getBloomFilterType().toString())) {
-                        properties.put(PhoenixTableProperties.BLOOMFILTER, columnFamily.getBloomFilterType().toString());
+                    if (columnFamily.getBloomFilterType() != BloomType.NONE) {
+                        properties.put(PhoenixTableProperties.BLOOMFILTER, columnFamily.getBloomFilterType());
                     }
                     if (columnFamily.getMaxVersions() != 1) {
                         properties.put(PhoenixTableProperties.VERSIONS, columnFamily.getMaxVersions());
@@ -173,14 +176,14 @@ public class PhoenixMetadata
                     if (columnFamily.getMinVersions() > 0) {
                         properties.put(PhoenixTableProperties.MIN_VERSIONS, columnFamily.getMinVersions());
                     }
-                    if (!columnFamily.getCompression().toString().equals("NONE")) {
-                        properties.put(PhoenixTableProperties.COMPRESSION, columnFamily.getCompression().toString());
+                    if (columnFamily.getCompression() != Compression.Algorithm.NONE) {
+                        properties.put(PhoenixTableProperties.COMPRESSION, columnFamily.getCompression());
                     }
                     if (columnFamily.getTimeToLive() < FOREVER) {
                         properties.put(PhoenixTableProperties.TTL, columnFamily.getTimeToLive());
                     }
-                    if (!columnFamily.getDataBlockEncoding().toString().equals("NONE")) {
-                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding().toString());
+                    if (columnFamily.getDataBlockEncoding() != DataBlockEncoding.NONE) {
+                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding());
                     }
                     break;
                 }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
@@ -15,6 +15,9 @@ package io.prestosql.plugin.phoenix;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.session.PropertyMetadata;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.util.StringUtils;
 
 import javax.inject.Inject;
@@ -26,6 +29,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static java.util.Objects.requireNonNull;
@@ -86,9 +90,10 @@ public final class PhoenixTableProperties
                         "The column family name to use by default.",
                         null,
                         false),
-                stringProperty(
+                enumProperty(
                         BLOOMFILTER,
                         "NONE, ROW or ROWCOL to enable blooms per column family.",
+                        BloomType.class,
                         null,
                         false),
                 integerProperty(
@@ -101,9 +106,10 @@ public final class PhoenixTableProperties
                         "The minimum number of row versions to store, configured per column family via HColumnDescriptor.",
                         null,
                         false),
-                stringProperty(
+                enumProperty(
                         COMPRESSION,
                         "Compression algorithm to use for HBase blocks. Options are: SNAPPY, GZIP, LZ, and others.",
+                        Compression.Algorithm.class,
                         null,
                         false),
                 integerProperty(
@@ -111,9 +117,10 @@ public final class PhoenixTableProperties
                         "Number of seconds for cell TTL.  HBase will automatically delete rows once the expiration time is reached.",
                         null,
                         false),
-                stringProperty(
+                enumProperty(
                         DATA_BLOCK_ENCODING,
                         "The block encoding algorithm to use for Cells in HBase blocks. Options are: NONE, PREFIX, DIFF, FAST_DIFF, ROW_INDEX_V1, and others.",
+                        DataBlockEncoding.class,
                         null,
                         false));
     }
@@ -128,11 +135,7 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         Integer value = (Integer) tableProperties.get(SALT_BUCKETS);
-        if (value == null) {
-            return Optional.empty();
-        }
-
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<String> getSplitOn(Map<String, Object> tableProperties)
@@ -140,11 +143,7 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         String value = (String) tableProperties.get(SPLIT_ON);
-        if (value == null) {
-            return Optional.empty();
-        }
-
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<List<String>> getRowkeys(Map<String, Object> tableProperties)
@@ -166,10 +165,7 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         Boolean value = (Boolean) tableProperties.get(DISABLE_WAL);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<Boolean> getImmutableRows(Map<String, Object> tableProperties)
@@ -177,10 +173,7 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         Boolean value = (Boolean) tableProperties.get(IMMUTABLE_ROWS);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<String> getDefaultColumnFamily(Map<String, Object> tableProperties)
@@ -188,21 +181,15 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         String value = (String) tableProperties.get(DEFAULT_COLUMN_FAMILY);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
-    public static Optional<String> getBloomfilter(Map<String, Object> tableProperties)
+    public static Optional<BloomType> getBloomfilter(Map<String, Object> tableProperties)
     {
         requireNonNull(tableProperties);
 
-        String value = (String) tableProperties.get(BLOOMFILTER);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        BloomType value = (BloomType) tableProperties.get(BLOOMFILTER);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<Integer> getVersions(Map<String, Object> tableProperties)
@@ -210,10 +197,7 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         Integer value = (Integer) tableProperties.get(VERSIONS);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     public static Optional<Integer> getMinVersions(Map<String, Object> tableProperties)
@@ -221,28 +205,22 @@ public final class PhoenixTableProperties
         requireNonNull(tableProperties);
 
         Integer value = (Integer) tableProperties.get(MIN_VERSIONS);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
-    public static Optional<String> getCompression(Map<String, Object> tableProperties)
+    public static Optional<Compression.Algorithm> getCompression(Map<String, Object> tableProperties)
     {
         requireNonNull(tableProperties);
 
-        String value = (String) tableProperties.get(COMPRESSION);
-        if (value == null) {
-            return Optional.empty();
-        }
-        return Optional.of(value);
+        Compression.Algorithm value = (Compression.Algorithm) tableProperties.get(COMPRESSION);
+        return Optional.ofNullable(value);
     }
 
-    public static Optional<String> getDataBlockEncoding(Map<String, Object> tableProperties)
+    public static Optional<DataBlockEncoding> getDataBlockEncoding(Map<String, Object> tableProperties)
     {
         requireNonNull(tableProperties);
 
-        String value = (String) tableProperties.get(DATA_BLOCK_ENCODING);
+        DataBlockEncoding value = (DataBlockEncoding) tableProperties.get(DATA_BLOCK_ENCODING);
         return Optional.ofNullable(value);
     }
 


### PR DESCRIPTION
- use proper public Phoenix/HBase enums for properties.
- fix documentation to state the NONE is the default for the Bloomfilter property
- use Optional.ofNullable where appropriate

As promised in #4617