### PR TITLE
Reuse s/SuiteConfig/EnvironmentConfig with env commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,5 +263,5 @@ jobs:
       - name: Product Tests
         run: |
           export PTL_BIND_PORTS=false &&
-          presto-product-tests-launcher/bin/run-launcher suite run --suite ${{ matrix.suite }} --suite-config ${{ matrix.config }}
+          presto-product-tests-launcher/bin/run-launcher suite run --suite ${{ matrix.suite }} --config ${{ matrix.config }}
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
@@ -39,9 +39,6 @@ public final class EnvironmentList
 {
     private final Module additionalEnvironments;
 
-    @Inject
-    public EnvironmentOptions environmentOptions = new EnvironmentOptions();
-
     public EnvironmentList(Extensions extensions)
     {
         this.additionalEnvironments = requireNonNull(extensions, "extensions is null").getAdditionalEnvironments();
@@ -53,8 +50,7 @@ public final class EnvironmentList
         runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
-                        .add(new EnvironmentModule(additionalEnvironments))
-                        .add(environmentOptions.toModule())
+                        .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
                         .build(),
                 EnvironmentList.Execution.class);
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
@@ -18,6 +18,7 @@ import com.google.inject.Module;
 import io.airlift.airline.Command;
 import io.prestosql.tests.product.launcher.Extensions;
 import io.prestosql.tests.product.launcher.LauncherModule;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
@@ -60,11 +61,13 @@ public final class EnvironmentList
     {
         private final PrintStream out;
         private final EnvironmentFactory factory;
+        private final EnvironmentConfigFactory configFactory;
 
         @Inject
-        public Execution(EnvironmentFactory factory)
+        public Execution(EnvironmentFactory factory, EnvironmentConfigFactory configFactory)
         {
             this.factory = requireNonNull(factory, "factory is null");
+            this.configFactory = requireNonNull(configFactory, "configFactory is null");
 
             try {
                 this.out = new PrintStream(new FileOutputStream(FileDescriptor.out), true, Charset.defaultCharset().name());
@@ -78,8 +81,10 @@ public final class EnvironmentList
         public void run()
         {
             out.println("Available environments: ");
-
             this.factory.list().forEach(out::println);
+
+            out.println("\nAvailable environment configs: ");
+            this.configFactory.listConfigs().forEach(out::println);
         }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -66,8 +66,7 @@ public final class EnvironmentUp
         runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
-                        .add(new EnvironmentModule(additionalEnvironments))
-                        .add(environmentOptions.toModule())
+                        .add(new EnvironmentModule(environmentOptions, additionalEnvironments))
                         .add(environmentUpOptions.toModule())
                         .build(),
                 EnvironmentUp.Execution.class);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
@@ -23,6 +23,7 @@ import io.prestosql.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.suite.SuiteFactory;
+import io.prestosql.tests.product.launcher.suite.SuiteModule;
 
 import javax.inject.Inject;
 
@@ -40,10 +41,12 @@ public final class SuiteList
         implements Runnable
 {
     private final Module additionalEnvironments;
+    private final Module additionalSuites;
 
     public SuiteList(Extensions extensions)
     {
         this.additionalEnvironments = requireNonNull(extensions, "extensions is null").getAdditionalEnvironments();
+        this.additionalSuites = requireNonNull(extensions, "extensions is null").getAdditionalSuites();
     }
 
     @Override
@@ -53,6 +56,7 @@ public final class SuiteList
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
                         .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
+                        .add(new SuiteModule(additionalSuites))
                         .build(),
                 SuiteList.Execution.class);
     }
@@ -84,7 +88,7 @@ public final class SuiteList
             out.println("Available suites: ");
             this.suiteFactory.listSuites().forEach(out::println);
 
-            out.println("\nAvailable environment configuration profiles: ");
+            out.println("\nAvailable environment configs: ");
             this.configFactory.listConfigs().forEach(out::println);
         }
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
@@ -21,6 +21,7 @@ import io.prestosql.tests.product.launcher.Extensions;
 import io.prestosql.tests.product.launcher.LauncherModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
+import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.suite.SuiteFactory;
 
 import javax.inject.Inject;
@@ -51,7 +52,7 @@ public final class SuiteList
         runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
-                        .add(new EnvironmentModule(additionalEnvironments))
+                        .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
                         .build(),
                 SuiteList.Execution.class);
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
@@ -24,11 +24,12 @@ import io.airlift.units.Duration;
 import io.prestosql.tests.product.launcher.Extensions;
 import io.prestosql.tests.product.launcher.LauncherModule;
 import io.prestosql.tests.product.launcher.PathResolver;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteFactory;
 import io.prestosql.tests.product.launcher.suite.SuiteModule;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
@@ -71,25 +72,25 @@ public class SuiteRun
     @Override
     public void run()
     {
-        Module suiteModule = new SuiteModule(additionalSuites);
-        SuiteConfig config = getSuiteConfig(suiteModule, suiteRunOptions.config);
+        Module environmentModule = new EnvironmentModule(additionalEnvironments);
+        EnvironmentConfig config = getEnvironmentConfig(environmentModule, suiteRunOptions.config);
 
         runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
-                        .add(suiteModule)
-                        .add(new EnvironmentModule(additionalEnvironments))
+                        .add(new SuiteModule(additionalSuites))
+                        .add(environmentModule)
                         .add(suiteRunOptions.toModule())
                         .add(applySuiteConfig(environmentOptions, config).toModule())
                         .build(),
                 SuiteRun.Execution.class);
     }
 
-    private static SuiteConfig getSuiteConfig(Module suiteModule, String configName)
+    private static EnvironmentConfig getEnvironmentConfig(Module environmentModule, String configName)
     {
-        Injector injector = Guice.createInjector(suiteModule);
-        SuiteFactory instance = injector.getInstance(SuiteFactory.class);
-        return instance.getSuiteConfig(configName);
+        Injector injector = Guice.createInjector(environmentModule);
+        EnvironmentConfigFactory instance = injector.getInstance(EnvironmentConfigFactory.class);
+        return instance.getConfig(configName);
     }
 
     public static class SuiteRunOptions
@@ -97,7 +98,7 @@ public class SuiteRun
         @Option(name = "--suite", title = "suite", description = "the name of the suite to run", required = true)
         public String suite;
 
