### PR TITLE
Standardize on "classpath" spelling.

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -3,7 +3,7 @@ JDBC Driver
 ===========
 
 Presto can be accessed from Java using the JDBC driver.
-Download :maven_download:`jdbc` and add it to the class path of your Java application.
+Download :maven_download:`jdbc` and add it to the classpath of your Java application.
 
 The driver is also available from Maven Central:
 


### PR DESCRIPTION
Single-character change to change the one instance of "class path" in the doc set to "classpath" for consistency and standardization.

There is no consensus in the world on this. The Google Style Guide is silent. MMS, CMS, Merriam-Webster.com, and dictionary.com do not have entries for either term.

However, classic Java documentation, now in the questionable hands of Oracle, fairly consistently uses "classpath" based on the model of the CLASSPATH environment variable and the -classpath argument to the java executable itself.

So we will standardize on "classpath".