### PR TITLE
Fix scan limit in SqlQueryManager

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlQueryManager.java
@@ -320,9 +320,12 @@ public class SqlQueryManager
     private void enforceScanLimits()
     {
         for (QueryExecution query : queryTracker.getAllQueries()) {
-            Optional<DataSize> limitOpt = getQueryMaxScanPhysicalBytes(query.getSession())
+            Optional<DataSize> limitOpt = getQueryMaxScanPhysicalBytes(query.getSession());
+            if (maxQueryScanPhysicalBytes.isPresent()) {
+                limitOpt = limitOpt
                     .flatMap(sessionLimit -> maxQueryScanPhysicalBytes.map(serverLimit -> Ordering.natural().min(serverLimit, sessionLimit)))
                     .or(() -> maxQueryScanPhysicalBytes);
+            }
 
             limitOpt.ifPresent(limit -> {
                 DataSize scan = query.getBasicQueryInfo().getQueryStats().getPhysicalInputDataSize();

--- a/presto-tests/src/test/java/io/prestosql/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestQueryManager.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.tests;
 
+import io.prestosql.Session;
+import io.prestosql.client.ClientCapabilities;
 import io.prestosql.dispatcher.DispatchManager;
 import io.prestosql.execution.QueryInfo;
 import io.prestosql.execution.QueryManager;
@@ -28,14 +30,18 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.execution.QueryState.FAILED;
 import static io.prestosql.execution.QueryState.RUNNING;
 import static io.prestosql.execution.TestQueryRunnerUtil.createQuery;
 import static io.prestosql.execution.TestQueryRunnerUtil.waitForQueryState;
+import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.spi.StandardErrorCode.EXCEEDED_CPU_LIMIT;
 import static io.prestosql.spi.StandardErrorCode.EXCEEDED_SCAN_LIMIT;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.util.Arrays.stream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
@@ -113,6 +119,27 @@ public class TestQueryManager
     {
         try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().setSingleExtraProperty("query.max-scan-physical-bytes", "0B").build()) {
             QueryId queryId = createQuery(queryRunner, TEST_SESSION, "SELECT * FROM system.runtime.nodes");
+            waitForQueryState(queryRunner, queryId, FAILED);
+            QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+            BasicQueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+            assertEquals(queryInfo.getState(), FAILED);
+            assertEquals(queryInfo.getErrorCode(), EXCEEDED_SCAN_LIMIT.toErrorCode());
+        }
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testQueryScanExceededSession() throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
+            Session session = testSessionBuilder()
+                    .setCatalog("tpch")
+                    .setSchema(TINY_SCHEMA_NAME)
+                    .setClientCapabilities(stream(ClientCapabilities.values())
+                        .map(ClientCapabilities::toString)
+                        .collect(toImmutableSet()))
+                    .setSystemProperty("query_max_scan_physical_bytes", "0B")
+                    .build();
+            QueryId queryId = createQuery(queryRunner, session, "SELECT * FROM system.runtime.nodes");
             waitForQueryState(queryRunner, queryId, FAILED);
             QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
             BasicQueryInfo queryInfo = queryManager.getQueryInfo(queryId);


### PR DESCRIPTION
Fixes bug where `query_max_scan_physical_bytes` session property got ignored if `maxQueryScanPhysicalBytes` is empty