-        @Option(name = "--suite-config", title = "suite-config", description = "the name of the suite config to use")
+        @Option(name = "--config", title = "config", description = "the name of the environment config to use")
         public String config = "config-default";
 
         @Option(name = "--test-jar", title = "test jar", description = "path to test jar")
@@ -117,15 +118,23 @@ public class SuiteRun
         private final PathResolver pathResolver;
         private final SuiteFactory suiteFactory;
         private final EnvironmentFactory environmentFactory;
+        private final EnvironmentConfigFactory configFactory;
 
         @Inject
-        public Execution(SuiteRunOptions suiteRunOptions, EnvironmentOptions environmentOptions, PathResolver pathResolver, SuiteFactory suiteFactory, EnvironmentFactory environmentFactory)
+        public Execution(
+                SuiteRunOptions suiteRunOptions,
+                EnvironmentOptions environmentOptions,
+                PathResolver pathResolver,
+                SuiteFactory suiteFactory,
+                EnvironmentFactory environmentFactory,
+                EnvironmentConfigFactory configFactory)
         {
             this.suiteRunOptions = requireNonNull(suiteRunOptions, "suiteRunOptions is null");
             this.environmentOptions = requireNonNull(environmentOptions, "environmentOptions is null");
             this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
             this.suiteFactory = requireNonNull(suiteFactory, "suiteFactory is null");
             this.environmentFactory = requireNonNull(environmentFactory, "environmentFactory is null");
+            this.configFactory = requireNonNull(configFactory, "configFactory is null");
         }
 
         @Override
@@ -134,10 +143,10 @@ public class SuiteRun
             String suiteName = requireNonNull(suiteRunOptions.suite, "suiteRunOptions.suite is null");
 
             Suite suite = suiteFactory.getSuite(suiteName);
-            SuiteConfig suiteConfig = suiteFactory.getSuiteConfig(suiteRunOptions.config);
-            List<SuiteTestRun> suiteTestRuns = suite.getTestRuns(suiteConfig);
+            EnvironmentConfig environmentConfig = configFactory.getConfig(suiteRunOptions.config);
+            List<SuiteTestRun> suiteTestRuns = suite.getTestRuns(environmentConfig);
 
-            log.info("Starting suite '%s' with config '%s' and test runs: ", suiteName, suiteConfig.getConfigName());
+            log.info("Starting suite '%s' with config '%s' and test runs: ", suiteName, environmentConfig.getConfigName());
             suiteTestRuns.forEach(job ->
                     log.info(" * environment '%s': groups: %s, excluded groups: %s, tests: %s, excluded tests: %s",
                             job.getEnvironmentName(), job.getGroups(), job.getExcludedGroups(), job.getTests(), job.getExcludedTests()));
@@ -146,7 +155,7 @@ public class SuiteRun
             ImmutableList.Builder<TestRunResult> results = ImmutableList.builder();
 
             for (SuiteTestRun testRun : suiteTestRuns) {
-                results.add(executeSuiteTestRun(suiteName, testRun, suiteConfig));
+                results.add(executeSuiteTestRun(suiteName, testRun, environmentConfig));
             }
 
             List<TestRunResult> testRunsResults = results.build();
@@ -174,32 +183,32 @@ public class SuiteRun
             results.forEach(result -> log.info(" * '%s' %s in %s", result.getSuiteRun(), result.isSuccessful() ? "PASSED" : "FAILED", result.getDuration()));
         }
 
-        public TestRunResult executeSuiteTestRun(String suiteName, SuiteTestRun suiteTestRun, SuiteConfig suiteConfig)
+        public TestRunResult executeSuiteTestRun(String suiteName, SuiteTestRun suiteTestRun, EnvironmentConfig environmentConfig)
         {
-            log.info("Starting test run %s with config %s", suiteTestRun, suiteConfig);
+            log.info("Starting test run %s with config %s", suiteTestRun, environmentConfig);
             long startTime = System.nanoTime();
 
             Throwable t = null;
             try {
-                TestRun.TestRunOptions testRunOptions = createTestRunOptions(suiteName, suiteTestRun, suiteConfig);
+                TestRun.TestRunOptions testRunOptions = createTestRunOptions(suiteName, suiteTestRun, environmentConfig);
                 log.info("Execute this test run using:\npresto-product-tests-launcher/bin/run-launcher test run %s", OptionsPrinter.format(environmentOptions, testRunOptions));
-                new TestRun.Execution(environmentFactory, pathResolver, environmentOptions, testRunOptions, suiteConfig.extendEnvironment(suiteTestRun.getEnvironment())).run();
+                new TestRun.Execution(environmentFactory, pathResolver, environmentOptions, testRunOptions, environmentConfig.extendEnvironment(suiteTestRun.getEnvironment())).run();
             }
             catch (Exception e) {
                 t = e;
                 log.error("Failed to execute test run %s", suiteTestRun, e);
             }
 
-            return new TestRunResult(suiteTestRun, suiteConfig, nanosSince(startTime), Optional.ofNullable(t));
+            return new TestRunResult(suiteTestRun, environmentConfig, nanosSince(startTime), Optional.ofNullable(t));
         }
 
-        private TestRun.TestRunOptions createTestRunOptions(String suiteName, SuiteTestRun suiteTestRun, SuiteConfig suiteConfig)
+        private TestRun.TestRunOptions createTestRunOptions(String suiteName, SuiteTestRun suiteTestRun, EnvironmentConfig environmentConfig)
         {
             TestRun.TestRunOptions testRunOptions = new TestRun.TestRunOptions();
             testRunOptions.environment = suiteTestRun.getEnvironmentName();
-            testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments(suiteConfig);
+            testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments(environmentConfig);
             testRunOptions.testJar = pathResolver.resolvePlaceholders(suiteRunOptions.testJar);
-            testRunOptions.reportsDir = format("presto-product-tests/target/%s/%s/%s", suiteName, suiteConfig.getConfigName(), suiteTestRun.getEnvironmentName());
+            testRunOptions.reportsDir = format("presto-product-tests/target/%s/%s/%s", suiteName, environmentConfig.getConfigName(), suiteTestRun.getEnvironmentName());
             return testRunOptions;
         }
     }
