### PR TITLE
Require identifying flakiness's exception

### DIFF
--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveStorageFormats.java
@@ -158,7 +158,7 @@ public class TestHiveStorageFormats
     }
 
     @Test(dataProvider = "storage_formats", groups = STORAGE_FORMATS)
-    @Flaky(issue = "https://github.com/prestosql/presto/issues/2390")
+    @Flaky(issue = "https://github.com/prestosql/presto/issues/2390", match = "File .* could only be written to 0 of the 1 minReplication nodes")
     public void testInsertIntoPartitionedTable(StorageFormat storageFormat)
     {
         // only admin user is allowed to change session properties

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalTable.java
@@ -66,7 +66,7 @@ public class TestHiveTransactionalTable
         doTestReadFullAcid(false, BucketingType.NONE);
     }
 
-    @Flaky(issue = "https://github.com/prestosql/presto/issues/4927")
+    @Flaky(issue = "https://github.com/prestosql/presto/issues/4927", match = "Hive table .* is is corrupt. Found sub-directory in bucket directory for partition")
     @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
     public void testReadFullAcidBucketed()
     {
@@ -88,13 +88,13 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = "https://github.com/prestosql/presto/issues/4857")
+    @Flaky(issue = "https://github.com/prestosql/presto/issues/4927", match = "Hive table .* is is corrupt. Found sub-directory in bucket directory for partition")
     public void testReadFullAcidBucketedV1()
     {
         doTestReadFullAcid(false, BucketingType.BUCKETED_V1);
     }
 
-    @Flaky(issue = "https://github.com/prestosql/presto/issues/4857")
+    @Flaky(issue = "https://github.com/prestosql/presto/issues/4927", match = "Hive table .* is is corrupt. Found sub-directory in bucket directory for partition")
     @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
     public void testReadFullAcidBucketedV2()
     {

--- a/presto-testng-services/src/main/java/io/prestosql/testng/services/Flaky.java
+++ b/presto-testng-services/src/main/java/io/prestosql/testng/services/Flaky.java
@@ -15,6 +15,7 @@ package io.prestosql.testng.services;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.regex.Matcher;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -28,4 +29,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Flaky
 {
     String issue();
+
+    /**
+     * A test is retried when it fails with a stacktrace, which string representation matches given regular expression.
+     * The pattern is searched for, as if {@link Matcher#find()} was used.
+     */
+    String match();
 }

--- a/presto-testng-services/src/test/java/io/prestosql/testng/services/TestFlakyTestRetryAnalyzer.java
+++ b/presto-testng-services/src/test/java/io/prestosql/testng/services/TestFlakyTestRetryAnalyzer.java
@@ -28,7 +28,7 @@ public class TestFlakyTestRetryAnalyzer
     private int testNoRetryingCount;
     private int[] testRetryingParametricTestCount = new int[2];
 
-    @Flaky(issue = "intentionally flaky for @Flaky test purposes")
+    @Flaky(issue = "intentionally flaky for @Flaky test purposes", match = "I am trying hard to fail!")
     @Test
     public void testRetrying()
     {
@@ -48,13 +48,13 @@ public class TestFlakyTestRetryAnalyzer
 
     @Override
     @Test
-    @Flaky(issue = "intentionally flaky for @Flaky test purposes")
+    @Flaky(issue = "intentionally flaky for @Flaky test purposes", match = "I am trying hard to fail!")
     public void testRetryingOverriddenTest()
     {
         super.testRetryingOverriddenTest();
     }
 
-    @Flaky(issue = "intentionally flaky for @Flaky test purposes")
+    @Flaky(issue = "intentionally flaky for @Flaky test purposes", match = "I am trying hard to fail!")
     @Test(dataProvider = "parameters")
     public void testRetryingParametricTest(int index)
     {


### PR DESCRIPTION
When marking a `@Flaky` test for retry, require identification of a
flakiness by providing matching exception pattern. This prevents further
regressions and helps as a code documentation.
