### PR TITLE
Enable table properties for JDBC connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -105,6 +105,7 @@ import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.sql.DatabaseMetaData.columnNoNulls;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -941,6 +942,12 @@ public abstract class BaseJdbcClient
                 remoteTableName.getCatalogName().orElse(null),
                 remoteTableName.getSchemaName().orElse(null),
                 remoteTableName.getTableName());
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    {
+        return emptyMap();
     }
 
     protected String quoted(@Nullable String catalog, @Nullable String schema, String table)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
@@ -333,6 +333,12 @@ public final class CachingJdbcClient
         return delegate.quoted(remoteTableName);
     }
 
+    @Override
+    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    {
+        return delegate.getTableProperties(identity, tableHandle);
+    }
+
     private void invalidateSchemasCache()
     {
         schemaNamesCache.invalidateAll();

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
@@ -274,4 +274,10 @@ public abstract class ForwardingJdbcClient
     {
         return delegate().quoted(remoteTableName);
     }
+
+    @Override
+    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    {
+        return delegate().getTableProperties(identity, tableHandle);
+    }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -129,4 +129,6 @@ public interface JdbcClient
     String quoted(String name);
 
     String quoted(RemoteTableName remoteTableName);
+
+    Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle);
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
@@ -54,6 +54,7 @@ public class JdbcConnector
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> tableProperties;
 
     private final ConcurrentMap<ConnectorTransactionHandle, JdbcMetadata> transactions = new ConcurrentHashMap<>();
 
@@ -66,7 +67,8 @@ public class JdbcConnector
             ConnectorPageSinkProvider jdbcPageSinkProvider,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
-            Set<SessionPropertiesProvider> sessionProperties)
+            Set<SessionPropertiesProvider> sessionProperties,
+            Set<TablePropertiesProvider> tableProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.jdbcMetadataFactory = requireNonNull(jdbcMetadataFactory, "jdbcMetadataFactory is null");
@@ -77,6 +79,9 @@ public class JdbcConnector
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null").stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null").stream()
+                .flatMap(tablePropertiesProvider -> tablePropertiesProvider.getTableProperties().stream())
                 .collect(toImmutableList());
     }
 
@@ -151,6 +156,12 @@ public class JdbcConnector
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -323,7 +323,7 @@ public class JdbcMetadata
         for (JdbcColumnHandle column : jdbcClient.getColumns(session, handle)) {
             columnMetadata.add(column.getColumnMetadata());
         }
-        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata.build());
+        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata.build(), jdbcClient.getTableProperties(JdbcIdentity.from(session), handle));
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
@@ -49,6 +49,7 @@ public class JdbcModule
         newOptionalBinder(binder, ConnectorAccessControl.class);
 
         procedureBinder(binder);
