### PR TITLE
interpolation support for access-control.properties

### DIFF
--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 


### PR DESCRIPTION
This pull request is to add interpolation support for access-control.properties file as mentioned in the ticket 
https://github.com/prestosql/presto/issues/4700

example :
property can be directly given as below for using environment variables in the properties file
security.refresh-period=${ENV:PRESTO_REFRESH_PERIOD}