### PR TITLE
128 bit arithmetic upgrades

### DIFF
--- a/presto-main/src/test/java/io/prestosql/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/BenchmarkDecimalOperators.java
@@ -210,7 +210,10 @@ public class BenchmarkDecimalOperators
                 "s1 + s2 + s3 + s4",
                 "l1 + l2",
                 "l1 + l2 + l3 + l4",
-                "s2 + l3 + l1 + s4"})
+                "s2 + l3 + l1 + s4",
+                "lz1 + lz2",
+                "lz1 + lz2 + lz3 + lz4",
+                "s2 + lz3 + lz1 + s4"})
         private String expression = "d1 + d2";
 
         @Setup
@@ -230,6 +233,11 @@ public class BenchmarkDecimalOperators
             addSymbol("l2", createDecimalType(25, 5));
             addSymbol("l3", createDecimalType(20, 6));
             addSymbol("l4", createDecimalType(25, 8));
+
+            addSymbol("lz1", createDecimalType(35, 0));
+            addSymbol("lz2", createDecimalType(25, 0));
+            addSymbol("lz3", createDecimalType(20, 0));
+            addSymbol("lz4", createDecimalType(25, 0));
 
             generateRandomInputPage();
             generateProcessor(expression);

--- a/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
@@ -724,27 +724,27 @@ public final class UnscaledDecimal128Arithmetic
 
     public static boolean isStrictlyNegative(Slice decimal)
     {
-        return isNegative(decimal) && (getLong(decimal, 0) != 0 || getLong(decimal, 1) != 0);
+        return isStrictlyNegative(getRawLong(decimal, 0), getRawLong(decimal, 1));
     }
 
     public static boolean isStrictlyNegative(long rawLow, long rawHigh)
     {
-        return isNegative(rawLow, rawHigh) && (rawLow != 0 || unpackUnsignedLong(rawHigh) != 0);
+        return isNegative(rawHigh) && (rawLow != 0 || unpackUnsignedLong(rawHigh) != 0);
     }
 
     private static boolean isNegative(int lastRawHigh)
     {
-        return (lastRawHigh & SIGN_INT_MASK) != 0;
+        return lastRawHigh >>> 31 != 0;
     }
 
     public static boolean isNegative(Slice decimal)
     {
-        return (getRawInt(decimal, SIGN_INT_INDEX) & SIGN_INT_MASK) != 0;
+        return isNegative(getRawInt(decimal, SIGN_INT_INDEX));
     }
 
-    public static boolean isNegative(long rawLow, long rawHigh)
+    public static boolean isNegative(long rawHigh)
     {
-        return (rawHigh & SIGN_LONG_MASK) != 0;
+        return rawHigh >>> 63 != 0;
     }
 
     public static boolean isZero(Slice decimal)
@@ -1215,8 +1215,8 @@ public final class UnscaledDecimal128Arithmetic
             throwOverflowException();
         }
 
-        boolean dividendIsNegative = isNegative(dividendLow, dividendHigh);
-        boolean divisorIsNegative = isNegative(divisorLow, divisorHigh);
+        boolean dividendIsNegative = isNegative(dividendHigh);
+        boolean divisorIsNegative = isNegative(divisorHigh);
         boolean quotientIsNegative = (dividendIsNegative != divisorIsNegative);
 
         // to fit 128b * 128b * 32b unsigned multiplication

--- a/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
@@ -327,19 +327,22 @@ public final class UnscaledDecimal128Arithmetic
 
     public static void subtract(Slice left, Slice right, Slice result)
     {
-        if (isNegative(left) != isNegative(right)) {
+        boolean leftNegative = isNegative(left);
+        boolean rightNegative = isNegative(right);
+
+        if (leftNegative != rightNegative) {
             // only one is negative
-            if (addUnsignedReturnOverflow(left, right, result, isNegative(left)) != 0) {
+            if (addUnsignedReturnOverflow(left, right, result, leftNegative) != 0) {
                 throwOverflowException();
             }
         }
         else {
             int compare = compareAbsolute(left, right);
             if (compare > 0) {
-                subtractUnsigned(left, right, result, isNegative(left) && isNegative(right));
+                subtractUnsigned(left, right, result, leftNegative);
             }
             else if (compare < 0) {
-                subtractUnsigned(right, left, result, !(isNegative(left) && isNegative(right)));
+                subtractUnsigned(right, left, result, !leftNegative);
             }
             else {
                 setToZero(result);


### PR DESCRIPTION
Addition throughput improved by ~7% by using 2x64 instead of 4x32 bit operations.
Everything improved 0.1-0.5% by changing & to >>>