+        tablePropertiesProviderBinder(binder);
 
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorSplitManager.class).setDefault().to(JdbcSplitManager.class).in(Scopes.SINGLETON);
@@ -84,5 +85,15 @@ public class JdbcModule
     public static void bindProcedure(Binder binder, Class<? extends Provider<? extends Procedure>> type)
     {
         procedureBinder(binder).addBinding().toProvider(type).in(Scopes.SINGLETON);
+    }
+
+    public static Multibinder<TablePropertiesProvider> tablePropertiesProviderBinder(Binder binder)
+    {
+        return newSetBinder(binder, TablePropertiesProvider.class);
+    }
+
+    public static void bindTablePropertiesProvider(Binder binder, Class<? extends TablePropertiesProvider> type)
+    {
+        tablePropertiesProviderBinder(binder).addBinding().to(type).in(Scopes.SINGLETON);
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TablePropertiesProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TablePropertiesProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.prestosql.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+public interface TablePropertiesProvider
+{
+    List<PropertyMetadata<?>> getTableProperties();
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -291,4 +291,10 @@ public final class StatisticsAwareJdbcClient
     {
         return delegate().quoted(remoteTableName);
     }
+
+    @Override
+    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    {
+        return delegate().getTableProperties(identity, tableHandle);
+    }
 }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.plugin.phoenix;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.ColumnMapping;
@@ -29,14 +31,26 @@ import io.prestosql.plugin.jdbc.QueryBuilder;
 import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
+import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.SchemaNotFoundException;
+import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.compile.QueryPlan;
 import org.apache.phoenix.compile.StatementContext;
+import org.apache.phoenix.exception.SQLExceptionCode;
 import org.apache.phoenix.iterate.ConcatResultIterator;
 import org.apache.phoenix.iterate.LookAheadResultIterator;
 import org.apache.phoenix.iterate.MapReduceParallelScanGrouper;
@@ -53,7 +67,11 @@ import org.apache.phoenix.mapreduce.PhoenixInputSplit;
 import org.apache.phoenix.monitoring.ScanMetricsHolder;
 import org.apache.phoenix.query.ConnectionQueryServices;
 import org.apache.phoenix.query.HBaseFactoryProvider;
+import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PName;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.TableProperty;
 import org.apache.phoenix.schema.types.PDataType;
 import org.apache.phoenix.util.SchemaUtil;
 
@@ -69,8 +87,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.BiFunction;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -82,8 +104,10 @@ import static io.prestosql.plugin.jdbc.StandardColumnMappings.timeWriteFunctionU
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.prestosql.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.prestosql.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.prestosql.plugin.phoenix.MetadataUtil.getEscapedTableName;
 import static io.prestosql.plugin.phoenix.MetadataUtil.toPhoenixSchemaName;
 import static io.prestosql.plugin.phoenix.PhoenixClientModule.getConnectionProperties;
+import static io.prestosql.plugin.phoenix.PhoenixColumnProperties.isPrimaryKey;
 import static io.prestosql.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
 import static io.prestosql.plugin.phoenix.PhoenixErrorCode.PHOENIX_QUERY_ERROR;
 import static io.prestosql.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
@@ -91,6 +115,7 @@ import static io.prestosql.plugin.phoenix.TypeUtils.getArrayElementPhoenixTypeNa
 import static io.prestosql.plugin.phoenix.TypeUtils.getJdbcObjectArray;
 import static io.prestosql.plugin.phoenix.TypeUtils.jdbcObjectArrayToBlock;
 import static io.prestosql.plugin.phoenix.TypeUtils.toBoxedArray;
+import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.RealType.REAL;
@@ -110,13 +135,19 @@ import static java.sql.Types.TIMESTAMP_WITH_TIMEZONE;
 import static java.sql.Types.TIME_WITH_TIMEZONE;
 import static java.sql.Types.VARCHAR;
 import static java.util.Collections.nCopies;
+import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.hadoop.hbase.HConstants.FOREVER;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SKIP_REGION_BOUNDARY_CHECK;
+import static org.apache.phoenix.util.PhoenixRuntime.getTable;
 import static org.apache.phoenix.util.SchemaUtil.ESCAPE_CHARACTER;
 
 public class PhoenixClient
         extends BaseJdbcClient
 {
+    private static final String ROWKEY = "ROWKEY";
+
     private final Configuration configuration;
 
     @Inject
@@ -307,6 +338,162 @@ public class PhoenixClient
     public boolean isLimitGuaranteed(ConnectorSession session)
     {
         return false;
+    }
+
+    @Override
+    public JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        Optional<String> schema = Optional.of(schemaTableName.getSchemaName());
+        String table = schemaTableName.getTableName();
+
+        if (!getSchemaNames(JdbcIdentity.from(session)).contains(schema.orElse(null))) {
+            throw new SchemaNotFoundException(schema.orElse(null));
+        }
+
+        try (Connection connection = connectionFactory.openConnection(JdbcIdentity.from(session))) {
+            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            if (uppercase) {
+                schema = schema.map(schemaName -> schemaName.toUpperCase(ENGLISH));
+                table = table.toUpperCase(ENGLISH);
+            }
+            schema = toPhoenixSchemaName(schema);
+            LinkedList<ColumnMetadata> tableColumns = new LinkedList<>(tableMetadata.getColumns());
+            Map<String, Object> tableProperties = tableMetadata.getProperties();
+            Optional<Boolean> immutableRows = PhoenixTableProperties.getImmutableRows(tableProperties);
+            String immutable = immutableRows.isPresent() && immutableRows.get() ? "IMMUTABLE" : "";
+
+            ImmutableList.Builder<String> columnNames = ImmutableList.builder();
+            ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
+            ImmutableList.Builder<String> columnList = ImmutableList.builder();
+            Set<ColumnMetadata> rowkeyColumns = tableColumns.stream().filter(col -> isPrimaryKey(col, tableProperties)).collect(toSet());
+            ImmutableList.Builder<String> pkNames = ImmutableList.builder();
+            Optional<String> rowkeyColumn = Optional.empty();
+            if (rowkeyColumns.isEmpty()) {
+                // Add a rowkey when not specified in DDL
+                columnList.add(ROWKEY + " bigint not null");
+                pkNames.add(ROWKEY);
+                execute(session, format("CREATE SEQUENCE %s", getEscapedTableName(schema, table + "_sequence")));
+                rowkeyColumn = Optional.of(ROWKEY);
+            }
+            for (ColumnMetadata column : tableColumns) {
+                String columnName = column.getName();
+                if (uppercase) {
+                    columnName = columnName.toUpperCase(ENGLISH);
+                }
+                columnNames.add(columnName);
+                columnTypes.add(column.getType());
+                String typeStatement = toWriteMapping(session, column.getType()).getDataType();
+                if (rowkeyColumns.contains(column)) {
+                    typeStatement += " not null";
+                    pkNames.add(columnName);
+                }
+                columnList.add(format("%s %s", columnName, typeStatement));
+            }
+
+            ImmutableList.Builder<String> tableOptions = ImmutableList.builder();
+            PhoenixTableProperties.getSaltBuckets(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.SALT_BUCKETS + "=" + value));
+            PhoenixTableProperties.getSplitOn(tableProperties).ifPresent(value -> tableOptions.add("SPLIT ON (" + value.replace('"', '\'') + ")"));
+            PhoenixTableProperties.getDisableWal(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DISABLE_WAL + "=" + value));
+            PhoenixTableProperties.getDefaultColumnFamily(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DEFAULT_COLUMN_FAMILY + "=" + value));
+            PhoenixTableProperties.getBloomfilter(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.BLOOMFILTER + "='" + value + "'"));
+            PhoenixTableProperties.getVersions(tableProperties).ifPresent(value -> tableOptions.add(HConstants.VERSIONS + "=" + value));
+            PhoenixTableProperties.getMinVersions(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.MIN_VERSIONS + "=" + value));
+            PhoenixTableProperties.getCompression(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.COMPRESSION + "='" + value + "'"));
+            PhoenixTableProperties.getTimeToLive(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.TTL + "=" + value));
+            PhoenixTableProperties.getDataBlockEncoding(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.DATA_BLOCK_ENCODING + "='" + value + "'"));
+
+            String sql = format(
+                    "CREATE %s TABLE %s (%s , CONSTRAINT PK PRIMARY KEY (%s)) %s",
+                    immutable,
+                    getEscapedTableName(schema, table),
+                    join(", ", columnList.build()),
+                    join(", ", pkNames.build()),
+                    join(", ", tableOptions.build()));
+
+            execute(session, sql);
+
+            return new PhoenixOutputTableHandle(
+                    schema,
+                    table,
+                    columnNames.build(),
+                    columnTypes.build(),
+                    Optional.empty(),
+                    rowkeyColumn);
+        }
+        catch (SQLException e) {
+            if (e.getErrorCode() == SQLExceptionCode.TABLE_ALREADY_EXIST.getErrorCode()) {
+                throw new PrestoException(ALREADY_EXISTS, "Phoenix table already exists", e);
+            }
+            throw new PrestoException(PHOENIX_METADATA_ERROR, "Error creating Phoenix table", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle handle)
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+
+        try (PhoenixConnection connection = (PhoenixConnection) connectionFactory.openConnection(identity);
+                HBaseAdmin admin = connection.getQueryServices().getAdmin()) {
+            String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
+            PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
+
+            boolean salted = table.getBucketNum() != null;
+            StringJoiner joiner = new StringJoiner(",");
+            List<PColumn> pkColumns = table.getPKColumns();
+            for (PColumn pkColumn : pkColumns.subList(salted ? 1 : 0, pkColumns.size())) {
+                joiner.add(pkColumn.getName().getString());
+            }
+            properties.put(PhoenixTableProperties.ROWKEYS, joiner.toString());
+
+            if (table.getBucketNum() != null) {
+                properties.put(PhoenixTableProperties.SALT_BUCKETS, table.getBucketNum());
+            }
+            if (table.isWALDisabled()) {
+                properties.put(PhoenixTableProperties.DISABLE_WAL, table.isWALDisabled());
+            }
+            if (table.isImmutableRows()) {
+                properties.put(PhoenixTableProperties.IMMUTABLE_ROWS, table.isImmutableRows());
+            }
+
+            String defaultFamilyName = QueryConstants.DEFAULT_COLUMN_FAMILY;
+            if (table.getDefaultFamilyName() != null) {
+                defaultFamilyName = table.getDefaultFamilyName().getString();
+                properties.put(PhoenixTableProperties.DEFAULT_COLUMN_FAMILY, defaultFamilyName);
+            }
+
+            HTableDescriptor tableDesc = admin.getTableDescriptor(table.getPhysicalName().getBytes());
+
+            HColumnDescriptor[] columnFamilies = tableDesc.getColumnFamilies();
+            for (HColumnDescriptor columnFamily : columnFamilies) {
+                if (columnFamily.getNameAsString().equals(defaultFamilyName)) {
+                    if (columnFamily.getBloomFilterType() != BloomType.NONE) {
+                        properties.put(PhoenixTableProperties.BLOOMFILTER, columnFamily.getBloomFilterType());
+                    }
+                    if (columnFamily.getMaxVersions() != 1) {
+                        properties.put(PhoenixTableProperties.VERSIONS, columnFamily.getMaxVersions());
+                    }
+                    if (columnFamily.getMinVersions() > 0) {
+                        properties.put(PhoenixTableProperties.MIN_VERSIONS, columnFamily.getMinVersions());
+                    }
+                    if (columnFamily.getCompression() != Compression.Algorithm.NONE) {
+                        properties.put(PhoenixTableProperties.COMPRESSION, columnFamily.getCompression());
+                    }
+                    if (columnFamily.getTimeToLive() < FOREVER) {
+                        properties.put(PhoenixTableProperties.TTL, columnFamily.getTimeToLive());
+                    }
+                    if (columnFamily.getDataBlockEncoding() != DataBlockEncoding.NONE) {
+                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding());
+                    }
+                    break;
+                }
+            }
+        }
+        catch (IOException | SQLException e) {
+            throw new PrestoException(PHOENIX_METADATA_ERROR, "Couldn't get Phoenix table properties", e);
+        }
+        return properties.build();
     }
 
     private static ColumnMapping arrayColumnMapping(ConnectorSession session, ArrayType arrayType, String elementJdbcTypeName)

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClientModule.java
@@ -56,6 +56,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.reflect.Reflection.newProxy;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.prestosql.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
+import static io.prestosql.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 import static io.prestosql.plugin.phoenix.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -91,7 +92,7 @@ public class PhoenixClientModule
         binder.bind(ConnectorMetadata.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixMetadata.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorMetadata.class).to(ClassLoaderSafeConnectorMetadata.class).in(Scopes.SINGLETON);
 
