### PR TITLE
kafka connector: add internal columns filter pushdown

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -145,16 +145,17 @@ built-in ones:
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Extra |                   Comment
-    -------------------+---------+-------+---------------------------------------------
-     _partition_id     | bigint  |       | Partition Id
-     _partition_offset | bigint  |       | Offset for the message within the partition
-     _key              | varchar |       | Key text
-     _key_corrupt      | boolean |       | Key data is corrupt
-     _key_length       | bigint  |       | Total number of key bytes
-     _message          | varchar |       | Message text
-     _message_corrupt  | boolean |       | Message data is corrupt
-     _message_length   | bigint  |       | Total number of message bytes
+          Column       |  Type      | Extra |                   Comment
+    -------------------+------------+-------+---------------------------------------------
+     _partition_id     | bigint     |       | Partition Id
+     _partition_offset | bigint     |       | Offset for the message within the partition
+     _key              | varchar    |       | Key text
+     _key_corrupt      | boolean    |       | Key data is corrupt
+     _key_length       | bigint     |       | Total number of key bytes
+     _message          | varchar    |       | Message text
+     _message_corrupt  | boolean    |       | Message data is corrupt
+     _message_length   | bigint     |       | Total number of message bytes
+     _timestamp        | timestamp  |       | Message timestamp
     (11 rows)
 
     presto:tpch> SELECT count(*) FROM customer;
@@ -218,17 +219,18 @@ The customer table now has an additional column: ``kafka_key``.
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Extra |                   Comment
-    -------------------+---------+-------+---------------------------------------------
-     kafka_key         | bigint  |       |
-     _partition_id     | bigint  |       | Partition Id
-     _partition_offset | bigint  |       | Offset for the message within the partition
-     _key              | varchar |       | Key text
-     _key_corrupt      | boolean |       | Key data is corrupt
-     _key_length       | bigint  |       | Total number of key bytes
-     _message          | varchar |       | Message text
-     _message_corrupt  | boolean |       | Message data is corrupt
-     _message_length   | bigint  |       | Total number of message bytes
+          Column       |  Type      | Extra |                   Comment
+    -------------------+------------+-------+---------------------------------------------
+     kafka_key         | bigint     |       |
+     _partition_id     | bigint     |       | Partition Id
+     _partition_offset | bigint     |       | Offset for the message within the partition
+     _key              | varchar    |       | Key text
+     _key_corrupt      | boolean    |       | Key data is corrupt
+     _key_length       | bigint     |       | Total number of key bytes
+     _message          | varchar    |       | Message text
+     _message_corrupt  | boolean    |       | Message data is corrupt
+     _message_length   | bigint     |       | Total number of message bytes
+     _timestamp        | timestamp  |       | Message timestamp
     (12 rows)
 
     presto:tpch> SELECT kafka_key FROM customer ORDER BY kafka_key LIMIT 10;
@@ -332,26 +334,27 @@ the sum query from earlier can operate on the ``account_balance`` column directl
 .. code-block:: none
 
     presto:tpch> DESCRIBE customer;
-          Column       |  Type   | Extra |                   Comment
-    -------------------+---------+-------+---------------------------------------------
-     kafka_key         | bigint  |       |
-     row_number        | bigint  |       |
-     customer_key      | bigint  |       |
-     name              | varchar |       |
-     address           | varchar |       |
-     nation_key        | bigint  |       |
-     phone             | varchar |       |
-     account_balance   | double  |       |
-     market_segment    | varchar |       |
-     comment           | varchar |       |
-     _partition_id     | bigint  |       | Partition Id
-     _partition_offset | bigint  |       | Offset for the message within the partition
-     _key              | varchar |       | Key text
-     _key_corrupt      | boolean |       | Key data is corrupt
-     _key_length       | bigint  |       | Total number of key bytes
-     _message          | varchar |       | Message text
-     _message_corrupt  | boolean |       | Message data is corrupt
-     _message_length   | bigint  |       | Total number of message bytes
+          Column       |  Type      | Extra |                   Comment
+    -------------------+------------+-------+---------------------------------------------
+     kafka_key         | bigint     |       |
+     row_number        | bigint     |       |
+     customer_key      | bigint     |       |
+     name              | varchar    |       |
+     address           | varchar    |       |
+     nation_key        | bigint     |       |
+     phone             | varchar    |       |
+     account_balance   | double     |       |
+     market_segment    | varchar    |       |
+     comment           | varchar    |       |
+     _partition_id     | bigint     |       | Partition Id
+     _partition_offset | bigint     |       | Offset for the message within the partition
+     _key              | varchar    |       | Key text
+     _key_corrupt      | boolean    |       | Key data is corrupt
+     _key_length       | bigint     |       | Total number of key bytes
+     _message          | varchar    |       | Message text
+     _message_corrupt  | boolean    |       | Message data is corrupt
+     _message_length   | bigint     |       | Total number of message bytes
+     _timestamp        | timestamp  |       | Message timestamp
     (21 rows)
 
     presto:tpch> SELECT * FROM customer LIMIT 5;

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -151,6 +151,7 @@ Column name             Type                            Description
 ``_key_corrupt``        BOOLEAN                         True if the key decoder could not decode the key for this row. When true, data columns mapped from the key should be treated as invalid.
 ``_key``                VARCHAR                         Key bytes as an UTF-8 encoded string. This is only useful for textual keys.
 ``_key_length``         BIGINT                          Number of bytes in the key.