@@ -207,14 +216,14 @@ public class SuiteRun
     private static class TestRunResult
     {
         private final SuiteTestRun suiteRun;
-        private final SuiteConfig suiteConfig;
+        private final EnvironmentConfig environmentConfig;
         private final Duration duration;
         private final Optional<Throwable> throwable;
 
-        public TestRunResult(SuiteTestRun suiteRun, SuiteConfig suiteConfig, Duration duration, Optional<Throwable> throwable)
+        public TestRunResult(SuiteTestRun suiteRun, EnvironmentConfig environmentConfig, Duration duration, Optional<Throwable> throwable)
         {
             this.suiteRun = requireNonNull(suiteRun, "suiteRun is null");
-            this.suiteConfig = requireNonNull(suiteConfig, "suiteConfig is null");
+            this.environmentConfig = requireNonNull(environmentConfig, "suiteConfig is null");
             this.duration = requireNonNull(duration, "duration is null");
             this.throwable = requireNonNull(throwable, "throwable is null");
         }
@@ -224,9 +233,9 @@ public class SuiteRun
             return this.suiteRun;
         }
 
-        public SuiteConfig getSuiteConfig()
+        public EnvironmentConfig getSuiteConfig()
         {
-            return this.suiteConfig;
+            return this.environmentConfig;
         }
 
         public Duration getDuration()
@@ -254,7 +263,7 @@ public class SuiteRun
         {
             return toStringHelper(this)
                     .add("suiteRun", suiteRun)
-                    .add("suiteConfig", suiteConfig)
+                    .add("suiteConfig", environmentConfig)
                     .add("duration", duration)
                     .add("throwable", throwable)
                     .toString();

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfig.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfig.java
@@ -46,7 +46,7 @@ public interface EnvironmentConfig
         return nameForConfigClass(getClass());
     }
 