-        binder.bind(PhoenixTableProperties.class).in(Scopes.SINGLETON);
+        bindTablePropertiesProvider(binder, PhoenixTableProperties.class);
         binder.bind(PhoenixColumnProperties.class).in(Scopes.SINGLETON);
 
         binder.bind(PhoenixConnector.class).in(Scopes.SINGLETON);

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
@@ -13,14 +13,11 @@
  */
 package io.prestosql.plugin.phoenix;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcMetadata;
 import io.prestosql.plugin.jdbc.JdbcMetadataConfig;
-import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.AggregateFunction;
@@ -34,55 +31,28 @@ import io.prestosql.spi.connector.ConnectorOutputTableHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
-import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.statistics.ComputedStatistics;
-import io.prestosql.spi.type.Type;
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.io.compress.Compression;
-import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
-import org.apache.hadoop.hbase.regionserver.BloomType;
-import org.apache.phoenix.exception.SQLExceptionCode;
-import org.apache.phoenix.jdbc.PhoenixConnection;
-import org.apache.phoenix.query.QueryConstants;
-import org.apache.phoenix.schema.PColumn;
-import org.apache.phoenix.schema.PTable;
-import org.apache.phoenix.schema.TableProperty;
-import org.apache.phoenix.util.SchemaUtil;
 
 import javax.inject.Inject;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.StringJoiner;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.phoenix.MetadataUtil.getEscapedTableName;