+``_timestamp``          TIMESTAMP                       Message timestamp.
 ======================= =============================== =============================
 
 For tables without a table definition file, the ``_key_corrupt`` and

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -56,17 +56,18 @@ Configuration Properties
 
 The following configuration properties are available:
 
-=============================== ==============================================================
-Property Name                   Description
-=============================== ==============================================================
-``kafka.table-names``           List of all tables provided by the catalog
-``kafka.default-schema``        Default schema name for tables
-``kafka.nodes``                 List of nodes in the Kafka cluster
-``kafka.buffer-size``           Kafka read buffer size
-``kafka.table-description-dir`` Directory containing topic description files
-``kafka.hide-internal-columns`` Controls whether internal columns are part of the table schema or not
-``kafka.messages-per-split``    Number of messages that are processed by each Presto split, defaults to 100000
-=============================== ==============================================================
+========================================================== ==============================================================================
+Property Name                                              Description
+========================================================== ==============================================================================
+``kafka.table-names``                                      List of all tables provided by the catalog
+``kafka.default-schema``                                   Default schema name for tables
+``kafka.nodes``                                            List of nodes in the Kafka cluster
+``kafka.buffer-size``                                      Kafka read buffer size
+``kafka.table-description-dir``                            Directory containing topic description files
+``kafka.hide-internal-columns``                            Controls whether internal columns are part of the table schema or not
+``kafka.messages-per-split``                               Number of messages that are processed by each Presto split, defaults to 100000
+``kafka.timestamp-upper-bound-force-push-down-enabled``    Controls if upper bound timestamp push down is enabled for topics using ``CreateTime`` mode
+========================================================== ==============================================================================
 
 ``kafka.table-names``
 ^^^^^^^^^^^^^^^^^^^^^
@@ -120,6 +121,18 @@ References a folder within Presto deployment that holds one or more JSON
 files (must end with ``.json``) which contain table description files.
 
 This property is optional; the default is ``etc/kafka``.
+
+``kafka.timestamp-upper-bound-force-push-down-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The upper bound predicate on ``_timestamp`` column
+is pushed down only for topics using ``LogAppendTime`` mode.
+
+For topics using ``CreateTime`` mode, upper bound push down must be explicitly
+allowed via ``kafka.timestamp-upper-bound-force-push-down-enabled`` config property
+or ``timestamp_upper_bound_force_push_down_enabled`` session property.
+
+This property is optional; the default is ``false``.
 
 ``kafka.hide-internal-columns``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaAdminFactory.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaAdminFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.kafka;
+
+import io.prestosql.spi.HostAddress;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+import javax.inject.Inject;
+
+import java.util.Properties;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
+
+public class KafkaAdminFactory
+{
+    private final Set<HostAddress> nodes;
+
+    @Inject
+    public KafkaAdminFactory(KafkaConfig kafkaConfig)
+    {
+        requireNonNull(kafkaConfig, "kafkaConfig is null");
+        nodes = kafkaConfig.getNodes();
+    }
+
+    public AdminClient create()
+    {
+        return KafkaAdminClient.create(configure());
+    }
+
+    public Properties configure()
+    {
+        Properties properties = new Properties();
+        properties.setProperty(BOOTSTRAP_SERVERS_CONFIG, nodes.stream()
+                .map(HostAddress::toString)
+                .collect(joining(",")));
+        return properties;
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConfig.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConfig.java
@@ -44,6 +44,7 @@ public class KafkaConfig
     private File tableDescriptionDir = new File("etc/kafka/");
     private boolean hideInternalColumns = true;
     private int messagesPerSplit = 100_000;
+    private boolean timestampUpperBoundPushDownEnabled;
 
     @Size(min = 1)
     public Set<HostAddress> getNodes()
@@ -151,6 +152,19 @@ public class KafkaConfig
     public KafkaConfig setMessagesPerSplit(int messagesPerSplit)
     {
         this.messagesPerSplit = messagesPerSplit;
+        return this;
+    }
+
+    public boolean isTimestampUpperBoundPushDownEnabled()
+    {
+        return timestampUpperBoundPushDownEnabled;
+    }
+
+    @Config("kafka.timestamp-upper-bound-force-push-down-enabled")
+    @ConfigDescription("timestamp upper bound force pushing down enabled")
+    public KafkaConfig setTimestampUpperBoundPushDownEnabled(boolean timestampUpperBoundPushDownEnabled)
+    {
+        this.timestampUpperBoundPushDownEnabled = timestampUpperBoundPushDownEnabled;
         return this;
     }
 }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnector.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnector.java
@@ -20,9 +20,12 @@ import io.prestosql.spi.connector.ConnectorPageSinkProvider;
 import io.prestosql.spi.connector.ConnectorRecordSetProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static io.prestosql.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.prestosql.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -36,6 +39,7 @@ public class KafkaConnector
     private final ConnectorSplitManager splitManager;
     private final ConnectorRecordSetProvider recordSetProvider;
     private final ConnectorPageSinkProvider pageSinkProvider;
+    private final KafkaSessionProperties sessionProperties;
 
     @Inject
     public KafkaConnector(
@@ -43,13 +47,15 @@ public class KafkaConnector
             ConnectorMetadata metadata,
             ConnectorSplitManager splitManager,
             ConnectorRecordSetProvider recordSetProvider,
-            ConnectorPageSinkProvider pageSinkProvider)
+            ConnectorPageSinkProvider pageSinkProvider,
+            KafkaSessionProperties sessionProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
     }
 
     @Override
