### PR TITLE
Use predicates on non-partition columns in Iceberg

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/ExpressionConverter.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.IntegerType;
+import io.prestosql.spi.type.LongTimestampWithTimeZone;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.RowType;
@@ -41,10 +42,12 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.plugin.iceberg.util.Timestamps.timestampTzToMicros;
 import static io.prestosql.spi.predicate.Marker.Bound.ABOVE;
 import static io.prestosql.spi.predicate.Marker.Bound.BELOW;
 import static io.prestosql.spi.predicate.Marker.Bound.EXACTLY;
 import static io.prestosql.spi.type.TimeType.TIME_MICROS;
+import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -183,6 +186,10 @@ public final class ExpressionConverter
 
         if (type.equals(TIME_MICROS)) {
             return ((long) marker.getValue()) / PICOSECONDS_PER_MICROSECOND;
+        }
+
+        if (type.equals(TIMESTAMP_TZ_MICROS)) {
+            return timestampTzToMicros((LongTimestampWithTimeZone) marker.getValue());
         }
 
         if (type instanceof VarcharType) {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -693,10 +693,10 @@ public class IcebergMetadata
         TupleDomain<IcebergColumnHandle> newUnenforcedConstraint = constraint.getSummary()
                 .transform(IcebergColumnHandle.class::cast)
                 .filter(isIdentityPartition.negate())
-                .intersect(table.getPredicate());
+                .intersect(table.getUnenforcedPredicate());
 
         if (newEnforcedConstraint.equals(table.getEnforcedPredicate())
-                && newUnenforcedConstraint.equals(table.getPredicate())) {
+                && newUnenforcedConstraint.equals(table.getUnenforcedPredicate())) {
             return Optional.empty();
         }
 

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -701,6 +701,8 @@ public class IcebergMetadata
                 .map(PartitionField::sourceId)
                 .collect(toImmutableSet());
 
+        // TODO: Avoid enforcing the constraint when partition filters have large IN expressions, since iceberg cannot
+        // support it. Such large expressions cannot be simplified since simplification changes the filtered set.
         BiPredicate<IcebergColumnHandle, Domain> contains = (column, domain) -> partitionSourceIds.contains(column.getId());
         TupleDomain<ColumnHandle> remainingTupleDomain = newDomain.filter(contains.negate()).transform(ColumnHandle.class::cast);
         TupleDomain<IcebergColumnHandle> enforcedTupleDomain = newDomain.filter(contains);

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSourceProvider.java
@@ -166,7 +166,7 @@ public class IcebergPageSourceProvider
                 split.getFileSize(),
                 split.getFileFormat(),
                 regularColumns,
-                table.getPredicate());
+                table.getUnenforcedPredicate());
 
         return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource, session.getTimeZoneKey());
     }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
@@ -72,7 +72,7 @@ public class IcebergSplitManager
                                 // is required for IN predicates on non-partition columns with large value list. Such
                                 // predicates on partition columns are not supported.
                                 // (See AbstractTestIcebergSmoke#testLargeInFailureOnPartitionedColumns)
-                                .intersect(table.getPredicate().simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD))))
+                                .intersect(table.getUnenforcedPredicate().simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD))))
                 .useSnapshot(table.getSnapshotId().get());
 
         // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableHandle.java
@@ -34,7 +34,7 @@ public class IcebergTableHandle
     private final Optional<Long> snapshotId;
 
     // Filter used during split generation and table scan, but not required to be strictly enforced by Iceberg Connector
-    private final TupleDomain<IcebergColumnHandle> predicate;
+    private final TupleDomain<IcebergColumnHandle> unenforcedPredicate;
 
     // Filter guaranteed to be enforced by Iceberg connector
     private final TupleDomain<IcebergColumnHandle> enforcedPredicate;
@@ -45,14 +45,14 @@ public class IcebergTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableType") TableType tableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
-            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate,
+            @JsonProperty("unenforcedPredicate") TupleDomain<IcebergColumnHandle> unenforcedPredicate,
             @JsonProperty("enforcedPredicate") TupleDomain<IcebergColumnHandle> enforcedPredicate)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
-        this.predicate = requireNonNull(predicate, "predicate is null");
+        this.unenforcedPredicate = requireNonNull(unenforcedPredicate, "unenforcedPredicate is null");
         this.enforcedPredicate = requireNonNull(enforcedPredicate, "enforcedPredicate is null");
     }
 
@@ -81,9 +81,9 @@ public class IcebergTableHandle
     }
 
     @JsonProperty
-    public TupleDomain<IcebergColumnHandle> getPredicate()
+    public TupleDomain<IcebergColumnHandle> getUnenforcedPredicate()
     {
-        return predicate;
+        return unenforcedPredicate;
     }
 
     @JsonProperty
@@ -117,14 +117,14 @@ public class IcebergTableHandle
                 Objects.equals(tableName, that.tableName) &&
                 tableType == that.tableType &&
                 Objects.equals(snapshotId, that.snapshotId) &&
-                Objects.equals(predicate, that.predicate) &&
+                Objects.equals(unenforcedPredicate, that.unenforcedPredicate) &&
                 Objects.equals(enforcedPredicate, that.enforcedPredicate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tableType, snapshotId, predicate, enforcedPredicate);
