### PR TITLE
Remove dedicated encoding for timestamp with precision <= 3

### DIFF
--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloPageSink.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloPageSink.java
@@ -57,7 +57,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.util.Objects.requireNonNull;
@@ -211,7 +211,7 @@ public class AccumuloPageSink
             else if (type.equals(TINYINT)) {
                 serializer.setByte(value, field.getByte());
             }
-            else if (type.equals(TIMESTAMP)) {
+            else if (type.equals(TIMESTAMP_MILLIS)) {
                 serializer.setTimestamp(value, field.getTimestamp());
             }
             else if (type.equals(VARBINARY)) {

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloRecordCursor.java
@@ -49,7 +49,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -196,7 +196,7 @@ public class AccumuloRecordCursor
     @Override
     public long getLong(int field)
     {
-        checkFieldType(field, BIGINT, DATE, INTEGER, REAL, SMALLINT, TIME, TIMESTAMP, TINYINT);
+        checkFieldType(field, BIGINT, DATE, INTEGER, REAL, SMALLINT, TIME, TIMESTAMP_MILLIS, TINYINT);
         Type type = getType(field);
         if (type.equals(BIGINT)) {
             return serializer.getLong(fieldToColumnName[field]);
@@ -216,7 +216,7 @@ public class AccumuloRecordCursor
         if (type.equals(TIME)) {
             return serializer.getTime(fieldToColumnName[field]).getTime();
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return serializer.getTimestamp(fieldToColumnName[field]).getTime();
         }
         if (type.equals(TINYINT)) {

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/io/AccumuloRecordCursor.java
@@ -50,6 +50,7 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -217,7 +218,7 @@ public class AccumuloRecordCursor
             return serializer.getTime(fieldToColumnName[field]).getTime();
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return serializer.getTimestamp(fieldToColumnName[field]).getTime();
+            return serializer.getTimestamp(fieldToColumnName[field]).getTime() * MICROSECONDS_PER_MILLISECOND;
         }
         if (type.equals(TINYINT)) {
             return serializer.getByte(fieldToColumnName[field]);

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/model/Field.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/model/Field.java
@@ -42,7 +42,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -102,7 +102,7 @@ public class Field
         else if (type.equals(TIME)) {
             this.value = new Time(field.getTime().getTime());
         }
-        else if (type.equals(TIMESTAMP)) {
+        else if (type.equals(TIMESTAMP_MILLIS)) {
             this.value = new Timestamp(field.getTimestamp().getTime());
         }
         else if (type.equals(TINYINT)) {
@@ -233,7 +233,7 @@ public class Field
                     // aren't they so fancy
                     retval = Arrays.equals((byte[]) value, (byte[]) field.getObject());
                 }
-                else if (type.equals(DATE) || type.equals(TIME) || type.equals(TIMESTAMP)) {
+                else if (type.equals(DATE) || type.equals(TIME) || type.equals(TIMESTAMP_MILLIS)) {
                     retval = value.toString().equals(field.getObject().toString());
                 }
                 else {
@@ -334,7 +334,7 @@ public class Field
             return new Time((long) value);
         }
 
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return new Timestamp((long) value);
         }
 

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/model/Field.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/model/Field.java
@@ -43,10 +43,12 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -335,7 +337,7 @@ public class Field
         }
 
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return new Timestamp((long) value);
+            return new Timestamp(floorDiv((Long) value, MICROSECONDS_PER_MILLISECOND));
         }
 
         if (type.equals(TINYINT)) {

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/serializers/LexicoderRowSerializer.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/serializers/LexicoderRowSerializer.java
@@ -46,7 +46,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -85,7 +85,7 @@ public class LexicoderRowSerializer
         LEXICODER_MAP.put(REAL, doubleLexicoder);
         LEXICODER_MAP.put(SMALLINT, longLexicoder);
         LEXICODER_MAP.put(TIME, longLexicoder);
-        LEXICODER_MAP.put(TIMESTAMP, longLexicoder);
+        LEXICODER_MAP.put(TIMESTAMP_MILLIS, longLexicoder);
         LEXICODER_MAP.put(TINYINT, longLexicoder);
         LEXICODER_MAP.put(VARBINARY, new BytesLexicoder());
         LEXICODER_MAP.put(VARCHAR, new StringLexicoder());
@@ -287,13 +287,13 @@ public class LexicoderRowSerializer
     @Override
     public Timestamp getTimestamp(String name)
     {
-        return new Timestamp(decode(TIMESTAMP, getFieldValue(name)));
+        return new Timestamp(decode(TIMESTAMP_MILLIS, getFieldValue(name)));
     }
 
     @Override
     public void setTimestamp(Text text, Timestamp value)
     {
-        text.set(encode(TIMESTAMP, value));
+        text.set(encode(TIMESTAMP_MILLIS, value));
     }
 
     @Override
@@ -353,7 +353,7 @@ public class LexicoderRowSerializer
         else if (type.equals(TIME) && value instanceof Time) {
             toEncode = ((Time) value).getTime();
         }
-        else if (type.equals(TIMESTAMP) && value instanceof Timestamp) {
+        else if (type.equals(TIMESTAMP_MILLIS) && value instanceof Timestamp) {
             toEncode = ((Timestamp) value).getTime();
         }
         else if (type.equals(TINYINT) && value instanceof Byte) {

--- a/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/serializers/StringRowSerializer.java
+++ b/presto-accumulo/src/main/java/io/prestosql/plugin/accumulo/serializers/StringRowSerializer.java
@@ -39,7 +39,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -337,7 +337,7 @@ public class StringRowSerializer
         else if (type.equals(TIME)) {
             setTime(text, (Time) value);
         }
-        else if (type.equals(TIMESTAMP)) {
+        else if (type.equals(TIMESTAMP_MILLIS)) {
             setTimestamp(text, (Timestamp) value);
         }
         else if (type.equals(TINYINT)) {
@@ -391,7 +391,7 @@ public class StringRowSerializer
         if (type.equals(TIME)) {
             return (T) (Long) Long.parseLong(strValue);
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return (T) (Long) Long.parseLong(strValue);
         }
         if (type.equals(TINYINT)) {

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestField.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestField.java
@@ -39,7 +39,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -201,7 +201,7 @@ public class TestField
     @Test
     public void testTimestamp()
     {
-        Type type = TIMESTAMP;
+        Type type = TIMESTAMP_MILLIS;
         Timestamp expected = new Timestamp(new GregorianCalendar(1999, 0, 1, 12, 30, 0).getTime().getTime());
         Field f1 = new Field(915219000000L, type);
         assertEquals(f1.getTimestamp(), expected);

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestField.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestField.java
@@ -203,7 +203,7 @@ public class TestField
     {
         Type type = TIMESTAMP_MILLIS;
         Timestamp expected = new Timestamp(new GregorianCalendar(1999, 0, 1, 12, 30, 0).getTime().getTime());
-        Field f1 = new Field(915219000000L, type);
+        Field f1 = new Field(915_219_000_000_000L, type);
         assertEquals(f1.getTimestamp(), expected);
         assertEquals(f1.getObject(), expected);
         assertEquals(f1.getType(), type);

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestRow.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/model/TestRow.java
@@ -32,7 +32,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -55,7 +55,7 @@ public class TestRow
         r1.addField(new Field(12345678L, BIGINT));
         r1.addField(new Field(12345L, SMALLINT));
         r1.addField(new GregorianCalendar(1970, 0, 1, 12, 30, 0).getTime().getTime(), TIME);
-        r1.addField(new Field(Timestamp.valueOf(LocalDateTime.of(1999, 1, 1, 12, 30, 0)).getTime(), TIMESTAMP));
+        r1.addField(new Field(Timestamp.valueOf(LocalDateTime.of(1999, 1, 1, 12, 30, 0)).getTime(), TIMESTAMP_MILLIS));
         r1.addField((long) 123, TINYINT);
         r1.addField(new Field(Slices.wrappedBuffer("O'Leary".getBytes(UTF_8)), VARBINARY));
         r1.addField(utf8Slice("O'Leary"), VARCHAR);

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
@@ -43,7 +43,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -235,7 +235,7 @@ public abstract class AbstractTestAccumuloRowSerializer
             throws Exception
     {
         AccumuloRowSerializer serializer = serializerClass.getConstructor().newInstance();
-        Type type = TIMESTAMP;
+        Type type = TIMESTAMP_MILLIS;
         Timestamp expected = new Timestamp(new java.util.Date().getTime());
         byte[] data = serializer.encode(type, expected);
         Timestamp actual = new Timestamp(serializer.decode(type, data));

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -55,7 +55,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_DAY;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_DAY;
@@ -352,7 +352,7 @@ public final class StandardColumnMappings
     public static ColumnMapping timestampColumnMappingUsingSqlTimestamp()
     {
         return ColumnMapping.longMapping(
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 (resultSet, columnIndex) -> {
                     Timestamp timestamp = resultSet.getTimestamp(columnIndex);
                     return toPrestoTimestamp(timestamp.toLocalDateTime());
@@ -363,7 +363,7 @@ public final class StandardColumnMappings
     public static ColumnMapping timestampColumnMapping()
     {
         return ColumnMapping.longMapping(
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 timestampReadFunction(),
                 timestampWriteFunction());
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -56,6 +56,7 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_DAY;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_DAY;
@@ -68,6 +69,7 @@ import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
@@ -392,12 +394,12 @@ public final class StandardColumnMappings
 
     public static long toPrestoTimestamp(LocalDateTime localDateTime)
     {
-        return localDateTime.atZone(UTC).toInstant().toEpochMilli();
+        return localDateTime.atZone(UTC).toInstant().toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
     }
 
     public static LocalDateTime fromPrestoTimestamp(long value)
     {
-        return Instant.ofEpochMilli(value).atZone(UTC).toLocalDateTime();
+        return Instant.ofEpochMilli(floorDiv(value, MICROSECONDS_PER_MILLISECOND)).atZone(UTC).toLocalDateTime();
     }
 
     public static LocalTime fromPrestoTime(long value)

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -74,6 +74,7 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimeOf;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -509,7 +510,7 @@ public class TestJdbcQueryBuilder
 
     private static long toPrestoTimestamp(int year, int month, int day, int hour, int minute, int second)
     {
-        return sqlTimestampOf(3, year, month, day, hour, minute, second, 0).getMillis();
+        return sqlTimestampOf(3, year, month, day, hour, minute, second, 0).getMillis() * MICROSECONDS_PER_MILLISECOND;
     }
 
     private static Timestamp toTimestamp(int year, int month, int day, int hour, int minute, int second)

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -68,7 +68,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimeOf;
@@ -126,7 +126,7 @@ public class TestJdbcQueryBuilder
                 new JdbcColumnHandle("col_3", JDBC_VARCHAR, VARCHAR),
                 new JdbcColumnHandle("col_4", JDBC_DATE, DATE),
                 new JdbcColumnHandle("col_5", JDBC_TIME, TIME),
-                new JdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP),
+                new JdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
                 new JdbcColumnHandle("col_7", JDBC_TINYINT, TINYINT),
                 new JdbcColumnHandle("col_8", JDBC_SMALLINT, SMALLINT),
                 new JdbcColumnHandle("col_9", JDBC_INTEGER, INTEGER),
@@ -366,11 +366,11 @@ public class TestJdbcQueryBuilder
             throws SQLException
     {
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
-                columns.get(6), Domain.create(SortedRangeSet.copyOf(TIMESTAMP,
+                columns.get(6), Domain.create(SortedRangeSet.copyOf(TIMESTAMP_MILLIS,
                         ImmutableList.of(
-                                Range.equal(TIMESTAMP, toPrestoTimestamp(2016, 6, 3, 0, 23, 37)),
-                                Range.equal(TIMESTAMP, toPrestoTimestamp(2016, 10, 19, 16, 23, 37)),
-                                Range.range(TIMESTAMP, toPrestoTimestamp(2016, 6, 7, 8, 23, 37), false, toPrestoTimestamp(2016, 6, 9, 12, 23, 37), true))),
+                                Range.equal(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 6, 3, 0, 23, 37)),
+                                Range.equal(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 10, 19, 16, 23, 37)),
+                                Range.range(TIMESTAMP_MILLIS, toPrestoTimestamp(2016, 6, 7, 8, 23, 37), false, toPrestoTimestamp(2016, 6, 9, 12, 23, 37), true))),
                         false)));
 
         Connection connection = database.getConnection();

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryResultPageSource.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryResultPageSource.java
@@ -62,7 +62,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -162,7 +162,7 @@ public class BigQueryResultPageSource
                 else if (type.equals(DATE)) {
                     type.writeLong(output, ((Number) value).intValue());
                 }
-                else if (type.equals(TIMESTAMP)) {
+                else if (type.equals(TIMESTAMP_MILLIS)) {
                     type.writeLong(output, toPrestoTimestamp(((Utf8) value).toString()));
                 }
                 else if (type.equals(TIME_WITH_TIME_ZONE)) {

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryType.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryType.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_PRECISION;
 import static io.prestosql.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_SCALE;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -117,7 +118,7 @@ public enum BigQueryType
 
     static long toPrestoTimestamp(String datetime)
     {
-        return toLocalDateTime(datetime).toInstant(UTC).toEpochMilli();
+        return toLocalDateTime(datetime).toInstant(UTC).toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
     }
 
     static String simpleToStringConverter(Object value)

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryType.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryType.java
@@ -57,7 +57,7 @@ public enum BigQueryType
     BOOLEAN(BooleanType.BOOLEAN, BigQueryType::simpleToStringConverter),
     BYTES(VarbinaryType.VARBINARY, BigQueryType::bytesToStringConverter),
     DATE(DateType.DATE, BigQueryType::dateToStringConverter),
-    DATETIME(TimestampType.TIMESTAMP, BigQueryType::datetimeToStringConverter),
+    DATETIME(TimestampType.TIMESTAMP_MILLIS, BigQueryType::datetimeToStringConverter),
     FLOAT(DoubleType.DOUBLE, BigQueryType::simpleToStringConverter),
     GEOGRAPHY(VarcharType.VARCHAR, BigQueryType::stringToStringConverter),
     INTEGER(BigintType.BIGINT, BigQueryType::simpleToStringConverter),

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestTypeConversions.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestTypeConversions.java
@@ -67,7 +67,7 @@ public class TestTypeConversions
     @Test
     public void testConvertDateTimeField()
     {
-        assertSimpleFieldTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP);
+        assertSimpleFieldTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MILLIS);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class TestTypeConversions
     @Test
     public void testConvertDateTimeColumn()
     {
-        assertSimpleColumnTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP);
+        assertSimpleColumnTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MILLIS);
     }
 
     @Test

--- a/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
@@ -42,7 +42,7 @@ import static io.prestosql.spi.type.StandardTypes.IPADDRESS;
 import static io.prestosql.spi.type.StandardTypes.JSON;
 import static io.prestosql.spi.type.StandardTypes.UUID;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.TypeSignature.arrayType;
@@ -67,7 +67,7 @@ public class TestFixJsonDataUtils
         assertQueryResult(DOUBLE.getTypeSignature(), 100.23456D, 100.23456);
         assertQueryResult(new TypeSignature(INTERVAL_DAY_TO_SECOND), "INTERVAL '2' DAY", "INTERVAL '2' DAY");
         assertQueryResult(new TypeSignature(INTERVAL_YEAR_TO_MONTH), "INTERVAL '3' MONTH", "INTERVAL '3' MONTH");
-        assertQueryResult(TIMESTAMP.getTypeSignature(), "2001-08-22 03:04:05.321", "2001-08-22 03:04:05.321");
+        assertQueryResult(TIMESTAMP_MILLIS.getTypeSignature(), "2001-08-22 03:04:05.321", "2001-08-22 03:04:05.321");
         assertQueryResult(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature(), "2001-08-22 03:04:05.321 America/Los_Angeles", "2001-08-22 03:04:05.321 America/Los_Angeles");
         assertQueryResult(TIME.getTypeSignature(), "01:02:03.456", "01:02:03.456");
         assertQueryResult(TIMESTAMP_WITH_TIME_ZONE.getTypeSignature(), "01:02:03.456 America/Los_Angeles", "01:02:03.456 America/Los_Angeles");

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
@@ -67,7 +67,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -306,7 +306,7 @@ public class ElasticsearchMetadata
         }
         else if (type instanceof DateTimeType) {
             if (((DateTimeType) type).getFormats().isEmpty()) {
-                return TIMESTAMP;
+                return TIMESTAMP_MILLIS;
             }
             // otherwise, skip -- we don't support custom formats, yet
         }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -43,8 +43,10 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
@@ -158,7 +160,7 @@ public final class ElasticsearchQueryBuilder
             return ((Slice) value).toStringUtf8();
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return Instant.ofEpochMilli((Long) value)
+            return Instant.ofEpochMilli(floorDiv((Long) value, MICROSECONDS_PER_MILLISECOND))
                     .atZone(ZoneOffset.UTC)
                     .toLocalDateTime()
                     .format(ISO_DATE_TIME);

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -42,7 +42,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.toIntExact;
@@ -157,7 +157,7 @@ public final class ElasticsearchQueryBuilder
         if (type.equals(VARCHAR)) {
             return ((Slice) value).toStringUtf8();
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return Instant.ofEpochMilli((Long) value)
                     .atZone(ZoneOffset.UTC)
                     .toLocalDateTime()

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ScanQueryPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ScanQueryPageSource.java
@@ -66,7 +66,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -109,7 +109,7 @@ public class ScanQueryPageSource
         // This is convenient for types such as DATE, TIMESTAMP, etc, which have multiple possible
         // representations in JSON, but a single normalized representation as doc_field.
         List<String> documentFields = flattenFields(columns).entrySet().stream()
-                .filter(entry -> entry.getValue().equals(TIMESTAMP))
+                .filter(entry -> entry.getValue().equals(TIMESTAMP_MILLIS))
                 .map(Map.Entry::getKey)
                 .collect(toImmutableList());
 
@@ -279,7 +279,7 @@ public class ScanQueryPageSource
         if (type.equals(VARBINARY)) {
             return new VarbinaryDecoder(path);
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return new TimestampDecoder(path);
         }
         if (type.equals(BOOLEAN)) {

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.Objects.requireNonNull;
@@ -77,11 +78,9 @@ public class TimestampDecoder
                         value.getClass().getSimpleName()));
             }
 
-            long epochMillis = timestamp.atOffset(ZoneOffset.UTC)
-                    .toInstant()
-                    .toEpochMilli();
+            long epochMicros = timestamp.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
 
-            TIMESTAMP_MILLIS.writeLong(output, epochMillis);
+            TIMESTAMP_MILLIS.writeLong(output, epochMicros);
         }
     }
 }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.Objects.requireNonNull;
@@ -81,7 +81,7 @@ public class TimestampDecoder
                     .toInstant()
                     .toEpochMilli();
 
-            TIMESTAMP.writeLong(output, epochMillis);
+            TIMESTAMP_MILLIS.writeLong(output, epochMillis);
         }
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
@@ -68,7 +68,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -480,7 +480,7 @@ public class GenericHiveRecordCursor<K, V extends Writable>
         else if (DATE.equals(type)) {
             parseLongColumn(column);
         }
-        else if (TIMESTAMP.equals(type)) {
+        else if (TIMESTAMP_MILLIS.equals(type)) {
             parseLongColumn(column);
         }
         else if (type instanceof DecimalType) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
@@ -69,6 +69,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -285,7 +286,7 @@ public class GenericHiveRecordCursor<K, V extends Writable>
             return ((Date) value).toEpochDay();
         }
         if (value instanceof Timestamp) {
-            return ((Timestamp) value).toEpochMilli();
+            return ((Timestamp) value).toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
         }
         if (value instanceof Float) {
             return floatToRawIntBits(((Float) value));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -106,7 +106,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -214,7 +214,7 @@ public class HivePageSource
                 else if (type.equals(DATE)) {
                     prefilledValue = datePartitionKey(columnValue, name);
                 }
-                else if (type.equals(TIMESTAMP)) {
+                else if (type.equals(TIMESTAMP_MILLIS)) {
                     prefilledValue = timestampPartitionKey(columnValue, name);
                 }
                 else if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
@@ -53,7 +53,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -141,7 +141,7 @@ public class HiveRecordCursor
                 else if (DATE.equals(type)) {
                     longs[columnIndex] = datePartitionKey(columnValue, name);
                 }
-                else if (TIMESTAMP.equals(type)) {
+                else if (TIMESTAMP_MILLIS.equals(type)) {
                     longs[columnIndex] = timestampPartitionKey(columnValue, name);
                 }
                 else if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
@@ -54,7 +54,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
@@ -296,7 +296,7 @@ public final class HiveType
             case DATE:
                 return DATE;
             case TIMESTAMP:
-                return TIMESTAMP;
+                return TIMESTAMP_MILLIS;
             case BINARY:
                 return VARBINARY;
             case DECIMAL:

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -126,7 +126,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -963,7 +963,7 @@ public final class ThriftMetastoreUtil
         if (type.equals(BOOLEAN)) {
             return ImmutableSet.of(NUMBER_OF_NON_NULL_VALUES, NUMBER_OF_TRUE_VALUES);
         }
-        if (isNumericType(type) || type.equals(DATE) || type.equals(TIMESTAMP)) {
+        if (isNumericType(type) || type.equals(DATE) || type.equals(TIMESTAMP_MILLIS)) {
             // TODO https://github.com/prestosql/presto/issues/37 support non-legacy TIMESTAMP
             return ImmutableSet.of(MIN_VALUE, MAX_VALUE, NUMBER_OF_DISTINCT_VALUES, NUMBER_OF_NON_NULL_VALUES);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
@@ -26,7 +26,6 @@ import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
@@ -57,6 +56,7 @@ import static io.prestosql.plugin.hive.util.HiveUtil.isArrayType;
 import static io.prestosql.plugin.hive.util.HiveUtil.isMapType;
 import static io.prestosql.plugin.hive.util.HiveUtil.isRowType;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.getHiveDecimal;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -116,7 +116,7 @@ public final class FieldSetterFactory
             return new DateFieldSetter(rowInspector, row, field);
         }
 
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return new TimestampFieldSetter(rowInspector, row, field, timeZone);
         }
 
@@ -374,7 +374,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            long epochMilli = TimestampType.TIMESTAMP.getLong(block, position);
+            long epochMilli = TIMESTAMP_MILLIS.getLong(block, position);
             epochMilli = timeZone.convertLocalToUTC(epochMilli, false);
             value.set(Timestamp.ofEpochMilli(epochMilli));
             rowInspector.setStructFieldData(row, field, value);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/FieldSetterFactory.java
@@ -57,7 +57,9 @@ import static io.prestosql.plugin.hive.util.HiveUtil.isMapType;
 import static io.prestosql.plugin.hive.util.HiveUtil.isRowType;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.getHiveDecimal;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -374,7 +376,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            long epochMilli = TIMESTAMP_MILLIS.getLong(block, position);
+            long epochMilli = floorDiv(TIMESTAMP_MILLIS.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
             epochMilli = timeZone.convertLocalToUTC(epochMilli, false);
             value.set(Timestamp.ofEpochMilli(epochMilli));
             rowInspector.setStructFieldData(row, field, value);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveTypeTranslator.java
@@ -49,7 +49,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.String.format;
@@ -113,7 +113,7 @@ public final class HiveTypeTranslator
         if (DATE.equals(type)) {
             return HIVE_DATE.getTypeInfo();
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             return HIVE_TIMESTAMP.getTypeInfo();
         }
         if (type instanceof DecimalType) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -151,7 +151,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Byte.parseByte;
@@ -517,7 +517,7 @@ public final class HiveUtil
                 REAL.equals(type) ||
                 DOUBLE.equals(type) ||
                 DATE.equals(type) ||
-                TIMESTAMP.equals(type) ||
+                TIMESTAMP_MILLIS.equals(type) ||
                 isVarcharType(type) ||
                 isCharType(type);
     }
@@ -604,11 +604,11 @@ public final class HiveUtil
             return NullableValue.of(DATE, datePartitionKey(value, partitionName));
         }
 
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             if (isNull) {
-                return NullableValue.asNull(TIMESTAMP);
+                return NullableValue.asNull(TIMESTAMP_MILLIS);
             }
-            return NullableValue.of(TIMESTAMP, timestampPartitionKey(value, partitionName));
+            return NullableValue.of(TIMESTAMP_MILLIS, timestampPartitionKey(value, partitionName));
         }
 
         if (REAL.equals(type)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -152,6 +152,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Byte.parseByte;
@@ -369,7 +370,7 @@ public final class HiveUtil
 
     public static long parseHiveTimestamp(String value)
     {
-        return HIVE_TIMESTAMP_PARSER.parseMillis(value);
+        return HIVE_TIMESTAMP_PARSER.parseMillis(value) * MICROSECONDS_PER_MILLISECOND;
     }
 
     public static boolean isSplittable(InputFormat<?, ?> inputFormat, FileSystem fileSystem, Path path)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -114,7 +114,9 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -319,7 +321,7 @@ public final class HiveWriteUtils
             return Date.ofEpochDay(toIntExact(type.getLong(block, position)));
         }
         if (TIMESTAMP_MILLIS.equals(type)) {
-            return Timestamp.ofEpochMilli(type.getLong(block, position));
+            return Timestamp.ofEpochMilli(floorDiv(type.getLong(block, position), MICROSECONDS_PER_MILLISECOND));
         }
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -47,7 +47,6 @@ import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
@@ -114,6 +113,7 @@ import static io.prestosql.plugin.hive.util.HiveUtil.isRowType;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -231,7 +231,7 @@ public final class HiveWriteUtils
         if (type.equals(DateType.DATE)) {
             return javaDateObjectInspector;
         }
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return javaTimestampObjectInspector;
         }
         if (type instanceof DecimalType) {
@@ -318,7 +318,7 @@ public final class HiveWriteUtils
         if (DateType.DATE.equals(type)) {
             return Date.ofEpochDay(toIntExact(type.getLong(block, position)));
         }
-        if (TimestampType.TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             return Timestamp.ofEpochMilli(type.getLong(block, position));
         }
         if (type instanceof DecimalType) {
@@ -670,7 +670,7 @@ public final class HiveWriteUtils
             return writableDateObjectInspector;
         }
 
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return writableTimestampObjectInspector;
         }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/SerDeUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/SerDeUtils.java
@@ -26,7 +26,6 @@ import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.common.type.HiveChar;
@@ -61,6 +60,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.type.Chars.truncateToLengthAndTrimSpaces;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
@@ -148,7 +148,7 @@ public final class SerDeUtils
                 DateType.DATE.writeLong(builder, formatDateAsLong(object, (DateObjectInspector) inspector));
                 return;
             case TIMESTAMP:
-                TimestampType.TIMESTAMP.writeLong(builder, formatTimestampAsLong(object, (TimestampObjectInspector) inspector));
+                TIMESTAMP_MILLIS.writeLong(builder, formatTimestampAsLong(object, (TimestampObjectInspector) inspector));
                 return;
             case BINARY:
                 VARBINARY.writeSlice(builder, Slices.wrappedBuffer(((BinaryObjectInspector) inspector).getPrimitiveJavaObject(object)));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/SerDeUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/SerDeUtils.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
@@ -325,8 +326,8 @@ public final class SerDeUtils
     private static long formatTimestampAsLong(Object object, TimestampObjectInspector inspector)
     {
         if (object instanceof TimestampWritable) {
-            return ((TimestampWritable) object).getTimestamp().getTime();
+            return ((TimestampWritable) object).getTimestamp().getTime() * MICROSECONDS_PER_MILLISECOND;
         }
-        return inspector.getPrimitiveJavaObject(object).toEpochMilli();
+        return inspector.getPrimitiveJavaObject(object).toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
@@ -71,7 +71,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -305,7 +305,7 @@ public final class Statistics
         else if (type.equals(DATE)) {
             result.setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty()));
         }
-        else if (type.equals(TIMESTAMP)) {
+        else if (type.equals(TIMESTAMP_MILLIS)) {
             result.setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty()));
         }
         else if (type instanceof DecimalType) {
@@ -423,7 +423,7 @@ public final class Statistics
         else if (type.equals(DATE)) {
             result.setDateStatistics(new DateStatistics(getDateValue(session, type, min), getDateValue(session, type, max)));
         }
-        else if (type.equals(TIMESTAMP)) {
+        else if (type.equals(TIMESTAMP_MILLIS)) {
             result.setIntegerStatistics(new IntegerStatistics(getTimestampValue(min), getTimestampValue(max)));
         }
         else if (type instanceof DecimalType) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/Statistics.java
@@ -72,9 +72,10 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static java.lang.Math.floorDiv;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class Statistics
 {
@@ -459,7 +460,7 @@ public final class Statistics
 
     private static OptionalLong getTimestampValue(Block block)
     {
-        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(MILLISECONDS.toSeconds(block.getLong(0, 0)));
+        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(floorDiv(block.getLong(0, 0), MICROSECONDS_PER_SECOND));
     }
 
     private static Optional<BigDecimal> getDecimalValue(ConnectorSession session, Type type, Block block)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -111,6 +111,7 @@ import io.prestosql.spi.type.SqlDate;
 import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.SqlVarbinary;
+import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.testing.MaterializedResult;
@@ -256,7 +257,7 @@ import static io.prestosql.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -473,7 +474,7 @@ public abstract class AbstractTestHive
             .add(new ColumnMetadata("t_char", createCharType(5)))
             .add(new ColumnMetadata("t_varbinary", VARBINARY))
             .add(new ColumnMetadata("t_date", DATE))
-            .add(new ColumnMetadata("t_timestamp", TIMESTAMP))
+            .add(new ColumnMetadata("t_timestamp", TIMESTAMP_MILLIS))
             .add(new ColumnMetadata("t_short_decimal", createDecimalType(5, 2)))
             .add(new ColumnMetadata("t_long_decimal", createDecimalType(20, 3)))
             .build();
@@ -4538,7 +4539,7 @@ public abstract class AbstractTestHive
                 else if (VARBINARY.equals(column.getType())) {
                     assertInstanceOf(value, SqlVarbinary.class);
                 }
-                else if (TIMESTAMP.equals(column.getType())) {
+                else if (TIMESTAMP_MILLIS.equals(column.getType())) {
                     assertInstanceOf(value, SqlTimestamp.class);
                 }
                 else if (TIMESTAMP_WITH_TIME_ZONE.equals(column.getType())) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -111,7 +111,6 @@ import io.prestosql.spi.type.SqlDate;
 import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.SqlVarbinary;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.testing.MaterializedResult;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -330,7 +330,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_map_timestamp",
                     getStandardMapObjectInspector(javaTimestampObjectInspector, javaTimestampObjectInspector),
                     ImmutableMap.of(HIVE_TIMESTAMP, HIVE_TIMESTAMP),
-                    mapBlockOf(TimestampType.TIMESTAMP, TimestampType.TIMESTAMP, TIMESTAMP, TIMESTAMP)))
+                    mapBlockOf(TimestampType.TIMESTAMP_MILLIS, TimestampType.TIMESTAMP_MILLIS, TIMESTAMP, TIMESTAMP)))
             .add(new TestColumn("t_map_decimal_precision_2",
                     getStandardMapObjectInspector(DECIMAL_INSPECTOR_PRECISION_2, DECIMAL_INSPECTOR_PRECISION_2),
                     ImmutableMap.of(WRITE_DECIMAL_PRECISION_2, WRITE_DECIMAL_PRECISION_2),
@@ -381,7 +381,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_array_timestamp",
                     getStandardListObjectInspector(javaTimestampObjectInspector),
                     ImmutableList.of(HIVE_TIMESTAMP),
-                    arrayBlockOf(TimestampType.TIMESTAMP, TIMESTAMP)))
+                    arrayBlockOf(TimestampType.TIMESTAMP_MILLIS, TIMESTAMP)))
             .add(new TestColumn("t_array_decimal_precision_2",
                     getStandardListObjectInspector(DECIMAL_INSPECTOR_PRECISION_2),
                     ImmutableList.of(WRITE_DECIMAL_PRECISION_2),
@@ -708,7 +708,7 @@ public abstract class AbstractTestHiveFileFormats
         if (DateType.DATE.equals(type)) {
             return cursor.getLong(field);
         }
-        if (TimestampType.TIMESTAMP.equals(type)) {
+        if (TimestampType.TIMESTAMP_MILLIS.equals(type)) {
             return cursor.getLong(field);
         }
         if (isStructuralType(type)) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -1181,7 +1181,7 @@ public class TestHiveIntegrationSmokeTest
         data.put("1.2345678901234578E14", new TypeAndEstimate(DOUBLE, new EstimatedStatsAndCost(1.0, 17.0, 17.0, 0.0, 0.0)));
         data.put("123456789012345678901234.567", new TypeAndEstimate(createDecimalType(30, 3), new EstimatedStatsAndCost(1.0, 25.0, 25.0, 0.0, 0.0)));
         data.put("2019-01-01", new TypeAndEstimate(DateType.DATE, new EstimatedStatsAndCost(1.0, 13.0, 13.0, 0.0, 0.0)));
-        data.put("2019-01-01 23:22:21.123", new TypeAndEstimate(TimestampType.TIMESTAMP, new EstimatedStatsAndCost(1.0, 17.0, 17.0, 0.0, 0.0)));
+        data.put("2019-01-01 23:22:21.123", new TypeAndEstimate(TimestampType.TIMESTAMP_MILLIS, new EstimatedStatsAndCost(1.0, 17.0, 17.0, 0.0, 0.0)));
         int index = 0;
         for (Map.Entry<Object, TypeAndEstimate> entry : data.entrySet()) {
             index++;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestIonSqlQueryBuilder.java
@@ -44,7 +44,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 
@@ -102,7 +102,7 @@ public class TestIonSqlQueryBuilder
     {
         IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
         List<HiveColumnHandle> columns = ImmutableList.of(
-                createBaseColumn("t1", 0, HIVE_TIMESTAMP, TIMESTAMP, REGULAR, Optional.empty()),
+                createBaseColumn("t1", 0, HIVE_TIMESTAMP, TIMESTAMP_MILLIS, REGULAR, Optional.empty()),
                 createBaseColumn("t2", 1, HIVE_DATE, DATE, REGULAR, Optional.empty()));
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 columns.get(1), Domain.create(SortedRangeSet.copyOf(DATE, ImmutableList.of(Range.equal(DATE, (long) DateTimeUtils.parseDate("2001-08-22")))), false)));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -77,7 +77,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.RowType.field;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -1447,7 +1447,7 @@ public abstract class AbstractTestParquetReader
         tester.testRoundTrip(javaTimestampObjectInspector,
                 transform(writeValues, AbstractTestParquetReader::intToTimestamp),
                 transform(writeValues, AbstractTestParquetReader::intToSqlTimestamp),
-                TIMESTAMP);
+                TIMESTAMP_MILLIS);
 
         tester.testRoundTrip(javaDateObjectInspector,
                 transform(writeValues, AbstractTestParquetReader::intToDate),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
@@ -111,7 +111,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -525,7 +525,7 @@ public class ParquetTester
         if (DATE.equals(type)) {
             return new SqlDate(((Long) fieldFromCursor).intValue());
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             return SqlTimestamp.fromMillis(3, (long) fieldFromCursor);
         }
         return fieldFromCursor;
@@ -782,7 +782,7 @@ public class ParquetTester
                 long days = ((SqlDate) value).getDays();
                 type.writeLong(blockBuilder, days);
             }
-            else if (TIMESTAMP.equals(type)) {
+            else if (TIMESTAMP_MILLIS.equals(type)) {
                 long millis = ((SqlTimestamp) value).getMillis();
                 type.writeLong(blockBuilder, millis);
             }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
@@ -783,8 +783,7 @@ public class ParquetTester
                 type.writeLong(blockBuilder, days);
             }
             else if (TIMESTAMP_MILLIS.equals(type)) {
-                long millis = ((SqlTimestamp) value).getMillis();
-                type.writeLong(blockBuilder, millis);
+                type.writeLong(blockBuilder, ((SqlTimestamp) value).getEpochMicros());
             }
             else {
                 if (type instanceof ArrayType) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveTypeTranslator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveTypeTranslator.java
@@ -38,7 +38,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RowType.field;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.TypeSignature.mapType;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -58,10 +58,10 @@ public class TestHiveTypeTranslator
             .put(createVarcharType(3), HiveType.valueOf("varchar(3)"))
             .put(VARCHAR, HiveType.HIVE_STRING)
             .put(DATE, HiveType.HIVE_DATE)
-            .put(TIMESTAMP, HiveType.HIVE_TIMESTAMP)
+            .put(TIMESTAMP_MILLIS, HiveType.HIVE_TIMESTAMP)
             .put(createDecimalType(5, 3), HiveType.valueOf("decimal(5,3)"))
             .put(VARBINARY, HiveType.HIVE_BINARY)
-            .put(new ArrayType(TIMESTAMP), HiveType.valueOf("array<timestamp>"))
+            .put(new ArrayType(TIMESTAMP_MILLIS), HiveType.valueOf("array<timestamp>"))
             .put(TYPE_MANAGER.getType(mapType(BOOLEAN.getTypeSignature(), VARBINARY.getTypeSignature())), HiveType.valueOf("map<boolean,binary>"))
             .put(RowType.from(List.of(field("col0", INTEGER), field("col1", VARBINARY))), HiveType.valueOf("struct<col0:int,col1:binary>"))
             .build();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestHiveUtil.java
@@ -33,6 +33,7 @@ import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializer;
 import static io.prestosql.plugin.hive.util.HiveUtil.parseHiveTimestamp;
 import static io.prestosql.plugin.hive.util.HiveUtil.toPartitionValues;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_CLASS;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_FORMAT;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
@@ -94,7 +95,7 @@ public class TestHiveUtil
     private static long unixTime(DateTime time, int factionalDigits)
     {
         int factor = (int) Math.pow(10, Math.max(0, 3 - factionalDigits));
-        return (time.getMillis() / factor) * factor;
+        return (time.getMillis() / factor) * factor * MICROSECONDS_PER_MILLISECOND;
     }
 
     public static DateTimeZone nonDefaultTimeZone()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestSerDeUtils.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/util/TestSerDeUtils.java
@@ -59,6 +59,7 @@ import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.testing.StructuralTestUtil.arrayBlockOf;
 import static io.prestosql.testing.StructuralTestUtil.mapBlockOf;
 import static io.prestosql.testing.StructuralTestUtil.rowBlockOf;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
@@ -167,7 +168,7 @@ public class TestSerDeUtils
 
         // timestamp
         DateTime dateTime = new DateTime(2008, 10, 28, 16, 7, 15, 0);
-        Block expectedTimestamp = VARBINARY.createBlockBuilder(null, 1).writeLong(dateTime.getMillis()).closeEntry().build();
+        Block expectedTimestamp = VARBINARY.createBlockBuilder(null, 1).writeLong(dateTime.getMillis() * MICROSECONDS_PER_MILLISECOND).closeEntry().build();
         Block actualTimestamp = toBinaryBlock(BIGINT, Timestamp.ofEpochMilli(dateTime.getMillis()), getInspector(Timestamp.class));
         assertBlockEquals(actualTimestamp, expectedTimestamp);
 

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDatabaseMetaData.java
@@ -764,7 +764,7 @@ public class TestPrestoDatabaseMetaData
                 assertColumnSpec(rs, Types.VARBINARY, (long) Integer.MAX_VALUE, null, null, (long) Integer.MAX_VALUE, VarbinaryType.VARBINARY);
                 assertColumnSpec(rs, Types.TIME, 12L, null, null, null, TimeType.TIME);
                 assertColumnSpec(rs, Types.TIME_WITH_TIMEZONE, 18L, null, null, null, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
-                assertColumnSpec(rs, Types.TIMESTAMP, 25L, null, null, null, TimestampType.TIMESTAMP);
+                assertColumnSpec(rs, Types.TIMESTAMP, 25L, null, null, null, TimestampType.TIMESTAMP_MILLIS);
                 assertColumnSpec(rs, Types.TIMESTAMP, 31L, null, null, null, createTimestampType(9));
                 assertColumnSpec(rs, Types.TIMESTAMP_WITH_TIMEZONE, 59L, null, null, null, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
                 assertColumnSpec(rs, Types.TIMESTAMP_WITH_TIMEZONE, 65L, null, null, null, createTimestampWithTimeZoneType(9));

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
@@ -45,7 +45,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.util.DateTimeUtils.convertToTimestampWithTimeZone;
 import static io.prestosql.util.DateTimeUtils.parseLegacyTime;
@@ -145,8 +145,8 @@ public class KafkaLoader
             if (TIME.equals(type)) {
                 return ISO8601_FORMATTER.print(parseLegacyTime(timeZoneKey, (String) value));
             }
-            if (TIMESTAMP.equals(type)) {
-                return ISO8601_FORMATTER.print(castToShortTimestamp(TIMESTAMP.getPrecision(), (String) value));
+            if (TIMESTAMP_MILLIS.equals(type)) {
+                return ISO8601_FORMATTER.print(castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), (String) value));
             }
             if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
                 return ISO8601_FORMATTER.print(unpackMillisUtc(convertToTimestampWithTimeZone(timeZoneKey, (String) value)));

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisInternalFieldDescription.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisInternalFieldDescription.java
@@ -39,7 +39,7 @@ public enum KinesisInternalFieldDescription
     SEGMENT_COUNT_FIELD("_segment_count", BigintType.BIGINT, "Running message count per segment"),
     MESSAGE_VALID_FIELD("_message_valid", BooleanType.BOOLEAN, "Message data is valid"),
     MESSAGE_FIELD("_message", VarcharType.VARCHAR, "Message text"),
-    MESSAGE_TIMESTAMP("_message_timestamp", TimestampType.TIMESTAMP, "Approximate message arrival timestamp"),
+    MESSAGE_TIMESTAMP("_message_timestamp", TimestampType.TIMESTAMP_MILLIS, "Approximate message arrival timestamp"),
     MESSAGE_LENGTH_FIELD("_message_length", BigintType.BIGINT, "Total number of message bytes"),
     PARTITION_KEY_FIELD("_partition_key", VarcharType.VARCHAR, "Key text");
 

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
@@ -50,6 +50,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.truncateEpochMicrosToMillis;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -141,7 +142,7 @@ public class KuduPageSink
             row.setNull(destChannel);
         }
         else if (TIMESTAMP_MILLIS.equals(type)) {
-            row.addLong(destChannel, type.getLong(block, position) * 1000);
+            row.addLong(destChannel, truncateEpochMicrosToMillis(type.getLong(block, position)));
         }
         else if (REAL.equals(type)) {
             row.addFloat(destChannel, intBitsToFloat(toIntExact(type.getLong(block, position))));

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
@@ -49,7 +49,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -140,7 +140,7 @@ public class KuduPageSink
         if (block.isNull(position)) {
             row.setNull(destChannel);
         }
-        else if (TIMESTAMP.equals(type)) {
+        else if (TIMESTAMP_MILLIS.equals(type)) {
             row.addLong(destChannel, type.getLong(block, position) * 1000);
         }
         else if (REAL.equals(type)) {

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
@@ -52,7 +52,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return org.apache.kudu.Type.STRING;
         }
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
             return org.apache.kudu.Type.UNIXTIME_MICROS;
         }
         if (type == BigintType.BIGINT) {
@@ -102,7 +102,7 @@ public final class TypeHelper
             case STRING:
                 return VarcharType.VARCHAR;
             case UNIXTIME_MICROS:
-                return TimestampType.TIMESTAMP;
+                return TimestampType.TIMESTAMP_MILLIS;
             case INT64:
                 return BigintType.BIGINT;
             case INT32:
@@ -131,7 +131,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return ((Slice) nativeValue).toStringUtf8();
         }
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
             return ((Long) nativeValue) * 1000;
         }
         if (type == BigintType.BIGINT) {
@@ -177,7 +177,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return row.getString(field);
         }
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
             return row.getLong(field) / 1000;
         }
         if (type == BigintType.BIGINT) {
@@ -212,7 +212,7 @@ public final class TypeHelper
 
     public static long getLong(Type type, RowResult row, int field)
     {
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
             return row.getLong(field) / 1000;
         }
         if (type == BigintType.BIGINT) {

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
@@ -26,7 +26,6 @@ import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
@@ -40,6 +39,8 @@ import java.math.BigInteger;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.Decimals.decodeUnscaledValue;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.truncateEpochMicrosToMillis;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 
@@ -52,7 +53,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return org.apache.kudu.Type.STRING;
         }
-        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return org.apache.kudu.Type.UNIXTIME_MICROS;
         }
         if (type == BigintType.BIGINT) {
@@ -102,7 +103,7 @@ public final class TypeHelper
             case STRING:
                 return VarcharType.VARCHAR;
             case UNIXTIME_MICROS:
-                return TimestampType.TIMESTAMP_MILLIS;
+                return TIMESTAMP_MILLIS;
             case INT64:
                 return BigintType.BIGINT;
             case INT32:
@@ -131,8 +132,9 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return ((Slice) nativeValue).toStringUtf8();
         }
-        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
-            return ((Long) nativeValue) * 1000;
+        if (type.equals(TIMESTAMP_MILLIS)) {
+            // Kudu's native format is in microseconds
+            return nativeValue;
         }
         if (type == BigintType.BIGINT) {
             return nativeValue;
@@ -177,8 +179,8 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return row.getString(field);
         }
-        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
-            return row.getLong(field) / 1000;
+        if (type.equals(TIMESTAMP_MILLIS)) {
+            return truncateEpochMicrosToMillis(row.getLong(field));
         }
         if (type == BigintType.BIGINT) {
             return row.getLong(field);
@@ -212,8 +214,8 @@ public final class TypeHelper
 
     public static long getLong(Type type, RowResult row, int field)
     {
-        if (type.equals(TimestampType.TIMESTAMP_MILLIS)) {
-            return row.getLong(field) / 1000;
+        if (type.equals(TIMESTAMP_MILLIS)) {
+            return truncateEpochMicrosToMillis(row.getLong(field));
         }
         if (type == BigintType.BIGINT) {
             return row.getLong(field);

--- a/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
@@ -47,7 +47,7 @@ import static io.prestosql.metadata.MetadataUtil.TableMetadataBuilder.tableMetad
 import static io.prestosql.security.AccessControlUtil.filterQueries;
 import static io.prestosql.spi.connector.SystemTable.Distribution.ALL_COORDINATORS;
 import static io.prestosql.spi.type.BigintType.BIGINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
 
@@ -68,10 +68,10 @@ public class QuerySystemTable
             .column("analysis_time_ms", BIGINT)
             .column("planning_time_ms", BIGINT)
 
-            .column("created", TIMESTAMP)
-            .column("started", TIMESTAMP)
-            .column("last_heartbeat", TIMESTAMP)
-            .column("end", TIMESTAMP)
+            .column("created", TIMESTAMP_MILLIS)
+            .column("started", TIMESTAMP_MILLIS)
+            .column("last_heartbeat", TIMESTAMP_MILLIS)
+            .column("end", TIMESTAMP_MILLIS)
 
             .column("error_type", createUnboundedVarcharType())
             .column("error_code", createUnboundedVarcharType())

--- a/presto-main/src/main/java/io/prestosql/connector/system/TaskSystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/TaskSystemTable.java
@@ -36,7 +36,7 @@ import javax.inject.Inject;
 import static io.prestosql.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.prestosql.spi.connector.SystemTable.Distribution.ALL_NODES;
 import static io.prestosql.spi.type.BigintType.BIGINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 
 public class TaskSystemTable
@@ -73,10 +73,10 @@ public class TaskSystemTable
             .column("physical_input_bytes", BIGINT)
             .column("physical_written_bytes", BIGINT)
 
-            .column("created", TIMESTAMP)
-            .column("start", TIMESTAMP)
-            .column("last_heartbeat", TIMESTAMP)
-            .column("end", TIMESTAMP)
+            .column("created", TIMESTAMP_MILLIS)
+            .column("start", TIMESTAMP_MILLIS)
+            .column("last_heartbeat", TIMESTAMP_MILLIS)
+            .column("end", TIMESTAMP_MILLIS)
             .build();
 
     private final TaskManager taskManager;

--- a/presto-main/src/main/java/io/prestosql/connector/system/TransactionsSystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/TransactionsSystemTable.java
@@ -42,7 +42,7 @@ import static io.prestosql.spi.connector.SystemTable.Distribution.SINGLE_COORDIN
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.StandardTypes.ARRAY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
 
@@ -62,7 +62,7 @@ public class TransactionsSystemTable
                 .column("isolation_level", createUnboundedVarcharType())
                 .column("read_only", BOOLEAN)
                 .column("auto_commit_context", BOOLEAN)
-                .column("create_time", TIMESTAMP)
+                .column("create_time", TIMESTAMP_MILLIS)
                 .column("idle_time_secs", BIGINT)
                 .column("written_catalog", createUnboundedVarcharType())
                 .column("catalogs", metadata.getParameterizedType(ARRAY, ImmutableList.of(TypeSignatureParameter.typeParameter(createUnboundedVarcharType().getTypeSignature()))))

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/DateTimeFunctions.java
@@ -46,6 +46,8 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_SECOND;
+import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static io.prestosql.util.DateTimeZoneIndex.getChronology;
 import static io.prestosql.util.DateTimeZoneIndex.getDateTimeZone;
 import static io.prestosql.util.DateTimeZoneIndex.packDateTimeWithZone;
@@ -112,7 +114,7 @@ public final class DateTimeFunctions
     @SqlType("timestamp(3)")
     public static long fromUnixTime(@SqlType(StandardTypes.DOUBLE) double unixTime)
     {
-        return Math.round(unixTime * 1000);
+        return Math.round(unixTime * MICROSECONDS_PER_SECOND);
     }
 
     @ScalarFunction("from_unixtime")
@@ -308,7 +310,7 @@ public final class DateTimeFunctions
                 .withLocale(session.getLocale());
 
         try {
-            return formatter.parseMillis(dateTime.toStringUtf8());
+            return scaleEpochMillisToMicros(formatter.parseMillis(dateTime.toStringUtf8()));
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/time/TimeToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/time/TimeToTimestampCast.java
@@ -30,7 +30,6 @@ import static io.prestosql.type.DateTimes.PICOSECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.SECONDS_PER_DAY;
 import static io.prestosql.type.DateTimes.rescale;
 import static io.prestosql.type.DateTimes.round;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
 import static java.lang.Math.multiplyExact;
 
 @ScalarOperator(CAST)
@@ -46,12 +45,7 @@ public final class TimeToTimestampCast
             ConnectorSession session,
             @SqlType("time(sourcePrecision)") long time)
     {
-        long epochMicros = cast(sourcePrecision, targetPrecision, session, time);
-        if (targetPrecision <= 3) {
-            return scaleEpochMicrosToMillis(epochMicros);
-        }
-
-        return epochMicros;
+        return cast(sourcePrecision, targetPrecision, session, time);
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateAdd.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateAdd.java
@@ -44,20 +44,16 @@ public class DateAdd
             @SqlType(StandardTypes.BIGINT) long value,
             @SqlType("timestamp(p)") long timestamp)
     {
-        long epochMillis = timestamp;
-        int microFraction = 0;
-        if (precision > 3) {
-            epochMillis = scaleEpochMicrosToMillis(timestamp);
-            microFraction = getMicrosOfMilli(timestamp);
-        }
+        long epochMillis = scaleEpochMicrosToMillis(timestamp);
+        int microsOfMilli = getMicrosOfMilli(timestamp);
 
-        long result = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).add(epochMillis, toIntExact(value));
+        epochMillis = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).add(epochMillis, toIntExact(value));
 
         if (precision <= 3) {
-            return round(result, (int) (3 - precision));
+            epochMillis = round(epochMillis, (int) (3 - precision));
         }
 
-        return scaleEpochMillisToMicros(result) + microFraction;
+        return scaleEpochMillisToMicros(epochMillis) + microsOfMilli;
     }
 
     @LiteralParameters({"x", "p"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateDiff.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateDiff.java
@@ -15,7 +15,6 @@ package io.prestosql.operator.scalar.timestamp;
 
 import io.airlift.slice.Slice;
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -35,17 +34,12 @@ public class DateDiff
     @LiteralParameters({"x", "p"})
     @SqlType(StandardTypes.BIGINT)
     public static long diff(
-            @LiteralParameter("p") long precision,
             @SqlType("varchar(x)") Slice unit,
             @SqlType("timestamp(p)") long timestamp1,
             @SqlType("timestamp(p)") long timestamp2)
     {
-        long epochMillis1 = timestamp1;
-        long epochMillis2 = timestamp2;
-        if (precision > 3) {
-            epochMillis1 = scaleEpochMicrosToMillis(timestamp1);
-            epochMillis2 = scaleEpochMicrosToMillis(timestamp2);
-        }
+        long epochMillis1 = scaleEpochMicrosToMillis(timestamp1);
+        long epochMillis2 = scaleEpochMicrosToMillis(timestamp2);
 
         return getTimestampField(ISOChronology.getInstanceUTC(), unit).getDifferenceAsLong(epochMillis2, epochMillis1);
     }
@@ -58,6 +52,6 @@ public class DateDiff
             @SqlType("timestamp(p)") LongTimestamp timestamp2)
     {
         // smallest unit of date_diff is "millisecond", so anything in the fraction is irrelevant
-        return diff(6, unit, timestamp1.getEpochMicros(), timestamp2.getEpochMicros());
+        return diff(unit, timestamp1.getEpochMicros(), timestamp2.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateFormat.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateFormat.java
@@ -25,8 +25,7 @@ import io.prestosql.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
 import static io.prestosql.operator.scalar.DateTimeFunctions.dateFormat;
-import static io.prestosql.type.DateTimes.round;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
+import static io.prestosql.type.DateTimes.epochMicrosToMillisWithRounding;
 
 @ScalarFunction
 @Description("Formats the given timestamp by the given format")
@@ -36,12 +35,10 @@ public class DateFormat
 
     @LiteralParameters({"x", "p"})
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice format(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") long timestamp, @SqlType("varchar(x)") Slice formatString)
+    public static Slice format(ConnectorSession session, @SqlType("timestamp(p)") long timestamp, @SqlType("varchar(x)") Slice formatString)
     {
         // TODO: currently, date formatting only supports up to millis, so round to that unit
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(round(timestamp, 3));
-        }
+        timestamp = epochMicrosToMillisWithRounding(timestamp);
 
         return dateFormat(ISOChronology.getInstanceUTC(), session.getLocale(), timestamp, formatString);
     }
@@ -51,6 +48,6 @@ public class DateFormat
     public static Slice format(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") LongTimestamp timestamp, @SqlType("varchar(x)") Slice formatString)
     {
         // Currently, date formatting only supports up to millis, so anything in the microsecond fraction is irrelevant
-        return format(6, session, timestamp.getEpochMicros(), formatString);
+        return format(session, timestamp.getEpochMicros(), formatString);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateToTimestampCast.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.operator.scalar.timestamp;
 
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarOperator;
 import io.prestosql.spi.function.SqlType;
@@ -23,7 +22,6 @@ import io.prestosql.spi.type.StandardTypes;
 import java.util.concurrent.TimeUnit;
 
 import static io.prestosql.spi.function.OperatorType.CAST;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 
 @ScalarOperator(CAST)
 public final class DateToTimestampCast
@@ -32,21 +30,15 @@ public final class DateToTimestampCast
 
     @LiteralParameters("p")
     @SqlType("timestamp(p)")
-    public static long cast(@LiteralParameter("p") long precision, @SqlType(StandardTypes.DATE) long date)
+    public static long castToShort(@SqlType(StandardTypes.DATE) long date)
     {
-        long result = TimeUnit.DAYS.toMillis(date);
-
-        if (precision > 3) {
-            return scaleEpochMillisToMicros(result);
-        }
-
-        return result;
+        return TimeUnit.DAYS.toMicros(date);
     }
 
     @LiteralParameters("p")
     @SqlType("timestamp(p)")
-    public static LongTimestamp cast(@SqlType(StandardTypes.DATE) long date)
+    public static LongTimestamp castToLong(@SqlType(StandardTypes.DATE) long date)
     {
-        return new LongTimestamp(cast(6, date), 0);
+        return new LongTimestamp(castToShort(date), 0);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateTrunc.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/DateTrunc.java
@@ -15,7 +15,6 @@ package io.prestosql.operator.scalar.timestamp;
 
 import io.airlift.slice.Slice;
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -35,21 +34,14 @@ public final class DateTrunc
     @LiteralParameters({"x", "p"})
     @SqlType("timestamp(p)")
     public static long truncate(
-            @LiteralParameter("p") long precision,
             @SqlType("varchar(x)") Slice unit,
             @SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
+        timestamp = scaleEpochMicrosToMillis(timestamp);
 
         long result = getTimestampField(ISOChronology.getInstanceUTC(), unit).roundFloor(timestamp);
 
-        if (precision > 3) {
-            result = scaleEpochMillisToMicros(result);
-        }
-
-        return result;
+        return scaleEpochMillisToMicros(result);
     }
 
     @LiteralParameters({"x", "p"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDay.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDay.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractDay
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().dayOfMonth().get(timestamp);
+        return ISOChronology.getInstanceUTC().dayOfMonth().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDayOfWeek.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDayOfWeek.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractDayOfWeek
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().dayOfWeek().get(timestamp);
+        return ISOChronology.getInstanceUTC().dayOfWeek().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDayOfYear.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractDayOfYear.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractDayOfYear
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().dayOfYear().get(timestamp);
+        return ISOChronology.getInstanceUTC().dayOfYear().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractHour.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractHour.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractHour
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().hourOfDay().get(timestamp);
+        return ISOChronology.getInstanceUTC().hourOfDay().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMillisecond.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMillisecond.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractMillisecond
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().millisOfSecond().get(timestamp);
+        return ISOChronology.getInstanceUTC().millisOfSecond().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMinute.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMinute.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractMinute
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().minuteOfHour().get(timestamp);
+        return ISOChronology.getInstanceUTC().minuteOfHour().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMonth.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractMonth.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractMonth
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().monthOfYear().get(timestamp);
+        return ISOChronology.getInstanceUTC().monthOfYear().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractQuarter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractQuarter.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -33,19 +32,15 @@ public class ExtractQuarter
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return QUARTER_OF_YEAR.getField(ISOChronology.getInstanceUTC()).get(timestamp);
+        return QUARTER_OF_YEAR.getField(ISOChronology.getInstanceUTC()).get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractSecond.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractSecond.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractSecond
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().secondOfMinute().get(timestamp);
+        return ISOChronology.getInstanceUTC().secondOfMinute().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractWeekOfYear.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractWeekOfYear.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractWeekOfYear
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().weekOfWeekyear().get(timestamp);
+        return ISOChronology.getInstanceUTC().weekOfWeekyear().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractYear.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractYear.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractYear
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().year().get(timestamp);
+        return ISOChronology.getInstanceUTC().year().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractYearOfWeek.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ExtractYearOfWeek.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -32,19 +31,15 @@ public class ExtractYearOfWeek
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
-    public static long extract(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long extract(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return ISOChronology.getInstanceUTC().weekyear().get(timestamp);
+        return ISOChronology.getInstanceUTC().weekyear().get(scaleEpochMicrosToMillis(timestamp));
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return extract(6, timestamp.getEpochMicros());
+        return extract(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/FormatDateTime.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/FormatDateTime.java
@@ -39,12 +39,10 @@ public class FormatDateTime
 
     @LiteralParameters({"x", "p"})
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice format(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") long timestamp, @SqlType("varchar(x)") Slice formatString)
+    public static Slice format(ConnectorSession session, @SqlType("timestamp(p)") long timestamp, @SqlType("varchar(x)") Slice formatString)
     {
         // TODO: currently, date formatting only supports up to millis, so we round to that unit
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(round(timestamp, 3));
-        }
+        timestamp = scaleEpochMicrosToMillis(round(timestamp, 3));
 
         if (datetimeFormatSpecifiesZone(formatString)) {
             // Timezone is unknown for TIMESTAMP w/o TZ so it cannot be printed out.
@@ -68,7 +66,7 @@ public class FormatDateTime
     public static Slice formatDatetime(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") LongTimestamp timestamp, @SqlType("varchar(x)") Slice formatString)
     {
         // Currently, date formatting only supports up to millis, so anything in the microsecond fraction is irrelevant
-        return format(6, session, timestamp.getEpochMicros(), formatString);
+        return format(session, timestamp.getEpochMicros(), formatString);
     }
 
     /**

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/LastDayOfMonth.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/LastDayOfMonth.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.function.Description;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -35,13 +34,9 @@ public class LastDayOfMonth
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.DATE)
-    public static long lastDayOfMonth(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static long lastDayOfMonth(@SqlType("timestamp(p)") long timestamp)
     {
-        long epochMillis = timestamp;
-        if (precision > 3) {
-            epochMillis = scaleEpochMicrosToMillis(timestamp);
-        }
-
+        long epochMillis = scaleEpochMicrosToMillis(timestamp);
         long millis = ISOChronology.getInstanceUTC().monthOfYear().roundCeiling(epochMillis + 1) - MILLISECONDS_IN_DAY;
         return MILLISECONDS.toDays(millis);
     }
@@ -50,6 +45,6 @@ public class LastDayOfMonth
     @SqlType(StandardTypes.DATE)
     public static long lastDayOfMonth(@SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return lastDayOfMonth(6, timestamp.getEpochMicros());
+        return lastDayOfMonth(timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/LocalTimestamp.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/LocalTimestamp.java
@@ -30,7 +30,6 @@ import static io.prestosql.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_NANOSECOND;
 import static io.prestosql.type.DateTimes.epochSecondToMicrosWithRounding;
 import static io.prestosql.type.DateTimes.round;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
 
 @ScalarFunction(value = "$localtimestamp", hidden = true)
 public final class LocalTimestamp
@@ -48,13 +47,7 @@ public final class LocalTimestamp
                 .toInstant(ZoneOffset.UTC);
 
         long epochMicros = epochSecondToMicrosWithRounding(start.getEpochSecond(), ((long) start.getNano()) * PICOSECONDS_PER_NANOSECOND);
-        epochMicros = round(epochMicros, (int) (MAX_SHORT_PRECISION - precision));
-
-        if (precision <= 3) {
-            epochMicros = scaleEpochMicrosToMillis(epochMicros);
-        }
-
-        return epochMicros;
+        return round(epochMicros, (int) (MAX_SHORT_PRECISION - precision));
     }
 
     @LiteralParameters("p")

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/SequenceIntervalDayToSecond.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/SequenceIntervalDayToSecond.java
@@ -15,7 +15,6 @@ package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -44,15 +43,12 @@ public final class SequenceIntervalDayToSecond
     @LiteralParameters("p")
     @SqlType("array(timestamp(p))")
     public static Block sequence(
-            @LiteralParameter("p") long precision,
             @SqlType("timestamp(p)") long start,
             @SqlType("timestamp(p)") long stop,
             @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long step)
     {
-        if (precision > 3) {
-            // scale to micros
-            step = multiplyExact(step, MICROSECONDS_PER_MILLISECOND);
-        }
+        // scale to micros
+        step = multiplyExact(step, MICROSECONDS_PER_MILLISECOND);
 
         checkValidStep(start, stop, step);
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/SequenceIntervalYearToMonth.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/SequenceIntervalYearToMonth.java
@@ -19,7 +19,6 @@ import io.prestosql.operator.scalar.timestamp.TimestampOperators.TimestampPlusIn
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.connector.ConnectorSession;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -47,21 +46,20 @@ public final class SequenceIntervalYearToMonth
     @LiteralParameters("p")
     @SqlType("array(timestamp(p))")
     public static Block sequence(
-            @LiteralParameter("p") long precision,
             @SqlType("timestamp(p)") long start,
             @SqlType("timestamp(p)") long stop,
             @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long step)
     {
         checkValidStep(start, stop, step);
 
-        int length = toIntExact(DateDiff.diff(precision, MONTH, start, stop) / step + 1);
+        int length = toIntExact(DateDiff.diff(MONTH, start, stop) / step + 1);
         checkMaxEntry(length);
 
         BlockBuilder blockBuilder = SHORT_TYPE.createBlockBuilder(null, length);
 
         int offset = 0;
         for (int i = 0; i < length; ++i) {
-            long value = TimestampPlusIntervalYearToMonth.add(precision, start, offset);
+            long value = TimestampPlusIntervalYearToMonth.add(start, offset);
             SHORT_TYPE.writeLong(blockBuilder, value);
             offset += step;
         }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimeWithTimezoneToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimeWithTimezoneToTimestampCast.java
@@ -31,7 +31,6 @@ import static io.prestosql.type.DateTimes.PICOSECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.SECONDS_PER_DAY;
 import static io.prestosql.type.DateTimes.rescale;
 import static io.prestosql.type.DateTimes.round;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
 import static java.lang.Math.multiplyExact;
 
 @ScalarOperator(CAST)
@@ -51,13 +50,7 @@ public final class TimeWithTimezoneToTimestampCast
         long picos = rescale(unpackTimeNanos(packedTime), 9, 12);
         picos = round(picos, (int) (12 - targetPrecision));
 
-        long epochMicros = calculateEpochMicros(session, picos);
-
-        if (targetPrecision <= 3) {
-            return scaleEpochMicrosToMillis(epochMicros);
-        }
-
-        return epochMicros;
+        return calculateEpochMicros(session, picos);
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
@@ -72,13 +65,7 @@ public final class TimeWithTimezoneToTimestampCast
         long picos = time.getPicoSeconds();
         picos = round(picos, (int) (12 - targetPrecision));
 
-        long epochMicros = calculateEpochMicros(session, picos);
-
-        if (targetPrecision <= 3) {
-            return scaleEpochMicrosToMillis(epochMicros);
-        }
-
-        return epochMicros;
+        return calculateEpochMicros(session, picos);
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToDateCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToDateCast.java
@@ -14,7 +14,6 @@
 package io.prestosql.operator.scalar.timestamp;
 
 import io.prestosql.spi.connector.ConnectorSession;
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.ScalarOperator;
@@ -22,10 +21,9 @@ import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.LongTimestamp;
 import io.prestosql.spi.type.StandardTypes;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.prestosql.spi.function.OperatorType.CAST;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_DAY;
+import static java.lang.Math.floorDiv;
 
 @ScalarOperator(CAST)
 @ScalarFunction("date")
@@ -35,19 +33,15 @@ public final class TimestampToDateCast
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.DATE)
-    public static long cast(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") long timestamp)
+    public static long cast(ConnectorSession session, @SqlType("timestamp(p)") long timestamp)
     {
-        if (precision > 3) {
-            timestamp = scaleEpochMicrosToMillis(timestamp);
-        }
-
-        return TimeUnit.MILLISECONDS.toDays(timestamp);
+        return floorDiv(timestamp, MICROSECONDS_PER_DAY);
     }
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.DATE)
     public static long cast(ConnectorSession session, @SqlType("timestamp(p)") LongTimestamp timestamp)
     {
-        return cast(6, session, timestamp.getEpochMicros());
+        return cast(session, timestamp.getEpochMicros());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToJsonCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToJsonCast.java
@@ -32,7 +32,6 @@ import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.type.StandardTypes.JSON;
 import static io.prestosql.type.DateTimes.formatTimestamp;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static io.prestosql.util.JsonUtil.JSON_FACTORY;
 import static io.prestosql.util.JsonUtil.createJsonGenerator;
 import static java.lang.String.format;
@@ -49,12 +48,7 @@ public final class TimestampToJsonCast
     @SqlType(JSON)
     public static Slice cast(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("timestamp(p)") long timestamp)
     {
-        long epochMicros = timestamp;
-        if (precision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(timestamp);
-        }
-
-        return toJson(formatTimestamp((int) precision, epochMicros, 0, UTC, TIMESTAMP_FORMATTER));
+        return toJson(formatTimestamp((int) precision, timestamp, 0, UTC, TIMESTAMP_FORMATTER));
     }
 
     @LiteralParameters({"x", "p"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimeCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimeCast.java
@@ -23,16 +23,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 import static io.prestosql.spi.function.OperatorType.CAST;
-import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.type.DateTimes.MICROSECONDS_PER_SECOND;
-import static io.prestosql.type.DateTimes.MILLISECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_DAY;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_MICROSECOND;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.rescale;
 import static io.prestosql.type.DateTimes.round;
 import static io.prestosql.type.DateTimes.scaleEpochMicrosToSeconds;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToSeconds;
 import static java.lang.Math.multiplyExact;
 
 @ScalarOperator(CAST)
@@ -47,16 +44,8 @@ public final class TimestampToTimeCast
             @LiteralParameter("targetPrecision") long targetPrecision,
             @SqlType("timestamp(sourcePrecision)") long timestamp)
     {
-        long epochSeconds;
-        long microOfSecond;
-        if (sourcePrecision <= 3) {
-            epochSeconds = scaleEpochMillisToSeconds(timestamp);
-            microOfSecond = (timestamp % MILLISECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND;
-        }
-        else {
-            epochSeconds = scaleEpochMicrosToSeconds(timestamp);
-            microOfSecond = timestamp % MICROSECONDS_PER_SECOND;
-        }
+        long epochSeconds = scaleEpochMicrosToSeconds(timestamp);
+        long microOfSecond = timestamp % MICROSECONDS_PER_SECOND;
 
         long microOfDay = multiplyExact(getSecondOfDay(epochSeconds), MICROSECONDS_PER_SECOND) + microOfSecond;
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimestampCast.java
@@ -25,8 +25,6 @@ import static io.prestosql.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_MICROSECOND;
 import static io.prestosql.type.DateTimes.round;
 import static io.prestosql.type.DateTimes.roundToNearest;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 
 @ScalarOperator(CAST)
 public final class TimestampToTimestampCast
@@ -41,39 +39,19 @@ public final class TimestampToTimestampCast
             @SqlType("timestamp(sourcePrecision)") long value)
     {
         long epochMicros = value;
-        if (sourcePrecision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(epochMicros);
-        }
 
         if (sourcePrecision <= targetPrecision) {
-            if (targetPrecision <= 3) {
-                return scaleEpochMicrosToMillis(epochMicros);
-            }
-
             return epochMicros;
         }
 
-        epochMicros = round(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
-
-        if (targetPrecision <= 3) {
-            return scaleEpochMicrosToMillis(epochMicros);
-        }
-
-        return epochMicros;
+        return round(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
     @SqlType("timestamp(targetPrecision)")
-    public static LongTimestamp shortToLong(
-            @LiteralParameter("sourcePrecision") long sourcePrecision,
-            @SqlType("timestamp(sourcePrecision)") long value)
+    public static LongTimestamp shortToLong(@SqlType("timestamp(sourcePrecision)") long value)
     {
-        long micros = value;
-        if (sourcePrecision <= 3) {
-            micros = scaleEpochMillisToMicros(value);
-        }
-
-        return new LongTimestamp(micros, 0);
+        return new LongTimestamp(value, 0);
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
@@ -83,10 +61,7 @@ public final class TimestampToTimestampCast
             @SqlType("timestamp(sourcePrecision)") LongTimestamp value)
     {
         long epochMicros = value.getEpochMicros();
-        if (targetPrecision <= 3) {
-            return scaleEpochMicrosToMillis(round(epochMicros, (int) (6 - targetPrecision)));
-        }
-        else if (targetPrecision < MAX_SHORT_PRECISION) {
+        if (targetPrecision < MAX_SHORT_PRECISION) {
             return round(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
         }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimestampWithTimezoneCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToTimestampWithTimezoneCast.java
@@ -30,7 +30,6 @@ import static io.prestosql.type.DateTimes.getMicrosOfMilli;
 import static io.prestosql.type.DateTimes.round;
 import static io.prestosql.type.DateTimes.roundToNearest;
 import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static io.prestosql.util.DateTimeZoneIndex.getChronology;
 
 @ScalarOperator(CAST)
@@ -41,17 +40,11 @@ public final class TimestampToTimestampWithTimezoneCast
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
     @SqlType("timestamp(targetPrecision) with time zone")
     public static long shortToShort(
-            @LiteralParameter("sourcePrecision") long sourcePrecision,
             @LiteralParameter("targetPrecision") long targetPrecision,
             ConnectorSession session,
             @SqlType("timestamp(sourcePrecision)") long timestamp)
     {
-        long epochMillis = timestamp;
-
-        if (sourcePrecision > 3) {
-            epochMillis = scaleEpochMicrosToMillis(round(timestamp, 3));
-        }
-
+        long epochMillis = scaleEpochMicrosToMillis(round(timestamp, 3));
         epochMillis = round(epochMillis, (int) (3 - targetPrecision));
         return toShort(session, epochMillis);
     }
@@ -73,13 +66,8 @@ public final class TimestampToTimestampWithTimezoneCast
             @LiteralParameter("sourcePrecision") long sourcePrecision,
             @LiteralParameter("targetPrecision") long targetPrecision,
             ConnectorSession session,
-            @SqlType("timestamp(sourcePrecision)") long timestamp)
+            @SqlType("timestamp(sourcePrecision)") long epochMicros)
     {
-        long epochMicros = timestamp;
-        if (sourcePrecision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(epochMicros);
-        }
-
         if (sourcePrecision > targetPrecision) {
             epochMicros = round(epochMicros, (int) (6 - targetPrecision));
         }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToVarcharCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimestampToVarcharCast.java
@@ -25,7 +25,6 @@ import java.time.format.DateTimeFormatter;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.function.OperatorType.CAST;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static java.time.ZoneOffset.UTC;
 
 @ScalarOperator(CAST)
@@ -37,13 +36,8 @@ public final class TimestampToVarcharCast
 
     @LiteralParameters({"x", "p"})
     @SqlType("varchar(x)")
-    public static Slice cast(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static Slice cast(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long epochMicros)
     {
-        long epochMicros = timestamp;
-        if (precision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(timestamp);
-        }
-
         return utf8Slice(DateTimes.formatTimestamp((int) precision, epochMicros, 0, UTC, TIMESTAMP_FORMATTER));
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ToIso8601.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ToIso8601.java
@@ -25,7 +25,6 @@ import java.time.format.DateTimeFormatter;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.type.DateTimes.formatTimestamp;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static java.time.ZoneOffset.UTC;
 
 @ScalarFunction("to_iso8601")
@@ -45,13 +44,8 @@ public final class ToIso8601
     @LiteralParameters({"p", "n"})
     @SqlType("varchar(n)")
     @Constraint(variable = "n", expression = RESULT_LENGTH)
-    public static Slice toIso8601(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static Slice toIso8601(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long epochMicros)
     {
-        long epochMicros = timestamp;
-        if (precision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(timestamp);
-        }
-
         return utf8Slice(formatTimestamp((int) precision, epochMicros, 0, UTC, ISO8601_FORMATTER));
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ToUnixTime.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/ToUnixTime.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.operator.scalar.timestamp;
 
-import io.prestosql.spi.function.LiteralParameter;
 import io.prestosql.spi.function.LiteralParameters;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -21,7 +20,6 @@ import io.prestosql.spi.type.LongTimestamp;
 import io.prestosql.spi.type.StandardTypes;
 
 import static io.prestosql.type.DateTimes.MICROSECONDS_PER_SECOND;
-import static io.prestosql.type.DateTimes.MILLISECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_SECOND;
 
 @ScalarFunction("to_unixtime")
@@ -31,12 +29,8 @@ public final class ToUnixTime
 
     @LiteralParameters("p")
     @SqlType(StandardTypes.DOUBLE)
-    public static double toUnixTime(@LiteralParameter("p") long precision, @SqlType("timestamp(p)") long timestamp)
+    public static double toUnixTime(@SqlType("timestamp(p)") long timestamp)
     {
-        if (precision <= 3) {
-            return timestamp * 1.0 / MILLISECONDS_PER_SECOND;
-        }
-
         return timestamp * 1.0 / MICROSECONDS_PER_SECOND;
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -33,7 +33,6 @@ import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.type.TimestampType.MAX_PRECISION;
 import static io.prestosql.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.prestosql.type.DateTimes.MICROSECONDS_PER_SECOND;
-import static io.prestosql.type.DateTimes.MILLISECONDS_PER_SECOND;
 import static io.prestosql.type.DateTimes.longTimestamp;
 import static io.prestosql.type.DateTimes.rescale;
 import static io.prestosql.type.DateTimes.round;
@@ -106,10 +105,6 @@ public final class VarcharToTimestampCast
 
         if (actualPrecision > precision) {
             fractionValue = round(fractionValue, actualPrecision - precision);
-        }
-
-        if (precision <= 3) {
-            return epochSecond * MILLISECONDS_PER_SECOND + rescale(fractionValue, actualPrecision, 3);
         }
 
         // scale to micros

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/WithTimeZone.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/WithTimeZone.java
@@ -55,7 +55,7 @@ public class WithTimeZone
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("'%s' is not a valid time zone", zoneId.toStringUtf8()));
         }
         DateTimeZone toDateTimeZone = getDateTimeZone(toTimeZoneKey);
-        return packDateTimeWithZone(UTC.getMillisKeepLocal(toDateTimeZone, timestamp), toTimeZoneKey);
+        return packDateTimeWithZone(UTC.getMillisKeepLocal(toDateTimeZone, scaleEpochMicrosToMillis(timestamp)), toTimeZoneKey);
     }
 
     @LiteralParameters({"x", "p"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimestampWithTimezoneToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimestampWithTimezoneToTimestampCast.java
@@ -47,10 +47,6 @@ public final class TimestampWithTimezoneToTimestampCast
                 .getZone()
                 .convertUTCToLocal(unpackMillisUtc(timestamp));
 
-        if (targetPrecision <= 3) {
-            return round(epochMillis, (int) (3 - targetPrecision));
-        }
-
         return round(scaleEpochMillisToMicros(epochMillis), (int) (6 - targetPrecision));
     }
 
@@ -64,17 +60,6 @@ public final class TimestampWithTimezoneToTimestampCast
                 .getZone()
                 .convertUTCToLocal(timestamp.getEpochMillis());
         int picosOfMilli = timestamp.getPicosOfMilli();
-
-        if (targetPrecision < 3) {
-            return round(epochMillis, (int) (3 - targetPrecision));
-        }
-
-        if (targetPrecision == 3) {
-            if (roundToNearest(timestamp.getPicosOfMilli(), PICOSECONDS_PER_MILLISECOND) == PICOSECONDS_PER_MILLISECOND) {
-                epochMillis++;
-            }
-            return epochMillis;
-        }
 
         long epochMicros = toEpochMicros(epochMillis, picosOfMilli);
         if (targetPrecision < 6) {
@@ -111,11 +96,7 @@ public final class TimestampWithTimezoneToTimestampCast
 
         long epochMicros;
         int picosOfMicro;
-        if (targetPrecision <= 3) {
-            epochMicros = scaleEpochMillisToMicros(round(epochMillis, (int) (3 - targetPrecision)));
-            picosOfMicro = 0;
-        }
-        else if (targetPrecision <= 6) {
+        if (targetPrecision <= 6) {
             epochMicros = toEpochMicros(epochMillis, timestamp.getPicosOfMilli());
             epochMicros = round(epochMicros, (int) (6 - targetPrecision));
             picosOfMicro = 0;

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -150,7 +150,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeType.createTimeType;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
@@ -415,7 +415,7 @@ public class ExpressionAnalyzer
                         type = createTimestampType(node.getPrecision());
                     }
                     else {
-                        type = TIMESTAMP;
+                        type = TIMESTAMP_MILLIS;
                     }
                     break;
                 default:

--- a/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
@@ -80,7 +80,6 @@ import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.prestosql.type.JsonType.JSON;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
@@ -298,12 +297,7 @@ public class MaterializedResult
         else if (type instanceof TimestampType) {
             long micros = ((SqlTimestamp) value).getEpochMicros();
             int precision = ((TimestampType) type).getPrecision();
-            if (precision <= 3) {
-                type.writeLong(blockBuilder, scaleEpochMicrosToMillis(micros));
-            }
-            else {
-                type.writeLong(blockBuilder, micros);
-            }
+            type.writeLong(blockBuilder, micros);
         }
         else if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             long millisUtc = ((SqlTimestampWithTimeZone) value).getMillisUtc();

--- a/presto-main/src/main/java/io/prestosql/util/JsonUtil.java
+++ b/presto-main/src/main/java/io/prestosql/util/JsonUtil.java
@@ -89,7 +89,6 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.type.DateTimes.formatTimestamp;
-import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static io.prestosql.type.JsonType.JSON;
 import static io.prestosql.type.TypeUtils.hashPosition;
 import static io.prestosql.type.TypeUtils.positionEqualsPosition;
@@ -520,9 +519,6 @@ public final class JsonUtil
 
                 if (type.isShort()) {
                     epochMicros = type.getLong(block, position);
-                    if (type.getPrecision() <= 3) {
-                        epochMicros = scaleEpochMillisToMicros(epochMicros);
-                    }
                     fraction = 0;
                 }
                 else {

--- a/presto-main/src/test/java/io/prestosql/SequencePageBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/SequencePageBuilder.java
@@ -29,7 +29,7 @@ import static io.prestosql.spi.type.Decimals.isLongDecimal;
 import static io.prestosql.spi.type.Decimals.isShortDecimal;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.RealType.REAL;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 
 public final class SequencePageBuilder
@@ -66,7 +66,7 @@ public final class SequencePageBuilder
             else if (type.equals(DATE)) {
                 blocks[i] = BlockAssertions.createDateSequenceBlock(initialValue, initialValue + length);
             }
-            else if (type.equals(TIMESTAMP)) {
+            else if (type.equals(TIMESTAMP_MILLIS)) {
                 blocks[i] = BlockAssertions.createTimestampSequenceBlock(initialValue, initialValue + length);
             }
             else if (isShortDecimal(type)) {

--- a/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
@@ -41,7 +41,7 @@ import static io.prestosql.spi.type.Decimals.writeBigDecimal;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -528,10 +528,10 @@ public final class BlockAssertions
 
     public static Block createTimestampSequenceBlock(int start, int end)
     {
-        BlockBuilder builder = TIMESTAMP.createFixedSizeBlockBuilder(end - start);
+        BlockBuilder builder = TIMESTAMP_MILLIS.createFixedSizeBlockBuilder(end - start);
 
         for (int i = start; i < end; i++) {
-            TIMESTAMP.writeLong(builder, i);
+            TIMESTAMP_MILLIS.writeLong(builder, i);
         }
 
         return builder.build();

--- a/presto-main/src/test/java/io/prestosql/metadata/TestSignatureBinder.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/TestSignatureBinder.java
@@ -41,7 +41,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.TypeSignature.arrayType;
 import static io.prestosql.spi.type.TypeSignature.functionType;
@@ -1022,7 +1022,7 @@ public class TestSignatureBinder
                         .setTypeVariable("F", INTEGER)
                         .setTypeVariable("T", VARCHAR));
         assertThat(castArray)
-                .boundTo(new ArrayType(INTEGER), new ArrayType(TIMESTAMP))
+                .boundTo(new ArrayType(INTEGER), new ArrayType(TIMESTAMP_MILLIS))
                 .fails();
 
         Signature multiCast = functionSignature()
@@ -1035,7 +1035,7 @@ public class TestSignatureBinder
                 .produces(new BoundVariables()
                         .setTypeVariable("E", TINYINT));
         assertThat(multiCast)
-                .boundTo(new ArrayType(TIMESTAMP))
+                .boundTo(new ArrayType(TIMESTAMP_MILLIS))
                 .fails();
     }
 
@@ -1065,7 +1065,7 @@ public class TestSignatureBinder
                 .produces(new BoundVariables()
                         .setTypeVariable("E", TINYINT));
         assertThat(multiCast)
-                .boundTo(new ArrayType(TIMESTAMP), JSON)
+                .boundTo(new ArrayType(TIMESTAMP_MILLIS), JSON)
                 .fails();
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
@@ -21,7 +21,6 @@ import io.prestosql.spi.type.SqlDate;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.TimeZoneKey;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.testing.TestingConnectorSession;
 import io.prestosql.testing.TestingSession;
@@ -54,6 +53,7 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
@@ -212,11 +212,11 @@ public class TestDateTimeFunctions
     {
         DateTime dateTime = new DateTime(2001, 1, 22, 3, 4, 5, 0, DATE_TIME_ZONE);
         double seconds = dateTime.getMillis() / 1000.0;
-        assertFunction("from_unixtime(" + seconds + ")", TimestampType.TIMESTAMP, sqlTimestampOf(dateTime));
+        assertFunction("from_unixtime(" + seconds + ")", TIMESTAMP_MILLIS, sqlTimestampOf(dateTime));
 
         dateTime = new DateTime(2001, 1, 22, 3, 4, 5, 888, DATE_TIME_ZONE);
         seconds = dateTime.getMillis() / 1000.0;
-        assertFunction("from_unixtime(" + seconds + ")", TimestampType.TIMESTAMP, sqlTimestampOf(dateTime));
+        assertFunction("from_unixtime(" + seconds + ")", TIMESTAMP_MILLIS, sqlTimestampOf(dateTime));
     }
 
     @Test
@@ -526,28 +526,28 @@ public class TestDateTimeFunctions
     {
         DateTime result = TIMESTAMP;
         result = result.withMillisOfSecond(0);
-        assertFunction("date_trunc('second', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('second', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withSecondOfMinute(0);
-        assertFunction("date_trunc('minute', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('minute', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withMinuteOfHour(0);
-        assertFunction("date_trunc('hour', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('hour', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withHourOfDay(0);
-        assertFunction("date_trunc('day', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('day', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withDayOfMonth(20);
-        assertFunction("date_trunc('week', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('week', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withDayOfMonth(1);
-        assertFunction("date_trunc('month', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('month', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withMonthOfYear(7);
-        assertFunction("date_trunc('quarter', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('quarter', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = result.withMonthOfYear(1);
-        assertFunction("date_trunc('year', " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(result));
+        assertFunction("date_trunc('year', " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(result));
 
         result = WEIRD_TIMESTAMP;
         result = result.withMillisOfSecond(0);
@@ -611,18 +611,18 @@ public class TestDateTimeFunctions
     @Test
     public void testAddFieldToTimestamp()
     {
-        assertFunction("date_add('millisecond', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusMillis(3)));
-        assertFunction("date_add('second', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusSeconds(3)));
-        assertFunction("date_add('minute', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusMinutes(3)));
-        assertFunction("date_add('hour', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusHours(3)));
-        assertFunction("date_add('hour', 23, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusHours(23)));
-        assertFunction("date_add('hour', -4, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.minusHours(4)));
-        assertFunction("date_add('hour', -23, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.minusHours(23)));
-        assertFunction("date_add('day', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusDays(3)));
-        assertFunction("date_add('week', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusWeeks(3)));
-        assertFunction("date_add('month', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusMonths(3)));
-        assertFunction("date_add('quarter', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusMonths(3 * 3)));
-        assertFunction("date_add('year', 3, " + TIMESTAMP_LITERAL + ")", TimestampType.TIMESTAMP, sqlTimestampOf(TIMESTAMP.plusYears(3)));
+        assertFunction("date_add('millisecond', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusMillis(3)));
+        assertFunction("date_add('second', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusSeconds(3)));
+        assertFunction("date_add('minute', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusMinutes(3)));
+        assertFunction("date_add('hour', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusHours(3)));
+        assertFunction("date_add('hour', 23, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusHours(23)));
+        assertFunction("date_add('hour', -4, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.minusHours(4)));
+        assertFunction("date_add('hour', -23, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.minusHours(23)));
+        assertFunction("date_add('day', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusDays(3)));
+        assertFunction("date_add('week', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusWeeks(3)));
+        assertFunction("date_add('month', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusMonths(3)));
+        assertFunction("date_add('quarter', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusMonths(3 * 3)));
+        assertFunction("date_add('year', 3, " + TIMESTAMP_LITERAL + ")", TIMESTAMP_MILLIS, sqlTimestampOf(TIMESTAMP.plusYears(3)));
 
         assertFunction("date_add('millisecond', 3, " + WEIRD_TIMESTAMP_LITERAL + ")", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(WEIRD_TIMESTAMP.plusMillis(3)));
         assertFunction("date_add('second', 3, " + WEIRD_TIMESTAMP_LITERAL + ")", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(WEIRD_TIMESTAMP.plusSeconds(3)));
@@ -860,67 +860,67 @@ public class TestDateTimeFunctions
     public void testDateParse()
     {
         assertFunction("date_parse('2013', '%Y')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 1, 1, 0, 0, 0, 0));
         assertFunction("date_parse('2013-05', '%Y-%m')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 1, 0, 0, 0, 0));
         assertFunction("date_parse('2013-05-17', '%Y-%m-%d')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 0, 0, 0, 0));
         assertFunction("date_parse('2013-05-17 12:35:10', '%Y-%m-%d %h:%i:%s')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 0, 35, 10, 0));
         assertFunction("date_parse('2013-05-17 12:35:10 PM', '%Y-%m-%d %h:%i:%s %p')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 12, 35, 10, 0));
         assertFunction("date_parse('2013-05-17 12:35:10 AM', '%Y-%m-%d %h:%i:%s %p')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 0, 35, 10, 0));
 
         assertFunction("date_parse('2013-05-17 00:35:10', '%Y-%m-%d %H:%i:%s')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 0, 35, 10, 0));
         assertFunction("date_parse('2013-05-17 23:35:10', '%Y-%m-%d %H:%i:%s')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 23, 35, 10, 0));
         assertFunction("date_parse('abc 2013-05-17 fff 23:35:10 xyz', 'abc %Y-%m-%d fff %H:%i:%s xyz')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2013, 5, 17, 23, 35, 10, 0));
 
         assertFunction("date_parse('2013 14', '%Y %y')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2014, 1, 1, 0, 0, 0, 0));
 
         assertFunction("date_parse('1998 53', '%x %v')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1998, 12, 28, 0, 0, 0, 0));
 
         assertFunction("date_parse('1.1', '%s.%f')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 1, 1, 0, 0, 1, 100));
         assertFunction("date_parse('1.01', '%s.%f')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 1, 1, 0, 0, 1, 10));
         assertFunction("date_parse('1.2006', '%s.%f')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 1, 1, 0, 0, 1, 200));
         assertFunction("date_parse('59.123456789', '%s.%f')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 1, 1, 0, 0, 59, 123));
 
         assertFunction("date_parse('0', '%k')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 1, 1, 0, 0, 0, 0));
 
         assertFunction("date_parse('28-JAN-16 11.45.46.421000 PM','%d-%b-%y %l.%i.%s.%f %p')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2016, 1, 28, 23, 45, 46, 421));
         assertFunction("date_parse('11-DEC-70 11.12.13.456000 AM','%d-%b-%y %l.%i.%s.%f %p')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 1970, 12, 11, 11, 12, 13, 456));
         assertFunction("date_parse('31-MAY-69 04.59.59.999000 AM','%d-%b-%y %l.%i.%s.%f %p')",
-                TimestampType.TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2069, 5, 31, 4, 59, 59, 999));
 
         assertInvalidFunction("date_parse('', '%D')", "%D not supported in date format string");
@@ -960,10 +960,10 @@ public class TestDateTimeFunctions
             localeAssertions.assertFunction("format_datetime(" + dateTimeLiteral + ", 'MMMM')", VARCHAR, "1월");
 
             localeAssertions.assertFunction("date_parse('2013-05-17 12:35:10 오후', '%Y-%m-%d %h:%i:%s %p')",
-                    TimestampType.TIMESTAMP,
+                    TIMESTAMP_MILLIS,
                     sqlTimestampOf(3, 2013, 5, 17, 12, 35, 10, 0));
             localeAssertions.assertFunction("date_parse('2013-05-17 12:35:10 오전', '%Y-%m-%d %h:%i:%s %p')",
-                    TimestampType.TIMESTAMP,
+                    TIMESTAMP_MILLIS,
                     sqlTimestampOf(3, 2013, 5, 17, 0, 35, 10, 0));
 
             localeAssertions.assertFunction("parse_datetime('2013-05-17 12:35:10 오후', 'yyyy-MM-dd hh:mm:ss a')",

--- a/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
+++ b/presto-main/src/test/java/io/prestosql/server/protocol/TestQueryResultRows.java
@@ -267,7 +267,7 @@ public class TestQueryResultRows
         List<Column> columns = ImmutableList.of(
                 new Column("_col0", TIMESTAMP, new ClientTypeSignature(TIMESTAMP)),
                 new Column("_col1", TIMESTAMP_WITH_TIME_ZONE, new ClientTypeSignature(TIMESTAMP_WITH_TIME_ZONE)));
-        List<Type> types = ImmutableList.of(TimestampType.TIMESTAMP, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+        List<Type> types = ImmutableList.of(TimestampType.TIMESTAMP_MILLIS, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
 
         List<Page> pages = rowPagesBuilder(types)
                 .row(null, null)

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -22,7 +22,6 @@ import io.prestosql.security.AllowAllAccessControl;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
 import io.prestosql.sql.parser.ParsingOptions;
@@ -80,6 +79,7 @@ import static io.prestosql.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferen
 import static io.prestosql.sql.ParsingUtil.createParsingOptions;
 import static io.prestosql.sql.planner.ExpressionInterpreter.expressionInterpreter;
 import static io.prestosql.sql.planner.ExpressionInterpreter.expressionOptimizer;
+import static io.prestosql.type.DateTimes.scaleEpochMillisToMicros;
 import static io.prestosql.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -1486,7 +1486,7 @@ public class TestExpressionInterpreter
                 case "bound_time":
                     return new LocalTime(3, 4, 5, 321).toDateTime(new DateTime(0, UTC)).getMillis();
                 case "bound_timestamp":
-                    return new DateTime(2001, 8, 22, 3, 4, 5, 321, UTC).getMillis();
+                    return scaleEpochMillisToMicros(new DateTime(2001, 8, 22, 3, 4, 5, 321, UTC).getMillis());
                 case "bound_pattern":
                     return utf8Slice("%el%");
                 case "bound_timestamp_with_timezone":

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -22,6 +22,7 @@ import io.prestosql.security.AllowAllAccessControl;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
+import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
 import io.prestosql.sql.parser.ParsingOptions;
@@ -68,7 +69,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.sql.ExpressionFormatter.formatExpression;
@@ -99,7 +100,7 @@ public class TestExpressionInterpreter
             .put(new Symbol("bound_boolean"), BOOLEAN)
             .put(new Symbol("bound_date"), DATE)
             .put(new Symbol("bound_time"), TIME)
-            .put(new Symbol("bound_timestamp"), TIMESTAMP)
+            .put(new Symbol("bound_timestamp"), TIMESTAMP_MILLIS)
             .put(new Symbol("bound_pattern"), VARCHAR)
             .put(new Symbol("bound_null_string"), VARCHAR)
             .put(new Symbol("bound_decimal_short"), createDecimalType(5, 2))
@@ -114,7 +115,7 @@ public class TestExpressionInterpreter
             .put(new Symbol("unbound_boolean"), BOOLEAN)
             .put(new Symbol("unbound_date"), DATE)
             .put(new Symbol("unbound_time"), TIME)
-            .put(new Symbol("unbound_timestamp"), TIMESTAMP)
+            .put(new Symbol("unbound_timestamp"), TIMESTAMP_MILLIS)
             .put(new Symbol("unbound_interval"), INTERVAL_DAY_TIME)
             .put(new Symbol("unbound_pattern"), VARCHAR)
             .put(new Symbol("unbound_null_string"), VARCHAR)

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -98,6 +98,7 @@ import static io.prestosql.sql.tree.Extract.Field.TIMEZONE_HOUR;
 import static io.prestosql.sql.tree.Extract.Field.TIMEZONE_MINUTE;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.SqlVarbinaryTestingUtil.sqlVarbinary;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.type.JsonType.JSON;
 import static io.prestosql.type.UnknownType.UNKNOWN;
 import static io.prestosql.util.StructuralTestUtil.mapType;
@@ -1528,16 +1529,16 @@ public class TestExpressionCompiler
                     continue;
                 }
                 Long expected = null;
-                Long millis = null;
+                Long micros = null;
                 if (left != null) {
-                    millis = left.getMillis();
-                    expected = callExtractFunction(TEST_SESSION.toConnectorSession(), millis, 3, field);
+                    micros = left.getMillis() * MICROSECONDS_PER_MILLISECOND;
+                    expected = callExtractFunction(TEST_SESSION.toConnectorSession(), micros, field);
                 }
                 String expressionPattern = format(
-                        "extract(%s from from_unixtime(cast(%s as double) / 1000))",
+                        "extract(%s from from_unixtime(cast(%s as double) / 1000000))",
                         field,
-                        millis);
-                assertExecute(generateExpression(expressionPattern, millis), BIGINT, expected);
+                        micros);
+                assertExecute(generateExpression(expressionPattern, micros), BIGINT, expected);
             }
         }
 
@@ -1545,35 +1546,35 @@ public class TestExpressionCompiler
     }
 
     @SuppressWarnings("fallthrough")
-    private static long callExtractFunction(ConnectorSession session, long value, int precision, Field field)
+    private static long callExtractFunction(ConnectorSession session, long value, Field field)
     {
         switch (field) {
             case YEAR:
-                return ExtractYear.extract(precision, value);
+                return ExtractYear.extract(value);
             case QUARTER:
-                return ExtractQuarter.extract(precision, value);
+                return ExtractQuarter.extract(value);
             case MONTH:
-                return ExtractMonth.extract(precision, value);
+                return ExtractMonth.extract(value);
             case WEEK:
-                return ExtractWeekOfYear.extract(precision, value);
+                return ExtractWeekOfYear.extract(value);
             case DAY:
             case DAY_OF_MONTH:
-                return ExtractDay.extract(precision, value);
+                return ExtractDay.extract(value);
             case DAY_OF_WEEK:
             case DOW:
-                return ExtractDayOfWeek.extract(precision, value);
+                return ExtractDayOfWeek.extract(value);
             case YEAR_OF_WEEK:
             case YOW:
-                return ExtractYearOfWeek.extract(precision, value);
+                return ExtractYearOfWeek.extract(value);
             case DAY_OF_YEAR:
             case DOY:
-                return ExtractDayOfYear.extract(precision, value);
+                return ExtractDayOfYear.extract(value);
             case HOUR:
-                return ExtractHour.extract(precision, value);
+                return ExtractHour.extract(value);
             case MINUTE:
-                return ExtractMinute.extract(precision, value);
+                return ExtractMinute.extract(value);
             case SECOND:
-                return ExtractSecond.extract(precision, value);
+                return ExtractSecond.extract(value);
         }
         throw new AssertionError("Unhandled field: " + field);
     }

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -88,7 +88,7 @@ import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -882,7 +882,7 @@ public class TestExpressionCompiler
         assertExecute("try_cast('foo' as varchar)", VARCHAR, "foo");
         assertExecute("try_cast('foo' as bigint)", BIGINT, null);
         assertExecute("try_cast('foo' as integer)", INTEGER, null);
-        assertExecute("try_cast('2001-08-22' as timestamp)", TIMESTAMP, sqlTimestampOf(3, 2001, 8, 22, 0, 0, 0, 0));
+        assertExecute("try_cast('2001-08-22' as timestamp)", TIMESTAMP_MILLIS, sqlTimestampOf(3, 2001, 8, 22, 0, 0, 0, 0));
         assertExecute("try_cast(bound_string as bigint)", BIGINT, null);
         assertExecute("try_cast(cast(null as varchar) as bigint)", BIGINT, null);
         assertExecute("try_cast(bound_long / 13  as bigint)", BIGINT, 94L);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDomainTranslator.java
@@ -75,7 +75,7 @@ import static io.prestosql.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -138,7 +138,7 @@ public class TestDomainTranslator
             .put(C_BIGINT_1, BIGINT)
             .put(C_DOUBLE_1, DOUBLE)
             .put(C_VARCHAR_1, VARCHAR)
-            .put(C_TIMESTAMP, TIMESTAMP)
+            .put(C_TIMESTAMP, TIMESTAMP_MILLIS)
             .put(C_DATE, DATE)
             .put(C_COLOR, COLOR) // Equatable, but not orderable
             .put(C_HYPER_LOG_LOG, HYPER_LOG_LOG) // Not Equatable or orderable
@@ -211,7 +211,7 @@ public class TestDomainTranslator
                 .put(C_BIGINT_1, Domain.singleValue(BIGINT, 2L))
                 .put(C_DOUBLE_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(DOUBLE, 1.1), Range.equal(DOUBLE, 2.0), Range.range(DOUBLE, 3.0, false, 3.5, true)), true))
                 .put(C_VARCHAR_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(VARCHAR, utf8Slice("2013-01-01")), Range.greaterThan(VARCHAR, utf8Slice("2013-10-01"))), false))
-                .put(C_TIMESTAMP, Domain.singleValue(TIMESTAMP, TIMESTAMP_VALUE))
+                .put(C_TIMESTAMP, Domain.singleValue(TIMESTAMP_MILLIS, TIMESTAMP_VALUE))
                 .put(C_DATE, Domain.singleValue(DATE, DATE_VALUE))
                 .put(C_COLOR, Domain.singleValue(COLOR, COLOR_VALUE_1))
                 .put(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))

--- a/presto-main/src/test/java/io/prestosql/type/TestDate.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDate.java
@@ -27,7 +27,7 @@ import static io.prestosql.spi.function.OperatorType.INDETERMINATE;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
@@ -127,7 +127,7 @@ public class TestDate
     public void testCastToTimestamp()
     {
         assertFunction("cast(DATE '2001-1-22' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 0, 0, 0, 0));
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
@@ -28,7 +28,7 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -153,28 +153,28 @@ public class TestDateTimeOperators
     public void testTimestampPlusInterval()
     {
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' + INTERVAL '3' hour",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 6, 4, 5, 321));
         assertFunction("INTERVAL '3' hour + TIMESTAMP '2001-1-22 03:04:05.321'",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 6, 4, 5, 321));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' + INTERVAL '3' day",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 25, 3, 4, 5, 321));
         assertFunction("INTERVAL '3' day + TIMESTAMP '2001-1-22 03:04:05.321'",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 25, 3, 4, 5, 321));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' + INTERVAL '3' month",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 4, 22, 3, 4, 5, 321));
         assertFunction("INTERVAL '3' month + TIMESTAMP '2001-1-22 03:04:05.321'",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 4, 22, 3, 4, 5, 321));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' + INTERVAL '3' year",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2004, 1, 22, 3, 4, 5, 321));
         assertFunction("INTERVAL '3' year + TIMESTAMP '2001-1-22 03:04:05.321'",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2004, 1, 22, 3, 4, 5, 321));
 
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321 +05:09' + INTERVAL '3' hour",
@@ -215,13 +215,13 @@ public class TestDateTimeOperators
     public void testTimestampMinusInterval()
     {
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' - INTERVAL '3' day",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 19, 3, 4, 5, 321));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321 +05:09' - INTERVAL '3' day",
                 TIMESTAMP_WITH_TIME_ZONE,
                 SqlTimestampWithTimeZone.newInstance(3, new DateTime(2001, 1, 19, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), 0, WEIRD_TIME_ZONE_KEY));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321' - INTERVAL '3' month",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2000, 10, 22, 3, 4, 5, 321));
         assertFunction("TIMESTAMP '2001-1-22 03:04:05.321 +05:09' - INTERVAL '3' month",
                 TIMESTAMP_WITH_TIME_ZONE,

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
@@ -30,7 +30,7 @@ import static io.prestosql.spi.function.OperatorType.INDETERMINATE;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -60,36 +60,36 @@ public class TestTimestamp
     {
         assertFunction(
                 "cast('2001-1-22 03:04:05.321 +07:09' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
         assertFunction(
                 "cast('2001-1-22 03:04:05 +07:09' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 5)));
         assertFunction(
                 "cast('2001-1-22 03:04 +07:09' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 0)));
         assertFunction(
                 "cast('2001-1-22 +07:09' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 0, 0, 0)));
 
         assertFunction(
                 "cast('2001-1-22 03:04:05.321 Asia/Oral' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
         assertFunction(
                 "cast('2001-1-22 03:04:05 Asia/Oral' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 5)));
         assertFunction(
                 "cast('2001-1-22 03:04 Asia/Oral' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 3, 4, 0)));
         assertFunction(
                 "cast('2001-1-22 Asia/Oral' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, LocalDateTime.of(2001, 1, 22, 0, 0, 0)));
     }
 
@@ -261,25 +261,25 @@ public class TestTimestamp
     public void testCastFromSlice()
     {
         assertFunction("cast('2001-1-22 03:04:05.321' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
         assertFunction("cast('2001-1-22 03:04:05' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 0));
         assertFunction("cast('2001-1-22 03:04' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 0, 0));
         assertFunction("cast('2001-1-22' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 0, 0, 0, 0));
         assertFunction("cast('\n\t 2001-1-22 03:04:05.321' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
         assertFunction("cast('2001-1-22 03:04:05.321 \t\n' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
         assertFunction("cast('\n\t 2001-1-22 03:04:05.321 \t\n' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestampType.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestampType.java
@@ -17,30 +17,30 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.SqlTimestamp;
 
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 
 public class TestTimestampType
         extends AbstractTestType
 {
     public TestTimestampType()
     {
-        super(TIMESTAMP, SqlTimestamp.class, createTestBlock());
+        super(TIMESTAMP_MILLIS, SqlTimestamp.class, createTestBlock());
     }
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(null, 15);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 3333);
-        TIMESTAMP.writeLong(blockBuilder, 3333);
-        TIMESTAMP.writeLong(blockBuilder, 4444);
+        BlockBuilder blockBuilder = TIMESTAMP_MILLIS.createBlockBuilder(null, 15);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 1111);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 1111);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 1111);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 2222);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 2222);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 2222);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 2222);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 2222);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 3333);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 3333);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, 4444);
         return blockBuilder.build();
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZone.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestampWithTimeZone.java
@@ -30,7 +30,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -283,12 +283,12 @@ public class TestTimestampWithTimeZone
     public void testCastToTimestamp()
     {
         assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
 
         // This TZ had switch in 2014, so if we test for 2014 and used unpacked value we would use wrong shift
         assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 Pacific/Bougainville' as timestamp)",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, 2001, 1, 22, 3, 4, 5, 321));
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTypeCoercion.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTypeCoercion.java
@@ -37,7 +37,7 @@ import static io.prestosql.spi.type.RowType.rowType;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -118,10 +118,10 @@ public class TestTypeCoercion
         assertThat(UNKNOWN, BIGINT).hasCommonSuperType(BIGINT).canCoerceFirstToSecondOnly();
 
         assertThat(BIGINT, DOUBLE).hasCommonSuperType(DOUBLE).canCoerceFirstToSecondOnly();
-        assertThat(DATE, TIMESTAMP).hasCommonSuperType(TIMESTAMP).canCoerceFirstToSecondOnly();
+        assertThat(DATE, TIMESTAMP_MILLIS).hasCommonSuperType(TIMESTAMP_MILLIS).canCoerceFirstToSecondOnly();
         assertThat(DATE, TIMESTAMP_WITH_TIME_ZONE).hasCommonSuperType(TIMESTAMP_WITH_TIME_ZONE).canCoerceFirstToSecondOnly();
         assertThat(TIME, TIME_WITH_TIME_ZONE).hasCommonSuperType(TIME_WITH_TIME_ZONE).canCoerceFirstToSecondOnly();
-        assertThat(TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE).hasCommonSuperType(TIMESTAMP_WITH_TIME_ZONE).canCoerceFirstToSecondOnly();
+        assertThat(TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE).hasCommonSuperType(TIMESTAMP_WITH_TIME_ZONE).canCoerceFirstToSecondOnly();
         assertThat(VARCHAR, JONI_REGEXP).hasCommonSuperType(JONI_REGEXP).canCoerceFirstToSecondOnly();
         assertThat(VARCHAR, re2jType).hasCommonSuperType(re2jType).canCoerceFirstToSecondOnly();
         assertThat(VARCHAR, JSON_PATH).hasCommonSuperType(JSON_PATH).canCoerceFirstToSecondOnly();
@@ -132,7 +132,7 @@ public class TestTypeCoercion
         assertThat(REAL, INTEGER).hasCommonSuperType(REAL).canCoerceSecondToFirstOnly();
         assertThat(REAL, BIGINT).hasCommonSuperType(REAL).canCoerceSecondToFirstOnly();
 
-        assertThat(TIMESTAMP, TIME_WITH_TIME_ZONE).isIncompatible();
+        assertThat(TIMESTAMP_MILLIS, TIME_WITH_TIME_ZONE).isIncompatible();
         assertThat(VARBINARY, VARCHAR).isIncompatible();
 
         assertThat(UNKNOWN, new ArrayType(BIGINT)).hasCommonSuperType(new ArrayType(BIGINT)).canCoerceFirstToSecondOnly();

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
@@ -37,7 +37,6 @@ import io.prestosql.spi.type.NamedTypeSignature;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
 import io.prestosql.spi.type.TimeType;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
@@ -65,6 +64,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.Decimals.readBigDecimal;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
@@ -168,7 +168,7 @@ public class MongoPageSink
             long picos = type.getLong(block, position);
             return new Date(roundDiv(picos, PICOSECONDS_PER_MILLISECOND));
         }
-        if (type.equals(TimestampType.TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             long millisUtc = type.getLong(block, position);
             return new Date(millisUtc);
         }

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
@@ -65,10 +65,12 @@ import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.Decimals.readBigDecimal;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
@@ -169,7 +171,7 @@ public class MongoPageSink
             return new Date(roundDiv(picos, PICOSECONDS_PER_MILLISECOND));
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            long millisUtc = type.getLong(block, position);
+            long millisUtc = floorDiv(type.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
             return new Date(millisUtc);
         }
         if (type.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE)) {

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSource.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSource.java
@@ -64,6 +64,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static java.lang.Float.floatToIntBits;
@@ -190,7 +191,7 @@ public class MongoPageSource
                 }
                 else if (type.equals(TIMESTAMP_MILLIS)) {
                     // TODO provide correct TIMESTAMP mapping, and respecting session.isLegacyTimestamp()
-                    type.writeLong(output, ((Date) value).getTime());
+                    type.writeLong(output, ((Date) value).getTime() * MICROSECONDS_PER_MILLISECOND);
                 }
                 else if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     type.writeLong(output, packDateTimeWithZone(((Date) value).getTime(), UTC_KEY));

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSource.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSource.java
@@ -62,7 +62,7 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
@@ -188,7 +188,7 @@ public class MongoPageSource
                     long millis = UTC_CHRONOLOGY.millisOfDay().get(((Date) value).getTime());
                     type.writeLong(output, multiplyExact(millis, PICOSECONDS_PER_MILLISECOND));
                 }
-                else if (type.equals(TIMESTAMP)) {
+                else if (type.equals(TIMESTAMP_MILLIS)) {
                     // TODO provide correct TIMESTAMP mapping, and respecting session.isLegacyTimestamp()
                     type.writeLong(output, ((Date) value).getTime());
                 }

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
@@ -74,7 +74,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.Math.toIntExact;
@@ -565,7 +565,7 @@ public class MongoSession
             typeSignature = DOUBLE.getTypeSignature();
         }
         else if (value instanceof Date) {
-            typeSignature = TIMESTAMP.getTypeSignature();
+            typeSignature = TIMESTAMP_MILLIS.getTypeSignature();
         }
         else if (value instanceof ObjectId) {
             typeSignature = OBJECT_ID.getTypeSignature();

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -89,7 +89,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
@@ -260,7 +260,7 @@ public class MySqlClient
         if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             // TODO use `timestampWriteFunction`
             return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp());
         }

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -94,7 +94,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -383,7 +383,7 @@ public class OracleClient
     public static ColumnMapping oracleTimestampColumnMapping()
     {
         return ColumnMapping.longMapping(
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 (resultSet, columnIndex) -> {
                     LocalDateTime timestamp = resultSet.getObject(columnIndex, LocalDateTime.class);
                     return timestamp.toInstant(ZoneOffset.UTC).toEpochMilli();
@@ -470,7 +470,7 @@ public class OracleClient
             }
             return WriteMapping.sliceMapping(dataType, longDecimalWriteFunction((DecimalType) type));
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return WriteMapping.longMapping("timestamp(3)", oracleTimestampWriteFunction());
         }
         WriteMapping writeMapping = WRITE_MAPPINGS.get(type);

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/OracleDataTypes.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/OracleDataTypes.java
@@ -222,7 +222,7 @@ public final class OracleDataTypes
 
     public static DataType<LocalDate> dateDataType()
     {
-        return dataType("DATE", TimestampType.TIMESTAMP,
+        return dataType("DATE", TimestampType.TIMESTAMP_MILLIS,
                 DateTimeFormatter.ofPattern("'DATE '''yyyy-MM-dd''")::format,
                 LocalDate::atStartOfDay);
     }

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
@@ -95,7 +95,6 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_NANOS;
@@ -560,7 +559,7 @@ public class OrcWriteValidation
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000, exclusive, and 1970-01-01 00:00:00.000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.
-                long mills = TIMESTAMP.getLong(block, position);
+                long mills = TIMESTAMP_MILLIS.getLong(block, position);
                 if (mills > -1000 && mills < 0) {
                     return AbstractLongType.hash(mills + 1000);
                 }

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcWriteValidation.java
@@ -559,7 +559,7 @@ public class OrcWriteValidation
                 // A flaw in ORC encoding makes it impossible to represent timestamp
                 // between 1969-12-31 23:59:59.000, exclusive, and 1970-01-01 00:00:00.000, exclusive.
                 // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.
-                long mills = TIMESTAMP_MILLIS.getLong(block, position);
+                long mills = floorDiv(TIMESTAMP_MILLIS.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
                 if (mills > -1000 && mills < 0) {
                     return AbstractLongType.hash(mills + 1000);
                 }
@@ -687,12 +687,7 @@ public class OrcWriteValidation
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (TIMESTAMP_MILLIS.equals(type)) {
-                statisticsBuilder = new TimestampStatisticsBuilder(Type::getLong);
-                fieldExtractor = ignored -> ImmutableList.of();
-                fieldBuilders = ImmutableList.of();
-            }
-            else if (TIMESTAMP_MICROS.equals(type)) {
+            else if (TIMESTAMP_MILLIS.equals(type) || TIMESTAMP_MICROS.equals(type)) {
                 statisticsBuilder = new TimestampStatisticsBuilder(this::timestampMicrosToMillis);
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -253,10 +253,7 @@ public class TupleDomainOrcPredicate
         else if (type instanceof DateType && columnStatistics.getDateStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getDateStatistics(), value -> (long) value);
         }
-        else if (type.equals(TIMESTAMP_MILLIS) && columnStatistics.getTimestampStatistics() != null) {
-            return createDomain(type, hasNullValue, columnStatistics.getTimestampStatistics(), value -> value);
-        }
-        else if (type.equals(TIMESTAMP_MICROS) && columnStatistics.getTimestampStatistics() != null) {
+        else if ((type.equals(TIMESTAMP_MILLIS) || type.equals(TIMESTAMP_MICROS)) && columnStatistics.getTimestampStatistics() != null) {
             return createDomain(
                     type,
                     hasNullValue,

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/TimestampColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/TimestampColumnReader.java
@@ -408,7 +408,7 @@ public class TimestampColumnReader
             millis = fileDateTimeZone.convertUTCToLocal(millis);
         }
 
-        return millis;
+        return millis * MICROSECONDS_PER_MILLISECOND;
     }
 
     // TIMESTAMP MICROS

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -190,8 +190,6 @@ public class TimestampColumnWriter
         // record values
         switch (timestampKind) {
             case TIMESTAMP_MILLIS:
-                writeTimestampMillis(block);
-                break;
             case TIMESTAMP_MICROS:
                 writeTimestampMicros(block);
                 break;

--- a/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
@@ -64,7 +64,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.toIntExact;
@@ -1026,7 +1026,7 @@ public class BenchmarkColumnReaders
         public void setup()
                 throws Exception
         {
-            setup(TIMESTAMP);
+            setup(TIMESTAMP_MILLIS);
         }
 
         @Override
@@ -1048,7 +1048,7 @@ public class BenchmarkColumnReaders
         public void setup()
                 throws Exception
         {
-            setup(TIMESTAMP);
+            setup(TIMESTAMP_MILLIS);
         }
 
         @Override

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -677,8 +677,7 @@ public class OrcTester
                 type.writeLong(blockBuilder, days);
             }
             else if (TIMESTAMP_MILLIS.equals(type)) {
-                long millis = ((SqlTimestamp) value).getMillis();
-                type.writeLong(blockBuilder, millis);
+                type.writeLong(blockBuilder, ((SqlTimestamp) value).getEpochMicros());
             }
             else if (TIMESTAMP_MICROS.equals(type)) {
                 long micros = ((SqlTimestamp) value).getEpochMicros();

--- a/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestOrcBloomFilters.java
@@ -55,7 +55,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -81,7 +81,7 @@ public class TestOrcBloomFilters
             .put(789, SMALLINT)
             .put(77, TINYINT)
             .put(901, DATE)
-            .put(987654L, TIMESTAMP)
+            .put(987654L, TIMESTAMP_MILLIS)
             .put(234.567, DOUBLE)
             .put((long) floatToIntBits(987.654f), REAL)
             .build();
@@ -230,7 +230,7 @@ public class TestOrcBloomFilters
                 .put(SMALLINT, 789L)
                 .put(TINYINT, 77L)
                 .put(DATE, 901L)
-                .put(TIMESTAMP, 987654L)
+                .put(TIMESTAMP_MILLIS, 987654L)
                 .put(BIGINT, 4321L)
                 .put(DOUBLE, 0.123)
                 .put(REAL, (long) (floatToIntBits(0.456f)))

--- a/presto-orc/src/test/java/io/prestosql/orc/TestReadBloomFilter.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestReadBloomFilter.java
@@ -43,7 +43,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -64,7 +64,7 @@ public class TestReadBloomFilter
         testType(BIGINT, ImmutableList.of(1L, 500_000L, 1_000_000L), 500_000L, 777_777L);
 
         testType(DATE, ImmutableList.of(new SqlDate(1), new SqlDate(5_000), new SqlDate(10_000)), 5_000L, 7_777L);
-        testType(TIMESTAMP,
+        testType(TIMESTAMP_MILLIS,
                 ImmutableList.of(SqlTimestamp.fromMillis(3, 1), SqlTimestamp.fromMillis(3, 500_000L), SqlTimestamp.fromMillis(3, 1_000_000L)),
                 500_000L,
                 777_777L);

--- a/presto-orc/src/test/java/io/prestosql/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestTupleDomainOrcPredicate.java
@@ -301,21 +301,21 @@ public class TestTupleDomainOrcPredicate
                 .isEqualTo(notNull(TIMESTAMP_MILLIS));
 
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(10L, 100L, 100L)))
-                .isEqualTo(singleValue(TIMESTAMP_MILLIS, 100L));
+                .isEqualTo(create(ValueSet.ofRanges(range(TIMESTAMP_MILLIS, 100000L, true, 100999L, true)), false));
 
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(10L, 13L, 100L)))
-                .isEqualTo(create(ValueSet.ofRanges(range(TIMESTAMP_MILLIS, 13L, true, 100L, true)), false));
+                .isEqualTo(create(ValueSet.ofRanges(range(TIMESTAMP_MILLIS, 13000L, true, 100999L, true)), false));
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(10L, null, 100L)))
-                .isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP_MILLIS, 100L)), false));
+                .isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP_MILLIS, 100999L)), false));
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(10L, 13L, null)))
-                .isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP_MILLIS, 13L)), false));
+                .isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP_MILLIS, 13000L)), false));
 
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(5L, 13L, 100L)))
-                .isEqualTo(create(ValueSet.ofRanges(range(TIMESTAMP_MILLIS, 13L, true, 100L, true)), true));
+                .isEqualTo(create(ValueSet.ofRanges(range(TIMESTAMP_MILLIS, 13000L, true, 100999L, true)), true));
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(5L, null, 100L)))
-                .isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP_MILLIS, 100L)), true));
+                .isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP_MILLIS, 100999L)), true));
         assertThat(getDomain(TIMESTAMP_MILLIS, 10, timeStampColumnStats(5L, 13L, null)))
-                .isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP_MILLIS, 13L)), true));
+                .isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP_MILLIS, 13000L)), true));
     }
 
     @Test

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/TupleDomainParquetPredicate.java
@@ -58,6 +58,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
@@ -250,9 +251,9 @@ public class TupleDomainParquetPredicate
         if (type instanceof TimestampType && statistics instanceof BinaryStatistics) {
             BinaryStatistics binaryStatistics = (BinaryStatistics) statistics;
             long max = getTimestampMillis(binaryStatistics.genericGetMax());
-            max = timeZone.convertUTCToLocal(max);
+            max = timeZone.convertUTCToLocal(max) * MICROSECONDS_PER_MILLISECOND;
             long min = getTimestampMillis(binaryStatistics.genericGetMin());
-            min = timeZone.convertUTCToLocal(min);
+            min = timeZone.convertUTCToLocal(min) * MICROSECONDS_PER_MILLISECOND;
             if (min > max) {
                 failWithCorruptionException(failOnCorruptedParquetStatistics, column, id, binaryStatistics);
                 return Domain.create(ValueSet.all(type), hasNullValue);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/Int64TimestampMillisColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/Int64TimestampMillisColumnReader.java
@@ -19,18 +19,17 @@ import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
-import static io.prestosql.parquet.ParquetTimestampUtils.getTimestampMillis;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.util.Objects.requireNonNull;
 
-public class TimestampColumnReader
+public class Int64TimestampMillisColumnReader
         extends PrimitiveColumnReader
 {
     private final DateTimeZone timeZone;
 
-    public TimestampColumnReader(RichColumnDescriptor descriptor, DateTimeZone timeZone)
+    public Int64TimestampMillisColumnReader(RichColumnDescriptor descriptor, DateTimeZone timeZone)
     {
         super(descriptor);
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
@@ -40,7 +39,7 @@ public class TimestampColumnReader
     protected void readValue(BlockBuilder blockBuilder, Type type)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
-            long utcMillis = getTimestampMillis(valuesReader.readBytes());
+            long utcMillis = valuesReader.readLong();
             if (type instanceof TimestampWithTimeZoneType) {
                 type.writeLong(blockBuilder, packDateTimeWithZone(utcMillis, UTC_KEY));
             }

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
@@ -92,6 +92,9 @@ public abstract class PrimitiveColumnReader
                 if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MICROS) {
                     return new TimestampMicrosColumnReader(descriptor);
                 }
+                if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MILLIS) {
+                    return new Int64TimestampMillisColumnReader(descriptor, timeZone);
+                }
                 return createDecimalColumnReader(descriptor).orElse(new LongColumnReader(descriptor));
             case INT96:
                 return new TimestampColumnReader(descriptor, timeZone);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/writer/ParquetWriters.java
@@ -24,6 +24,7 @@ import io.prestosql.parquet.writer.valuewriter.IntegerValueWriter;
 import io.prestosql.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.prestosql.parquet.writer.valuewriter.RealValueWriter;
 import io.prestosql.parquet.writer.valuewriter.TimeMicrosValueWriter;
+import io.prestosql.parquet.writer.valuewriter.TimestampMillisValueWriter;
 import io.prestosql.parquet.writer.valuewriter.TimestampTzMicrosValueWriter;
 import io.prestosql.parquet.writer.valuewriter.TimestampTzMillisValueWriter;
 import io.prestosql.spi.PrestoException;
@@ -183,7 +184,7 @@ final class ParquetWriters
         }
         if (TIMESTAMP_MILLIS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
-            return new BigintValueWriter(valuesWriter, type, parquetType);
+            return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
         }
         if (TIMESTAMP_MICROS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);

--- a/presto-parquet/src/main/java/io/prestosql/parquet/writer/valuewriter/TimestampMillisValueWriter.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/writer/valuewriter/TimestampMillisValueWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.parquet.writer.valuewriter;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static java.lang.Math.floorDiv;
+import static java.util.Objects.requireNonNull;
+
+public class TimestampMillisValueWriter
+        extends PrimitiveValueWriter
+{
+    private final Type type;
+
+    public TimestampMillisValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                long scaledValue = floorDiv(type.getLong(block, i), MICROSECONDS_PER_MILLISECOND);
+                getValueWriter().writeLong(scaledValue);
+                getStatistics().updateStats(scaledValue);
+            }
+        }
+    }
+}

--- a/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
@@ -71,6 +71,7 @@ import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Float.NaN;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
@@ -359,10 +360,10 @@ public class TestTupleDomainParquetPredicate
         String column = "timestampColumn";
         TimestampType timestampType = createTimestampType(3);
         assertEquals(getDomain(timestampType, 0, null, ID, column, true, UTC), all(timestampType));
-        assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime, baseTime), ID, column, true, UTC), singleValue(timestampType, baseTime.toEpochMilli()));
+        assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime, baseTime), ID, column, true, UTC), singleValue(timestampType, baseTime.toEpochMilli() * MICROSECONDS_PER_MILLISECOND));
         assertEquals(
                 getDomain(timestampType, 10, timestampColumnStats(baseTime.minusSeconds(10), baseTime), ID, column, true, UTC),
-                create(ValueSet.ofRanges(range(timestampType, baseTime.minusSeconds(10).toEpochMilli(), true, baseTime.toEpochMilli(), true)), false));
+                create(ValueSet.ofRanges(range(timestampType, baseTime.minusSeconds(10).toEpochMilli() * MICROSECONDS_PER_MILLISECOND, true, baseTime.toEpochMilli() * MICROSECONDS_PER_MILLISECOND, true)), false));
 
         // ignore corrupted statistics
         assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime.plusSeconds(10), baseTime), ID, column, false, UTC), create(ValueSet.all(timestampType), false));

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -130,7 +130,7 @@ import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.StandardTypes.JSON;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TypeSignature.mapType;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -353,7 +353,7 @@ public class PostgreSqlClient
         }
         if (typeHandle.getJdbcType() == Types.TIMESTAMP) {
             return Optional.of(ColumnMapping.longMapping(
-                    TIMESTAMP,
+                    TIMESTAMP_MILLIS,
                     timestampReadFunction(),
                     timestampWriteFunction()));
         }
@@ -431,7 +431,7 @@ public class PostgreSqlClient
         if (TIME.equals(type)) {
             return WriteMapping.longMapping("time", timeWriteFunction());
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             return WriteMapping.longMapping("timestamp", timestampWriteFunction());
         }
         if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/TypeUtils.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/TypeUtils.java
@@ -48,7 +48,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.TypeUtils.readNativeValue;
@@ -176,7 +176,7 @@ final class TypeUtils
             return new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis));
         }
 
-        if (TIMESTAMP.equals(prestoType)) {
+        if (TIMESTAMP_MILLIS.equals(prestoType)) {
             return toPgTimestamp(fromPrestoTimestamp((long) prestoNative));
         }
 

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorMetadata.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorMetadata.java
@@ -116,7 +116,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.block.SortOrder.ASC_NULLS_FIRST;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
@@ -568,7 +568,7 @@ public class RaptorMetadata
 
         if (temporalColumnHandle.isPresent()) {
             RaptorColumnHandle column = temporalColumnHandle.get();
-            if (!column.getColumnType().equals(TIMESTAMP) && !column.getColumnType().equals(DATE)) {
+            if (!column.getColumnType().equals(TIMESTAMP_MILLIS) && !column.getColumnType().equals(DATE)) {
                 throw new PrestoException(NOT_SUPPORTED, "Temporal column must be of type timestamp or date: " + column.getColumnName());
             }
         }

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorPageSink.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorPageSink.java
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.MoreFutures.allAsList;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -98,7 +98,7 @@ public class RaptorPageSink
         if (temporalColumnHandle.isPresent() && columnIds.contains(temporalColumnHandle.get().getColumnId())) {
             temporalColumnIndex = OptionalInt.of(columnIds.indexOf(temporalColumnHandle.get().getColumnId()));
             temporalColumnType = Optional.of(columnTypes.get(temporalColumnIndex.getAsInt()));
-            checkArgument(temporalColumnType.get() == DATE || temporalColumnType.get().equals(TIMESTAMP),
+            checkArgument(temporalColumnType.get() == DATE || temporalColumnType.get().equals(TIMESTAMP_MILLIS),
                     "temporalColumnType can only be DATE or TIMESTAMP");
         }
         else {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/ColumnIndexStatsUtils.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/ColumnIndexStatsUtils.java
@@ -23,7 +23,7 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 
 public final class ColumnIndexStatsUtils
 {
@@ -34,7 +34,7 @@ public final class ColumnIndexStatsUtils
         if (type.equals(BOOLEAN)) {
             return JDBCType.BOOLEAN;
         }
-        if (type.equals(BIGINT) || type.equals(TIMESTAMP)) {
+        if (type.equals(BIGINT) || type.equals(TIMESTAMP_MILLIS)) {
             return JDBCType.BIGINT;
         }
         if (type.equals(INTEGER)) {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
@@ -59,7 +59,6 @@ import io.prestosql.spi.type.RowFieldName;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.RowType.Field;
 import io.prestosql.spi.type.StandardTypes;
-import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeManager;
 import io.prestosql.spi.type.TypeSignature;
@@ -118,6 +117,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
@@ -553,7 +553,7 @@ public class OrcStorageManager
     static Type toOrcFileType(Type raptorType, TypeManager typeManager)
     {
         // TIMESTAMPS are stored as BIGINT to void the poor encoding in ORC
-        if (raptorType.equals(TimestampType.TIMESTAMP)) {
+        if (raptorType.equals(TIMESTAMP_MILLIS)) {
             return BIGINT;
         }
         if (raptorType instanceof ArrayType) {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/ShardStats.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/ShardStats.java
@@ -86,7 +86,7 @@ public final class ShardStats
         }
         if (type.equals(BigintType.BIGINT) ||
                 type.equals(DateType.DATE) ||
-                type.equals(TimestampType.TIMESTAMP)) {
+                type.equals(TimestampType.TIMESTAMP_MILLIS)) {
             return indexLong(type, reader, columnId);
         }
         if (type.equals(DoubleType.DOUBLE)) {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/ShardCompactionManager.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/ShardCompactionManager.java
@@ -49,7 +49,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.prestosql.plugin.raptor.legacy.storage.organization.ShardOrganizerUtil.getOrganizationEligibleShards;
 import static io.prestosql.plugin.raptor.legacy.util.DatabaseUtil.onDemandDao;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -213,7 +213,7 @@ public class ShardCompactionManager
 
     private static boolean isValidTemporalColumn(long tableId, Type type)
     {
-        if (!type.equals(DATE) && !type.equals(TIMESTAMP)) {
+        if (!type.equals(DATE) && !type.equals(TIMESTAMP_MILLIS)) {
             log.warn("Temporal column type of table ID %s set incorrectly to %s", tableId, type);
             return false;
         }

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/TemporalFunction.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/TemporalFunction.java
@@ -22,8 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_DAY;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class TemporalFunction
 {
@@ -36,8 +37,7 @@ public final class TemporalFunction
         }
 
         if (type.equals(TIMESTAMP_MILLIS)) {
-            long millis = TIMESTAMP_MILLIS.getLong(block, position);
-            long days = MILLISECONDS.toDays(millis);
+            long days = floorDiv(TIMESTAMP_MILLIS.getLong(block, position), MICROSECONDS_PER_DAY);
             return toIntExact(days);
         }
 

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/TemporalFunction.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/organization/TemporalFunction.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -35,8 +35,8 @@ public final class TemporalFunction
             return toIntExact(DATE.getLong(block, position));
         }
 
-        if (type.equals(TIMESTAMP)) {
-            long millis = TIMESTAMP.getLong(block, position);
+        if (type.equals(TIMESTAMP_MILLIS)) {
+            long millis = TIMESTAMP_MILLIS.getLong(block, position);
             long days = MILLISECONDS.toDays(millis);
             return toIntExact(days);
         }
@@ -55,7 +55,7 @@ public final class TemporalFunction
             return (int) getOnlyElement(min.getValues());
         }
 
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             long minValue = (long) getOnlyElement(min.getValues());
             long maxValue = (long) getOnlyElement(max.getValues());
             return determineDay(minValue, maxValue);

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ColumnRangesSystemTable.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ColumnRangesSystemTable.java
@@ -49,6 +49,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -125,10 +126,19 @@ public class ColumnRangesSystemTable
                 for (int i = 0; i < columnTypes.size(); ++i) {
                     BlockBuilder blockBuilder = pageListBuilder.nextBlockBuilder();
                     Type columnType = columnTypes.get(i);
-                    if (columnType.equals(BIGINT) || columnType.equals(DATE) || columnType.equals(TIMESTAMP_MILLIS)) {
+                    if (columnType.equals(BIGINT) || columnType.equals(DATE)) {
                         long value = resultSet.getLong(i + 1);
                         if (!resultSet.wasNull()) {
                             columnType.writeLong(blockBuilder, value);
+                        }
+                        else {
+                            blockBuilder.appendNull();
+                        }
+                    }
+                    else if (columnType.equals(TIMESTAMP_MILLIS)) {
+                        long value = resultSet.getLong(i + 1);
+                        if (!resultSet.wasNull()) {
+                            columnType.writeLong(blockBuilder, value * MICROSECONDS_PER_MILLISECOND);
                         }
                         else {
                             blockBuilder.appendNull();

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ColumnRangesSystemTable.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ColumnRangesSystemTable.java
@@ -48,7 +48,7 @@ import static io.prestosql.spi.connector.SystemTable.Distribution.SINGLE_COORDIN
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -125,7 +125,7 @@ public class ColumnRangesSystemTable
                 for (int i = 0; i < columnTypes.size(); ++i) {
                     BlockBuilder blockBuilder = pageListBuilder.nextBlockBuilder();
                     Type columnType = columnTypes.get(i);
-                    if (columnType.equals(BIGINT) || columnType.equals(DATE) || columnType.equals(TIMESTAMP)) {
+                    if (columnType.equals(BIGINT) || columnType.equals(DATE) || columnType.equals(TIMESTAMP_MILLIS)) {
                         long value = resultSet.getLong(i + 1);
                         if (!resultSet.wasNull()) {
                             columnType.writeLong(blockBuilder, value);
@@ -162,7 +162,7 @@ public class ColumnRangesSystemTable
         // Exclude INTEGER because we don't collect column stats for INTEGER type.
         // Exclude DOUBLE because Java double is not completely compatible with MySQL double
         // Exclude VARCHAR because they can be truncated
-        return type.equals(BOOLEAN) || type.equals(BIGINT) || type.equals(DATE) || type.equals(TIMESTAMP);
+        return type.equals(BOOLEAN) || type.equals(BIGINT) || type.equals(DATE) || type.equals(TIMESTAMP_MILLIS);
     }
 
     private static String getColumnRangesMetadataSqlQuery(RaptorTableHandle raptorTableHandle, List<TableColumn> raptorColumns)

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ShardMetadataRecordCursor.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/ShardMetadataRecordCursor.java
@@ -52,7 +52,7 @@ import static io.prestosql.plugin.raptor.legacy.util.DatabaseUtil.metadataError;
 import static io.prestosql.plugin.raptor.legacy.util.DatabaseUtil.onDemandDao;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
@@ -83,8 +83,8 @@ public class ShardMetadataRecordCursor
                     new ColumnMetadata("compressed_size", BIGINT),
                     new ColumnMetadata("row_count", BIGINT),
                     new ColumnMetadata(XXHASH64, createVarcharType(16)),
-                    new ColumnMetadata(MIN_TIMESTAMP, TIMESTAMP),
-                    new ColumnMetadata(MAX_TIMESTAMP, TIMESTAMP),
+                    new ColumnMetadata(MIN_TIMESTAMP, TIMESTAMP_MILLIS),
+                    new ColumnMetadata(MAX_TIMESTAMP, TIMESTAMP_MILLIS),
                     new ColumnMetadata(MIN_DATE, DATE),
                     new ColumnMetadata(MAX_DATE, DATE)));
 
@@ -278,7 +278,7 @@ public class ShardMetadataRecordCursor
             if (temporalType.equals(DATE)) {
                 columnNames = getMappedColumnNames("null", "null", minColumn(columnId), maxColumn(columnId));
             }
-            else if (temporalType.equals(TIMESTAMP)) {
+            else if (temporalType.equals(TIMESTAMP_MILLIS)) {
                 columnNames = getMappedColumnNames(minColumn(columnId), maxColumn(columnId), "null", "null");
             }
             else {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableStatsSystemTable.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableStatsSystemTable.java
@@ -44,6 +44,7 @@ import static io.prestosql.spi.connector.SystemTable.Distribution.SINGLE_COORDIN
 import static io.prestosql.spi.predicate.TupleDomain.extractFixedValues;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.stream.Collectors.toList;
@@ -108,8 +109,8 @@ public class TableStatsSystemTable
             pageBuilder.beginRow();
             VARCHAR.writeSlice(pageBuilder.nextBlockBuilder(), utf8Slice(row.getSchemaName()));
             VARCHAR.writeSlice(pageBuilder.nextBlockBuilder(), utf8Slice(row.getTableName()));
-            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getCreateTime());
-            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getUpdateTime());
+            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getCreateTime() * MICROSECONDS_PER_MILLISECOND);
+            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getUpdateTime() * MICROSECONDS_PER_MILLISECOND);
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getTableVersion());
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getShardCount());
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getRowCount());

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableStatsSystemTable.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/TableStatsSystemTable.java
@@ -43,7 +43,7 @@ import static io.prestosql.plugin.raptor.legacy.util.DatabaseUtil.onDemandDao;
 import static io.prestosql.spi.connector.SystemTable.Distribution.SINGLE_COORDINATOR;
 import static io.prestosql.spi.predicate.TupleDomain.extractFixedValues;
 import static io.prestosql.spi.type.BigintType.BIGINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.stream.Collectors.toList;
@@ -59,8 +59,8 @@ public class TableStatsSystemTable
             ImmutableList.<ColumnMetadata>builder()
                     .add(new ColumnMetadata(SCHEMA_NAME, createUnboundedVarcharType()))
                     .add(new ColumnMetadata(TABLE_NAME, createUnboundedVarcharType()))
-                    .add(new ColumnMetadata("create_time", TIMESTAMP))
-                    .add(new ColumnMetadata("update_time", TIMESTAMP))
+                    .add(new ColumnMetadata("create_time", TIMESTAMP_MILLIS))
+                    .add(new ColumnMetadata("update_time", TIMESTAMP_MILLIS))
                     .add(new ColumnMetadata("table_version", BIGINT))
                     .add(new ColumnMetadata("shard_count", BIGINT))
                     .add(new ColumnMetadata("row_count", BIGINT))
@@ -108,8 +108,8 @@ public class TableStatsSystemTable
             pageBuilder.beginRow();
             VARCHAR.writeSlice(pageBuilder.nextBlockBuilder(), utf8Slice(row.getSchemaName()));
             VARCHAR.writeSlice(pageBuilder.nextBlockBuilder(), utf8Slice(row.getTableName()));
-            TIMESTAMP.writeLong(pageBuilder.nextBlockBuilder(), row.getCreateTime());
-            TIMESTAMP.writeLong(pageBuilder.nextBlockBuilder(), row.getUpdateTime());
+            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getCreateTime());
+            TIMESTAMP_MILLIS.writeLong(pageBuilder.nextBlockBuilder(), row.getUpdateTime());
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getTableVersion());
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getShardCount());
             BIGINT.writeLong(pageBuilder.nextBlockBuilder(), row.getRowCount());

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorConnector.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorConnector.java
@@ -232,8 +232,8 @@ public class TestRaptorConnector
         Object timestamp1 = null;
         Object timestamp2 = null;
         if (temporalType.equals(TIMESTAMP_MILLIS)) {
-            timestamp1 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), min));
-            timestamp2 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), max));
+            timestamp1 = SqlTimestamp.newInstance(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), min), 0);
+            timestamp2 = SqlTimestamp.newInstance(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), max), 0);
         }
         else if (temporalType.equals(DATE)) {
             timestamp1 = new SqlDate(parseDate(min));

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorConnector.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorConnector.java
@@ -67,7 +67,7 @@ import static io.prestosql.plugin.raptor.legacy.storage.TestOrcStorageManager.cr
 import static io.prestosql.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static io.prestosql.util.DateTimeUtils.parseDate;
 import static org.testng.Assert.assertEquals;
@@ -201,10 +201,10 @@ public class TestRaptorConnector
         assertSplitShard(DATE, "2001-08-22", "2001-08-23", 2);
 
         // Same timestamp should be in same split
-        assertSplitShard(TIMESTAMP, "2001-08-22 00:00:01.000", "2001-08-22 23:59:01.000", 1);
+        assertSplitShard(TIMESTAMP_MILLIS, "2001-08-22 00:00:01.000", "2001-08-22 23:59:01.000", 1);
 
         // Same timestamp should be in different splits
-        assertSplitShard(TIMESTAMP, "2001-08-22 23:59:01.000", "2001-08-23 00:00:01.000", 2);
+        assertSplitShard(TIMESTAMP_MILLIS, "2001-08-22 23:59:01.000", "2001-08-23 00:00:01.000", 2);
     }
 
     private void assertSplitShard(Type temporalType, String min, String max, int expectedSplits)
@@ -231,9 +231,9 @@ public class TestRaptorConnector
 
         Object timestamp1 = null;
         Object timestamp2 = null;
-        if (temporalType.equals(TIMESTAMP)) {
-            timestamp1 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP.getPrecision(), min));
-            timestamp2 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP.getPrecision(), max));
+        if (temporalType.equals(TIMESTAMP_MILLIS)) {
+            timestamp1 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), min));
+            timestamp2 = SqlTimestamp.fromMillis(3, castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), max));
         }
         else if (temporalType.equals(DATE)) {
             timestamp1 = new SqlDate(parseDate(min));

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/metadata/TestDatabaseShardManager.java
@@ -84,7 +84,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
@@ -440,11 +440,11 @@ public class TestDatabaseShardManager
     public void testTemporalColumnTableCreation()
     {
         long tableId = createTable("test");
-        List<ColumnInfo> columns = ImmutableList.of(new ColumnInfo(1, TIMESTAMP));
+        List<ColumnInfo> columns = ImmutableList.of(new ColumnInfo(1, TIMESTAMP_MILLIS));
         shardManager.createTable(tableId, columns, false, OptionalLong.of(1));
 
         long tableId2 = createTable("test2");
-        List<ColumnInfo> columns2 = ImmutableList.of(new ColumnInfo(1, TIMESTAMP));
+        List<ColumnInfo> columns2 = ImmutableList.of(new ColumnInfo(1, TIMESTAMP_MILLIS));
         shardManager.createTable(tableId2, columns2, true, OptionalLong.of(1));
     }
 
@@ -497,7 +497,7 @@ public class TestDatabaseShardManager
                 .add(new ColumnInfo(1, BIGINT))
                 .add(new ColumnInfo(2, DOUBLE))
                 .add(new ColumnInfo(3, DATE))
-                .add(new ColumnInfo(4, TIMESTAMP))
+                .add(new ColumnInfo(4, TIMESTAMP_MILLIS))
                 .add(new ColumnInfo(5, createVarcharType(10)))
                 .add(new ColumnInfo(6, BOOLEAN))
                 .add(new ColumnInfo(7, VARBINARY))
@@ -506,7 +506,7 @@ public class TestDatabaseShardManager
         RaptorColumnHandle c1 = new RaptorColumnHandle("c1", 1, BIGINT);
         RaptorColumnHandle c2 = new RaptorColumnHandle("c2", 2, DOUBLE);
         RaptorColumnHandle c3 = new RaptorColumnHandle("c3", 3, DATE);
-        RaptorColumnHandle c4 = new RaptorColumnHandle("c4", 4, TIMESTAMP);
+        RaptorColumnHandle c4 = new RaptorColumnHandle("c4", 4, TIMESTAMP_MILLIS);
         RaptorColumnHandle c5 = new RaptorColumnHandle("c5", 5, createVarcharType(10));
         RaptorColumnHandle c6 = new RaptorColumnHandle("c6", 6, BOOLEAN);
 
@@ -542,7 +542,7 @@ public class TestDatabaseShardManager
                 .between(c1, BIGINT, -25L, 25L)
                 .between(c2, DOUBLE, -1000.0, 1000.0)
                 .between(c3, BIGINT, 0L, 50000L)
-                .between(c4, TIMESTAMP, 0L, timestamp(2015, 1, 2, 3, 4, 5))
+                .between(c4, TIMESTAMP_MILLIS, 0L, timestamp(2015, 1, 2, 3, 4, 5))
                 .between(c5, createVarcharType(10), utf8Slice("a"), utf8Slice("zzzzz"))
                 .between(c6, BOOLEAN, false, true)
                 .expected(shards);
@@ -557,7 +557,7 @@ public class TestDatabaseShardManager
 
         shardAssertion(tableId).equal(c3, DATE, date(2013, 5, 12)).expected(shard1, shard3);
 
-        shardAssertion(tableId).range(c4, greaterThan(TIMESTAMP, timestamp(2013, 1, 1, 0, 0, 0))).expected(shard1, shard3);
+        shardAssertion(tableId).range(c4, greaterThan(TIMESTAMP_MILLIS, timestamp(2013, 1, 1, 0, 0, 0))).expected(shard1, shard3);
 
         shardAssertion(tableId).between(c5, createVarcharType(10), utf8Slice("cow"), utf8Slice("milk")).expected(shards);
         shardAssertion(tableId).equal(c5, createVarcharType(10), utf8Slice("fruit")).expected();

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/TestOrcStorageManager.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/TestOrcStorageManager.java
@@ -89,7 +89,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
@@ -499,7 +499,7 @@ public class TestOrcStorageManager
         long maxTimestamp = sqlTimestamp(2002, 4, 13, 6, 7, 8).getMillis();
         long minTimestamp = sqlTimestamp(2001, 3, 15, 9, 10, 11).getMillis();
 
-        List<ColumnStats> stats = columnStats(types(DATE, TIMESTAMP),
+        List<ColumnStats> stats = columnStats(types(DATE, TIMESTAMP_MILLIS),
                 row(minDate, maxTimestamp),
                 row(maxDate, minTimestamp));
         assertColumnStats(stats, 1, minDate, maxDate);

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestCompactionSetCreator.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestCompactionSetCreator.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -104,11 +104,11 @@ public class TestCompactionSetCreator
         long day3 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 2).toMillis();
 
         List<ShardIndexInfo> inputShards = ImmutableList.of(
-                shardWithTemporalRange(TIMESTAMP, day1, day1),
-                shardWithTemporalRange(TIMESTAMP, day2, day2),
-                shardWithTemporalRange(TIMESTAMP, day2, day2),
-                shardWithTemporalRange(TIMESTAMP, day1, day1),
-                shardWithTemporalRange(TIMESTAMP, day3, day3));
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1, day1),
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day2, day2),
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day2, day2),
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1, day1),
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day3, day3));
 
         Set<OrganizationSet> actual = compactionSetCreator.createCompactionSets(temporalTableInfo, inputShards);
         assertEquals(actual.size(), 2);
@@ -128,13 +128,13 @@ public class TestCompactionSetCreator
         long day4 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 3).toMillis();
 
         List<ShardIndexInfo> inputShards = ImmutableList.of(
-                shardWithTemporalRange(TIMESTAMP, day1, day3), // day2
-                shardWithTemporalRange(TIMESTAMP, day2, day2), // day2
-                shardWithTemporalRange(TIMESTAMP, day1, day1), // day1
-                shardWithTemporalRange(TIMESTAMP, day1 + 100, day2 + 100), // day1
-                shardWithTemporalRange(TIMESTAMP, day1 - 100, day2 - 100), // day1
-                shardWithTemporalRange(TIMESTAMP, day2 - 100, day3 - 100),  // day2
-                shardWithTemporalRange(TIMESTAMP, day1, day4)); // day2
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1, day3), // day2
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day2, day2), // day2
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1, day1), // day1
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1 + 100, day2 + 100), // day1
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1 - 100, day2 - 100), // day1
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day2 - 100, day3 - 100),  // day2
+                shardWithTemporalRange(TIMESTAMP_MILLIS, day1, day4)); // day2
 
         long tableId = temporalTableInfo.getTableId();
         Set<OrganizationSet> compactionSets = compactionSetCreator.createCompactionSets(temporalTableInfo, inputShards);

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
@@ -58,7 +58,7 @@ import static io.prestosql.spi.block.SortOrder.ASC_NULLS_FIRST;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.testing.MaterializedResult.materializeSourceDataStream;
 import static io.prestosql.testing.QueryAssertions.assertEqualsIgnoreOrder;
@@ -109,7 +109,7 @@ public class TestShardCompactor
             throws Exception
     {
         List<Long> columnIds = ImmutableList.of(3L, 7L, 2L, 1L, 5L);
-        List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(20), DOUBLE, DATE, TIMESTAMP);
+        List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(20), DOUBLE, DATE, TIMESTAMP_MILLIS);
 
         List<ShardInfo> inputShards = createShards(storageManager, columnIds, columnTypes, 3);
         assertEquals(inputShards.size(), 3);
@@ -133,7 +133,7 @@ public class TestShardCompactor
     public void testShardCompactorSorted()
             throws Exception
     {
-        List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(20), DATE, TIMESTAMP, DOUBLE);
+        List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(20), DATE, TIMESTAMP_MILLIS, DOUBLE);
         List<Long> columnIds = ImmutableList.of(3L, 7L, 2L, 1L, 5L);
         List<Long> sortColumnIds = ImmutableList.of(1L, 2L, 3L, 5L, 7L);
         List<SortOrder> sortOrders = nCopies(sortColumnIds.size(), ASC_NULLS_FIRST);

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardOrganizationManager.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardOrganizationManager.java
@@ -43,7 +43,7 @@ import static io.prestosql.plugin.raptor.legacy.storage.organization.TestCompact
 import static io.prestosql.plugin.raptor.legacy.storage.organization.TestShardOrganizer.createShardOrganizer;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -61,7 +61,7 @@ public class TestShardOrganizationManager
     private static final Table tableInfo = new Table(1L, Optional.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), true);
     private static final Table temporalTableInfo = new Table(1L, Optional.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), true);
 
-    private static final List<Type> types = ImmutableList.of(BIGINT, VARCHAR, DATE, TIMESTAMP);
+    private static final List<Type> types = ImmutableList.of(BIGINT, VARCHAR, DATE, TIMESTAMP_MILLIS);
 
     @BeforeMethod
     public void setup()

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardOrganizerUtil.java
@@ -55,7 +55,7 @@ import static io.prestosql.plugin.raptor.legacy.metadata.TestDatabaseShardManage
 import static io.prestosql.plugin.raptor.legacy.storage.organization.ShardOrganizerUtil.getOrganizationEligibleShards;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
@@ -65,7 +65,7 @@ import static org.testng.Assert.assertEquals;
 public class TestShardOrganizerUtil
 {
     private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
-            new ColumnInfo(1, TIMESTAMP),
+            new ColumnInfo(1, TIMESTAMP_MILLIS),
             new ColumnInfo(2, BIGINT),
             new ColumnInfo(3, VARCHAR));
 

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardRange.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestShardRange.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -31,7 +31,7 @@ public class TestShardRange
     @Test
     public void testEnclosesIsSymmetric()
     {
-        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, TIMESTAMP);
+        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, TIMESTAMP_MILLIS);
         ShardRange range = ShardRange.of(new Tuple(types, 2L, "aaa", true, 1L), new Tuple(types, 5L, "ccc", false, 2L));
         assertTrue(range.encloses(range));
     }
@@ -61,7 +61,7 @@ public class TestShardRange
     @Test
     public void testOverlapsIsSymmetric()
     {
-        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, TIMESTAMP);
+        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, TIMESTAMP_MILLIS);
         ShardRange range = ShardRange.of(new Tuple(types, 2L, "aaa", true, 1L), new Tuple(types, 5L, "ccc", false, 2L));
         assertTrue(range.overlaps(range));
     }

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTemporalFunction.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTemporalFunction.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import java.time.Duration;
 
 import static io.prestosql.spi.type.DateType.DATE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
 
@@ -44,16 +44,16 @@ public class TestTemporalFunction
     @Test
     public void testTimestampBlock()
     {
-        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(null, 4);
+        BlockBuilder blockBuilder = TIMESTAMP_MILLIS.createBlockBuilder(null, 4);
 
         // start and end of UTC day
-        TIMESTAMP.writeLong(blockBuilder, DATE_TIME.getMillis());
-        TIMESTAMP.writeLong(blockBuilder, DATE_TIME.getMillis() + Duration.ofHours(23).toMillis());
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, DATE_TIME.getMillis());
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, DATE_TIME.getMillis() + Duration.ofHours(23).toMillis());
 
         Block block = blockBuilder.build();
 
-        assertEquals(TemporalFunction.getDay(TIMESTAMP, block, 0), 1);
-        assertEquals(TemporalFunction.getDay(TIMESTAMP, block, 1), 1);
+        assertEquals(TemporalFunction.getDay(TIMESTAMP_MILLIS, block, 0), 1);
+        assertEquals(TemporalFunction.getDay(TIMESTAMP_MILLIS, block, 1), 1);
     }
 
     @Test
@@ -89,7 +89,7 @@ public class TestTemporalFunction
     private static ShardRange timeRange(long start, Duration duration)
     {
         return ShardRange.of(
-                new Tuple(TIMESTAMP, start),
-                new Tuple(TIMESTAMP, start + duration.toMillis()));
+                new Tuple(TIMESTAMP_MILLIS, start),
+                new Tuple(TIMESTAMP_MILLIS, start + duration.toMillis()));
     }
 }

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTemporalFunction.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTemporalFunction.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
 
@@ -47,8 +48,8 @@ public class TestTemporalFunction
         BlockBuilder blockBuilder = TIMESTAMP_MILLIS.createBlockBuilder(null, 4);
 
         // start and end of UTC day
-        TIMESTAMP_MILLIS.writeLong(blockBuilder, DATE_TIME.getMillis());
-        TIMESTAMP_MILLIS.writeLong(blockBuilder, DATE_TIME.getMillis() + Duration.ofHours(23).toMillis());
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, DATE_TIME.getMillis() * MICROSECONDS_PER_MILLISECOND);
+        TIMESTAMP_MILLIS.writeLong(blockBuilder, (DATE_TIME.getMillis() + Duration.ofHours(23).toMillis()) * MICROSECONDS_PER_MILLISECOND);
 
         Block block = blockBuilder.build();
 

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTuple.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/storage/organization/TestTuple.java
@@ -25,7 +25,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static org.testng.Assert.assertEquals;
@@ -35,7 +35,7 @@ public class TestTuple
     @Test
     public void testComparableTuple()
     {
-        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, DOUBLE, DATE, TIMESTAMP);
+        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, BOOLEAN, DOUBLE, DATE, TIMESTAMP_MILLIS);
 
         Tuple tuple1 = new Tuple(types, ImmutableList.of(1L, "hello", false, 1.2d, 11111, 1112));
         Tuple equalToTuple1 = new Tuple(types, ImmutableList.of(1L, "hello", false, 1.2d, 11111, 1112));

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/RcFileEncoding.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/RcFileEncoding.java
@@ -32,7 +32,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.util.stream.Collectors.toList;
@@ -104,7 +104,7 @@ public interface RcFileEncoding
         if (DATE.equals(type)) {
             return dateEncoding(type);
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type)) {
             return timestampEncoding(type);
         }
         if (type instanceof ArrayType) {

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/text/TimestampEncoding.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/text/TimestampEncoding.java
@@ -26,6 +26,8 @@ import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
 import org.joda.time.format.DateTimePrinter;
 
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static java.lang.Math.floorDiv;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class TimestampEncoding
@@ -66,7 +68,7 @@ public class TimestampEncoding
                 output.writeBytes(nullSequence);
             }
             else {
-                long millis = type.getLong(block, position);
+                long millis = floorDiv(type.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
                 buffer.setLength(0);
                 HIVE_TIMESTAMP_PARSER.printTo(buffer, millis);
                 for (int index = 0; index < buffer.length(); index++) {
@@ -80,7 +82,7 @@ public class TimestampEncoding
     @Override
     public void encodeValueInto(int depth, Block block, int position, SliceOutput output)
     {
-        long millis = type.getLong(block, position);
+        long millis = floorDiv(type.getLong(block, position), MICROSECONDS_PER_MILLISECOND);
         buffer.setLength(0);
         HIVE_TIMESTAMP_PARSER.printTo(buffer, millis);
         for (int index = 0; index < buffer.length(); index++) {
@@ -111,12 +113,11 @@ public class TimestampEncoding
     @Override
     public void decodeValueInto(int depth, BlockBuilder builder, Slice slice, int offset, int length)
     {
-        long millis = parseTimestamp(slice, offset, length);
-        type.writeLong(builder, millis);
+        type.writeLong(builder, parseTimestamp(slice, offset, length));
     }
 
     private static long parseTimestamp(Slice slice, int offset, int length)
     {
-        return HIVE_TIMESTAMP_PARSER.parseMillis(new String(slice.getBytes(offset, length), US_ASCII));
+        return HIVE_TIMESTAMP_PARSER.parseMillis(new String(slice.getBytes(offset, length), US_ASCII)) * MICROSECONDS_PER_MILLISECOND;
     }
 }

--- a/presto-rcfile/src/test/java/io/prestosql/rcfile/AbstractTestRcFileReader.java
+++ b/presto-rcfile/src/test/java/io/prestosql/rcfile/AbstractTestRcFileReader.java
@@ -40,7 +40,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -163,7 +163,7 @@ public abstract class AbstractTestRcFileReader
             throws Exception
     {
         tester.testRoundTrip(
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 intsBetween(123_406_789, 123_456_789).stream()
                         .filter(i -> i % 19 == 0)
                         .map(timestamp -> sqlTimestampOf(timestamp))

--- a/presto-rcfile/src/test/java/io/prestosql/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/io/prestosql/rcfile/RcFileTester.java
@@ -148,6 +148,7 @@ import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
+import static io.prestosql.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Math.toIntExact;
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
@@ -710,7 +711,7 @@ public class RcFileTester
             }
             else if (TIMESTAMP_MILLIS.equals(type)) {
                 long millis = ((SqlTimestamp) value).getMillis();
-                type.writeLong(blockBuilder, millis);
+                type.writeLong(blockBuilder, millis * MICROSECONDS_PER_MILLISECOND);
             }
             else {
                 if (type instanceof ArrayType) {

--- a/presto-rcfile/src/test/java/io/prestosql/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/io/prestosql/rcfile/RcFileTester.java
@@ -142,7 +142,7 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.StandardTypes.MAP;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -708,7 +708,7 @@ public class RcFileTester
                 long days = ((SqlDate) value).getDays();
                 type.writeLong(blockBuilder, days);
             }
-            else if (TIMESTAMP.equals(type)) {
+            else if (TIMESTAMP_MILLIS.equals(type)) {
                 long millis = ((SqlTimestamp) value).getMillis();
                 type.writeLong(blockBuilder, millis);
             }
@@ -965,7 +965,7 @@ public class RcFileTester
         if (type.equals(DATE)) {
             return javaDateObjectInspector;
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return javaTimestampObjectInspector;
         }
         if (type instanceof DecimalType) {
@@ -1028,7 +1028,7 @@ public class RcFileTester
         if (type.equals(DATE)) {
             return Date.ofEpochDay(((SqlDate) value).getDays());
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             long millis = ((SqlTimestamp) value).getMillis();
             if (format == Format.BINARY) {
                 millis = HIVE_STORAGE_TIME_ZONE.convertLocalToUTC(millis, false);

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -30,6 +30,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static java.lang.String.format;
@@ -74,7 +75,7 @@ public abstract class AbstractDateTimeJsonValueProvider
             return millis * PICOSECONDS_PER_MILLISECOND;
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return millis;
+            return millis * MICROSECONDS_PER_MILLISECOND;
         }
         if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
             return packDateTimeWithZone(millis, getTimeZone());

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -28,7 +28,7 @@ import static io.prestosql.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
@@ -73,7 +73,7 @@ public abstract class AbstractDateTimeJsonValueProvider
         if (type.equals(TIME)) {
             return millis * PICOSECONDS_PER_MILLISECOND;
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP_MILLIS)) {
             return millis;
         }
         if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/CustomDateTimeJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/CustomDateTimeJsonFieldDecoder.java
@@ -35,7 +35,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -50,7 +50,7 @@ import static java.util.Objects.requireNonNull;
 public class CustomDateTimeJsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
     private final DateTimeFormatter formatter;

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
@@ -47,6 +47,7 @@ import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
 import static java.time.format.DateTimeFormatter.ISO_TIME;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.INSTANT_SECONDS;
+import static java.time.temporal.ChronoField.MICRO_OF_DAY;
 import static java.time.temporal.ChronoField.MILLI_OF_DAY;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.util.Objects.requireNonNull;
@@ -111,11 +112,11 @@ public class ISO8601JsonFieldDecoder
                     // Equivalent to: ISO_DATE_TIME.parse(textValue, LocalDateTime::from).toInstant(UTC).toEpochMilli();
                     try {
                         TemporalAccessor parseResult = ISO_OFFSET_DATE_TIME.parse(textValue);
-                        return TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY);
+                        return TimeUnit.DAYS.toMicros(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MICRO_OF_DAY);
                     }
                     catch (DateTimeParseException e) {
                         TemporalAccessor parseResult = ISO_DATE_TIME.parse(textValue);
-                        return TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY);
+                        return TimeUnit.DAYS.toMicros(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MICRO_OF_DAY);
                     }
                 }
                 if (columnType.equals(TIMESTAMP_WITH_TIME_ZONE)) {

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
@@ -35,7 +35,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
@@ -59,7 +59,7 @@ import static java.util.Objects.requireNonNull;
 public class ISO8601JsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
 
@@ -107,7 +107,7 @@ public class ISO8601JsonFieldDecoder
 
             try {
                 String textValue = value.asText();
-                if (columnType.equals(TIMESTAMP)) {
+                if (columnType.equals(TIMESTAMP_MILLIS)) {
                     // Equivalent to: ISO_DATE_TIME.parse(textValue, LocalDateTime::from).toInstant(UTC).toEpochMilli();
                     try {
                         TemporalAccessor parseResult = ISO_OFFSET_DATE_TIME.parse(textValue);

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/MillisecondsSinceEpochJsonFieldDecoder.java
@@ -27,7 +27,7 @@ import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPO
 import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedColumnType;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
 public class MillisecondsSinceEpochJsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
 

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/RFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/RFC2822JsonFieldDecoder.java
@@ -33,7 +33,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
 public class RFC2822JsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE);
 
     /**
      * Todo - configurable time zones and locales.

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/SecondsSinceEpochJsonFieldDecoder.java
@@ -28,7 +28,7 @@ import static io.prestosql.decoder.json.JsonRowDecoderFactory.throwUnsupportedCo
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.lang.Long.parseLong;
 import static java.lang.Math.multiplyExact;
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
 public class SecondsSinceEpochJsonFieldDecoder
         implements JsonFieldDecoder
 {
-    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE);
+    private static final Set<Type> SUPPORTED_TYPES = ImmutableSet.of(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE);
 
     private final DecoderColumnHandle columnHandle;
 

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
@@ -42,8 +42,8 @@ public class TestCustomDateTimeJsonFieldDecoder
     @Test
     public void testDecode()
     {
-        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_MILLIS, 1519032011000L);
-        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_MILLIS, 1519032011000L);
+        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_MILLIS, 1_519_032_011_000_000L);
+        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_MILLIS, 1_519_032_011_000_000L);
         timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, UTC_KEY));
         timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, getTimeZoneKeyForOffset(120))); // TODO: extract TZ from pattern
         timeTester.assertDecodedAs("\"15:13:18\"", TIME, 47_718_000_000_000_000L);

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestCustomDateTimeJsonFieldDecoder.java
@@ -26,7 +26,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,8 +42,8 @@ public class TestCustomDateTimeJsonFieldDecoder
     @Test
     public void testDecode()
     {
-        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP, 1519032011000L);
-        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP, 1519032011000L);
+        timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_MILLIS, 1519032011000L);
+        timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_MILLIS, 1519032011000L);
         timestampTester.assertDecodedAs("\"02/2018/19 9:20:11\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, UTC_KEY));
         timestampWithTimeZoneTester.assertDecodedAs("\"02/2018/19 11:20:11 +02:00\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032011000L, getTimeZoneKeyForOffset(120))); // TODO: extract TZ from pattern
         timeTester.assertDecodedAs("\"15:13:18\"", TIME, 47_718_000_000_000_000L);
@@ -65,8 +65,8 @@ public class TestCustomDateTimeJsonFieldDecoder
         timeTester.assertDecodedAsNull("null", TIME_WITH_TIME_ZONE);
         timeTester.assertMissingDecodedAsNull(TIME_WITH_TIME_ZONE);
 
-        timestampTester.assertDecodedAsNull("null", TIMESTAMP);
-        timestampTester.assertMissingDecodedAsNull(TIMESTAMP);
+        timestampTester.assertDecodedAsNull("null", TIMESTAMP_MILLIS);
+        timestampTester.assertMissingDecodedAsNull(TIMESTAMP_MILLIS);
 
         timestampTester.assertDecodedAsNull("null", TIMESTAMP_WITH_TIME_ZONE);
         timestampTester.assertMissingDecodedAsNull(TIMESTAMP_WITH_TIME_ZONE);
@@ -75,11 +75,11 @@ public class TestCustomDateTimeJsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        timestampTester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"15:13:18\"", TIMESTAMP, "\\Qcould not parse value '15:13:18' as 'timestamp(3)' for column 'some_column'\\E");
-        timestampTester.assertInvalidInput("\"02/2018/11\"", TIMESTAMP, "\\Qcould not parse value '02/2018/11' as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("1", TIMESTAMP_MILLIS, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("{}", TIMESTAMP_MILLIS, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"a\"", TIMESTAMP_MILLIS, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"15:13:18\"", TIMESTAMP_MILLIS, "\\Qcould not parse value '15:13:18' as 'timestamp(3)' for column 'some_column'\\E");
+        timestampTester.assertInvalidInput("\"02/2018/11\"", TIMESTAMP_MILLIS, "\\Qcould not parse value '02/2018/11' as 'timestamp(3)' for column 'some_column'\\E");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class TestCustomDateTimeJsonFieldDecoder
         DecoderTestColumnHandle columnHandle = new DecoderTestColumnHandle(
                 0,
                 "some_column",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 "mappedField",
                 "custom-date-time",
                 "XXMM/yyyy/dd H:m:sXX",

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
@@ -33,9 +33,9 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecode()
     {
-        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", TIMESTAMP_MILLIS, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP_MILLIS, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", TIMESTAMP_MILLIS, 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", TIMESTAMP_MILLIS, 1_519_032_011_000_000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP_MILLIS, 1_519_032_011_000_000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", TIMESTAMP_MILLIS, 1_519_032_011_000_000L);
         tester.assertDecodedAs("\"13:15:18\"", TIME, 47_718_000_000_000_000L);
         tester.assertDecodedAs("\"13:15\"", TIME, 47_700_000_000_000_000L);
         tester.assertDecodedAs("\"13:15:18Z\"", TIME, 47_718_000_000_000_000L);

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestISO8601JsonFieldDecoder.java
@@ -22,7 +22,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.Arrays.asList;
 
@@ -33,9 +33,9 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecode()
     {
-        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", TIMESTAMP, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP, 1519032011000L);
-        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", TIMESTAMP, 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11\"", TIMESTAMP_MILLIS, 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11Z\"", TIMESTAMP_MILLIS, 1519032011000L);
+        tester.assertDecodedAs("\"2018-02-19T09:20:11+10:00\"", TIMESTAMP_MILLIS, 1519032011000L);
         tester.assertDecodedAs("\"13:15:18\"", TIME, 47_718_000_000_000_000L);
         tester.assertDecodedAs("\"13:15\"", TIME, 47_700_000_000_000_000L);
         tester.assertDecodedAs("\"13:15:18Z\"", TIME, 47_718_000_000_000_000L);
@@ -52,7 +52,7 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -61,10 +61,10 @@ public class TestISO8601JsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        tester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("1", TIMESTAMP, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", TIMESTAMP_MILLIS, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("{}", TIMESTAMP_MILLIS, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"a\"", TIMESTAMP_MILLIS, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("1", TIMESTAMP_MILLIS, "\\Qcould not parse value '1' as 'timestamp(3)' for column 'some_column'\\E");
 
         tester.assertInvalidInput("\"2018-02-19T09:20:11\"", DATE, "could not parse value '2018-02-19T09:20:11' as 'date' for column 'some_column'");
         tester.assertInvalidInput("\"2018-02-19T09:20:11Z\"", DATE, "could not parse value '2018-02-19T09:20:11Z' as 'date' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestJsonDecoder.java
@@ -42,7 +42,7 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
@@ -150,14 +150,14 @@ public class TestJsonDecoder
             singleColumnDecoder(DATE, dataFormat);
             singleColumnDecoder(TIME, dataFormat);
             singleColumnDecoder(TIME_WITH_TIME_ZONE, dataFormat);
-            singleColumnDecoder(TIMESTAMP, dataFormat);
+            singleColumnDecoder(TIMESTAMP_MILLIS, dataFormat);
             singleColumnDecoder(TIMESTAMP_WITH_TIME_ZONE, dataFormat);
         }
 
         for (String dataFormat : ImmutableSet.of("seconds-since-epoch", "milliseconds-since-epoch")) {
             singleColumnDecoder(TIME, dataFormat);
             singleColumnDecoder(TIME_WITH_TIME_ZONE, dataFormat);
-            singleColumnDecoder(TIMESTAMP, dataFormat);
+            singleColumnDecoder(TIMESTAMP_MILLIS, dataFormat);
             singleColumnDecoder(TIMESTAMP_WITH_TIME_ZONE, dataFormat);
         }
 
@@ -170,7 +170,7 @@ public class TestJsonDecoder
         assertUnsupportedColumnTypeException(() -> singleColumnDecoder(DATE, null));
         assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TIME, null));
         assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TIME_WITH_TIME_ZONE, null));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TIMESTAMP, null));
+        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TIMESTAMP_MILLIS, null));
         assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TIMESTAMP_WITH_TIME_ZONE, null));
 
         // non temporal types are not supported by temporal field decoders
@@ -201,7 +201,7 @@ public class TestJsonDecoder
     @Test
     public void testDataFormatValidation()
     {
-        for (Type type : asList(TIMESTAMP, DOUBLE)) {
+        for (Type type : asList(TIMESTAMP_MILLIS, DOUBLE)) {
             assertThatThrownBy(() -> singleColumnDecoder(type, "wrong_format"))
                     .isInstanceOf(PrestoException.class)
                     .hasMessage("unknown data format 'wrong_format' used for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
@@ -38,8 +38,8 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701000\"", TIME, 33_701_000_000_000_000L);
         tester.assertDecodedAs("33701000", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
         tester.assertDecodedAs("\"33701000\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
-        tester.assertDecodedAs("1519032101123", TIMESTAMP_MILLIS, 1519032101123L);
-        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_MILLIS, 1519032101123L);
+        tester.assertDecodedAs("1519032101123", TIMESTAMP_MILLIS, 1_519_032_101_123_000L);
+        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_MILLIS, 1_519_032_101_123_000L);
         tester.assertDecodedAs("1519032101123", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestMillisecondsSinceEpochJsonFieldDecoder.java
@@ -23,7 +23,7 @@ import static io.prestosql.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.Arrays.asList;
 
@@ -38,8 +38,8 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701000\"", TIME, 33_701_000_000_000_000L);
         tester.assertDecodedAs("33701000", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
         tester.assertDecodedAs("\"33701000\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
-        tester.assertDecodedAs("1519032101123", TIMESTAMP, 1519032101123L);
-        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP, 1519032101123L);
+        tester.assertDecodedAs("1519032101123", TIMESTAMP_MILLIS, 1519032101123L);
+        tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_MILLIS, 1519032101123L);
         tester.assertDecodedAs("1519032101123", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101123\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101123L, UTC_KEY));
     }
@@ -47,7 +47,7 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -56,7 +56,7 @@ public class TestMillisecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertInvalidInput("{}", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[]", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[10]", type, "could not parse non-value node as '.*' for column 'some_column'");

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
@@ -37,9 +37,9 @@ public class TestRFC2822JsonFieldDecoder
         tester.assertDecodedAs("\"Mon Feb 12 13:15:16 Z 2018\"", DATE, 17574); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME, 47_719_000_000_000_000L); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(47_719_000_000_000L, 0)); // TODO should it be supported really?
-        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_MILLIS, 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_MILLIS, 1_518_182_119_000_000L);
         tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, UTC_KEY));
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_MILLIS, 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_MILLIS, 1_518_182_119_000_000L);
         tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, getTimeZoneKeyForOffset(120)));
     }
 

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestRFC2822JsonFieldDecoder.java
@@ -23,7 +23,7 @@ import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.Arrays.asList;
 
@@ -37,16 +37,16 @@ public class TestRFC2822JsonFieldDecoder
         tester.assertDecodedAs("\"Mon Feb 12 13:15:16 Z 2018\"", DATE, 17574); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME, 47_719_000_000_000_000L); // TODO should it be supported really?
         tester.assertDecodedAs("\"Thu Jan 01 13:15:19 Z 1970\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(47_719_000_000_000L, 0)); // TODO should it be supported really?
-        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP, 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_MILLIS, 1518182119000L);
         tester.assertDecodedAs("\"Fri Feb 09 13:15:19 Z 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, UTC_KEY));
-        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP, 1518182119000L);
+        tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_MILLIS, 1518182119000L);
         tester.assertDecodedAs("\"Fri Feb 09 15:15:19 +02:00 2018\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1518182119000L, getTimeZoneKeyForOffset(120)));
     }
 
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(DATE, TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -55,16 +55,16 @@ public class TestRFC2822JsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        tester.assertInvalidInput("{}", TIMESTAMP, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"a\"", TIMESTAMP, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("2018", TIMESTAMP, "\\Qcould not parse value '2018' as 'timestamp(3)' for column 'some_column'\\E");
-        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 Z\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 12 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon Feb 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Mon 12 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Feb 12 13:15:16 Z 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 Europe/Warsaw 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
-        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 EST 2018\"", TIMESTAMP, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("{}", TIMESTAMP_MILLIS, "\\Qcould not parse non-value node as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"a\"", TIMESTAMP_MILLIS, "\\Qcould not parse value 'a' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("2018", TIMESTAMP_MILLIS, "\\Qcould not parse value '2018' as 'timestamp(3)' for column 'some_column'\\E");
+        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 Z\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 12 13:15:16 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 12 Z 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon Feb 13:15:16 Z 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Mon 12 13:15:16 Z 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Feb 12 13:15:16 Z 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 Europe/Warsaw 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
+        tester.assertInvalidInput("\"Fri Feb 09 13:15:19 EST 2018\"", TIMESTAMP_MILLIS, "could not parse value '.*' as 'timestamp\\(3\\)' for column 'some_column'");
     }
 }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
@@ -38,10 +38,10 @@ public class TestSecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701\"", TIME, 33_701_000_000_000_000L);
         tester.assertDecodedAs("33701", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
         tester.assertDecodedAs("\"33701\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
-        tester.assertDecodedAs("1519032101", TIMESTAMP_MILLIS, 1519032101000L);
-        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_MILLIS, 1519032101000L);
-        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), TIMESTAMP_MILLIS, Long.MAX_VALUE / 1000 * 1000);
-        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), TIMESTAMP_MILLIS, Long.MIN_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("1519032101", TIMESTAMP_MILLIS, 1_519_032_101_000_000L);
+        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_MILLIS, 1_519_032_101_000_000L);
+        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1_000_000), TIMESTAMP_MILLIS, Long.MAX_VALUE / 1_000_000 * 1_000_000);
+        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1_000_000), TIMESTAMP_MILLIS, Long.MIN_VALUE / 1_000_000 * 1_000_000);
         tester.assertDecodedAs("1519032101", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
     }

--- a/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
+++ b/presto-record-decoder/src/test/java/io/prestosql/decoder/json/TestSecondsSinceEpochJsonFieldDecoder.java
@@ -23,7 +23,7 @@ import static io.prestosql.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static java.util.Arrays.asList;
 
@@ -38,10 +38,10 @@ public class TestSecondsSinceEpochJsonFieldDecoder
         tester.assertDecodedAs("\"33701\"", TIME, 33_701_000_000_000_000L);
         tester.assertDecodedAs("33701", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
         tester.assertDecodedAs("\"33701\"", TIME_WITH_TIME_ZONE, packTimeWithTimeZone(33_701_000_000_000L, 0));
-        tester.assertDecodedAs("1519032101", TIMESTAMP, 1519032101000L);
-        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP, 1519032101000L);
-        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), TIMESTAMP, Long.MAX_VALUE / 1000 * 1000);
-        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), TIMESTAMP, Long.MIN_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("1519032101", TIMESTAMP_MILLIS, 1519032101000L);
+        tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_MILLIS, 1519032101000L);
+        tester.assertDecodedAs("" + (Long.MAX_VALUE / 1000), TIMESTAMP_MILLIS, Long.MAX_VALUE / 1000 * 1000);
+        tester.assertDecodedAs("" + (Long.MIN_VALUE / 1000), TIMESTAMP_MILLIS, Long.MIN_VALUE / 1000 * 1000);
         tester.assertDecodedAs("1519032101", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
         tester.assertDecodedAs("\"1519032101\"", TIMESTAMP_WITH_TIME_ZONE, packDateTimeWithZone(1519032101000L, UTC_KEY));
     }
@@ -49,7 +49,7 @@ public class TestSecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeNulls()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertDecodedAsNull("null", type);
             tester.assertMissingDecodedAsNull(type);
         }
@@ -58,7 +58,7 @@ public class TestSecondsSinceEpochJsonFieldDecoder
     @Test
     public void testDecodeInvalid()
     {
-        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE)) {
+        for (Type type : asList(TIME, TIME_WITH_TIME_ZONE, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE)) {
             tester.assertInvalidInput("{}", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[]", type, "could not parse non-value node as '.*' for column 'some_column'");
             tester.assertInvalidInput("[10]", type, "could not parse non-value node as '.*' for column 'some_column'");

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
@@ -30,6 +30,7 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -66,7 +67,7 @@ class ISO8601HashRedisFieldDecoder
                 return MILLISECONDS.toDays(millis);
             }
             if (type.equals(TIMESTAMP_MILLIS)) {
-                return millis;
+                return millis * MICROSECONDS_PER_MILLISECOND;
             }
             if (type.equals(TIME)) {
                 return millis * PICOSECONDS_PER_MILLISECOND;

--- a/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
+++ b/presto-redis/src/main/java/io/prestosql/plugin/redis/decoder/hash/ISO8601HashRedisFieldDecoder.java
@@ -28,7 +28,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKey;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -65,7 +65,7 @@ class ISO8601HashRedisFieldDecoder
             if (type.equals(DATE)) {
                 return MILLISECONDS.toDays(millis);
             }
-            if (type.equals(TIMESTAMP)) {
+            if (type.equals(TIMESTAMP_MILLIS)) {
                 return millis;
             }
             if (type.equals(TIME)) {

--- a/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
+++ b/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
@@ -46,7 +46,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.util.DateTimeUtils.parseLegacyTime;
 import static java.util.Objects.requireNonNull;
@@ -168,8 +168,8 @@ public class RedisLoader
             if (TIME.equals(type)) {
                 return ISO8601_FORMATTER.print(parseLegacyTime(timeZoneKey, (String) value));
             }
-            if (TIMESTAMP.equals(type)) {
-                return ISO8601_FORMATTER.print(castToShortTimestamp(TIMESTAMP.getPrecision(), (String) value));
+            if (TIMESTAMP_MILLIS.equals(type)) {
+                return ISO8601_FORMATTER.print(castToShortTimestamp(TIMESTAMP_MILLIS.getPrecision(), (String) value));
             }
             if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
                 return ISO8601_FORMATTER.print(unpackMillisUtc(DateTimeUtils.convertToTimestampWithTimeZone(timeZoneKey, (String) value)));

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/InMemoryRecordSet.java
@@ -34,7 +34,7 @@ import static io.prestosql.spi.type.Decimals.isLongDecimal;
 import static io.prestosql.spi.type.Decimals.isShortDecimal;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -221,7 +221,7 @@ public class InMemoryRecordSet
                 else if (INTEGER.equals(type)) {
                     checkArgument(value instanceof Integer, "Expected value %s to be an instance of Integer, but is a %s", i, value.getClass().getSimpleName());
                 }
-                else if (BIGINT.equals(type) || DATE.equals(type) || TIMESTAMP.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
+                else if (BIGINT.equals(type) || DATE.equals(type) || TIMESTAMP_MILLIS.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
                     checkArgument(value instanceof Integer || value instanceof Long,
                             "Expected value %d to be an instance of Integer or Long, but is a %s", i, value.getClass().getSimpleName());
                 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/ShortTimestampType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/ShortTimestampType.java
@@ -21,14 +21,13 @@ import io.prestosql.spi.block.PageBuilderStatus;
 import io.prestosql.spi.connector.ConnectorSession;
 
 import static io.prestosql.spi.type.TimestampTypes.hashShortTimestamp;
-import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
 
 /**
  * Encodes timestamps up to p = 6.
  * <p>
- * For 0 <= p <= 3, the value is encoded as milliseconds from the 1970-01-01 00:00:00 epoch.
- * For 3 < p <= 6, the value is encoded as microseconds from the 1970-01-01 00:00:00 epoch.
+ * The value is encoded as microseconds from the 1970-01-01 00:00:00 epoch and is to be interpreted as
+ * local date time without regards to any time zone.
  */
 class ShortTimestampType
         extends TimestampType
@@ -67,29 +66,29 @@ class ShortTimestampType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(getLong(block, position)).closeEntry();
         }
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = getLong(leftBlock, leftPosition);
+        long rightValue = getLong(rightBlock, rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hashShortTimestamp(block.getLong(position, 0));
+        return hashShortTimestamp(getLong(block, position));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = getLong(leftBlock, leftPosition);
+        long rightValue = getLong(rightBlock, rightPosition);
         return Long.compare(leftValue, rightValue);
     }
 
@@ -127,17 +126,7 @@ class ShortTimestampType
             return null;
         }
 
-        long value = block.getLong(position, 0);
-
-        if (getPrecision() <= 3) {
-            value = scaleEpochMillisToMicros(value);
-        }
-
-        return SqlTimestamp.newInstance(getPrecision(), value, 0);
-    }
-
-    private static long scaleEpochMillisToMicros(long epochMillis)
-    {
-        return multiplyExact(epochMillis, 1000);
+        long epochMicros = getLong(block, position);
+        return SqlTimestamp.newInstance(getPrecision(), epochMicros, 0);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimestampParametricType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimestampParametricType.java
@@ -30,7 +30,7 @@ public class TimestampParametricType
     public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
     {
         if (parameters.isEmpty()) {
-            return TimestampType.TIMESTAMP;
+            return TimestampType.TIMESTAMP_MILLIS;
         }
         if (parameters.size() != 1) {
             throw new IllegalArgumentException("Expected exactly one parameter for TIMESTAMP");

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Timestamps.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Timestamps.java
@@ -19,6 +19,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import static io.prestosql.spi.type.TimestampType.MAX_PRECISION;
+import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
@@ -46,6 +47,7 @@ public class Timestamps
     public static final int MILLISECONDS_PER_SECOND = 1_000;
     public static final int MICROSECONDS_PER_MILLISECOND = 1_000;
     public static final int MICROSECONDS_PER_SECOND = 1_000_000;
+    public static final long MICROSECONDS_PER_DAY = 24 * 60 * 60 * 1_000_000L;
     public static final int NANOSECONDS_PER_MICROSECOND = 1_000;
     public static final int NANOSECONDS_PER_MILLISECOND = 1_000_000;
     public static final long NANOSECONDS_PER_SECOND = 1_000_000_000;
@@ -105,9 +107,19 @@ public class Timestamps
         return (value + 1 - (factor / 2)) / factor;
     }
 
+    public static long truncateEpochMicrosToMillis(long epochMicros)
+    {
+        return floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND) * MICROSECONDS_PER_MILLISECOND;
+    }
+
+    public static long epochMicrosToMillisWithRounding(long epochMicros)
+    {
+        return roundDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+    }
+
     static String formatTimestamp(int precision, long epochMicros, int picosOfMicro)
     {
-        Instant instant = Instant.ofEpochSecond(Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND));
+        Instant instant = Instant.ofEpochSecond(floorDiv(epochMicros, MICROSECONDS_PER_SECOND));
         long picoFraction = ((long) floorMod(epochMicros, MICROSECONDS_PER_SECOND)) * PICOSECONDS_PER_MICROSECOND + picosOfMicro;
         LocalDateTime dateTime = LocalDateTime.ofInstant(instant, UTC);
 

--- a/presto-spi/src/test/java/io/prestosql/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/type/TestingTypeManager.java
@@ -27,7 +27,7 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.TestingIdType.ID;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -35,7 +35,7 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 public class TestingTypeManager
         implements TypeManager
 {
-    private static final List<Type> TYPES = ImmutableList.of(BOOLEAN, BIGINT, DOUBLE, INTEGER, VARCHAR, VARBINARY, TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, DATE, ID, HYPER_LOG_LOG);
+    private static final List<Type> TYPES = ImmutableList.of(BOOLEAN, BIGINT, DOUBLE, INTEGER, VARCHAR, VARBINARY, TIMESTAMP_MILLIS, TIMESTAMP_WITH_TIME_ZONE, DATE, ID, HYPER_LOG_LOG);
 
     @Override
     public Type getType(TypeSignature signature)

--- a/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataDateFunctions.java
+++ b/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataDateFunctions.java
@@ -38,6 +38,7 @@ import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.prestosql.spi.type.TimeZoneKey.MAX_TIME_ZONE_KEY;
 import static io.prestosql.spi.type.TimeZoneKey.getTimeZoneKeys;
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.teradata.functions.dateformat.DateFormatParser.createDateTimeFormatter;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -84,7 +85,7 @@ public final class TeradataDateFunctions
             @SqlType(StandardTypes.VARCHAR) Slice dateTime,
             @SqlType(StandardTypes.VARCHAR) Slice formatString)
     {
-        return parseMillis(session, dateTime, formatString);
+        return parseMillis(session, dateTime, formatString) * MICROSECONDS_PER_MILLISECOND;
     }
 
     private static long parseMillis(ConnectorSession session, Slice dateTime, Slice formatString)

--- a/presto-teradata-functions/src/test/java/io/prestosql/teradata/functions/TestTeradataDateFunctions.java
+++ b/presto-teradata-functions/src/test/java/io/prestosql/teradata/functions/TestTeradataDateFunctions.java
@@ -143,7 +143,7 @@ public class TestTeradataDateFunctions
     {
         assertFunction(
                 projection,
-                TimestampType.TIMESTAMP,
+                TimestampType.TIMESTAMP_MILLIS,
                 sqlTimestampOf(3, year, month, day, hour, minutes, seconds, 0));
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestAggregations.java
@@ -718,8 +718,8 @@ public abstract class AbstractTestAggregations
         assertQuery("SELECT approx_distinct(orderdate, 0.023) FROM orders", "SELECT 2443");
 
         // test timestamp
-        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP)) FROM orders", "SELECT 2384");
-        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP), 0.023) FROM orders", "SELECT 2384");
+        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP)) FROM orders", "SELECT 2379");
+        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP), 0.023) FROM orders", "SELECT 2379");
 
         // test timestamp with time zone
         assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP WITH TIME ZONE)) FROM orders", "SELECT 2347");

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
@@ -39,7 +39,7 @@ import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.TimeType.TIME;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.type.JsonType.JSON;
 import static java.lang.String.format;
@@ -189,7 +189,7 @@ public class DataType<T>
     {
         return dataType(
                 "timestamp",
-                TIMESTAMP,
+                TIMESTAMP_MILLIS,
                 DateTimeFormatter.ofPattern("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss.SSS''")::format,
                 identity());
     }

--- a/presto-testing/src/test/java/io/prestosql/testing/TestH2QueryRunner.java
+++ b/presto-testing/src/test/java/io/prestosql/testing/TestH2QueryRunner.java
@@ -24,7 +24,7 @@ import java.time.format.DateTimeFormatter;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static org.testng.Assert.assertEquals;
 
 public class TestH2QueryRunner
@@ -50,13 +50,13 @@ public class TestH2QueryRunner
         // allow running tests with a connector that supports TIMESTAMP but not DATE
 
         // ordinary date
-        MaterializedResult rows = h2QueryRunner.execute(TEST_SESSION, "SELECT DATE '2018-01-13'", ImmutableList.of(TIMESTAMP));
+        MaterializedResult rows = h2QueryRunner.execute(TEST_SESSION, "SELECT DATE '2018-01-13'", ImmutableList.of(TIMESTAMP_MILLIS));
         assertEquals(rows.getOnlyValue(), LocalDate.of(2018, 1, 13).atStartOfDay());
 
         // date, which midnight was skipped in JVM zone
         LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
         checkState(ZoneId.systemDefault().getRules().getValidOffsets(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay()).size() == 0, "This test assumes certain JVM time zone");
-        rows = h2QueryRunner.execute(TEST_SESSION, DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(forwardOffsetChangeAtMidnightInJvmZone), ImmutableList.of(TIMESTAMP));
+        rows = h2QueryRunner.execute(TEST_SESSION, DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(forwardOffsetChangeAtMidnightInJvmZone), ImmutableList.of(TIMESTAMP_MILLIS));
         assertEquals(rows.getOnlyValue(), forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay());
     }
 }

--- a/presto-thrift-api/src/main/java/io/prestosql/plugin/thrift/api/datatypes/PrestoThriftTimestamp.java
+++ b/presto-thrift-api/src/main/java/io/prestosql/plugin/thrift/api/datatypes/PrestoThriftTimestamp.java
@@ -34,7 +34,7 @@ import static io.airlift.drift.annotations.ThriftField.Requiredness.OPTIONAL;
 import static io.prestosql.plugin.thrift.api.PrestoThriftBlock.timestampData;
 import static io.prestosql.plugin.thrift.api.datatypes.PrestoThriftTypeUtils.fromLongBasedBlock;
 import static io.prestosql.plugin.thrift.api.datatypes.PrestoThriftTypeUtils.fromLongBasedColumn;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 
 /**
  * Elements of {@code nulls} array determine if a value for a corresponding row is null.
@@ -76,7 +76,7 @@ public final class PrestoThriftTimestamp
     @Override
     public Block toBlock(Type desiredType)
     {
-        checkArgument(TIMESTAMP.equals(desiredType), "type doesn't match: %s", desiredType);
+        checkArgument(TIMESTAMP_MILLIS.equals(desiredType), "type doesn't match: %s", desiredType);
         int numberOfRecords = numberOfRecords();
         return new LongArrayBlock(
                 numberOfRecords,
@@ -126,7 +126,7 @@ public final class PrestoThriftTimestamp
 
     public static PrestoThriftBlock fromBlock(Block block)
     {
-        return fromLongBasedBlock(block, TIMESTAMP, (nulls, longs) -> timestampData(new PrestoThriftTimestamp(nulls, longs)));
+        return fromLongBasedBlock(block, TIMESTAMP_MILLIS, (nulls, longs) -> timestampData(new PrestoThriftTimestamp(nulls, longs)));
     }
 
     public static PrestoThriftBlock fromRecordSetColumn(RecordSet recordSet, int columnIndex, int totalRecords)

--- a/presto-thrift-api/src/test/java/io/prestosql/plugin/thrift/api/TestReadWrite.java
+++ b/presto-thrift-api/src/test/java/io/prestosql/plugin/thrift/api/TestReadWrite.java
@@ -41,7 +41,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
 import static io.prestosql.type.JsonType.JSON;
@@ -405,19 +405,19 @@ public class TestReadWrite
     {
         public TimestampColumn()
         {
-            super(TIMESTAMP);
+            super(TIMESTAMP_MILLIS);
         }
 
         @Override
         Object extractValue(Block block, int position)
         {
-            return TIMESTAMP.getLong(block, position);
+            return TIMESTAMP_MILLIS.getLong(block, position);
         }
 
         @Override
         void writeNextRandomValue(Random random, BlockBuilder builder)
         {
-            TIMESTAMP.writeLong(builder, nextTimestamp(random));
+            TIMESTAMP_MILLIS.writeLong(builder, nextTimestamp(random));
         }
     }
 


### PR DESCRIPTION
The recent legacy timestamp changes broke compatibility for the
engine-connector interface. We're taking the opportunity to
remove the special encoding for timestamp with p <= 3, which
we added for the sole purpose of maintaining backward compatibility.

This helps simplify all code paths that deal with the short representation
for timestamps.