### PR TITLE
Upgrade MongoDB test container to 4.4.0

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -6,7 +6,7 @@ The ``mongodb`` connector allows the use of `MongoDB <https://www.mongodb.com/>`
 
 .. note::
 
-    MongoDB 2.6+ is supported, although it is highly recommend to use 3.0 or later.
+    MongoDB 2.6+ is supported, although it is highly recommend to use 4.0 or later.
 
 Configuration
 -------------

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -169,6 +169,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoServer.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoServer.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.mongodb;
 
 import com.google.common.net.HostAndPort;
 import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.Closeable;
 
@@ -27,9 +28,12 @@ public class MongoServer
 
     public MongoServer()
     {
-        this.dockerContainer = new MongoDBContainer("mongo:3.4.0")
+        this.dockerContainer = new MongoDBContainer("mongo:4.4.0")
                 .withEnv("MONGO_INITDB_DATABASE", "tpch")
                 .withCommand("--bind_ip 0.0.0.0");
+
+        // Overriding what is defined in the constructor -- the log message is different
+        this.dockerContainer.waitingFor(Wait.forLogMessage(".*Waiting for connections.*", 1));
         this.dockerContainer.start();
     }
 


### PR DESCRIPTION
There is a newer MongoDB driver 4.x, however it breaks the build (different API) and would likely break backwards compatibility for older Mongo deployments.  This commit tests against the latest MongoDB version 4.4.0.