### PR TITLE
Allow to configure insert into Hive partition via configuration property

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -217,6 +217,20 @@ Property Name                                      Description                  
                                                    format or the default Presto format?
 
 ``hive.immutable-partitions``                      Can new data be inserted into existing partitions?           ``false``
+                                                   If ``true`` then setting
+                                                   ``hive.insert-existing-partitions-behavior`` to ``APPEND``
+                                                   is not allowed.
+                                                   This also affects the
+                                                   ``insert_existing_partitions_behavior``
+                                                   session property in the same way.
+
+``hive.insert-existing-partitions-behavior``       What happens when data is inserted into an existing          ``APPEND``
+                                                   partition?
+                                                   Possible values are
+
+                                                   * ``APPEND`` - appends data to existing partitions
+                                                   * ``OVERWRITE`` - overwrites existing partitions
+                                                   * ``ERROR`` - modifying existing partitions is not allowed
 
 ``hive.create-empty-bucket-files``                 Should empty files be created for buckets that have no data? ``false``
 

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveHadoop2Plugin.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveHadoop2Plugin.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.qubole.rubix.core.CachingFileSystem;
 import io.prestosql.spi.Plugin;
+import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.testing.TestingConnectorContext;
 import org.testng.annotations.AfterClass;
@@ -31,7 +32,10 @@ import java.nio.file.Path;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.APPEND;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.ERROR;
 import static java.nio.file.Files.createTempDirectory;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveHadoop2Plugin
@@ -97,6 +101,65 @@ public class TestHiveHadoop2Plugin
                 new TestingConnectorContext())
                 .shutdown())
                 .hasMessageContaining("Use of GCS access token is not compatible with Hive caching");
+    }
+
+    @Test
+    public void testImmutablePartitionsAndInsertOverwriteMutuallyExclusive()
+    {
+        Plugin plugin = new HiveHadoop2Plugin();
+        ConnectorFactory connectorFactory = Iterables.getOnlyElement(plugin.getConnectorFactories());
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.insert-existing-partitions-behavior", "APPEND")
+                        .put("hive.immutable-partitions", "true")
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .build(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("insert-existing-partitions-behavior cannot be APPEND when immutable-partitions is true");
+    }
+
+    @Test
+    public void testInsertOverwriteIsSetToErrorWhenImmutablePartitionsIsTrue()
+    {
+        Plugin plugin = new HiveHadoop2Plugin();
+        ConnectorFactory connectorFactory = Iterables.getOnlyElement(plugin.getConnectorFactories());
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.immutable-partitions", "true")
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .build(),
+                new TestingConnectorContext());
+
+        assertThat(getDefaultValueInsertExistingPartitionsBehavior(connector)).isEqualTo(ERROR);
+    }
+
+    @Test
+    public void testInsertOverwriteIsSetToAppendWhenImmutablePartitionsIsFalseByDefault()
+    {
+        Plugin plugin = new HiveHadoop2Plugin();
+        ConnectorFactory connectorFactory = Iterables.getOnlyElement(plugin.getConnectorFactories());
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .build(),
+                new TestingConnectorContext());
+
+        assertThat(getDefaultValueInsertExistingPartitionsBehavior(connector)).isEqualTo(APPEND);
+    }
+
+    private Object getDefaultValueInsertExistingPartitionsBehavior(Connector connector)
+    {
+        return connector.getSessionProperties().stream()
+                .filter(propertyMetadata -> "insert_existing_partitions_behavior".equals(propertyMetadata.getName()))
+                .findAny()
+                .orElseThrow()
+                .getDefaultValue();
     }
 
     @Test

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -23,9 +23,11 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
+import io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -35,6 +37,8 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.APPEND;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.ERROR;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -80,6 +84,7 @@ public class HiveConfig
     private HiveCompressionCodec hiveCompressionCodec = HiveCompressionCodec.GZIP;
     private boolean respectTableFormat = true;
     private boolean immutablePartitions;
+    private Optional<InsertExistingPartitionsBehavior> insertExistingPartitionsBehavior = Optional.empty();
     private boolean createEmptyBucketFiles;
     private int maxPartitionsPerWriter = 100;
     private int maxOpenSortFiles = 50;
@@ -450,6 +455,27 @@ public class HiveConfig
     {
         this.immutablePartitions = immutablePartitions;
         return this;
+    }
+
+    public InsertExistingPartitionsBehavior getInsertExistingPartitionsBehavior()
+    {
+        return insertExistingPartitionsBehavior.orElse(immutablePartitions ? ERROR : APPEND);
+    }
+
+    @Config("hive.insert-existing-partitions-behavior")
+    @ConfigDescription("Default value for insert existing partitions behavior")
+    public HiveConfig setInsertExistingPartitionsBehavior(InsertExistingPartitionsBehavior insertExistingPartitionsBehavior)
+    {
+        this.insertExistingPartitionsBehavior = Optional.ofNullable(insertExistingPartitionsBehavior);
+        return this;
+    }
+
+    @AssertTrue(message = "insert-existing-partitions-behavior cannot be APPEND when immutable-partitions is true")
+    public boolean isInsertExistingPartitionsBehaviorValid()
+    {
+        return insertExistingPartitionsBehavior
+                .map(v -> InsertExistingPartitionsBehavior.isValid(v, immutablePartitions))
+                .orElse(true);
     }
 
     public boolean isCreateEmptyBucketFiles()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSinkProvider.java
@@ -61,7 +61,6 @@ public class HivePageSinkProvider
     private final int maxOpenPartitions;
     private final int maxOpenSortFiles;
     private final DataSize writerSortBufferSize;
