### PR TITLE
Configure Oracle UCP inactive connection timeout

### DIFF
--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClientModule.java
@@ -59,7 +59,8 @@ public class OracleClientModule
                     connectionProperties,
                     credentialProvider,
                     oracleConfig.getConnectionPoolMinSize(),
-                    oracleConfig.getConnectionPoolMaxSize());
+                    oracleConfig.getConnectionPoolMaxSize(),
+                    oracleConfig.getInactiveConnectionTimeout());
         }
 
         return new DriverConnectionFactory(

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleConfig.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleConfig.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.oracle;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Max;
@@ -24,6 +25,8 @@ import javax.validation.constraints.NotNull;
 import java.math.RoundingMode;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 public class OracleConfig
 {
     private boolean synonymsEnabled;
@@ -32,6 +35,7 @@ public class OracleConfig
     private boolean connectionPoolEnabled = true;
     private int connectionPoolMinSize = 1;
     private int connectionPoolMaxSize = 30;
+    private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
 
     @NotNull
     public boolean isSynonymsEnabled()
@@ -108,6 +112,20 @@ public class OracleConfig
     public OracleConfig setConnectionPoolMaxSize(int connectionPoolMaxSize)
     {
         this.connectionPoolMaxSize = connectionPoolMaxSize;
+        return this;
+    }
+
+    @NotNull
+    public Duration getInactiveConnectionTimeout()
+    {
+        return inactiveConnectionTimeout;
+    }
+
+    @Config("oracle.connection-pool.inactive-timeout")
+    @ConfigDescription("How long a connection in the pool can remain idle before it is closed")
+    public OracleConfig setInactiveConnectionTimeout(Duration inactiveConnectionTimeout)
+    {
+        this.inactiveConnectionTimeout = inactiveConnectionTimeout;
         return this;
     }
 

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OraclePoolConnectorFactory.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OraclePoolConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.oracle;
 
+import io.airlift.units.Duration;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
@@ -25,6 +26,9 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Properties;
 
+import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public class OraclePoolConnectorFactory
         implements ConnectionFactory
 {
@@ -35,7 +39,8 @@ public class OraclePoolConnectorFactory
             Properties connectionProperties,
             CredentialProvider credentialProvider,
             int connectionPoolMinSize,
-            int connectionPoolMaxSize)
+            int connectionPoolMaxSize,
+            Duration inactiveConnectionTimeout)
             throws SQLException
     {
         this.dataSource = PoolDataSourceFactory.getPoolDataSource();
@@ -50,6 +55,7 @@ public class OraclePoolConnectorFactory
         this.dataSource.setMaxPoolSize(connectionPoolMaxSize);
         this.dataSource.setValidateConnectionOnBorrow(true);
         this.dataSource.setConnectionProperties(connectionProperties);
+        this.dataSource.setInactiveConnectionTimeout(toIntExact(inactiveConnectionTimeout.roundTo(SECONDS)));
         credentialProvider.getConnectionUser(Optional.empty())
                 .ifPresent(user -> {
                     try {

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleConfig.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleConfig.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.oracle;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.Max;
@@ -26,6 +27,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestOracleConfig
 {
@@ -38,7 +40,8 @@ public class TestOracleConfig
                 .setNumberRoundingMode(RoundingMode.UNNECESSARY)
                 .setConnectionPoolEnabled(true)
                 .setConnectionPoolMinSize(1)
-                .setConnectionPoolMaxSize(30));
+                .setConnectionPoolMaxSize(30)
+                .setInactiveConnectionTimeout(Duration.valueOf("20m")));
     }
 
     @Test
@@ -51,6 +54,7 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.enabled", "false")
                 .put("oracle.connection-pool.min-size", "10")
                 .put("oracle.connection-pool.max-size", "20")
+                .put("oracle.connection-pool.inactive-timeout", "30s")
                 .build();
 
         OracleConfig expected = new OracleConfig()
@@ -59,7 +63,8 @@ public class TestOracleConfig
                 .setNumberRoundingMode(RoundingMode.CEILING)
                 .setConnectionPoolEnabled(false)
                 .setConnectionPoolMinSize(10)
-                .setConnectionPoolMaxSize(20);
+                .setConnectionPoolMaxSize(20)
+                .setInactiveConnectionTimeout(new Duration(30, SECONDS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This PR adds `oracle.connection-pool.inactive-timeout` which allows specifying how long connection can be inactive before it is closed.