### PR TITLE
Test for removed dynamic filters explicitly

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -321,7 +321,7 @@ public class TestRemoveUnsupportedDynamicFilters
                                 values("RIGHT_SYMBOL"))));
     }
 
-    PlanNode removeUnsupportedDynamicFilters(PlanNode root)
+    private PlanNode removeUnsupportedDynamicFilters(PlanNode root)
     {
         return getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -116,7 +116,8 @@ public class TestRemoveUnsupportedDynamicFilters
                 join(
                         INNER,
                         ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                        filter("ORDERS_OK > 0",
+                        filter(
+                                "ORDERS_OK > 0",
                                 tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
                         tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))));
     }
@@ -179,7 +180,8 @@ public class TestRemoveUnsupportedDynamicFilters
                         join(INNER,
                                 ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
                                 tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
-                                filter("LINEITEM_OK > 0",
+                                filter(
+                                        "LINEITEM_OK > 0",
                                         tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
     }
 


### PR DESCRIPTION
Previously some tests were passing even without DF removal while they shouldn't