### PR TITLE
Send driver version even without matching pattern

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriver.java
@@ -28,7 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Strings.nullToEmpty;
 import static io.prestosql.client.OkHttpUtil.setupChannelSocket;
 import static io.prestosql.client.OkHttpUtil.userAgent;
 import static java.lang.Integer.parseInt;
@@ -46,15 +45,14 @@ public class PrestoDriver
     private final OkHttpClient httpClient = newHttpClient();
 
     static {
-        String version = nullToEmpty(PrestoDriver.class.getPackage().getImplementationVersion());
-        Matcher matcher = Pattern.compile("^(\\d+)(\\.(\\d+))?($|[.-])").matcher(version);
+        String implementationVersion = PrestoDriver.class.getPackage().getImplementationVersion();
+        DRIVER_VERSION = implementationVersion == null ? "unknown" : implementationVersion;
+        Matcher matcher = Pattern.compile("^(\\d+)(\\.(\\d+))?($|[.-])").matcher(DRIVER_VERSION);
         if (!matcher.find()) {
-            DRIVER_VERSION = "unknown";
             DRIVER_VERSION_MAJOR = 0;
             DRIVER_VERSION_MINOR = 0;
         }
         else {
-            DRIVER_VERSION = version;
             DRIVER_VERSION_MAJOR = parseInt(matcher.group(1));
             DRIVER_VERSION_MINOR = parseInt(firstNonNull(matcher.group(3), "0"));
         }


### PR DESCRIPTION
Reason: 

`PrestoDriver.class.getPackage().getImplementationVersion()` may not match the pattern due to internal build/versioning. The driver version is logged as `useragent` in the event listener, which is useful for tracking the usage (and upgrades) of different JDBC drivers. Even if major and minor versions cannot be parsed, there's no harm in sending the driver version as is. 