@@ -81,6 +87,12 @@ public class KafkaConnector
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return pageSinkProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties.getSessionProperties();
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaConnectorModule.java
@@ -55,6 +55,9 @@ public class KafkaConnectorModule
         binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(KafkaConnector.class).in(Scopes.SINGLETON);
         binder.bind(KafkaInternalFieldManager.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaSessionProperties.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaAdminFactory.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaFilterManager.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(KafkaConfig.class);
         newSetBinder(binder, TableDescriptionSupplier.class).addBinding().toProvider(KafkaTableDescriptionSupplier.class).in(Scopes.SINGLETON);

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaFilterManager.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaFilterManager.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Marker;
+import io.prestosql.spi.predicate.Ranges;
+import io.prestosql.spi.predicate.SortedRangeSet;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.predicate.ValueSet;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+
+import javax.inject.Inject;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
+import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.OFFSET_TIMESTAMP_FIELD;
+import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
+import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.PARTITION_OFFSET_FIELD;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class KafkaFilterManager
+{
+    private static final long INVALID_KAFKA_RANGE_INDEX = -1;
+    private static final String TOPIC_CONFIG_TIMESTAMP_KEY = "message.timestamp.type";
+    private static final String TOPIC_CONFIG_TIMESTAMP_VALUE_LOG_APPEND_TIME = "LogAppendTime";
+
+    private final KafkaConsumerFactory consumerFactory;
+    private final KafkaAdminFactory adminFactory;
+
+    @Inject
+    public KafkaFilterManager(KafkaConsumerFactory consumerFactory, KafkaAdminFactory adminFactory)
+    {
+        this.consumerFactory = requireNonNull(consumerFactory, "consumerManager is null");
+        this.adminFactory = requireNonNull(adminFactory, "adminFactory is null");
+    }
+
+    public KafkaFilteringResult getKafkaFilterResult(
+            ConnectorSession session,
+            KafkaTableHandle kafkaTableHandle,
+            List<PartitionInfo> partitionInfos,
+            Map<TopicPartition, Long> partitionBeginOffsets,
+            Map<TopicPartition, Long> partitionEndOffsets)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(kafkaTableHandle, "kafkaTableHandle is null");
+        requireNonNull(partitionInfos, "partitionInfos is null");
+        requireNonNull(partitionBeginOffsets, "partitionBeginOffsets is null");
+        requireNonNull(partitionEndOffsets, "partitionEndOffsets is null");
+
+        TupleDomain<ColumnHandle> constraint = kafkaTableHandle.getConstraint();
+        verify(!constraint.isNone(), "constraint is none");
+
+        if (!constraint.isAll()) {
+            Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
+            Optional<Range> offsetRanged = Optional.empty();
+            Optional<Range> offsetTimestampRanged = Optional.empty();
+            Set<Long> partitionIdsFiltered = partitionIds;
+            Optional<Map<ColumnHandle, Domain>> domains = constraint.getDomains();
+
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
+                KafkaColumnHandle columnHandle = (KafkaColumnHandle) entry.getKey();
+                if (!columnHandle.isInternal()) {
+                    continue;
+                }
+                switch (columnHandle.getName()) {
+                    case PARTITION_OFFSET_FIELD:
+                        offsetRanged = filterRangeByDomain(entry.getValue());
+                        break;
+                    case PARTITION_ID_FIELD:
+                        partitionIdsFiltered = filterValuesByDomain(entry.getValue(), partitionIds);
+                        break;
+                    case OFFSET_TIMESTAMP_FIELD:
+                        offsetTimestampRanged = filterRangeByDomain(entry.getValue());
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // push down offset
+            if (offsetRanged.isPresent()) {
+                Range range = offsetRanged.get();
+                partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                        partition -> (range.getBegin() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getBegin()) : Optional.empty());
+                partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                        partition -> (range.getEnd() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getEnd()) : Optional.empty());
+            }
+
+            // push down timestamp if possible
+            if (offsetTimestampRanged.isPresent()) {
+                try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create()) {
+                    Optional<Range> finalOffsetTimestampRanged = offsetTimestampRanged;
+                    partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                            partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getBegin()));
+                    if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
+                        partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getEnd()));
+                    }
+                }
+            }
+
+            // push down partitions
+            final Set<Long> finalPartitionIdsFiltered = partitionIdsFiltered;
+            List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
+                    .filter(partitionInfo -> finalPartitionIdsFiltered.contains((long) partitionInfo.partition()))
+                    .collect(toImmutableList());
+            return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
+        }
+        return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
+
+    private boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session, String topic)
+    {
+        try (AdminClient adminClient = adminFactory.create()) {
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+
+            DescribeConfigsResult describeResult = adminClient.describeConfigs(Collections.singleton(topicResource));
+            Map<ConfigResource, Config> configMap = describeResult.all().get();
+
+            if (configMap != null) {
+                Config config = configMap.get(topicResource);
+                String timestampType = config.get(TOPIC_CONFIG_TIMESTAMP_KEY).value();
+                if (TOPIC_CONFIG_TIMESTAMP_VALUE_LOG_APPEND_TIME.equals(timestampType)) {
+                    return true;
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new PrestoException(KAFKA_SPLIT_ERROR, format("Failed to get configuration for topic '%s'", topic), e);
+        }
+        return KafkaSessionProperties.isTimestampUpperBoundPushdownEnabled(session);
+    }
+
+    private static Optional<Long> findOffsetsForTimestampGreaterOrEqual(KafkaConsumer<byte[], byte[]> kafkaConsumer, TopicPartition topicPartition, long timestamp)
+    {
+        final long transferTimestamp = floorDiv(timestamp, MICROSECONDS_PER_MILLISECOND);
+        Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsets = kafkaConsumer.offsetsForTimes(ImmutableMap.of(topicPartition, transferTimestamp));
+        return Optional.ofNullable(getOnlyElement(topicPartitionOffsets.values(), null)).map(OffsetAndTimestamp::offset);
+    }
+
+    private static Map<TopicPartition, Long> overridePartitionBeginOffsets(Map<TopicPartition, Long> partitionBeginOffsets,
+                                                                           Function<TopicPartition, Optional<Long>> overrideFunction)
+    {
+        ImmutableMap.Builder<TopicPartition, Long> partitionFilteredBeginOffsetsBuilder = ImmutableMap.builder();
+        partitionBeginOffsets.forEach((partition, partitionIndex) -> {
+            Optional<Long> newOffset = overrideFunction.apply(partition);
+            partitionFilteredBeginOffsetsBuilder.put(partition, newOffset.map(index -> Long.max(partitionIndex, index)).orElse(partitionIndex));
+        });
+        return partitionFilteredBeginOffsetsBuilder.build();
+    }
+
+    private static Map<TopicPartition, Long> overridePartitionEndOffsets(Map<TopicPartition, Long> partitionEndOffsets,
+                                                                         Function<TopicPartition, Optional<Long>> overrideFunction)
+    {
+        ImmutableMap.Builder<TopicPartition, Long> partitionFilteredEndOffsetsBuilder = ImmutableMap.builder();
+        partitionEndOffsets.forEach((partition, partitionIndex) -> {
+            Optional<Long> newOffset = overrideFunction.apply(partition);
+            partitionFilteredEndOffsetsBuilder.put(partition, newOffset.map(index -> Long.min(partitionIndex, index)).orElse(partitionIndex));
+        });
+        return partitionFilteredEndOffsetsBuilder.build();
+    }
+
+    @VisibleForTesting
+    public static Optional<Range> filterRangeByDomain(Domain domain)
+    {
+        Long low = INVALID_KAFKA_RANGE_INDEX;
+        Long high = INVALID_KAFKA_RANGE_INDEX;
+        if (domain.isSingleValue()) {
+            // still return range for single value case like (_partition_offset=XXX or _timestamp=XXX)
+            low = (long) domain.getSingleValue();
+            high = (long) domain.getSingleValue();
+        }
+        else {
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet) {
+                // still return range for single value case like (_partition_offset in (XXX1,XXX2) or _timestamp in XXX1, XXX2)
+                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                List<io.prestosql.spi.predicate.Range> rangeList = ranges.getOrderedRanges();
+                if (rangeList.stream().allMatch(io.prestosql.spi.predicate.Range::isSingleValue)) {
+                    List<Long> values = rangeList.stream()
+                            .map(range -> (Long) range.getSingleValue())
+                            .collect(toImmutableList());
+                    low = Collections.min(values);
+                    high = Collections.max(values);
+                }
+                else {
+                    Marker lowMark = ranges.getSpan().getLow();
+                    low = getLowByLowMark(lowMark).orElse(low);
+                    Marker highMark = ranges.getSpan().getHigh();
+                    high = getHighByHighMark(highMark).orElse(high);
+                }
+            }
+        }
+        if (high != INVALID_KAFKA_RANGE_INDEX) {
+            high = high + 1;
+        }
+        return Optional.of(new Range(low, high));
+    }
+
+    @VisibleForTesting
+    public static Set<Long> filterValuesByDomain(Domain domain, Set<Long> sourceValues)
+    {
+        requireNonNull(sourceValues, "sourceValues is none");
+        if (domain.isSingleValue()) {
+            long singleValue = (long) domain.getSingleValue();
+            return sourceValues.stream().filter(sourceValue -> sourceValue == singleValue).collect(toImmutableSet());
+        }
+        else {
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet) {
+                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                List<io.prestosql.spi.predicate.Range> rangeList = ranges.getOrderedRanges();
+                if (rangeList.stream().allMatch(io.prestosql.spi.predicate.Range::isSingleValue)) {
+                    return rangeList.stream()
+                            .map(range -> (Long) range.getSingleValue())
+                            .filter(sourceValues::contains)
+                            .collect(toImmutableSet());
+                }
+                else {
+                    // still return values for range case like (_partition_id > 1)
+                    long low = 0;
+                    long high = Long.MAX_VALUE;
+
+                    Marker lowMark = ranges.getSpan().getLow();
+                    low = maxLow(low, lowMark);
+                    Marker highMark = ranges.getSpan().getHigh();
+                    high = minHigh(high, highMark);
+                    final long finalLow = low;
+                    final long finalHigh = high;
+                    return sourceValues.stream()
+                            .filter(item -> item >= finalLow && item <= finalHigh)
+                            .collect(toImmutableSet());
+                }
+            }
+        }
+        return sourceValues;
+    }
+
+    private static long minHigh(long high, Marker highMark)
+    {
+        Optional<Long> highByHighMark = getHighByHighMark(highMark);
+        if (highByHighMark.isPresent()) {
+            high = Long.min(highByHighMark.get(), high);
+        }
+        return high;
+    }
+
+    private static long maxLow(long low, Marker lowMark)
+    {
+        Optional<Long> lowByLowMark = getLowByLowMark(lowMark);
+        if (lowByLowMark.isPresent()) {
+            low = Long.max(lowByLowMark.get(), low);
+        }
+        return low;
+    }
+
+    private static Optional<Long> getHighByHighMark(Marker highMark)
+    {
+        if (!highMark.isUpperUnbounded()) {
+            long high = (Long) highMark.getValue();
+            switch (highMark.getBound()) {
+                case EXACTLY:
+                    break;
+                case BELOW:
+                    high--;
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + highMark.getBound());
+            }
+            return Optional.of(high);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Long> getLowByLowMark(Marker lowMark)
+    {
+        if (!lowMark.isLowerUnbounded()) {
+            long low = (Long) lowMark.getValue();
+            switch (lowMark.getBound()) {
+                case EXACTLY:
+                    break;
+                case ABOVE:
+                    low++;
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + lowMark.getBound());
+            }
+            return Optional.of(low);
+        }
+        return Optional.empty();
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaFilteringResult.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaFilteringResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.List;
+import java.util.Map;
+
+public class KafkaFilteringResult
+{
+    private final List<PartitionInfo> partitionInfos;
+    private final Map<TopicPartition, Long> partitionBeginOffsets;
+    private final Map<TopicPartition, Long> partitionEndOffsets;
+
+    public KafkaFilteringResult(List<PartitionInfo> partitionInfos,
+                                Map<TopicPartition, Long> partitionBeginOffsets,
+                                Map<TopicPartition, Long> partitionEndOffsets)
+    {
+        this.partitionInfos = ImmutableList.copyOf(partitionInfos);
+        this.partitionBeginOffsets = ImmutableMap.copyOf(partitionBeginOffsets);
+        this.partitionEndOffsets = ImmutableMap.copyOf(partitionEndOffsets);
+    }
+
+    public List<PartitionInfo> getPartitionInfos()
+    {
+        return partitionInfos;
+    }
+
+    public Map<TopicPartition, Long> getPartitionBeginOffsets()
+    {
+        return partitionBeginOffsets;
+    }
+
+    public Map<TopicPartition, Long> getPartitionEndOffsets()
+    {
+        return partitionEndOffsets;
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaInternalFieldManager.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaInternalFieldManager.java
@@ -24,6 +24,7 @@ import io.prestosql.spi.type.TypeManager;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TypeSignature.arrayType;
 import static io.prestosql.spi.type.TypeSignature.mapType;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -77,6 +78,11 @@ public class KafkaInternalFieldManager
      * <tt>_key_length</tt> - length in bytes of the key.
      */
     public static final String KEY_LENGTH_FIELD = "_key_length";
+
+    /**
+     * <tt>_timestamp</tt> - message timestamp
+     */
+    public static final String OFFSET_TIMESTAMP_FIELD = "_timestamp";
 
     public static class InternalField
     {
@@ -169,6 +175,10 @@ public class KafkaInternalFieldManager
                         KEY_LENGTH_FIELD,
                         "Total number of key bytes",
                         BigintType.BIGINT))
+                .put(OFFSET_TIMESTAMP_FIELD, new InternalField(
+                        OFFSET_TIMESTAMP_FIELD,
+                        "Message timestamp",
+                        TIMESTAMP_MILLIS))
                 .build();
     }
 

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaMetadata.java
@@ -26,9 +26,12 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.ConnectorTableProperties;
+import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.statistics.ComputedStatistics;
 
 import javax.inject.Inject;
@@ -94,7 +97,8 @@ public class KafkaMetadata
                         kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getDataSchema),
                         getColumnHandles(schemaTableName).values().stream()
                                 .map(KafkaColumnHandle.class::cast)