-    private final boolean immutablePartitions;
     private final LocationService locationService;
     private final ListeningExecutorService writeVerificationExecutor;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
@@ -97,7 +96,6 @@ public class HivePageSinkProvider
         this.maxOpenPartitions = config.getMaxPartitionsPerWriter();
         this.maxOpenSortFiles = config.getMaxOpenSortFiles();
         this.writerSortBufferSize = requireNonNull(config.getWriterSortBufferSize(), "writerSortBufferSize is null");
-        this.immutablePartitions = config.isImmutablePartitions();
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.writeVerificationExecutor = listeningDecorator(newFixedThreadPool(config.getWriteValidationThreads(), daemonThreadsNamed("hive-write-validation-%s")));
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
@@ -157,7 +155,6 @@ public class HivePageSinkProvider
                 pageSorter,
                 writerSortBufferSize,
                 maxOpenSortFiles,
-                immutablePartitions,
                 parquetTimeZone,
                 session,
                 nodeManager,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -81,6 +81,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_TABLE_READ_ONLY;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getCompressionCodec;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getInsertExistingPartitionsBehavior;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getTemporaryStagingDirectoryPath;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isTemporaryStagingDirectoryEnabled;
 import static io.prestosql.plugin.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
@@ -200,10 +201,7 @@ public class HiveWriterFactory
         this.sortedWritingTempStagingPathEnabled = isTemporaryStagingDirectoryEnabled(session);
         this.sortedWritingTempStagingPath = getTemporaryStagingDirectoryPath(session);
         this.immutablePartitions = immutablePartitions;
-        this.insertExistingPartitionsBehavior = HiveSessionProperties.getInsertExistingPartitionsBehavior(session);
-        if (immutablePartitions) {
-            checkArgument(insertExistingPartitionsBehavior != InsertExistingPartitionsBehavior.APPEND, "insertExistingPartitionsBehavior cannot be APPEND");
-        }
+        this.insertExistingPartitionsBehavior = getInsertExistingPartitionsBehavior(session);
         this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
 
         // divide input columns into partition and data columns

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -136,7 +136,6 @@ public class HiveWriterFactory
     private final int maxOpenSortFiles;
     private final boolean sortedWritingTempStagingPathEnabled;
     private final String sortedWritingTempStagingPath;
-    private final boolean immutablePartitions;
     private final InsertExistingPartitionsBehavior insertExistingPartitionsBehavior;
     private final DateTimeZone parquetTimeZone;
 
@@ -171,7 +170,6 @@ public class HiveWriterFactory
             PageSorter pageSorter,
             DataSize sortBufferSize,
             int maxOpenSortFiles,
-            boolean immutablePartitions,
             DateTimeZone parquetTimeZone,
             ConnectorSession session,
             NodeManager nodeManager,
@@ -200,7 +198,6 @@ public class HiveWriterFactory
         this.maxOpenSortFiles = maxOpenSortFiles;
         this.sortedWritingTempStagingPathEnabled = isTemporaryStagingDirectoryEnabled(session);
         this.sortedWritingTempStagingPath = getTemporaryStagingDirectoryPath(session);
-        this.immutablePartitions = immutablePartitions;
         this.insertExistingPartitionsBehavior = getInsertExistingPartitionsBehavior(session);
         this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
 
@@ -351,7 +348,6 @@ public class HiveWriterFactory
                 else {
                     switch (insertExistingPartitionsBehavior) {
                         case APPEND:
-                            checkState(!immutablePartitions);
                             updateMode = UpdateMode.APPEND;
                             writeInfo = locationService.getTableWriteInfo(locationHandle, false);
                             break;
@@ -382,7 +378,6 @@ public class HiveWriterFactory
             // Write to: an existing partition in an existing partitioned table
             if (insertExistingPartitionsBehavior == InsertExistingPartitionsBehavior.APPEND) {
                 // Append to an existing partition
-                checkState(!immutablePartitions);
                 updateMode = UpdateMode.APPEND;
                 // Check the column types in partition schema match the column types in table schema
                 List<Column> tableColumns = table.getDataColumns();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.APPEND;
+import static io.prestosql.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.OVERWRITE;
 import static io.prestosql.plugin.hive.util.TestHiveUtil.nonDefaultTimeZone;
 
 public class TestHiveConfig
@@ -58,6 +60,7 @@ public class TestHiveConfig
                 .setHiveCompressionCodec(HiveCompressionCodec.GZIP)
                 .setRespectTableFormat(true)
                 .setImmutablePartitions(false)
+                .setInsertExistingPartitionsBehavior(APPEND)
                 .setCreateEmptyBucketFiles(false)
                 .setSortedWritingEnabled(true)
                 .setMaxPartitionsPerWriter(100)
@@ -124,6 +127,7 @@ public class TestHiveConfig
                 .put("hive.compression-codec", "NONE")
                 .put("hive.respect-table-format", "false")
                 .put("hive.immutable-partitions", "true")
+                .put("hive.insert-existing-partitions-behavior", "OVERWRITE")
                 .put("hive.create-empty-bucket-files", "true")
                 .put("hive.max-partitions-per-writers", "222")
                 .put("hive.max-open-sort-files", "333")
@@ -193,6 +197,7 @@ public class TestHiveConfig
                 .setHiveCompressionCodec(HiveCompressionCodec.NONE)
                 .setRespectTableFormat(false)
                 .setImmutablePartitions(true)
+                .setInsertExistingPartitionsBehavior(OVERWRITE)
                 .setCreateEmptyBucketFiles(true)
                 .setMaxPartitionsPerWriter(222)
                 .setMaxOpenSortFiles(333)


### PR DESCRIPTION
Allow to set default value for hive.insert_existing_partitions_behavior property
