### PR TITLE
Move noJoinReordering() to AbstractTestQueryFramework

### DIFF
--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -22,10 +22,7 @@ import org.testng.annotations.Test;
 import java.util.stream.Stream;
 
 import static io.prestosql.SystemSessionProperties.IGNORE_STATS_CALCULATOR_FAILURES;
-import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
-import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static io.prestosql.testing.QueryAssertions.assertContains;
 import static io.prestosql.testing.TestngUtils.toDataProvider;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
@@ -210,10 +207,7 @@ public abstract class AbstractTestIntegrationSmokeTest
     @Test(timeOut = 300_000, dataProvider = "joinDistributionTypes")
     public void testJoinWithEmptySides(JoinDistributionType joinDistributionType)
     {
-        Session session = Session.builder(getSession())
-                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, joinDistributionType.toString())
-                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.toString())
-                .build();
+        Session session = noJoinReordering(joinDistributionType);
         // empty build side
         assertQuery(session, "SELECT count(*) FROM nation JOIN region ON nation.regionkey = region.regionkey AND region.name = ''", "VALUES 0");
         assertQuery(session, "SELECT count(*) FROM nation JOIN region ON nation.regionkey = region.regionkey AND region.regionkey < 0", "VALUES 0");

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
@@ -22,8 +22,6 @@ import io.prestosql.tests.QueryTemplate;
 import org.testng.annotations.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
-import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.QueryAssertions.assertEqualsIgnoreOrder;
@@ -2280,13 +2278,5 @@ public abstract class AbstractTestJoinQueries
                         "WHERE lineitem.orderkey = 31718 " +
                         "AND customer.name >= 'Customer#000001463' ",
                 "VALUES 3");
-    }
-
-    private Session noJoinReordering()
-    {
-        return Session.builder(getSession())
-                .setSystemProperty(JOIN_REORDERING_STRATEGY, FeaturesConfig.JoinReorderingStrategy.NONE.name())
-                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.PARTITIONED.name())
-                .build();
     }
 }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -29,6 +29,7 @@ import io.prestosql.metadata.Metadata;
 import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.analyzer.FeaturesConfig;
+import io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import io.prestosql.sql.analyzer.QueryExplainer;
 import io.prestosql.sql.parser.SqlParser;
 import io.prestosql.sql.planner.Plan;
@@ -58,6 +59,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
+import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.sql.ParsingUtil.createParsingOptions;
 import static io.prestosql.sql.SqlFormatter.formatSql;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
@@ -401,5 +404,18 @@ public abstract class AbstractTestQueryFramework
     {
         checkState(queryRunner != null, "queryRunner not set");
         return queryRunner;
+    }
+
+    protected Session noJoinReordering()
+    {
+        return noJoinReordering(JoinDistributionType.PARTITIONED);
+    }
+
+    protected Session noJoinReordering(JoinDistributionType distributionType)
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, FeaturesConfig.JoinReorderingStrategy.NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, distributionType.name())
+                .build();
     }
 }


### PR DESCRIPTION
Move noJoinReordering() to AbstractTestQueryFramework