-    default Optional<EnvironmentExtender> extendEnvironment(Class<? extends EnvironmentProvider> environment)
+    default Optional<EnvironmentExtender> extendEnvironment(String environmentName)
     {
         return Optional.empty();
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfig.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfig.java
@@ -11,18 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.tests.product.launcher.suite;
+package io.prestosql.tests.product.launcher.env;
 
 import com.google.common.collect.ImmutableList;
-import io.prestosql.tests.product.launcher.env.EnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.EnvironmentExtender;
 
 import java.util.List;
 import java.util.Optional;
 
-import static io.prestosql.tests.product.launcher.suite.Suites.nameForConfigClass;
+import static io.prestosql.tests.product.launcher.env.Environments.nameForConfigClass;
 
-public interface SuiteConfig
+public interface EnvironmentConfig
 {
     String getImagesVersion();
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfigFactory.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfigFactory.java
@@ -11,36 +11,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.tests.product.launcher.suite;
+package io.prestosql.tests.product.launcher.env;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
-
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
 
-public final class SuiteFactory
+public class EnvironmentConfigFactory
 {
-    private final Map<String, Suite> suiteProviders;
+    private final Map<String, EnvironmentConfig> configurations;
 
     @Inject
-    public SuiteFactory(Map<String, Suite> suiteProviders)
+    public EnvironmentConfigFactory(Map<String, EnvironmentConfig> configurations)
     {
-        this.suiteProviders = requireNonNull(suiteProviders, "suiteProviders is null");
+        this.configurations = ImmutableMap.copyOf(configurations);
     }
 
-    public Suite getSuite(String suiteName)
+    public EnvironmentConfig getConfig(String configName)
     {
-        checkArgument(suiteProviders.containsKey(suiteName), "No suite with name '%s'. Those do exist, however: %s", suiteName, listSuites());
-        return suiteProviders.get(suiteName);
+        checkArgument(configurations.containsKey(configName), "No environment config with name '%s'. Those do exist, however: %s", configName, listConfigs());
+        return configurations.get(configName);
     }
 
-    public List<String> listSuites()
+    public List<String> listConfigs()
     {
-        return Ordering.natural().sortedCopy(suiteProviders.keySet());
+        return Ordering.natural().sortedCopy(configurations.keySet());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentModule.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentModule.java
@@ -24,12 +24,14 @@ import io.prestosql.tests.product.launcher.env.common.Standard;
 import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static io.prestosql.tests.product.launcher.env.Environments.nameForConfigClass;
 import static java.util.Objects.requireNonNull;
 
 public final class EnvironmentModule
         implements Module
 {
     public static final String BASE_PACKAGE = "io.prestosql.tests.product.launcher.env.environment";
+    public static final String BASE_CONFIG_PACKAGE = "io.prestosql.tests.product.launcher.env.configs";
     private final Module additionalEnvironments;
 
     public EnvironmentModule(Module additionalEnvironments)
@@ -42,6 +44,7 @@ public final class EnvironmentModule
     {
         binder.bind(PortBinder.class);
         binder.bind(EnvironmentFactory.class);
+        binder.bind(EnvironmentConfigFactory.class);
         binder.bind(Standard.class);
         binder.bind(Hadoop.class);
         binder.bind(Kerberos.class);
@@ -51,6 +54,9 @@ public final class EnvironmentModule
         MapBinder<String, EnvironmentProvider> environments = newMapBinder(binder, String.class, EnvironmentProvider.class);
 
         Environments.findByBasePackage(BASE_PACKAGE).forEach(clazz -> environments.addBinding(Environments.nameForClass(clazz)).to(clazz));
+
+        MapBinder<String, EnvironmentConfig> environmentConfigs = newMapBinder(binder, String.class, EnvironmentConfig.class);
+        Environments.findConfigsByBasePackage(BASE_CONFIG_PACKAGE).forEach(clazz -> environmentConfigs.addBinding(nameForConfigClass(clazz)).to(clazz));
 
         binder.install(additionalEnvironments);
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -38,6 +38,17 @@ public final class EnvironmentOptions
     @Option(name = "--debug", description = "open Java debug ports")
     public boolean debug;
 
+    public EnvironmentOptions copyOf()
+    {
+        EnvironmentOptions copy = new EnvironmentOptions();
+        copy.bindPorts = bindPorts;
+        copy.debug = debug;
+        copy.withoutPrestoMaster = withoutPrestoMaster;
+        copy.serverPackage = serverPackage;
+        copy.config = config;
+        return copy;
+    }
+
     private static boolean toBoolean(String value)
     {
         requireNonNull(value, "value is null");

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -16,7 +16,6 @@ package io.prestosql.tests.product.launcher.env;
 import com.google.inject.Module;
 import io.airlift.airline.Option;
 import io.prestosql.tests.product.launcher.PathResolver;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 
 import java.io.File;
 import java.util.Locale;
@@ -71,14 +70,14 @@ public final class EnvironmentOptions
         return copy;
     }
 
-    public static EnvironmentOptions applySuiteConfig(EnvironmentOptions source, SuiteConfig suiteConfig)
+    public static EnvironmentOptions applySuiteConfig(EnvironmentOptions source, EnvironmentConfig environmentConfig)
     {
         // Override environment options using SuiteConfig values
         EnvironmentOptions copy = copy(source);
-        copy.imagesVersion = suiteConfig.getImagesVersion();
-        copy.hadoopBaseImage = suiteConfig.getHadoopBaseImage();
-        copy.temptoEnvironmentConfigFile = suiteConfig.getTemptoEnvironmentConfigFile();
-        copy.hadoopImagesVersion = suiteConfig.getHadoopImagesVersion();
+        copy.imagesVersion = environmentConfig.getImagesVersion();
+        copy.hadoopBaseImage = environmentConfig.getHadoopBaseImage();
+        copy.temptoEnvironmentConfigFile = environmentConfig.getTemptoEnvironmentConfigFile();
+        copy.hadoopImagesVersion = environmentConfig.getHadoopImagesVersion();
         copy.serverPackage = new PathResolver().resolvePlaceholders(copy.serverPackage);
         return copy;
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -13,9 +13,7 @@
  */
 package io.prestosql.tests.product.launcher.env;
 
-import com.google.inject.Module;
 import io.airlift.airline.Option;
-import io.prestosql.tests.product.launcher.PathResolver;
 
 import java.io.File;
 import java.util.Locale;
@@ -25,17 +23,8 @@ import static java.util.Objects.requireNonNull;
 
 public final class EnvironmentOptions
 {
-    @Option(name = "--hadoop-base-image", title = "image", description = "Hadoop base image")
-    public String hadoopBaseImage = EnvironmentDefaults.HADOOP_BASE_IMAGE;
-
-    @Option(name = "--image-version", title = "version", description = "docker images version")
-    public String imagesVersion = EnvironmentDefaults.DOCKER_IMAGES_VERSION;
-
-    @Option(name = "--hadoop-image-version", title = "version", description = "docker images version")
-    public String hadoopImagesVersion = EnvironmentDefaults.HADOOP_IMAGES_VERSION;
-
-    @Option(name = "--tempto-environment-config-file", title = "tempto-config-file", description = "tempto environment config file")
-    public String temptoEnvironmentConfigFile = EnvironmentDefaults.TEMPTO_ENVIRONMENT_CONFIG;
+    @Option(name = "--config", title = "config", description = "Environment config to use")
+    public String config = "config-default";
 
     @Option(name = "--server-package", title = "server-package", description = "path to Presto server package")
     public File serverPackage = new File("presto-server/target/presto-server-${project.version}.tar.gz");
@@ -49,39 +38,6 @@ public final class EnvironmentOptions
     @Option(name = "--debug", description = "open Java debug ports")
     public boolean debug;
 
-    public Module toModule()
-    {
-        return binder -> {
-            binder.bind(EnvironmentOptions.class).toInstance(this);
-        };
-    }
-
-    public static EnvironmentOptions copy(EnvironmentOptions options)
-    {
-        EnvironmentOptions copy = new EnvironmentOptions();
-        copy.hadoopBaseImage = options.hadoopBaseImage;
-        copy.imagesVersion = options.imagesVersion;
-        copy.hadoopImagesVersion = options.hadoopImagesVersion;
-        copy.temptoEnvironmentConfigFile = options.temptoEnvironmentConfigFile;
-        copy.serverPackage = options.serverPackage;
-        copy.withoutPrestoMaster = options.withoutPrestoMaster;
-        copy.bindPorts = options.bindPorts;
-        copy.debug = options.debug;
-        return copy;
-    }
-
-    public static EnvironmentOptions applySuiteConfig(EnvironmentOptions source, EnvironmentConfig environmentConfig)
-    {
-        // Override environment options using SuiteConfig values
-        EnvironmentOptions copy = copy(source);
-        copy.imagesVersion = environmentConfig.getImagesVersion();
-        copy.hadoopBaseImage = environmentConfig.getHadoopBaseImage();
-        copy.temptoEnvironmentConfigFile = environmentConfig.getTemptoEnvironmentConfigFile();
-        copy.hadoopImagesVersion = environmentConfig.getHadoopImagesVersion();
-        copy.serverPackage = new PathResolver().resolvePlaceholders(copy.serverPackage);
-        return copy;
-    }
-
     private static boolean toBoolean(String value)
     {
         requireNonNull(value, "value is null");
@@ -92,5 +48,10 @@ public final class EnvironmentOptions
                 return false;
         }
         throw new IllegalArgumentException("Cannot convert to boolean: " + value);
+    }
+
+    public static EnvironmentOptions empty()
+    {
+        return new EnvironmentOptions();
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environments.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environments.java
@@ -31,6 +31,7 @@ import static io.prestosql.tests.product.launcher.docker.ContainerUtil.removeNet
 import static io.prestosql.tests.product.launcher.env.Environment.PRODUCT_TEST_LAUNCHER_NETWORK;
 import static io.prestosql.tests.product.launcher.env.Environment.PRODUCT_TEST_LAUNCHER_STARTED_LABEL_NAME;
 import static io.prestosql.tests.product.launcher.env.Environment.PRODUCT_TEST_LAUNCHER_STARTED_LABEL_VALUE;
+import static java.lang.reflect.Modifier.isAbstract;
 
 public final class Environments
 {
@@ -68,7 +69,27 @@ public final class Environments
         }
     }
 
+    public static List<Class<? extends EnvironmentConfig>> findConfigsByBasePackage(String packageName)
+    {
+        try {
+            return ClassPath.from(Environments.class.getClassLoader()).getTopLevelClassesRecursive(packageName).stream()
+                    .map(ClassPath.ClassInfo::load)
+                    .filter(clazz -> !isAbstract(clazz.getModifiers()))
+                    .filter(clazz -> EnvironmentConfig.class.isAssignableFrom(clazz))
+                    .map(clazz -> (Class<? extends EnvironmentConfig>) clazz.asSubclass(EnvironmentConfig.class))
+                    .collect(toImmutableList());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static String nameForClass(Class<? extends EnvironmentProvider> clazz)
+    {
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName());
+    }
+
+    public static String nameForConfigClass(Class<? extends EnvironmentConfig> clazz)
     {
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName());
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/ServerPackage.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/ServerPackage.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ServerPackage {
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
@@ -16,7 +16,7 @@ package io.prestosql.tests.product.launcher.env.common;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 import io.prestosql.tests.product.launcher.testcontainers.SelectedPortWaitStrategy;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
@@ -46,13 +46,12 @@ public final class Hadoop
     public Hadoop(
             DockerFiles dockerFiles,
             PortBinder portBinder,
-            EnvironmentOptions environmentOptions)
+            EnvironmentConfig environmentConfig)
     {
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        requireNonNull(environmentOptions, "environmentOptions is null");
-        hadoopBaseImage = requireNonNull(environmentOptions.hadoopBaseImage, "environmentOptions.hadoopBaseImage is null");
-        hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        hadoopBaseImage = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopBaseImage();
+        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kerberos.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kerberos.java
@@ -15,7 +15,7 @@ package io.prestosql.tests.product.launcher.env.common;
 
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 
 import javax.inject.Inject;
@@ -38,13 +38,12 @@ public class Kerberos
     public Kerberos(
             DockerFiles dockerFiles,
             PortBinder portBinder,
-            EnvironmentOptions environmentOptions)
+            EnvironmentConfig environmentConfig)
     {
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        requireNonNull(environmentOptions, "environmentOptions is null");
-        hadoopBaseImage = requireNonNull(environmentOptions.hadoopBaseImage, "environmentOptions.hadoopBaseImage is null");
-        hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        hadoopBaseImage = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopBaseImage();
+        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/KerberosKms.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/KerberosKms.java
@@ -15,7 +15,7 @@ package io.prestosql.tests.product.launcher.env.common;
 
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 
 import javax.inject.Inject;
 
@@ -31,11 +31,11 @@ public class KerberosKms
     private final String hadoopImagesVersion;
 
     @Inject
-    public KerberosKms(DockerFiles dockerFiles, EnvironmentOptions environmentOptions)
+    public KerberosKms(DockerFiles dockerFiles, EnvironmentConfig environmentConfig)
     {
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        requireNonNull(environmentOptions, "environmentOptions is null");
-        hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        requireNonNull(environmentConfig, "environmentOptions is null");
+        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
@@ -17,6 +17,7 @@ import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
@@ -67,13 +68,14 @@ public final class Standard
             PathResolver pathResolver,
             DockerFiles dockerFiles,
             PortBinder portBinder,
-            EnvironmentOptions environmentOptions)
+            EnvironmentOptions environmentOptions,
+            EnvironmentConfig environmentConfig)
     {
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
         requireNonNull(environmentOptions, "environmentOptions is null");
-        this.imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
+        this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
         this.serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
         checkArgument(serverPackage.getName().endsWith(".tar.gz"), "Currently only server .tar.gz package is supported");
         this.debug = environmentOptions.debug;

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
@@ -24,7 +24,6 @@ import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
-import org.testcontainers.utility.MountableFile;
 
 import javax.inject.Inject;
 
@@ -157,7 +156,7 @@ public final class Standard
                             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:" + debugPort,
                             CONTAINER_PRESTO_JVM_CONFIG),
                     UTF_8);
-            container.withCopyFileToContainer(MountableFile.forHostPath(script), "/docker/presto-init.d/enable-java-debugger.sh");
+            container.withCopyFileToContainer(forHostPath(script), "/docker/presto-init.d/enable-java-debugger.sh");
 
             // expose debug port unconditionally when debug is enabled
             exposePort(container, debugPort);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigCdh5.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigCdh5.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.tests.product.launcher.suite.configs;
+package io.prestosql.tests.product.launcher.env.configs;
 
 import com.google.common.collect.ImmutableList;
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigDefault.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigDefault.java
@@ -11,16 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.tests.product.launcher.suite.configs;
+package io.prestosql.tests.product.launcher.env.configs;
 
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentDefaults;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.prestosql.tests.product.launcher.suite.Suites.nameForConfigClass;
+import static io.prestosql.tests.product.launcher.env.Environments.nameForConfigClass;
 
 public class ConfigDefault
-        implements SuiteConfig
+        implements EnvironmentConfig
 {
     @Override
     public String getHadoopBaseImage()

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigEnvBased.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigEnvBased.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env.configs;
+
+import com.google.common.base.Splitter;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.System.getenv;
+
+public class ConfigEnvBased
+        extends ConfigDefault
+{
+    @Override
+    public String getHadoopBaseImage()
+    {
+        return getEnvOrDefault("HADOOP_BASE_IMAGE", super.getHadoopBaseImage());
+    }
+
+    @Override
+    public String getImagesVersion()
+    {
+        return getEnvOrDefault("DOCKER_IMAGES_VERSION", super.getImagesVersion());
+    }
+
+    @Override
+    public String getHadoopImagesVersion()
+    {
+        return getEnvOrDefault("HADOOP_IMAGES_VERSION", super.getHadoopImagesVersion());
+    }
+
+    @Override
+    public String getTemptoEnvironmentConfigFile()
+    {
+        return getEnvOrDefault("TEMPTO_ENVIRONMENT_CONFIG_FILE", super.getTemptoEnvironmentConfigFile());
+    }
+
+    @Override
+    public List<String> getExcludedGroups()
+    {
+        return Optional
+                .ofNullable(getenv("DISTRO_SKIP_GROUP"))
+                .map(value -> Splitter.on(',')
+                        .omitEmptyStrings()
+                        .trimResults()
+                        .splitToList(value))
+                .orElse(super.getExcludedGroups());
+    }
+
+    @Override
+    public List<String> getExcludedTests()
+    {
+        return Optional
+                .ofNullable(getenv("DISTRO_SKIP_TEST"))
+                .map(value -> Splitter.on(',')
+                        .omitEmptyStrings()
+                        .trimResults()
+                        .splitToList(value))
+                .orElse(super.getExcludedTests());
+    }
+
+    private static String getEnvOrDefault(String envKey, String defaultValue)
+    {
+        return Optional
+                .ofNullable(getenv(envKey))
+                .orElse(defaultValue);
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigHdp3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigHdp3.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.tests.product.launcher.suite.configs;
+package io.prestosql.tests.product.launcher.env.configs;
 
 import com.google.common.collect.ImmutableList;
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/AbstractSinglenodeLdap.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/AbstractSinglenodeLdap.java
@@ -16,7 +16,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.EnvironmentExtender;
 import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
@@ -42,12 +42,12 @@ public abstract class AbstractSinglenodeLdap
 
     private static final int LDAP_PORT = 636;
 
-    protected AbstractSinglenodeLdap(List<EnvironmentExtender> bases, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentOptions environmentOptions)
+    protected AbstractSinglenodeLdap(List<EnvironmentExtender> bases, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentConfig environmentConfig)
     {
         super(bases);
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        this.imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
+        this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
@@ -18,6 +18,7 @@ import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -54,12 +55,13 @@ public final class Multinode
             DockerFiles dockerFiles,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions)
+            EnvironmentOptions environmentOptions,
+            EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        this.imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
+        this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
         this.serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
         this.debug = environmentOptions.debug;
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
@@ -19,7 +19,7 @@ import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.ServerPackage;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
@@ -34,7 +34,6 @@ import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PR
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_JVM_CONFIG;
 import static io.prestosql.tests.product.launcher.env.common.Standard.createPrestoContainer;
-import static io.prestosql.tests.product.launcher.env.common.Standard.enablePrestoJavaDebugger;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -47,7 +46,6 @@ public final class Multinode
 
     private final String imagesVersion;
     private final File serverPackage;
-    private final boolean debug;
 
     @Inject
     public Multinode(
@@ -55,15 +53,14 @@ public final class Multinode
             DockerFiles dockerFiles,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions,
-            EnvironmentConfig environmentConfig)
+            EnvironmentConfig environmentConfig,
+            @ServerPackage File serverPackage)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
-        this.serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
-        this.debug = environmentOptions.debug;
+        this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
     }
 
     @Override
@@ -81,16 +78,10 @@ public final class Multinode
     @SuppressWarnings("resource")
     private DockerContainer createPrestoWorker()
     {
-        DockerContainer container = createPrestoContainer(dockerFiles, pathResolver, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
+        return createPrestoContainer(dockerFiles, pathResolver, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES);
-
-        if (debug) {
-            enablePrestoJavaDebugger(container, 5008); // debug port
-        }
-
-        return container;
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
@@ -17,10 +17,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
-import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.ServerPackage;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
@@ -35,7 +34,6 @@ import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_JVM_CONFIG;
 import static io.prestosql.tests.product.launcher.env.common.Standard.createPrestoContainer;
-import static io.prestosql.tests.product.launcher.env.common.Standard.enablePrestoJavaDebugger;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -50,7 +48,6 @@ public final class MultinodeHiveCaching
 
     private final String imagesVersion;
     private final File serverPackage;
-    private final boolean debug;
 
     @Inject
     public MultinodeHiveCaching(
@@ -58,15 +55,14 @@ public final class MultinodeHiveCaching
             DockerFiles dockerFiles,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions,
-            EnvironmentConfig environmentConfig)
+            EnvironmentConfig environmentConfig,
+            @ServerPackage File serverPackage)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
-        this.serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
-        this.debug = environmentOptions.debug;
+        this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
     }
 
     @Override
@@ -86,17 +82,11 @@ public final class MultinodeHiveCaching
     @SuppressWarnings("resource")
     private void createPrestoWorker(Environment.Builder builder, int workerNumber)
     {
-        DockerContainer container = createPrestoContainer(dockerFiles, pathResolver, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
+        builder.addContainer("presto-worker-" + workerNumber, createPrestoContainer(dockerFiles, pathResolver, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_NON_CACHED_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-cached/hive-worker.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
-                .withTmpFs(ImmutableMap.of("/tmp/cache", "rw"));
-
-        if (debug) {
-            enablePrestoJavaDebugger(container, 5008 + workerNumber); // debug port
-        }
-
-        builder.addContainer("presto-worker-" + workerNumber, container);
+                .withTmpFs(ImmutableMap.of("/tmp/cache", "rw")));
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
@@ -19,6 +19,7 @@ import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -57,12 +58,13 @@ public final class MultinodeHiveCaching
             DockerFiles dockerFiles,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions)
+            EnvironmentOptions environmentOptions,
+            EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        this.imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
+        this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
         this.serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
         this.debug = environmentOptions.debug;
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTls.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTls.java
@@ -19,7 +19,7 @@ import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.ServerPackage;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
@@ -56,15 +56,15 @@ public final class MultinodeTls
             PortBinder portBinder,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions,
-            EnvironmentConfig environmentConfig)
+            EnvironmentConfig environmentConfig,
+            @ServerPackage File serverPackage)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
-        serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
+        this.imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
+        this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTls.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTls.java
@@ -18,6 +18,7 @@ import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -55,13 +56,14 @@ public final class MultinodeTls
             PortBinder portBinder,
             Standard standard,
             Hadoop hadoop,
-            EnvironmentOptions environmentOptions)
+            EnvironmentOptions environmentOptions,
+            EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        imagesVersion = requireNonNull(environmentOptions.imagesVersion, "environmentOptions.imagesVersion is null");
+        imagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getImagesVersion();
         serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
     }
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTlsKerberos.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTlsKerberos.java
@@ -19,7 +19,7 @@ import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.ServerPackage;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Kerberos;
@@ -56,16 +56,16 @@ public final class MultinodeTlsKerberos
             Standard standard,
             Hadoop hadoop,
             Kerberos kerberos,
-            EnvironmentOptions environmentOptions,
-            EnvironmentConfig config)
+            EnvironmentConfig config,
+            @ServerPackage File serverPackage)
     {
         super(ImmutableList.of(standard, hadoop, kerberos));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         String hadoopBaseImage = requireNonNull(config, "config is null").getHadoopBaseImage();
         String hadoopImagesVersion = requireNonNull(config, "config is null").getHadoopImagesVersion();
-        prestoDockerImageName = hadoopBaseImage + "-kerberized:" + hadoopImagesVersion;
-        serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
+        this.prestoDockerImageName = hadoopBaseImage + "-kerberized:" + hadoopImagesVersion;
+        this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTlsKerberos.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeTlsKerberos.java
@@ -18,6 +18,7 @@ import io.prestosql.tests.product.launcher.PathResolver;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
@@ -55,13 +56,14 @@ public final class MultinodeTlsKerberos
             Standard standard,
             Hadoop hadoop,
             Kerberos kerberos,
-            EnvironmentOptions environmentOptions)
+            EnvironmentOptions environmentOptions,
+            EnvironmentConfig config)
     {
         super(ImmutableList.of(standard, hadoop, kerberos));
         this.pathResolver = requireNonNull(pathResolver, "pathResolver is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        String hadoopBaseImage = requireNonNull(environmentOptions.hadoopBaseImage, "environmentOptions.hadoopBaseImage is null");
-        String hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        String hadoopBaseImage = requireNonNull(config, "config is null").getHadoopBaseImage();
+        String hadoopImagesVersion = requireNonNull(config, "config is null").getHadoopImagesVersion();
         prestoDockerImageName = hadoopBaseImage + "-kerberized:" + hadoopImagesVersion;
         serverPackage = requireNonNull(environmentOptions.serverPackage, "environmentOptions.serverPackage is null");
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdp3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdp3.java
@@ -16,7 +16,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
@@ -38,11 +38,11 @@ public class SinglenodeHdp3
     private final String hadoopImagesVersion;
 
     @Inject
-    protected SinglenodeHdp3(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentOptions environmentOptions)
+    protected SinglenodeHdp3(DockerFiles dockerFiles, Standard standard, Hadoop hadoop, EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        this.hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        this.hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdap.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdap.java
@@ -15,7 +15,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
 import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
@@ -28,9 +28,9 @@ public class SinglenodeLdap
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdap(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentOptions environmentOptions)
+    public SinglenodeLdap(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentConfig config)
     {
-        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, config);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapBindDn.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapBindDn.java
@@ -15,7 +15,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
 import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
@@ -28,9 +28,9 @@ public class SinglenodeLdapBindDn
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdapBindDn(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentOptions environmentOptions)
+    public SinglenodeLdapBindDn(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentConfig environmentConfig)
     {
-        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, environmentConfig);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapInsecure.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapInsecure.java
@@ -16,7 +16,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
 import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
@@ -33,9 +33,9 @@ public class SinglenodeLdapInsecure
     private final PortBinder portBinder;
 
     @Inject
-    public SinglenodeLdapInsecure(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentOptions environmentOptions)
+    public SinglenodeLdapInsecure(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentConfig config)
     {
-        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, config);
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
     }
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapReferrals.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeLdapReferrals.java
@@ -15,7 +15,7 @@ package io.prestosql.tests.product.launcher.env.environment;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
 import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
@@ -28,9 +28,9 @@ public class SinglenodeLdapReferrals
         extends AbstractSinglenodeLdap
 {
     @Inject
-    public SinglenodeLdapReferrals(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentOptions environmentOptions)
+    public SinglenodeLdapReferrals(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, PortBinder portBinder, EnvironmentConfig config)
     {
-        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, environmentOptions);
+        super(ImmutableList.of(standard, hadoop), dockerFiles, portBinder, config);
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Standard;
@@ -43,12 +43,12 @@ public class SinglenodeSparkIceberg
     private final String hadoopImagesVersion;
 
     @Inject
-    public SinglenodeSparkIceberg(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, EnvironmentOptions environmentOptions, PortBinder portBinder)
+    public SinglenodeSparkIceberg(Standard standard, Hadoop hadoop, DockerFiles dockerFiles, EnvironmentConfig config, PortBinder portBinder)
     {
         super(ImmutableList.of(standard, hadoop));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
-        this.hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        this.hadoopImagesVersion = requireNonNull(config, "config is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoKerberosHives.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoKerberosHives.java
@@ -18,7 +18,7 @@ import com.google.common.io.Closer;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Kerberos;
@@ -65,12 +65,12 @@ public final class TwoKerberosHives
             Standard standard,
             Hadoop hadoop,
             Kerberos kerberos,
-            EnvironmentOptions environmentOptions)
+            EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop, kerberos));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        hadoopBaseImage = requireNonNull(environmentOptions.hadoopBaseImage, "environmentOptions.hadoopBaseImage is null");
-        hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        hadoopBaseImage = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopBaseImage();
+        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @PreDestroy

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoMixedHives.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoMixedHives.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.docker.DockerFiles;
 import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
-import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.common.Hadoop;
 import io.prestosql.tests.product.launcher.env.common.Kerberos;
@@ -53,12 +53,12 @@ public final class TwoMixedHives
             Standard standard,
             Hadoop hadoop,
             Kerberos kerberos,
-            EnvironmentOptions environmentOptions)
+            EnvironmentConfig environmentConfig)
     {
         super(ImmutableList.of(standard, hadoop, kerberos));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
-        hadoopBaseImage = requireNonNull(environmentOptions.hadoopBaseImage, "environmentOptions.hadoopBaseImage is null");
-        hadoopImagesVersion = requireNonNull(environmentOptions.hadoopImagesVersion, "environmentOptions.hadoopImagesVersion is null");
+        hadoopBaseImage = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopBaseImage();
+        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/Suite.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/Suite.java
@@ -13,7 +13,8 @@
  */
 package io.prestosql.tests.product.launcher.suite;
 
-import io.prestosql.tests.product.launcher.suite.configs.ConfigDefault;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
+import io.prestosql.tests.product.launcher.env.configs.ConfigDefault;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ import static io.prestosql.tests.product.launcher.suite.Suites.nameForSuiteClass
 
 public abstract class Suite
 {
-    public abstract List<SuiteTestRun> getTestRuns(SuiteConfig config);
+    public abstract List<SuiteTestRun> getTestRuns(EnvironmentConfig config);
 
     @Override
     public String toString()

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteModule.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteModule.java
@@ -18,7 +18,6 @@ import com.google.inject.Module;
 import com.google.inject.multibindings.MapBinder;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
-import static io.prestosql.tests.product.launcher.suite.Suites.nameForConfigClass;
 import static io.prestosql.tests.product.launcher.suite.Suites.nameForSuiteClass;
 import static java.util.Objects.requireNonNull;
 
@@ -40,9 +39,6 @@ public final class SuiteModule
 
         MapBinder<String, Suite> suites = newMapBinder(binder, String.class, Suite.class);
         Suites.findSuitesByPackageName(BASE_SUITES_PACKAGE).forEach(clazz -> suites.addBinding(nameForSuiteClass(clazz)).to(clazz));
-
-        MapBinder<String, SuiteConfig> suiteConfigs = newMapBinder(binder, String.class, SuiteConfig.class);
-        Suites.findSuiteConfigsByPackageName(BASE_SUITES_PACKAGE).forEach(clazz -> suiteConfigs.addBinding(nameForConfigClass(clazz)).to(clazz));
 
         binder.install(additionalSuites);
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteTestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteTestRun.java
@@ -18,6 +18,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentProvider;
 import io.prestosql.tests.product.launcher.env.Environments;
 
@@ -88,7 +89,7 @@ public class SuiteTestRun
                 .build();
     }
 
-    public List<String> getTemptoRunArguments(SuiteConfig suiteConfig)
+    public List<String> getTemptoRunArguments(EnvironmentConfig environmentConfig)
     {
         ImmutableList.Builder<String> arguments = ImmutableList.builder();
         Joiner joiner = Joiner.on(",");
@@ -97,7 +98,7 @@ public class SuiteTestRun
             arguments.add(TEMPTO_GROUP_ARG, joiner.join(groups));
         }
 
-        Iterable<String> excludedGroups = Iterables.concat(getExcludedGroups(), suiteConfig.getExcludedGroups());
+        Iterable<String> excludedGroups = Iterables.concat(getExcludedGroups(), environmentConfig.getExcludedGroups());
         if (!Iterables.isEmpty(excludedGroups)) {
             arguments.add(TEMPTO_EXCLUDE_GROUP_ARG, joiner.join(excludedGroups));
         }
@@ -106,7 +107,7 @@ public class SuiteTestRun
             arguments.add(TEMPTO_TEST_ARG, joiner.join(tests));
         }
 
-        Iterable<String> excludedTests = Iterables.concat(getExcludedTests(), suiteConfig.getExcludedTests());
+        Iterable<String> excludedTests = Iterables.concat(getExcludedTests(), environmentConfig.getExcludedTests());
         if (!Iterables.isEmpty(excludedTests)) {
             arguments.add(TEMPTO_EXCLUDE_TEST_ARG, joiner.join(excludedTests));
         }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/Suites.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/Suites.java
@@ -42,28 +42,8 @@ public class Suites
         }
     }
 
-    public static List<Class<? extends SuiteConfig>> findSuiteConfigsByPackageName(String packageName)
-    {
-        try {
-            return ClassPath.from(Environments.class.getClassLoader()).getTopLevelClassesRecursive(packageName).stream()
-                    .map(ClassPath.ClassInfo::load)
-                    .filter(clazz -> !isAbstract(clazz.getModifiers()))
-                    .filter(clazz -> SuiteConfig.class.isAssignableFrom(clazz))
-                    .map(clazz -> (Class<? extends SuiteConfig>) clazz.asSubclass(SuiteConfig.class))
-                    .collect(toImmutableList());
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static String nameForSuiteClass(Class<? extends Suite> clazz)
     {
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName().replace("Suite", "Suite-")).replace("--", "-");
-    }
-
-    public static String nameForConfigClass(Class<? extends SuiteConfig> clazz)
-    {
-        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite1.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite1.java
@@ -14,9 +14,9 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.environment.Multinode;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -27,7 +27,7 @@ public class Suite1
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
             /**

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite2.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite2.java
@@ -14,12 +14,12 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.environment.Singlenode;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeHdfsImpersonation;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonation;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsNoImpersonation;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -30,7 +30,7 @@ public class Suite2
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
                 /**

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite3.java
@@ -14,12 +14,12 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.environment.MultinodeTls;
 import io.prestosql.tests.product.launcher.env.environment.MultinodeTlsKerberos;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonationWithDataProtection;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonationWithWireEncryption;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -30,7 +30,7 @@ public class Suite3
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
                 /**

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite5.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite5.java
@@ -14,11 +14,11 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.environment.MultinodeHiveCaching;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeHiveImpersonation;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHiveImpersonation;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -29,7 +29,7 @@ public class Suite5
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
                 /**

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite6NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite6NonGeneric.java
@@ -14,6 +14,7 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentDefaults;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeCassandra;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKafka;
@@ -23,7 +24,6 @@ import io.prestosql.tests.product.launcher.env.environment.SinglenodeLdap;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeLdapInsecure;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeLdapReferrals;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -35,7 +35,7 @@ public class Suite6NonGeneric
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
@@ -14,6 +14,7 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentDefaults;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonationCrossRealm;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeLdapBindDn;
@@ -24,7 +25,6 @@ import io.prestosql.tests.product.launcher.env.environment.SinglenodeSqlserver;
 import io.prestosql.tests.product.launcher.env.environment.TwoKerberosHives;
 import io.prestosql.tests.product.launcher.env.environment.TwoMixedHives;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -36,7 +36,7 @@ public class Suite7NonGeneric
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite8NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite8NonGeneric.java
@@ -14,10 +14,10 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentDefaults;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeHdp3;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -29,7 +29,7 @@ public class Suite8NonGeneric
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/SuiteTpcds.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/SuiteTpcds.java
@@ -14,9 +14,9 @@
 package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.environment.Multinode;
 import io.prestosql.tests.product.launcher.suite.Suite;
-import io.prestosql.tests.product.launcher.suite.SuiteConfig;
 import io.prestosql.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
@@ -27,7 +27,7 @@ public class SuiteTpcds
         extends Suite
 {
     @Override
-    public List<SuiteTestRun> getTestRuns(SuiteConfig config)
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
             /**


### PR DESCRIPTION
This PR:

- renames `SuiteConfig` to `EnvironmentConfig` (it's closer to Environment than to Suite)
- uses `EnvironmentConfig` when running tests with `test run` and for `env up`)
- lists configs in `env list` command
- removes passing of `EnvironmentConfig` values through command-line options (it's not necessary anymore)
- provides `ConfigEnvBased` (`config-env-based`) that extends `config-default` but allows individual values to be overwritten using `ENV` variables
- simplifies environment definitions removing direct usage of `EnvironmentOptions` when possible
- makes debugging of Presto containers consistent for every environment