### PR TITLE
Override getCompletedBytes method in KafkaPageSink

### DIFF
--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.kafka.KafkaErrorCode.KAFKA_PRODUCER_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -44,7 +45,8 @@ public class KafkaPageSink
     private final RowEncoder keyEncoder;
     private final RowEncoder messageEncoder;
     private final KafkaProducer<byte[], byte[]> producer;
-    private final ErrorCountingCallback errorCounter;
+    private final ProducerCallback producerCallback;
+    private long expectedWrittenBytes;
 
     public KafkaPageSink(
             String topicName,
@@ -59,17 +61,20 @@ public class KafkaPageSink
         this.messageEncoder = requireNonNull(messageEncoder, "messageEncoder is null");
         requireNonNull(producerFactory, "producerFactory is null");
         this.producer = producerFactory.create();
-        this.errorCounter = new ErrorCountingCallback();
+        this.producerCallback = new ProducerCallback();
+        this.expectedWrittenBytes = 0;
     }
 
-    private static class ErrorCountingCallback
+    private static class ProducerCallback
             implements Callback
     {
         private final AtomicLong errorCounter;
+        private long writtenBytes;
 
-        public ErrorCountingCallback()
+        public ProducerCallback()
         {
             this.errorCounter = new AtomicLong(0);
+            this.writtenBytes = 0;
         }
 
         @Override
@@ -78,17 +83,34 @@ public class KafkaPageSink
             if (e != null) {
                 errorCounter.incrementAndGet();
             }
+            else {
+                writtenBytes += recordMetadata.serializedValueSize() + recordMetadata.serializedKeySize();
+            }
         }
 
         public long getErrorCount()
         {
             return errorCounter.get();
         }
+
+        public long getWrittenBytes()
+        {
+            return writtenBytes;
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return producerCallback.getWrittenBytes();
     }
 
     @Override
     public CompletableFuture<?> appendPage(Page page)
     {
+        byte[] keyBytes;
+        byte[] messageBytes;
+
         for (int position = 0; position < page.getPositionCount(); position++) {
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
                 if (columns.get(channel).isKeyCodec()) {
@@ -98,7 +120,13 @@ public class KafkaPageSink
                     messageEncoder.appendColumnValue(page.getBlock(channel), position);
                 }
             }
-            producer.send(new ProducerRecord<>(topicName, keyEncoder.toByteArray(), messageEncoder.toByteArray()), errorCounter);
+
+            keyBytes = keyEncoder.toByteArray();
+            messageBytes = messageEncoder.toByteArray();
+
+            expectedWrittenBytes += keyBytes.length + messageBytes.length;
+
+            producer.send(new ProducerRecord<>(topicName, keyBytes, messageBytes), producerCallback);
         }
         return NOT_BLOCKED;
     }
@@ -115,9 +143,16 @@ public class KafkaPageSink
         catch (IOException e) {
             throw new UncheckedIOException("Failed to close row encoders", e);
         }
-        if (errorCounter.getErrorCount() > 0) {
-            throw new PrestoException(KAFKA_PRODUCER_ERROR, format("%d producer record('s) failed to send", errorCounter.getErrorCount()));
+
+        checkArgument(producerCallback.getWrittenBytes() == expectedWrittenBytes,
+                format("Actual written bytes: '%s' not equal to expected written bytes: '%s'",
+                        producerCallback.getWrittenBytes(),
+                        expectedWrittenBytes));
+
+        if (producerCallback.getErrorCount() > 0) {
+            throw new PrestoException(KAFKA_PRODUCER_ERROR, format("%d producer record(s) failed to send", producerCallback.getErrorCount()));
         }
+
         return completedFuture(ImmutableList.of());
     }
 

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaPageSink.java
@@ -29,7 +29,6 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.kafka.KafkaErrorCode.KAFKA_PRODUCER_ERROR;
@@ -68,12 +67,12 @@ public class KafkaPageSink
     private static class ProducerCallback
             implements Callback
     {
-        private final AtomicLong errorCounter;
+        private long errorCount;
         private long writtenBytes;
 
         public ProducerCallback()
         {
-            this.errorCounter = new AtomicLong(0);
+            this.errorCount = 0;
             this.writtenBytes = 0;
         }
 
@@ -81,7 +80,7 @@ public class KafkaPageSink
         public void onCompletion(RecordMetadata recordMetadata, Exception e)
         {
             if (e != null) {
-                errorCounter.incrementAndGet();
+                errorCount++;
             }
             else {
                 writtenBytes += recordMetadata.serializedValueSize() + recordMetadata.serializedKeySize();
@@ -90,7 +89,7 @@ public class KafkaPageSink
 
         public long getErrorCount()
         {
-            return errorCounter.get();
+            return errorCount;
         }
 
         public long getWrittenBytes()


### PR DESCRIPTION
- Track completed and expected written bytes in `KafkaPageSink`
- Override `getCompletedBytes` method to return the current completed bytes