+        return Objects.hash(schemaName, tableName, tableType, snapshotId, unenforcedPredicate, enforcedPredicate);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergTableHandle.java
@@ -32,7 +32,12 @@ public class IcebergTableHandle
     private final String tableName;
     private final TableType tableType;
     private final Optional<Long> snapshotId;
+
+    // Filter used during split generation and table scan, but not required to be strictly enforced by Iceberg Connector
     private final TupleDomain<IcebergColumnHandle> predicate;
+
+    // Filter guaranteed to be enforced by Iceberg connector
+    private final TupleDomain<IcebergColumnHandle> enforcedPredicate;
 
     @JsonCreator
     public IcebergTableHandle(
@@ -40,13 +45,15 @@ public class IcebergTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableType") TableType tableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
-            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate)
+            @JsonProperty("predicate") TupleDomain<IcebergColumnHandle> predicate,
+            @JsonProperty("enforcedPredicate") TupleDomain<IcebergColumnHandle> enforcedPredicate)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
         this.predicate = requireNonNull(predicate, "predicate is null");
+        this.enforcedPredicate = requireNonNull(enforcedPredicate, "enforcedPredicate is null");
     }
 
     @JsonProperty
@@ -79,6 +86,12 @@ public class IcebergTableHandle
         return predicate;
     }
 
+    @JsonProperty
+    public TupleDomain<IcebergColumnHandle> getEnforcedPredicate()
+    {
+        return enforcedPredicate;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -104,13 +117,14 @@ public class IcebergTableHandle
                 Objects.equals(tableName, that.tableName) &&
                 tableType == that.tableType &&
                 Objects.equals(snapshotId, that.snapshotId) &&
-                Objects.equals(predicate, that.predicate);
+                Objects.equals(predicate, that.predicate) &&
+                Objects.equals(enforcedPredicate, that.enforcedPredicate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tableType, snapshotId, predicate);
+        return Objects.hash(schemaName, tableName, tableType, snapshotId, predicate, enforcedPredicate);
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/TableStatisticsMaker.java
@@ -80,7 +80,7 @@ public class TableStatisticsMaker
 
         TupleDomain<IcebergColumnHandle> intersection = constraint.getSummary()
                 .transform(IcebergColumnHandle.class::cast)
-                .intersect(tableHandle.getPredicate());
+                .intersect(tableHandle.getEnforcedPredicate());
 
         if (intersection.isNone()) {
             return TableStatistics.empty();

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/AbstractTestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/AbstractTestIcebergSmoke.java
@@ -1290,7 +1290,7 @@ public abstract class AbstractTestIcebergSmoke
             QualifiedObjectName tableName,
             Map<String, Domain> filter,
             Map<String, Domain> expectedEnforcedPredicate,
-            Map<String, Domain> expectedPredicate)
+            Map<String, Domain> expectedUnenforcedPredicate)
     {
         Metadata metadata = getQueryRunner().getMetadata();
 
@@ -1305,7 +1305,7 @@ public abstract class AbstractTestIcebergSmoke
 
             Optional<ConstraintApplicationResult<TableHandle>> result = metadata.applyFilter(session, table, new Constraint(domains));
 
-            assertTrue(result.isEmpty() == (expectedPredicate == null && expectedEnforcedPredicate == null));
+            assertTrue(result.isEmpty() == (expectedUnenforcedPredicate == null && expectedEnforcedPredicate == null));
 
             if (!result.isEmpty()) {
                 IcebergTableHandle newTable = (IcebergTableHandle) result.get().getHandle().getConnectorHandle();
@@ -1314,8 +1314,8 @@ public abstract class AbstractTestIcebergSmoke
                         TupleDomain.withColumnDomains(expectedEnforcedPredicate.entrySet().stream()
                                 .collect(toImmutableMap(entry -> columns.get(entry.getKey()), Map.Entry::getValue))));
 
-                assertEquals(newTable.getPredicate(),
-                        TupleDomain.withColumnDomains(expectedPredicate.entrySet().stream()
+                assertEquals(newTable.getUnenforcedPredicate(),
+                        TupleDomain.withColumnDomains(expectedUnenforcedPredicate.entrySet().stream()
                                 .collect(toImmutableMap(entry -> columns.get(entry.getKey()), Map.Entry::getValue))));
             }
         });


### PR DESCRIPTION
This has two benefits: (w.r.t. predicates on non-partition columns)

- predicates can be used during split generation, reducing the number of splits scheduled
- predicates can be used by ORC/Parquet readers

For example, without this patch, the SELECT query in the sequence below would schedule 2 splits instead of 1. 
```
CREATE TABLE T (a bigint, b bigint) WITH (partitioning=array['b'])
INSERT INTO T VALUES (5, 6), (6, 7);
SELECT * FROM T WHERE a = 5;
```

IN predicates with large value set throw a stackoverflow error in iceberg because iceberg seems to translate it to `OR` expressions. To avoid this, we loosen up such conditions in `tableScan.filter`  for predicates on non-partition columns. However, we cannot do the same for partition columns to maintain correctness. 