-import static io.prestosql.plugin.phoenix.MetadataUtil.toPhoenixSchemaName;
 import static io.prestosql.plugin.phoenix.MetadataUtil.toPrestoSchemaName;
-import static io.prestosql.plugin.phoenix.PhoenixColumnProperties.isPrimaryKey;
 import static io.prestosql.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
-import static io.prestosql.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
-import static java.lang.String.join;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toSet;
-import static org.apache.hadoop.hbase.HConstants.FOREVER;
-import static org.apache.phoenix.util.PhoenixRuntime.getTable;
 import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
 
 public class PhoenixMetadata
@@ -126,73 +96,7 @@ public class PhoenixMetadata
                 .filter(column -> rowkeyRequired || !ROWKEY.equalsIgnoreCase(column.getColumnName()))
                 .map(JdbcColumnHandle::getColumnMetadata)
                 .collect(toImmutableList());
-        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata, getTableProperties(session, handle));
-    }
-
-    private Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle handle)
-    {
-        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
-
-        try (PhoenixConnection connection = phoenixClient.getConnection(JdbcIdentity.from(session));
-                HBaseAdmin admin = connection.getQueryServices().getAdmin()) {
-            String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
-            PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
-
-            boolean salted = table.getBucketNum() != null;
-            StringJoiner joiner = new StringJoiner(",");
-            List<PColumn> pkColumns = table.getPKColumns();
-            for (PColumn pkColumn : pkColumns.subList(salted ? 1 : 0, pkColumns.size())) {
-                joiner.add(pkColumn.getName().getString());
-            }
-            properties.put(PhoenixTableProperties.ROWKEYS, joiner.toString());
-
-            if (table.getBucketNum() != null) {
-                properties.put(PhoenixTableProperties.SALT_BUCKETS, table.getBucketNum());
-            }
-            if (table.isWALDisabled()) {
-                properties.put(PhoenixTableProperties.DISABLE_WAL, table.isWALDisabled());
-            }
-            if (table.isImmutableRows()) {
-                properties.put(PhoenixTableProperties.IMMUTABLE_ROWS, table.isImmutableRows());
-            }
-
-            String defaultFamilyName = QueryConstants.DEFAULT_COLUMN_FAMILY;
-            if (table.getDefaultFamilyName() != null) {
-                defaultFamilyName = table.getDefaultFamilyName().getString();
-                properties.put(PhoenixTableProperties.DEFAULT_COLUMN_FAMILY, defaultFamilyName);
-            }
-
-            HTableDescriptor tableDesc = admin.getTableDescriptor(table.getPhysicalName().getBytes());
-
-            HColumnDescriptor[] columnFamilies = tableDesc.getColumnFamilies();
-            for (HColumnDescriptor columnFamily : columnFamilies) {
-                if (columnFamily.getNameAsString().equals(defaultFamilyName)) {
-                    if (columnFamily.getBloomFilterType() != BloomType.NONE) {
-                        properties.put(PhoenixTableProperties.BLOOMFILTER, columnFamily.getBloomFilterType());
-                    }
-                    if (columnFamily.getMaxVersions() != 1) {
-                        properties.put(PhoenixTableProperties.VERSIONS, columnFamily.getMaxVersions());
-                    }
-                    if (columnFamily.getMinVersions() > 0) {
-                        properties.put(PhoenixTableProperties.MIN_VERSIONS, columnFamily.getMinVersions());
-                    }
-                    if (columnFamily.getCompression() != Compression.Algorithm.NONE) {
-                        properties.put(PhoenixTableProperties.COMPRESSION, columnFamily.getCompression());
-                    }
-                    if (columnFamily.getTimeToLive() < FOREVER) {
-                        properties.put(PhoenixTableProperties.TTL, columnFamily.getTimeToLive());
-                    }
-                    if (columnFamily.getDataBlockEncoding() != DataBlockEncoding.NONE) {
-                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding());
-                    }
-                    break;
-                }
-            }
-        }
-        catch (IOException | SQLException e) {
-            throw new PrestoException(PHOENIX_METADATA_ERROR, "Couldn't get Phoenix table properties", e);
-        }
-        return properties.build();
+        return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata, phoenixClient.getTableProperties(JdbcIdentity.from(session), handle));
     }
 
     @Override