-                                .collect(toImmutableList())))
+                                .collect(toImmutableList()),
+                        TupleDomain.all()))
                 .orElse(null);
     }
 
@@ -235,6 +239,30 @@ public class KafkaMetadata
         return new ConnectorTableProperties();
     }
 
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    {
+        KafkaTableHandle handle = (KafkaTableHandle) table;
+        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        if (oldDomain.equals(newDomain)) {
+            return Optional.empty();
+        }
+
+        handle = new KafkaTableHandle(
+                handle.getSchemaName(),
+                handle.getTableName(),
+                handle.getTopicName(),
+                handle.getKeyDataFormat(),
+                handle.getMessageDataFormat(),
+                handle.getKeyDataSchemaLocation(),
+                handle.getMessageDataSchemaLocation(),
+                handle.getColumns(),
+                newDomain);
+
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary()));
+    }
+
     private KafkaTopicDescription getRequiredTopicDescription(SchemaTableName schemaTableName)
     {
         return getTopicDescription(schemaTableName).orElseThrow(() -> new TableNotFoundException(schemaTableName));
@@ -268,7 +296,8 @@ public class KafkaMetadata
                 table.getMessageDataFormat(),
                 table.getKeyDataSchemaLocation(),
                 table.getMessageDataSchemaLocation(),
-                actualColumns);
+                actualColumns,
+                TupleDomain.none());
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
@@ -55,8 +55,10 @@ import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.KEY_LENGTH_FIE
 import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.MESSAGE_CORRUPT_FIELD;
 import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.MESSAGE_FIELD;
 import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.MESSAGE_LENGTH_FIELD;
