### PR TITLE
Deduplicate ValuesNode output symbols

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
@@ -276,6 +276,19 @@ public class TestLogicalPlanner
     }
 
     @Test
+    public void testTrivialFilterOverDuplicateSymbol()
+    {
+        assertPlan(
+                "WITH t AS (SELECT DISTINCT cast(null AS varchar), cast(null AS varchar)) " +
+                        "SELECT * FROM t WHERE 1 = 0",
+                output(ImmutableList.of("expr", "expr"), values("expr")));
+
+        assertPlan(
+                "SELECT * FROM (SELECT DISTINCT 1, 1) WHERE 1 = 0",
+                output(ImmutableList.of("expr", "expr"), values("expr")));
+    }
+
+    @Test
     public void testDistinctLimitOverInequalityJoin()
     {
         assertPlan("SELECT DISTINCT o.orderkey FROM orders o JOIN lineitem l ON o.orderkey < l.orderkey LIMIT 1",


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/4782

In `UnaliasSymbolReferences`, duplicate output symbols of ValuesNode can be removed.
No other code depends on the number (or order) of outputs.

Note: for certain nodes, i.e. `ApplyNode`, `ProjectNode` and `ExchangeNode`, there are new symbol mappings derived on the basis of the node's input-to-output assignments.
For `ValuesNode`, this pattern wasn't followed. It is possible to add new symbol mappings between output symbols which result from the same expressions. However, it would be necessary to:
- check that the expressions are deterministic,
- in case when there are no expressions present, only add mappings between symbols of the same types.