### PR TITLE
Update BigQuery dependencies to support HOURLY partitioning of tables

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>4.4.1</version>
+                <version>8.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threetenbp</artifactId>
-                <version>1.4.2</version>
+                <version>1.4.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -68,6 +68,12 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax-grpc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -93,6 +99,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -103,6 +113,10 @@
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConfig.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConfig.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.bigquery;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.validation.FileExists;
 
 import javax.validation.constraints.AssertTrue;
@@ -66,6 +67,7 @@ public class BigQueryConfig
 
     @Config("bigquery.credentials-key")
     @ConfigDescription("The base64 encoded credentials key")
+    @ConfigSecuritySensitive
     public BigQueryConfig setCredentialsKey(String credentialsKey)
     {
         this.credentialsKey = Optional.of(credentialsKey);

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/BigQueryQueryRunner.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/BigQueryQueryRunner.java
@@ -13,6 +13,9 @@
  */
 package io.prestosql.plugin.bigquery;
 
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -20,6 +23,11 @@ import io.prestosql.Session;
 import io.prestosql.plugin.tpch.TpchPlugin;
 import io.prestosql.testing.DistributedQueryRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Base64;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -51,6 +59,20 @@ public class BigQueryQueryRunner
         catch (Throwable e) {
             closeAllSuppress(e, queryRunner);
             throw e;
+        }
+    }
+
+    public static BigQuery createBigQueryClient()
+    {
+        try {
+            InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(System.getProperty("bigquery.credentials-key")));
+            return BigQueryOptions.newBuilder()
+                    .setCredentials(ServiceAccountCredentials.fromStream(jsonKey))
+                    .build()
+                    .getService();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -13,15 +13,22 @@
  */
 package io.prestosql.plugin.bigquery;
 
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
 import org.testng.annotations.Test;
 
+import static io.prestosql.plugin.bigquery.BigQueryQueryRunner.createBigQueryClient;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
 
 @Test
 public class TestBigQueryIntegrationSmokeTest
@@ -50,5 +57,45 @@ public class TestBigQueryIntegrationSmokeTest
                 .build();
         MaterializedResult actualColumns = computeActual("DESCRIBE orders");
         assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Test(enabled = false)
+    public void testSelectFromHourlyPartitionedTable()
+    {
+        BigQuery client = createBigQueryClient();
+
+        executeBigQuerySql(client, "DROP TABLE IF EXISTS test.hourly_partitioned");
+        executeBigQuerySql(client, "CREATE TABLE test.hourly_partitioned (value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, HOUR)");
+        executeBigQuerySql(client, "INSERT INTO test.hourly_partitioned (value, ts) VALUES (1000, '2018-01-01 10:00:00')");
+
+        MaterializedResult actualValues = computeActual("SELECT COUNT(1) FROM test.hourly_partitioned");
+
+        assertEquals((long) actualValues.getOnlyValue(), 1L);
+    }
+
+    private static void executeBigQuerySql(BigQuery bigquery, String query)
+    {
+        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
+                .setUseLegacySql(false)
+                .build();
+
+        JobId jobId = JobId.of();
+        Job queryJob = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
+
+        try {
+            queryJob = queryJob.waitFor();
+
+            if (queryJob == null) {
+                throw new RuntimeException(format("Job with uuid %s does not longer exists", jobId.getJob()));
+            }
+
+            if (queryJob.getStatus().getError() != null) {
+                throw new RuntimeException(format("Query '%s' failed: %s", query, queryJob.getStatus().getError()));
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
I did not update to latest BOM version to minimize the impact of this change.

Hourly partitioning was added in https://github.com/googleapis/java-bigquery/commit/90f998040bbca5882ac3dbcdb4b157f26f48eb01#diff-3dfcf884473c6d47c7c3debc58ce20c0