### PR TITLE
Only test time zones provided by both, JDK and joda-time

### DIFF
--- a/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.util;
 
+import com.google.common.collect.Sets;
 import io.prestosql.spi.type.TimeZoneKey;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -33,8 +34,9 @@ public class TestTimeZoneUtils
     @Test
     public void test()
     {
-        TreeSet<String> jdkZones = new TreeSet<>(ZoneId.getAvailableZoneIds());
-        for (String zoneId : jdkZones) {
+        // Only test zones known to JDK and Joda.
+        TreeSet<String> testedZones = new TreeSet<>(Sets.intersection(ZoneId.getAvailableZoneIds(), DateTimeZone.getAvailableIDs()));
+        for (String zoneId : testedZones) {
             if (zoneId.startsWith("Etc/") || zoneId.startsWith("GMT") || zoneId.startsWith("SystemV/")) {
                 continue;
             }


### PR DESCRIPTION
When installing a JDK/JRE on OpenSuSE or Fedora, the package manager installs a distribution-specific timezone package (with `tzdb.dat`). At least for OpenSuSE  this package's content differs from that OpenJDK/JRE ships. 

As a result, `ZoneId.getAvailableZoneIds()` on OpenSuSE returns (among others) a zone 'Asia/Beijing'. This zone is unknown to IANA because Beijing is part of the 'Asia/Shanghai' timezone.

But the JDK gets this zone from the SuSE-specific timezone-java package. When `TestTimeZoneUtils` now calls joda-time's  `DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);` an exception is thrown because joda-time ships with its own tzdb (which differs from JDK's tzdb as well) and joda doesn't know 'Asia/Beijing'.

As the result the unit test must fail on every system where the JDK's timezone information is incompatible to joda-time's zone information.

This PR prohibits the usage of timezones not known to joda-time in `TestTimeZoneUtils.java`.