+import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.OFFSET_TIMESTAMP_FIELD;
 import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
 import static io.prestosql.plugin.kafka.KafkaInternalFieldManager.PARTITION_OFFSET_FIELD;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Math.max;
 import static java.lang.invoke.MethodType.methodType;
@@ -185,6 +187,7 @@ public class KafkaRecordSet
             if (message.value() != null) {
                 messageData = message.value();
             }
+            long timeStamp = message.timestamp();
 
             Map<ColumnHandle, FieldValueProvider> currentRowValuesMap = new HashMap<>();
 
@@ -208,6 +211,10 @@ public class KafkaRecordSet
                             break;
                         case KEY_LENGTH_FIELD:
                             currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
+                            break;
+                        case OFFSET_TIMESTAMP_FIELD:
+                            timeStamp *= MICROSECONDS_PER_MILLISECOND;
+                            currentRowValuesMap.put(columnHandle, longValueProvider(timeStamp));
                             break;
                         case KEY_CORRUPT_FIELD:
                             currentRowValuesMap.put(columnHandle, booleanValueProvider(decodedKey.isEmpty()));

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaSessionProperties.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaSessionProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+public final class KafkaSessionProperties
+{
+    private static final String TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED = "timestamp_upper_bound_force_push_down_enabled";
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public KafkaSessionProperties(KafkaConfig kafkaConfig)
+    {
+        sessionProperties = ImmutableList.of(PropertyMetadata.booleanProperty(
+                TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
+                "Enable or disable timestamp upper bound push down for topic createTime mode",
+                kafkaConfig.isTimestampUpperBoundPushDownEnabled(), false));
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    /**
+     * If predicate specifies lower bound on _timestamp column (_timestamp > XXXX), it is always pushed down.
+     * The upper bound predicate is pushed down only for topics using ``LogAppendTime`` mode.
+     * For topics using ``CreateTime`` mode, upper bound push down must be explicitly
+     *  allowed via ``kafka.timestamp-upper-bound-force-push-down-enabled`` config property
+     *  or ``timestamp_upper_bound_force_push_down_enabled`` session property.
+     */
+    public static boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED, Boolean.class);
+    }
+}

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaTableHandle.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaTableHandle.java
@@ -16,9 +16,11 @@ package io.prestosql.plugin.kafka;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorInsertTableHandle;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.predicate.TupleDomain;
 
 import java.util.List;
 import java.util.Objects;
