### PR TITLE
Allow configuring HDFS replication factor directly in hive.properties

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -232,6 +232,8 @@ Property Name                                      Description                  
 
 ``hive.hdfs.presto.keytab``                        HDFS client keytab location.
 
+``hive.dfs.replication``                           Hadoop file system replication factor.
+
 ``hive.security``                                  See :doc:`hive-security`.
 
 ``security.config-file``                           Path of config file to use when ``hive.security=file``.

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfig.java
@@ -49,6 +49,7 @@ public class HdfsConfig
     private HostAndPort socksProxy;
     private boolean wireEncryptionEnabled;
     private int fileSystemMaxCacheSize = 1000;
+    private Integer dfsReplication;
 
     @NotNull
     public List<@FileExists File> getResourceConfigFiles()
@@ -214,6 +215,20 @@ public class HdfsConfig
     public HdfsConfig setFileSystemMaxCacheSize(int fileSystemMaxCacheSize)
     {
         this.fileSystemMaxCacheSize = fileSystemMaxCacheSize;
+        return this;
+    }
+
+    @Min(1)
+    public Integer getDfsReplication()
+    {
+        return dfsReplication;
+    }
+
+    @Config("hive.dfs.replication")
+    @ConfigDescription("Hadoop FileSystem replication factor")
+    public HdfsConfig setDfsReplication(Integer dfsReplication)
+    {
+        this.dfsReplication = dfsReplication;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HdfsConfigurationInitializer.java
@@ -44,6 +44,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NO
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_MS;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_SOCKET_TIMEOUT_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DOMAIN_SOCKET_PATH_KEY;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_REPLICATION_KEY;
 
 public class HdfsConfigurationInitializer
 {
@@ -58,6 +59,7 @@ public class HdfsConfigurationInitializer
     private final int fileSystemMaxCacheSize;
     private final Set<ConfigurationInitializer> configurationInitializers;
     private final boolean wireEncryptionEnabled;
+    private final Integer dfsReplication;
 
     @VisibleForTesting
     public HdfsConfigurationInitializer(HdfsConfig hdfsConfig)
@@ -80,6 +82,7 @@ public class HdfsConfigurationInitializer
         this.resourcesConfiguration = readConfiguration(config.getResourceConfigFiles());
         this.fileSystemMaxCacheSize = config.getFileSystemMaxCacheSize();
         this.wireEncryptionEnabled = config.isWireEncryptionEnabled();
+        this.dfsReplication = config.getDfsReplication();
 
         this.configurationInitializers = ImmutableSet.copyOf(requireNonNull(configurationInitializers, "configurationInitializers is null"));
     }
@@ -117,6 +120,10 @@ public class HdfsConfigurationInitializer
         }
 
         config.setInt("fs.cache.max-size", fileSystemMaxCacheSize);
+
+        if (dfsReplication != null) {
+            config.setInt(DFS_REPLICATION_KEY, dfsReplication);
+        }
 
         configurationInitializers.forEach(configurationInitializer -> configurationInitializer.initializeConfiguration(config));
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHdfsConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHdfsConfig.java
@@ -46,7 +46,8 @@ public class TestHdfsConfig
                 .setDomainSocketPath(null)
                 .setSocksProxy(null)
                 .setWireEncryptionEnabled(false)
-                .setFileSystemMaxCacheSize(1000));
+                .setFileSystemMaxCacheSize(1000)
+                .setDfsReplication(null));
     }
 
     @Test
@@ -69,6 +70,7 @@ public class TestHdfsConfig
                 .put("hive.hdfs.socks-proxy", "localhost:4567")
                 .put("hive.hdfs.wire-encryption.enabled", "true")
                 .put("hive.fs.cache.max-size", "1010")
+                .put("hive.dfs.replication", "1")
                 .build();
 
         HdfsConfig expected = new HdfsConfig()
@@ -83,7 +85,8 @@ public class TestHdfsConfig
                 .setDomainSocketPath("/foo")
                 .setSocksProxy(HostAndPort.fromParts("localhost", 4567))
                 .setWireEncryptionEnabled(true)
-                .setFileSystemMaxCacheSize(1010);
+                .setFileSystemMaxCacheSize(1010)
+                .setDfsReplication(1);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Allow configuring HDFS replication factor directly in hive.properties. Fixes #1829 