### PR TITLE
Add Spark/Iceberg compatibility test for nested data

### DIFF
--- a/presto-product-tests/src/main/java/io/prestosql/tests/iceberg/TestSparkCompatibility.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/iceberg/TestSparkCompatibility.java
@@ -248,6 +248,117 @@ public class TestSparkCompatibility
         assertThat(sparkResult).containsOnly(row);
     }
 
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testPrestoReadingNestedSparkData()
+    {
+        String baseTableName = "test_presto_reading_nested_spark_data";
+        String sparkTableName = sparkTableName(baseTableName);
+
+        String sparkTableDefinition = "" +
+                "CREATE TABLE %s (\n" +
+                "  doc_id STRING\n" +
+                ", nested_map MAP<STRING, ARRAY<STRUCT<sname: STRING, snumber: INT>>>\n" +
+                ", nested_array ARRAY<MAP<STRING, ARRAY<STRUCT<mname: STRING, mnumber: INT>>>>\n" +
+                ", nested_struct STRUCT<name:STRING, complicated: ARRAY<MAP<STRING, ARRAY<STRUCT<mname: STRING, mnumber: INT>>>>>)\n" +
+                " USING ICEBERG";
+        onSpark().executeQuery(format(sparkTableDefinition, sparkTableName));
+
+        String insert = "" +
+                "INSERT INTO TABLE %s SELECT" +
+                "  'Doc213'" +
+                ", map('s1', array(named_struct('sname', 'ASName1', 'snumber', 201), named_struct('sname', 'ASName2', 'snumber', 202)))" +
+                ", array(map('m1', array(named_struct('mname', 'MAS1Name1', 'mnumber', 301), named_struct('mname', 'MAS1Name2', 'mnumber', 302)))" +
+                "       ,map('m2', array(named_struct('mname', 'MAS2Name1', 'mnumber', 401), named_struct('mname', 'MAS2Name2', 'mnumber', 402))))" +
+                ", named_struct('name', 'S1'," +
+                "               'complicated', array(map('m1', array(named_struct('mname', 'SAMA1Name1', 'mnumber', 301), named_struct('mname', 'SAMA1Name2', 'mnumber', 302)))" +
+                "                                   ,map('m2', array(named_struct('mname', 'SAMA2Name1', 'mnumber', 401), named_struct('mname', 'SAMA2Name2', 'mnumber', 402)))))";
+        onSpark().executeQuery(format(insert, sparkTableName));
+
+        Row row = row("Doc213", "ASName2", 201, "MAS2Name1", 302, "SAMA1Name1", 402);
+
+        String sparkSelect = "SELECT" +
+                "  doc_id" +
+                ", nested_map['s1'][1].sname" +
+                ", nested_map['s1'][0].snumber" +
+                ", nested_array[1]['m2'][0].mname" +
+                ", nested_array[0]['m1'][1].mnumber" +
+                ", nested_struct.complicated[0]['m1'][0].mname" +
+                ", nested_struct.complicated[1]['m2'][1].mnumber" +
+                "  FROM ";
+
+        QueryResult sparkResult = onSpark().executeQuery(sparkSelect + sparkTableName);
+        assertThat(sparkResult).containsOnly(row);
+
+        String prestoTableName = prestoTableName(baseTableName);
+        String prestoSelect = "SELECT" +
+                "  doc_id" +
+                ", nested_map['s1'][2].sname" +
+                ", nested_map['s1'][1].snumber" +
+                ", nested_array[2]['m2'][1].mname" +
+                ", nested_array[1]['m1'][2].mnumber" +
+                ", nested_struct.complicated[1]['m1'][1].mname" +
+                ", nested_struct.complicated[2]['m2'][2].mnumber" +
+                "  FROM ";
+
+        QueryResult prestoResult = onPresto().executeQuery(prestoSelect + prestoTableName);
+        assertThat(prestoResult).containsOnly(row);
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testSparkReadingNestedPrestoData()
+    {
+        String baseTableName = "test_spark_reading_nested_presto_data";
+        String prestoTableName = prestoTableName(baseTableName);
+
+        String prestoTableDefinition = "" +
+                "CREATE TABLE %s (\n" +
+                "  doc_id VARCHAR\n" +
+                ", nested_map MAP(VARCHAR, ARRAY(ROW(sname VARCHAR, snumber INT)))\n" +
+                ", nested_array ARRAY(MAP(VARCHAR, ARRAY(ROW(mname VARCHAR, mnumber INT))))\n" +
+                ", nested_struct ROW(name VARCHAR, complicated ARRAY(MAP(VARCHAR, ARRAY(ROW(mname VARCHAR, mnumber INT))))))";
+        onPresto().executeQuery(format(prestoTableDefinition, prestoTableName));
+
+        String insert = "" +
+                "INSERT INTO %s SELECT" +
+                "  'Doc213'" +
+                ", map(array['s1'], array[array[row('ASName1', 201), row('ASName2', 202)]])" +
+                ", array[map(array['m1'], array[array[row('MAS1Name1', 301), row('MAS1Name2', 302)]])" +
+                "       ,map(array['m2'], array[array[row('MAS2Name1', 401), row('MAS2Name2', 402)]])]" +
+                ", row('S1'" +
+                "      ,array[map(array['m1'], array[array[row('SAMA1Name1', 301), row('SAMA1Name2', 302)]])" +
+                "            ,map(array['m2'], array[array[row('SAMA2Name1', 401), row('SAMA2Name2', 402)]])])";
+        onPresto().executeQuery(format(insert, prestoTableName));
+
+        Row row = row("Doc213", "ASName2", 201, "MAS2Name1", 302, "SAMA1Name1", 402);
+
+        String prestoSelect = "SELECT" +
+                "  doc_id" +
+                ", nested_map['s1'][2].sname" +
+                ", nested_map['s1'][1].snumber" +
+                ", nested_array[2]['m2'][1].mname" +
+                ", nested_array[1]['m1'][2].mnumber" +
+                ", nested_struct.complicated[1]['m1'][1].mname" +
+                ", nested_struct.complicated[2]['m2'][2].mnumber" +
+                "  FROM ";
+
+        QueryResult prestoResult = onPresto().executeQuery(prestoSelect + prestoTableName);
+        assertThat(prestoResult).containsOnly(row);
+
+        String sparkTableName = sparkTableName(baseTableName);
+        String sparkSelect = "SELECT" +
+                "  doc_id" +
+                ", nested_map['s1'][1].sname" +
+                ", nested_map['s1'][0].snumber" +
+                ", nested_array[1]['m2'][0].mname" +
+                ", nested_array[0]['m1'][1].mnumber" +
+                ", nested_struct.complicated[0]['m1'][0].mname" +
+                ", nested_struct.complicated[1]['m2'][1].mnumber" +
+                "  FROM ";
+
+        QueryResult sparkResult = onSpark().executeQuery(sparkSelect + sparkTableName);
+        assertThat(sparkResult).containsOnly(row);
+    }
+
     private static String sparkTableName(String tableName)
     {
         return format("%s.default.%s", SPARK_CATALOG, tableName);


### PR DESCRIPTION
This commit adds tests that ensure that Presto can read Spark
data with nested array, map and row types, and vice versa.