@@ -51,6 +53,7 @@ public final class KafkaTableHandle
     private final Optional<String> keyDataSchemaLocation;
     private final Optional<String> messageDataSchemaLocation;
     private final List<KafkaColumnHandle> columns;
+    private final TupleDomain<ColumnHandle> constraint;
 
     @JsonCreator
     public KafkaTableHandle(
@@ -61,7 +64,8 @@ public final class KafkaTableHandle
             @JsonProperty("messageDataFormat") String messageDataFormat,
             @JsonProperty("keyDataSchemaLocation") Optional<String> keyDataSchemaLocation,
             @JsonProperty("messageDataSchemaLocation") Optional<String> messageDataSchemaLocation,
-            @JsonProperty("columns") List<KafkaColumnHandle> columns)
+            @JsonProperty("columns") List<KafkaColumnHandle> columns,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +75,7 @@ public final class KafkaTableHandle
         this.keyDataSchemaLocation = requireNonNull(keyDataSchemaLocation, "keyDataSchemaLocation is null");
         this.messageDataSchemaLocation = requireNonNull(messageDataSchemaLocation, "messageDataSchemaLocation is null");
         this.columns = requireNonNull(ImmutableList.copyOf(columns), "columns is null");
+        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -121,6 +126,12 @@ public final class KafkaTableHandle
         return columns;
     }
 
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -129,7 +140,7 @@ public final class KafkaTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, topicName, keyDataFormat, messageDataFormat, keyDataSchemaLocation, messageDataSchemaLocation, columns);
+        return Objects.hash(schemaName, tableName, topicName, keyDataFormat, messageDataFormat, keyDataSchemaLocation, messageDataSchemaLocation, columns, constraint);
     }
 
     @Override
@@ -150,7 +161,8 @@ public final class KafkaTableHandle
                 && Objects.equals(this.messageDataFormat, other.messageDataFormat)
                 && Objects.equals(this.keyDataSchemaLocation, other.keyDataSchemaLocation)
                 && Objects.equals(this.messageDataSchemaLocation, other.messageDataSchemaLocation)
-                && Objects.equals(this.columns, other.columns);
+                && Objects.equals(this.columns, other.columns)
+                && Objects.equals(this.constraint, other.constraint);
     }
 
     @Override
@@ -165,6 +177,7 @@ public final class KafkaTableHandle
                 .add("keyDataSchemaLocation", keyDataSchemaLocation)
                 .add("messageDataSchemaLocation", messageDataSchemaLocation)
                 .add("columns", columns)
+                .add("constraint", constraint)
                 .toString();
     }
 }

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaConfig.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaConfig.java
@@ -35,7 +35,8 @@ public class TestKafkaConfig
                 .setTableNames("")
                 .setTableDescriptionDir(new File("etc/kafka/"))
                 .setHideInternalColumns(true)
-                .setMessagesPerSplit(100_000));
+                .setMessagesPerSplit(100_000)
+                .setTimestampUpperBoundPushDownEnabled(false));
     }
 
     @Test
