### PR TITLE
Dynamic filtering for semi-joins: execution and testing

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
+++ b/presto-main/src/main/java/io/prestosql/operator/JoinUtils.java
@@ -21,14 +21,18 @@ import io.prestosql.sql.planner.plan.ExchangeNode;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.SemiJoinNode;
 import io.prestosql.util.MorePredicates;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.prestosql.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.prestosql.util.MorePredicates.isInstanceOfAny;
 
 /**
  * This class must be public as it is accessed via join compiler reflection.
@@ -55,12 +59,21 @@ public final class JoinUtils
         return pagesBuilder.build();
     }
 
-    public static boolean isBuildSideReplicated(JoinNode joinNode)
+    public static boolean isBuildSideReplicated(PlanNode node)
     {
-        return PlanNodeSearcher.searchFrom(joinNode.getRight())
+        checkArgument(isInstanceOfAny(JoinNode.class, SemiJoinNode.class).test(node));
+        if (node instanceof JoinNode) {
+            return PlanNodeSearcher.searchFrom(((JoinNode) node).getRight())
+                    .recurseOnlyWhen(
+                            MorePredicates.<PlanNode>isInstanceOfAny(ProjectNode.class)
+                                    .or(JoinUtils::isLocalRepartitionExchange))
+                    .where(JoinUtils::isRemoteReplicatedExchange)
+                    .matches();
+        }
+        return PlanNodeSearcher.searchFrom(((SemiJoinNode) node).getFilteringSource())
                 .recurseOnlyWhen(
                         MorePredicates.<PlanNode>isInstanceOfAny(ProjectNode.class)
-                                .or(JoinUtils::isLocalRepartitionExchange))
+                                .or(JoinUtils::isLocalGatherExchange))
                 .where(JoinUtils::isRemoteReplicatedExchange)
                 .matches();
     }
@@ -83,5 +96,15 @@ public final class JoinUtils
 
         ExchangeNode exchangeNode = (ExchangeNode) node;
         return exchangeNode.getScope() == LOCAL && exchangeNode.getType() == REPARTITION;
+    }
+
+    private static boolean isLocalGatherExchange(PlanNode node)
+    {
+        if (!(node instanceof ExchangeNode)) {
+            return false;
+        }
+
+        ExchangeNode exchangeNode = (ExchangeNode) node;
+        return exchangeNode.getScope() == LOCAL && exchangeNode.getType() == GATHER;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -42,6 +43,7 @@ import io.prestosql.sql.planner.optimizations.PlanNodeSearcher;
 import io.prestosql.sql.planner.plan.DynamicFilterId;
 import io.prestosql.sql.planner.plan.JoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.sql.planner.plan.SemiJoinNode;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -69,10 +71,12 @@ import static com.google.common.collect.Sets.difference;
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.prestosql.operator.JoinUtils.isBuildSideReplicated;
 import static io.prestosql.spi.connector.DynamicFilter.EMPTY;
 import static io.prestosql.spi.predicate.Domain.union;
 import static io.prestosql.sql.DynamicFilters.extractDynamicFilters;
 import static io.prestosql.sql.planner.ExpressionExtractor.extractExpressions;
+import static io.prestosql.util.MorePredicates.isInstanceOfAny;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -323,20 +327,31 @@ public class DynamicFilterService
     private static Set<DynamicFilterId> getReplicatedDynamicFilters(PlanNode planNode)
     {
         return PlanNodeSearcher.searchFrom(planNode)
-                .where(JoinNode.class::isInstance)
-                .<JoinNode>findAll().stream()
-                .filter(JoinUtils::isBuildSideReplicated)
-                .flatMap(node -> node.getDynamicFilters().keySet().stream())
+                .where(isInstanceOfAny(JoinNode.class, SemiJoinNode.class))
+                .findAll().stream()
+                .filter((JoinUtils::isBuildSideReplicated))
+                .flatMap(node -> getDynamicFiltersProducedInPlanNode(node).stream())
                 .collect(toImmutableSet());
     }
 
     private static Set<DynamicFilterId> getProducedDynamicFilters(PlanNode planNode)
     {
         return PlanNodeSearcher.searchFrom(planNode)
-                .where(JoinNode.class::isInstance)
-                .<JoinNode>findAll().stream()
-                .flatMap(node -> node.getDynamicFilters().keySet().stream())
+                .where(isInstanceOfAny(JoinNode.class, SemiJoinNode.class))
+                .findAll().stream()
+                .flatMap(node -> getDynamicFiltersProducedInPlanNode(node).stream())
                 .collect(toImmutableSet());
+    }
+
+    private static Set<DynamicFilterId> getDynamicFiltersProducedInPlanNode(PlanNode planNode)
+    {
+        if (planNode instanceof JoinNode) {
+            return ((JoinNode) planNode).getDynamicFilters().keySet();
+        }
+        if (planNode instanceof SemiJoinNode) {
+            return ((SemiJoinNode) planNode).getDynamicFilterId().map(ImmutableSet::of).orElse(ImmutableSet.of());
+        }
+        throw new IllegalStateException("getDynamicFiltersProducedInPlanNode called with neither JoinNode nor SemiJoinNode");
     }
 
     private static Set<DynamicFilterId> getConsumedDynamicFilters(PlanNode planNode)

--- a/presto-tests/src/test/java/io/prestosql/execution/TestLazyCoordinatorDynamicFiltering.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestLazyCoordinatorDynamicFiltering.java
@@ -114,6 +114,27 @@ public class TestLazyCoordinatorDynamicFiltering
         // for broadcast joins lazy dynamic filters are non blocking
     }
 
+    @Test(enabled = false)
+    @Override
+    public void testBroadcastSemiJoinWithSelectiveBuildSide()
+    {
+        // for broadcast semi-joins lazy dynamic filters are non blocking
+    }
+
+    @Test(enabled = false)
+    @Override
+    public void testBroadcastSemiJoinWithEmptyBuildSide()
+    {
+        // for broadcast semi-joins lazy dynamic filters are non blocking
+    }
+
+    @Test(enabled = false)
+    @Override
+    public void testBroadcastSemiJoinWithLargeBuildSide()
+    {
+        // for broadcast semi-joins lazy dynamic filters are non blocking
+    }
+
     private class TestPlugin
             implements Plugin
     {


### PR DESCRIPTION
Follows #4942 
Supersedes #2190