### PR TITLE
Pushdown domains with many ranges in Oracle connector

### DIFF
--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -116,6 +116,13 @@
 
         <dependency>
             <groupId>io.prestosql</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
             <artifactId>presto-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseOracleIntegrationSmokeTest.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseOracleIntegrationSmokeTest.java
@@ -27,6 +27,7 @@ import static io.prestosql.tpch.TpchTable.CUSTOMER;
 import static io.prestosql.tpch.TpchTable.NATION;
 import static io.prestosql.tpch.TpchTable.ORDERS;
 import static io.prestosql.tpch.TpchTable.REGION;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 abstract class BaseOracleIntegrationSmokeTest
@@ -87,5 +88,64 @@ abstract class BaseOracleIntegrationSmokeTest
                         "   shippriority decimal(10, 0),\n" +
                         "   comment varchar(79)\n" +
                         ")");
+    }
+
+    @Test
+    public void testPredicatePushdown()
+            throws Exception
+    {
+        // varchar equality
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'ROMANIA'"))
+                .matches("VALUES (CAST(3 AS DECIMAL(19,0)), CAST(19 AS DECIMAL(19,0)), CAST('ROMANIA' AS varchar(25)))")
+                .isCorrectlyPushedDown();
+
+        // varchar range
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name BETWEEN 'POLAND' AND 'RPA'"))
+                .matches("VALUES (CAST(3 AS DECIMAL(19,0)), CAST(19 AS DECIMAL(19,0)), CAST('ROMANIA' AS varchar(25)))")
+                .isCorrectlyPushedDown();
+
+        // varchar different case
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'romania'"))
+                .returnsEmptyResult()
+                .isCorrectlyPushedDown();
+
+        // date equality
+        assertThat(query("SELECT orderkey FROM orders WHERE orderdate = DATE '1992-09-29'"))
+                .matches("VALUES CAST(1250 AS DECIMAL(19,0)), 34406, 38436, 57570")
+                .isCorrectlyPushedDown();
+
+        predicatePushdownTest("decimal(9, 3)", "123.321", "<=", "124", "CAST(123.321 AS decimal(9, 3))");
+        predicatePushdownTest("decimal(9, 3)", "123.321", "<=", "123.321", "CAST(123.321 AS decimal(9, 3))");
+        predicatePushdownTest("decimal(9, 3)", "123.321", "=", "123.321", "CAST(123.321 AS decimal(9, 3))");
+        predicatePushdownTest("decimal(30, 10)", "123456789.987654321", "<=", "123456790", "CAST(123456789.987654321 AS decimal(30, 10))");
+        predicatePushdownTest("decimal(30, 10)", "123456789.987654321", "<=", "123456789.987654321", "CAST(123456789.987654321 AS decimal(30, 10))");
+        predicatePushdownTest("decimal(30, 10)", "123456789.987654321", "=", "123456789.987654321", "CAST(123456789.987654321 AS decimal(30, 10))");
+        predicatePushdownTest("float(63)", "123456789.987654321", "<=", "CAST(123456789.99 AS REAL)", "CAST(123456789.987654321 AS DOUBLE)");
+        predicatePushdownTest("float(63)", "123456789.987654321", "<=", "CAST(123456789.99 AS DOUBLE)", "CAST(123456789.987654321 AS DOUBLE)");
+        predicatePushdownTest("float(126)", "123456789.987654321", "<=", "CAST(123456789.99 AS REAL)", "CAST(123456789.987654321 AS DOUBLE)");
+        predicatePushdownTest("float(126)", "123456789.987654321", "<=", "CAST(123456789.99 AS DOUBLE)", "CAST(123456789.987654321 AS DOUBLE)");
+        predicatePushdownTest("CHAR(1)", "'0'", "=", "'0'", "CHAR'0'");
+        predicatePushdownTest("CHAR(1)", "'0'", "<=", "'0'", "CHAR'0'");
+        predicatePushdownTest("CHAR(5)", "'0'", "=", "CHAR'0'", "CHAR'0    '");
+    }
+
+    private void predicatePushdownTest(String oracleType, String oracleLiteral, String operator, String filterLiteral, String compareLiteral)
+            throws Exception
+    {
+        String tableName = "test_pushdown_" + oracleType.replaceAll("[^a-zA-Z0-9]", "");
+        try (AutoCloseable ignored = withTable(tableName, format("(c %s)", oracleType))) {
+            oracleServer.execute(format("INSERT INTO %s VALUES (%s)", tableName, oracleLiteral));
+
+            assertThat(query(format("SELECT * FROM %s WHERE c %s %s", tableName, operator, filterLiteral)))
+                    .matches(format("VALUES (%s)", compareLiteral))
+                    .isCorrectlyPushedDown();
+        }
+    }
+
+    private AutoCloseable withTable(String tableName, String tableDefinition)
+            throws Exception
+    {
+        oracleServer.execute(format("CREATE TABLE %s%s", tableName, tableDefinition));
+        return () -> oracleServer.execute(format("DROP TABLE %s", tableName));
     }
 }

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleDistributedQueries.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleDistributedQueries.java
@@ -32,8 +32,6 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.IntStream.range;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -122,27 +120,6 @@ public class TestOracleDistributedQueries
                         "col_default decimal(20,0) DEFAULT 43," +
                         "col_nonnull_default decimal(20,0) DEFAULT 42 NOT NULL ," +
                         "col_required2 decimal(20,0) NOT NULL)");
-    }
-
-    @Test
-    @Override
-    public void testLargeIn()
-    {
-        int numberOfElements = 1000;
-        String longValues = range(0, numberOfElements)
-                .mapToObj(Integer::toString)
-                .collect(joining(", "));
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (" + longValues + ")");
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (" + longValues + ")");
-
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (mod(1000, orderkey), " + longValues + ")");
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (mod(1000, orderkey), " + longValues + ")");
-
-        String arrayValues = range(0, numberOfElements)
-                .mapToObj(i -> format("ARRAY[%s, %s, %s]", i, i + 1, i + 2))
-                .collect(joining(", "));
-        assertQuery("SELECT ARRAY[0, 0, 0] in (ARRAY[0, 0, 0], " + arrayValues + ")", "values true");
-        assertQuery("SELECT ARRAY[0, 0, 0] in (" + arrayValues + ")", "values false");
     }
 
     @Test


### PR DESCRIPTION
If domain has more that 1000 ranges it is simplified, before pushdown
attempt. Without this query would fails with:
ORA-01795: maximum number of expressions in a list is 1000