@@ -49,6 +50,7 @@ public class TestKafkaConfig
                 .put("kafka.buffer-size", "1MB")
                 .put("kafka.hide-internal-columns", "false")
                 .put("kafka.messages-per-split", "1")
+                .put("kafka.timestamp-upper-bound-force-push-down-enabled", "true")
                 .build();
 
         KafkaConfig expected = new KafkaConfig()
@@ -58,7 +60,8 @@ public class TestKafkaConfig
                 .setNodes("localhost:12345, localhost:23456")
                 .setKafkaBufferSize("1MB")
                 .setHideInternalColumns(false)
-                .setMessagesPerSplit(1);
+                .setMessagesPerSplit(1)
+                .setTimestampUpperBoundPushDownEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaFilterManager.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaFilterManager.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.SortedRangeSet;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static io.prestosql.spi.predicate.Domain.multipleValues;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKafkaFilterManager
+{
+    @Test
+    public void testFilterValuesByDomain()
+    {
+        Set<Long> source = Set.of(1L, 2L, 3L, 4L, 5L, 6L);
+
+        Domain testDomain = Domain.singleValue(BIGINT, 1L);
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Set.of(1L));
+
+        testDomain = multipleValues(BIGINT, ImmutableList.of(3L, 8L));
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Set.of(3L));
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(BIGINT,
+                ImmutableList.of(
+                        Range.range(BIGINT, 2L, true, 4L, true))),
+                false);
+
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Set.of(2L, 3L, 4L));
+    }
+
+    @Test
+    public void testFilterRangeByDomain()
+    {
+        Domain testDomain = Domain.singleValue(BIGINT, 1L);
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 1L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 2L);
+
+        testDomain = multipleValues(BIGINT, ImmutableList.of(3L, 8L));
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 3L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 9L);
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(BIGINT,
+                ImmutableList.of(
+                        Range.range(BIGINT, 2L, true, 4L, true))),
+                false);
+
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 2L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 5L);
+    }
+}

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationPushDown.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaIntegrationPushDown.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import io.prestosql.Session;
+import io.prestosql.execution.QueryInfo;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.ResultWithQueryId;
+import io.prestosql.testing.kafka.TestingKafka;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+import org.testng.internal.collections.Pair;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static io.prestosql.plugin.kafka.util.TestUtils.createEmptyTopicDescription;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestKafkaIntegrationPushDown
+        extends AbstractTestQueryFramework
+{
+    private static final int MESSAGE_NUM = 1000;
+    private static final int TIMESTAMP_TEST_COUNT = 5;
+    private static final int TIMESTAMP_TEST_START_INDEX = 2;
+    private static final int TIMESTAMP_TEST_END_INDEX = 4;
+
+    private TestingKafka testingKafka;
+    private String topicNamePartition;
+    private String topicNameOffset;
+    private String topicNameCreateTime;
+    private String topicNameLogAppend;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = new TestingKafka();
+        topicNamePartition = "test_push_down_partition_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameOffset = "test_push_down_offset_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameCreateTime = "test_push_down_create_time_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameLogAppend = "test_push_down_log_append_" + UUID.randomUUID().toString().replaceAll("-", "_");
+
+        QueryRunner queryRunner = KafkaQueryRunner.builder(testingKafka)
+                .setExtraTopicDescription(ImmutableMap.<SchemaTableName, KafkaTopicDescription>builder()
+                        .put(createEmptyTopicDescription(topicNamePartition, new SchemaTableName("default", topicNamePartition)))
+                        .put(createEmptyTopicDescription(topicNameOffset, new SchemaTableName("default", topicNameOffset)))
+                        .put(createEmptyTopicDescription(topicNameCreateTime, new SchemaTableName("default", topicNameCreateTime)))
+                        .put(createEmptyTopicDescription(topicNameLogAppend, new SchemaTableName("default", topicNameLogAppend)))
+                        .build())
+                .setExtraKafkaProperties(ImmutableMap.<String, String>builder()
+                        .put("kafka.messages-per-split", "100")
+                        .build())
+                .build();
+        testingKafka.createTopicWithConfig(2, 1, topicNamePartition, false);
+        testingKafka.createTopicWithConfig(2, 1, topicNameOffset, false);
+        testingKafka.createTopicWithConfig(2, 1, topicNameCreateTime, false);
+        testingKafka.createTopicWithConfig(2, 1, topicNameLogAppend, true);
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopKafka()
+    {
+        if (testingKafka != null) {
+            testingKafka.close();
+            testingKafka = null;
+        }
+    }
+
+    @Test
+    public void testPartitionPushDown() throws ExecutionException, InterruptedException
+    {
+        createMessages(topicNamePartition);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        String sql = String.format("SELECT count(*) FROM default.%s WHERE _partition_id=1",
+                topicNamePartition);
+
+        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), MESSAGE_NUM / 2);
+    }
+
+    @Test
+    public void testOffsetPushDown() throws ExecutionException, InterruptedException
+    {
+        createMessages(topicNameOffset);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        String sql = String.format("SELECT count(*) FROM default.%s WHERE _partition_offset between 2 and 10",
+                topicNameOffset);
+
+        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 18);
+
+        sql = String.format("SELECT count(*) FROM default.%s WHERE _partition_offset > 2 and _partition_offset < 10",
+                topicNameOffset);
+
+        queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 14);
+
+        sql = String.format("SELECT count(*) FROM default.%s WHERE _partition_offset = 3",
+                topicNameOffset);
+
+        queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 2);
+    }
+
+    @Test
+    public void testTimestampCreateTimeModePushDown() throws ExecutionException, InterruptedException
+    {
+        Pair<String, String> timePair = createTimestampTestMessages(topicNameCreateTime);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        // ">= startTime" insure including index 2, "< endTime"  insure excluding index 4;
+        String sql = String.format("SELECT count(*) FROM default.%s WHERE _timestamp >= timestamp '%s' and _timestamp < timestamp '%s'",
+                topicNameCreateTime, timePair.first(), timePair.second());
+
+        // timestamp_upper_bound_force_push_down_enabled default as false.
+        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 998);
+
+        // timestamp_upper_bound_force_push_down_enabled set as true.
+        Session sessionWithUpperBoundPushDownEnabled = Session.builder(getSession())
+                .setSystemProperty("kafka.timestamp_upper_bound_force_push_down_enabled", "true")
+                .build();
+
+        queryResult = queryRunner.executeWithQueryId(sessionWithUpperBoundPushDownEnabled, sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 2);
+    }
+
+    @Test
+    public void testTimestampLogAppendModePushDown() throws ExecutionException, InterruptedException
+    {
+        Pair<String, String> timePair = createTimestampTestMessages(topicNameLogAppend);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        // ">= startTime" insure including index 2, "< endTime"  insure excluding index 4;
+        String sql = String.format("SELECT count(*) FROM default.%s WHERE _timestamp >= timestamp '%s' and _timestamp < timestamp '%s'",
+                topicNameLogAppend, timePair.first(), timePair.second());
+        ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+        assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), 2);
+    }
+
+    private QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, ResultWithQueryId<MaterializedResult> queryResult)
+    {
+        return queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryResult.getQueryId());
+    }
+
+    private Pair<String, String> createTimestampTestMessages(String topicName) throws ExecutionException, InterruptedException
+    {
+        String startTime = null;
+        String endTime = null;
+        Future<RecordMetadata> lastSendFuture = Futures.immediateFuture(null);
+        long lastTimeStamp = -1;
+        try (KafkaProducer<Long, Object> producer = testingKafka.createProducer()) {
+            for (long messageNum = 0; messageNum < MESSAGE_NUM; messageNum++) {
+                long key = messageNum;
+                long value = messageNum;
+                lastSendFuture = producer.send(new ProducerRecord<>(topicName, key, value));
+                // Record timestamp to build expected timestamp
+                if (messageNum < TIMESTAMP_TEST_COUNT) {
+                    RecordMetadata r = lastSendFuture.get();
+                    assertTrue(lastTimeStamp != r.timestamp());
+                    lastTimeStamp = r.timestamp();
+                    if (messageNum == TIMESTAMP_TEST_START_INDEX) {
+                        startTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+                                .format(LocalDateTime.ofInstant(Instant.ofEpochMilli(r.timestamp()), ZoneId.of("UTC")));
+                    }
+                    else if (messageNum == TIMESTAMP_TEST_END_INDEX) {
+                        endTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+                                .format(LocalDateTime.ofInstant(Instant.ofEpochMilli(r.timestamp()), ZoneId.of("UTC")));
+                    }
+                    // Sleep for a while to ensure different timestamps for different messages..
+                    Thread.sleep(20);
+                }
+            }
+        }
+        lastSendFuture.get();
+        requireNonNull(startTime, "startTime result is none");
+        requireNonNull(endTime, "endTime result is none");
+        return Pair.of(startTime, endTime);
+    }
+
+    private void createMessages(String topicName)
+            throws ExecutionException, InterruptedException
+    {
+        Future<RecordMetadata> lastSendFuture = Futures.immediateFuture(null);
+        try (KafkaProducer<Long, Object> producer = testingKafka.createProducer()) {
+            for (long messageNum = 0; messageNum < MESSAGE_NUM; messageNum++) {
+                long key = messageNum;
+                long value = messageNum;
+                lastSendFuture = producer.send(new ProducerRecord<>(topicName, key, value));
+            }
+        }
+        lastSendFuture.get();
+    }
+}

