### PR TITLE
Attach product test execution to existing environment

### DIFF
--- a/presto-product-tests-launcher/pom.xml
+++ b/presto-product-tests-launcher/pom.xml
@@ -64,6 +64,12 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
+
+        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>
         </dependency>

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
@@ -95,4 +95,9 @@ public class DockerContainer
             throw new IllegalArgumentException("Host path does not exist: " + hostPath);
         }
     }
+
+    public void clearDependencies()
+    {
+        dependencies.clear();
+    }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/testcontainers/ExistingNetwork.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/testcontainers/ExistingNetwork.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.testcontainers;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testcontainers.containers.Network;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ExistingNetwork
+        implements Network
+{
+    private final String networkId;
+
+    public ExistingNetwork(String networkId)
+    {
+        this.networkId = requireNonNull(networkId, "networkId is null");
+    }
+
+    @Override
+    public String getId()
+    {
+        return networkId;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public Statement apply(Statement statement, Description description)
+    {
+        // junit4 integration
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Allow running product tests against environment brought up with `env
up`.

1. start environment with `env up`
2. run tests with `test run`, adding `--attach` parameter

Fixes https://github.com/prestosql/presto/issues/4911