@@ -231,13 +135,13 @@ public class PhoenixMetadata
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
-        createTable(session, tableMetadata);
+        phoenixClient.beginCreateTable(session, tableMetadata);
     }
 
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
-        return createTable(session, tableMetadata);
+        return phoenixClient.beginCreateTable(session, tableMetadata);
     }
 
     @Override
@@ -315,94 +219,6 @@ public class PhoenixMetadata
             phoenixClient.execute(session, format("DROP SEQUENCE %s", getEscapedTableName(Optional.ofNullable(jdbcHandle.getSchemaName()), jdbcHandle.getTableName() + "_sequence")));
         }
         phoenixClient.dropTable(JdbcIdentity.from(session), (JdbcTableHandle) tableHandle);
-    }
-
-    private JdbcOutputTableHandle createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
-    {
-        SchemaTableName schemaTableName = tableMetadata.getTable();
-        Optional<String> schema = Optional.of(schemaTableName.getSchemaName());
-        String table = schemaTableName.getTableName();
-
-        if (!phoenixClient.getSchemaNames(JdbcIdentity.from(session)).contains(schema.orElse(null))) {
-            throw new SchemaNotFoundException(schema.orElse(null));
-        }
-
-        try (Connection connection = phoenixClient.getConnection(JdbcIdentity.from(session))) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
-            if (uppercase) {
-                schema = schema.map(schemaName -> schemaName.toUpperCase(ENGLISH));
-                table = table.toUpperCase(ENGLISH);
-            }
-            schema = toPhoenixSchemaName(schema);
-            LinkedList<ColumnMetadata> tableColumns = new LinkedList<>(tableMetadata.getColumns());
-            Map<String, Object> tableProperties = tableMetadata.getProperties();
-            Optional<Boolean> immutableRows = PhoenixTableProperties.getImmutableRows(tableProperties);
-            String immutable = immutableRows.isPresent() && immutableRows.get() ? "IMMUTABLE" : "";
-
-            ImmutableList.Builder<String> columnNames = ImmutableList.builder();
-            ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
-            ImmutableList.Builder<String> columnList = ImmutableList.builder();
-            Set<ColumnMetadata> rowkeyColumns = tableColumns.stream().filter(col -> isPrimaryKey(col, tableProperties)).collect(toSet());
-            ImmutableList.Builder<String> pkNames = ImmutableList.builder();
-            Optional<String> rowkeyColumn = Optional.empty();
-            if (rowkeyColumns.isEmpty()) {
-                // Add a rowkey when not specified in DDL
-                columnList.add(ROWKEY + " bigint not null");
-                pkNames.add(ROWKEY);
-                phoenixClient.execute(session, format("CREATE SEQUENCE %s", getEscapedTableName(schema, table + "_sequence")));
-                rowkeyColumn = Optional.of(ROWKEY);
-            }
-            for (ColumnMetadata column : tableColumns) {
-                String columnName = column.getName();
-                if (uppercase) {
-                    columnName = columnName.toUpperCase(ENGLISH);
-                }
-                columnNames.add(columnName);
-                columnTypes.add(column.getType());
-                String typeStatement = phoenixClient.toWriteMapping(session, column.getType()).getDataType();
-                if (rowkeyColumns.contains(column)) {
-                    typeStatement += " not null";
-                    pkNames.add(columnName);
-                }
-                columnList.add(format("%s %s", columnName, typeStatement));
-            }
-
-            ImmutableList.Builder<String> tableOptions = ImmutableList.builder();
-            PhoenixTableProperties.getSaltBuckets(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.SALT_BUCKETS + "=" + value));
-            PhoenixTableProperties.getSplitOn(tableProperties).ifPresent(value -> tableOptions.add("SPLIT ON (" + value.replace('"', '\'') + ")"));
-            PhoenixTableProperties.getDisableWal(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DISABLE_WAL + "=" + value));
-            PhoenixTableProperties.getDefaultColumnFamily(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DEFAULT_COLUMN_FAMILY + "=" + value));
-            PhoenixTableProperties.getBloomfilter(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.BLOOMFILTER + "='" + value + "'"));
-            PhoenixTableProperties.getVersions(tableProperties).ifPresent(value -> tableOptions.add(HConstants.VERSIONS + "=" + value));
-            PhoenixTableProperties.getMinVersions(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.MIN_VERSIONS + "=" + value));
-            PhoenixTableProperties.getCompression(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.COMPRESSION + "='" + value + "'"));
-            PhoenixTableProperties.getTimeToLive(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.TTL + "=" + value));
-            PhoenixTableProperties.getDataBlockEncoding(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.DATA_BLOCK_ENCODING + "='" + value + "'"));
-
-            String sql = format(
-                    "CREATE %s TABLE %s (%s , CONSTRAINT PK PRIMARY KEY (%s)) %s",
-                    immutable,
-                    getEscapedTableName(schema, table),
-                    join(", ", columnList.build()),
-                    join(", ", pkNames.build()),
-                    join(", ", tableOptions.build()));
-
-            phoenixClient.execute(session, sql);
-
-            return new PhoenixOutputTableHandle(
-                    schema,
-                    table,
-                    columnNames.build(),
-                    columnTypes.build(),
-                    Optional.empty(),
-                    rowkeyColumn);
-        }
-        catch (SQLException e) {
-            if (e.getErrorCode() == SQLExceptionCode.TABLE_ALREADY_EXIST.getErrorCode()) {
-                throw new PrestoException(ALREADY_EXISTS, "Phoenix table already exists", e);
-            }
-            throw new PrestoException(PHOENIX_METADATA_ERROR, "Error creating Phoenix table", e);
-        }
     }
 
     @Override

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixTableProperties.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.phoenix;
 
 import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.jdbc.TablePropertiesProvider;
 import io.prestosql.spi.session.PropertyMetadata;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
@@ -40,6 +41,7 @@ import static java.util.Objects.requireNonNull;
  * <pre>CREATE TABLE foo (a VARCHAR with (primary_key = true), b INT) WITH (SALT_BUCKETS=10, VERSIONS=5, COMPRESSION='lz');</pre>
  */
 public final class PhoenixTableProperties
+        implements TablePropertiesProvider
 {
     public static final String ROWKEYS = "rowkeys";
     public static final String SALT_BUCKETS = "salt_buckets";
@@ -125,6 +127,7 @@ public final class PhoenixTableProperties
                         false));
     }
 
+    @Override
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties;


### PR DESCRIPTION
Similar to session property we can allow table properties to be configured when creating tables for JDBC based connector