### PR TITLE
Remove redundant condition check in LongOutputStreamV2

### DIFF
--- a/presto-orc/src/main/java/io/prestosql/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/stream/LongOutputStreamV2.java
@@ -716,7 +716,7 @@ public class LongOutputStreamV2
             return;
         }
 
-        if (fixedRunLength >= MIN_REPEAT && fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
+        if (fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
             writeValues(EncodingType.SHORT_REPEAT);
             return;
         }


### PR DESCRIPTION
We do not need to check `fixedRunLength >= MIN_REPEAT` because we can make sure `fixedRunLength` is non-negative by the previous condition at the line 712.

```java
if (fixedRunLength < MIN_REPEAT) {
  // ...
}
```