--- a/presto-testing-kafka/src/main/java/io/prestosql/testing/kafka/TestingKafka.java
+++ b/presto-testing-kafka/src/main/java/io/prestosql/testing/kafka/TestingKafka.java
@@ -72,6 +72,32 @@ public class TestingKafka
         }
     }
 
+    public void createTopicWithConfig(int partitions, int replication, String topic, boolean enableLogAppendTime)
+    {
+        try {
+            List<String> command = new ArrayList<>();
+            command.add("kafka-topics");
+            command.add("--create");
+            command.add("--topic");
+            command.add(topic);
+            command.add("--partitions");
+            command.add(Integer.toString(partitions));
+            command.add("--replication-factor");
+            command.add(Integer.toString(replication));
+            command.add("--zookeeper");
+            command.add("localhost:2181");
+            if (enableLogAppendTime) {
+                command.add("--config");
+                command.add("message.timestamp.type=LogAppendTime");
+            }
+
+            container.execInContainer(command.toArray(new String[0]));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public String getConnectString()
     {
         return container.getContainerIpAddress() + ":" + container.getMappedPort(KAFKA_PORT);


### PR DESCRIPTION
add _timestamp as internal columns.
add _partion_offset/_partition_id/_timestamp filter pushdown.

Signed-off-by: Li Wang <wangli@thinkingdata.cn>