### PR TITLE
Fix unauthorized error by the benchmark driver

### DIFF
--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriver.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriver.java
@@ -47,7 +47,7 @@ public class BenchmarkDriver
         this.clientSession = requireNonNull(clientSession, "clientSession is null");
         this.queries = ImmutableList.copyOf(requireNonNull(queries, "queries is null"));
 
-        queryRunner = new BenchmarkQueryRunner(warm, runs, debug, maxFailures, clientSession.getServer(), socksProxy);
+        queryRunner = new BenchmarkQueryRunner(warm, runs, debug, maxFailures, clientSession.getServer(), socksProxy, clientSession.getUser());
     }
 
     public void run(Suite suite)


### PR DESCRIPTION
Although Presto coordinator requires `X-Presto-User` header for the default authentication, BenchmarkDriver fails to send the header when it gets the list of URIs even a user name is specified by the option.

```
$ ./presto-benchmark-driver-341-SNAPSHOT-executable.jar --debug --catalog tpch --user "a"
Exception in thread "main" UnexpectedResponseException{request=Request{uri=http://localhost:8080/v1/service/presto, method=GET, headers={}, bodyGenerator=null, followRedirects=true, preserveAuthorizationOnRedirect=false}, statusCode=401, headers={WWW-Authenticate=[Basic realm="Presto"], Content-Length=[50], Date=[Wed, 19 Aug 2020 06:38:19 GMT], Content-Type=[text/plain;charset=UTF-8]}}
	at io.airlift.http.client.JsonResponseHandler.handle(JsonResponseHandler.java:71)
	at io.airlift.http.client.jetty.JettyHttpClient.execute(JettyHttpClient.java:549)
	at io.prestosql.benchmark.driver.BenchmarkQueryRunner.getAllNodes(BenchmarkQueryRunner.java:278)
	at io.prestosql.benchmark.driver.BenchmarkQueryRunner.<init>(BenchmarkQueryRunner.java:98)
	at io.prestosql.benchmark.driver.BenchmarkDriver.<init>(BenchmarkDriver.java:50)
	at io.prestosql.benchmark.driver.PrestoBenchmarkDriver.run(PrestoBenchmarkDriver.java:111)
	at io.prestosql.benchmark.driver.PrestoBenchmarkDriver.main(PrestoBenchmarkDriver.java:52)
```

Fixes #4923