### PR TITLE
Fix IndexOutOfBounds non-nested-loop joins with no columns on build side

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/PagesIndex.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PagesIndex.java
@@ -237,7 +237,7 @@ public class PagesIndex
 
     public void compact()
     {
-        if (eagerCompact) {
+        if (eagerCompact || channels.length == 0) {
             return;
         }
         for (int channel = 0; channel < types.size(); channel++) {

--- a/presto-main/src/main/java/io/prestosql/operator/PagesIndex.java
+++ b/presto-main/src/main/java/io/prestosql/operator/PagesIndex.java
@@ -35,6 +35,7 @@ import io.prestosql.sql.gen.JoinCompiler.LookupSourceSupplierFactory;
 import io.prestosql.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import io.prestosql.sql.gen.OrderingCompiler;
 import it.unimi.dsi.fastutil.Swapper;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.openjdk.jol.info.ClassLayout;
@@ -84,8 +85,10 @@ public class PagesIndex
     private final List<Type> types;
     private final LongArrayList valueAddresses;
     private final ObjectArrayList<Block>[] channels;
+    private final IntArrayList positionCounts;
     private final boolean eagerCompact;
 
+    private int pageCount;
     private int nextBlockToCompact;
     private int positionCount;
     private long pagesMemorySize;
@@ -111,6 +114,8 @@ public class PagesIndex
         for (int i = 0; i < channels.length; i++) {
             channels[i] = ObjectArrayList.wrap(new Block[1024], 0);
         }
+
+        positionCounts = new IntArrayList(1024);
 
         estimatedSize = calculateEstimatedSize();
     }
@@ -206,7 +211,9 @@ public class PagesIndex
             return;
         }
 
+        pageCount++;
         positionCount += page.getPositionCount();
+        positionCounts.add(page.getPositionCount());
 
         int pageIndex = (channels.length > 0) ? channels[0].size() : 0;
         for (int i = 0; i < channels.length; i++) {
@@ -261,7 +268,8 @@ public class PagesIndex
         long elementsSize = (channels.length > 0) ? sizeOf(channels[0].elements()) : 0;
         long channelsArraySize = elementsSize * channels.length;
         long addressesArraySize = sizeOf(valueAddresses.elements());
-        return INSTANCE_SIZE + pagesMemorySize + channelsArraySize + addressesArraySize;
+        long positionCountsSize = sizeOf(positionCounts.elements());
+        return INSTANCE_SIZE + pagesMemorySize + channelsArraySize + addressesArraySize + positionCountsSize;
     }
 
     public Type getType(int channel)
@@ -542,20 +550,22 @@ public class PagesIndex
     {
         return new AbstractIterator<>()
         {
-            private int pageCounter;
+            private int currentPage;
 
             @Override
             protected Page computeNext()
             {
-                if (pageCounter == channels[0].size()) {
+                if (currentPage == pageCount) {
                     return endOfData();
                 }
 
+                int positions = positionCounts.getInt(currentPage);
                 Block[] blocks = Stream.of(channels)
-                        .map(channel -> channel.get(pageCounter))
+                        .map(channel -> channel.get(currentPage))
                         .toArray(Block[]::new);
-                pageCounter++;
-                return new Page(blocks);
+
+                currentPage++;
+                return new Page(positions, blocks);
             }
         };
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
@@ -19,6 +19,7 @@ import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import static io.prestosql.SequencePageBuilder.createSequencePage;
@@ -26,6 +27,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestPagesIndex
@@ -92,6 +94,19 @@ public class TestPagesIndex
         index.compact();
 
         assertEquals(index.getPositionCount(), 30);
+    }
+
+    @Test
+    public void testGetPagesWithNoColumns()
+    {
+        PagesIndex index = newPagesIndex(ImmutableList.of(), 50, false);
+        index.addPage(new Page(10));
+        index.addPage(new Page(20));
+
+        Iterator<Page> pages = index.getPages();
+        assertEquals(pages.next().getPositionCount(), 10);
+        assertEquals(pages.next().getPositionCount(), 20);
+        assertFalse(pages.hasNext());
     }
 
     private static PagesIndex newPagesIndex(List<Type> types, int expectedPositions, boolean eagerCompact)

--- a/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestPagesIndex.java
@@ -82,6 +82,18 @@ public class TestPagesIndex
         assertEquals(lazyCompactPagesIndex.getEstimatedSize(), eagerCompactPagesIndex.getEstimatedSize());
     }
 
+    @Test
+    public void testCompactWithNoColumns()
+    {
+        PagesIndex index = newPagesIndex(ImmutableList.of(), 50, false);
+        index.addPage(new Page(10));
+        index.addPage(new Page(20));
+
+        index.compact();
+
+        assertEquals(index.getPositionCount(), 30);
+    }
+
     private static PagesIndex newPagesIndex(List<Type> types, int expectedPositions, boolean eagerCompact)
     {
         return new PagesIndex.TestingFactory(eagerCompact).newPagesIndex(types, expectedPositions);


### PR DESCRIPTION
Queries that involve an outer join or are pure non-equi joins get planned
as regular lookup joins. If the right side doesn't contain any columns (i.e.,
due to column pruning), calls to PagesIndex.compact() will fail with
ArrayIndexOutOfBounds -- this can happen if there's not enough local memory
available and the operator attempts to optimize the organization of the
PagesIndex.