### PR TITLE
Hive ACID row-by-row delete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,8 @@
             <dependency>
                 <groupId>io.prestosql.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.1.2-1</version>
+                <!-- TODO: Replace with the released version before merging -->
+                <version>3.1.2-2-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidOperation.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidOperation.java
@@ -13,23 +13,23 @@
  */
 package io.prestosql.plugin.hive;
 
-import io.prestosql.plugin.hive.metastore.StorageFormat;
-import io.prestosql.spi.connector.ConnectorSession;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
-
-public interface HiveFileWriterFactory
+public enum AcidOperation
 {
-    Optional<FileWriter> createFileWriter(
-            Path path,
-            List<String> inputColumnNames,
-            StorageFormat storageFormat,
-            Properties schema,
-            JobConf conf,
-            ConnectorSession session,
-            AcidTransaction transaction);
+    // INSERT and UPDATE will be added when they are implemented
+    NONE,
+    DELETE;
+
+    @JsonIgnore
+    public DataOperationType getOperationType()
+    {
+        switch (this) {
+            case DELETE:
+                return DataOperationType.DELETE;
+            default:
+                return DataOperationType.NO_TXN;
+        }
+    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidSchema.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidSchema.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.ql.io.IOConstants;
+
+import java.util.List;
+import java.util.Properties;
+
+import static io.prestosql.plugin.hive.HiveType.HIVE_INT;
+import static io.prestosql.plugin.hive.HiveType.HIVE_LONG;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_BUCKET;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_CURRENT_TRANSACTION;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_OPERATION;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_ORIGINAL_TRANSACTION;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_ROW_ID;
+import static io.prestosql.plugin.hive.orc.OrcPageSourceFactory.ACID_COLUMN_ROW_STRUCT;
+import static java.util.stream.Collectors.joining;
+
+public final class AcidSchema
+{
+    public static final List<String> ACID_COLUMN_NAMES = ImmutableList.of(
+            ACID_COLUMN_OPERATION,
+            ACID_COLUMN_ORIGINAL_TRANSACTION,
+            ACID_COLUMN_BUCKET,
+            ACID_COLUMN_ROW_ID,
+            ACID_COLUMN_CURRENT_TRANSACTION,
+            ACID_COLUMN_ROW_STRUCT);
+
+    private AcidSchema() {}
+
+    public static Properties createAcidSchema(HiveType rowType)
+    {
+        Properties hiveAcidSchema = new Properties();
+        hiveAcidSchema.setProperty(IOConstants.COLUMNS, String.join(",", ACID_COLUMN_NAMES));
+        // We must supply an accurate row type, because Apache ORC code we don't control has a consistency
+        // check that the layout of this "row" must agree with the layout of an inserted row.
+        hiveAcidSchema.setProperty(IOConstants.COLUMNS_TYPES, createAcidColumnTypes(rowType).stream()
+                .map(HiveType::getHiveTypeName)
+                .map(HiveTypeName::toString)
+                .collect(joining(":")));
+        return hiveAcidSchema;
+    }
+
+    public static List<HiveType> createAcidColumnTypes(HiveType rowType)
+    {
+        return ImmutableList.of(HIVE_INT, HIVE_LONG, HIVE_INT, HIVE_LONG, HIVE_LONG, rowType);
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidTransaction.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/AcidTransaction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static io.prestosql.plugin.hive.AcidOperation.DELETE;
+import static io.prestosql.plugin.hive.AcidOperation.NONE;
+import static java.util.Objects.requireNonNull;
+
+public class AcidTransaction
+{
+    public static final AcidTransaction NO_ACID_TRANSACTION = new AcidTransaction(NONE, 0, 0);
+    private final AcidOperation operation;
+    private final long transactionId;
+    private final long writeId;
+
+    @JsonCreator
+    public AcidTransaction(@JsonProperty("operation") AcidOperation operation, @JsonProperty("transactionId") long transactionId, @JsonProperty("writeId") long writeId)
+    {
+        this.operation = requireNonNull(operation, "operation is null");
+        this.transactionId = transactionId;
+        this.writeId = writeId;
+    }
+
+    public boolean isTransactionRunning()
+    {
+        return operation != AcidOperation.NONE;
+    }
+
+    public static AcidTransaction forDelete(long transactionId, long writeId)
+    {
+        return new AcidTransaction(DELETE, transactionId, writeId);
+    }
+
+    @JsonProperty
+    public AcidOperation getOperation()
+    {
+        return operation;
+    }
+
+    @JsonProperty("transactionId")
+    public long getAcidTransactionIdForSerialization()
+    {
+        return transactionId;
+    }
+
+    @JsonProperty("writeId")
+    public long getWriteIdForSerialization()
+    {
+        return writeId;
+    }
+
+    @JsonIgnore
+    public long getAcidTransactionId()
+    {
+        ensureTransactionRunning("accessing transactionId");
+        return transactionId;
+    }
+
+    @JsonIgnore
+    public long getWriteId()
+    {
+        ensureTransactionRunning("accessing writeId");
+        return writeId;
+    }
+
+    @JsonIgnore
+    public boolean isDelete()
+    {
+        return operation == DELETE;
+    }
+
+    private void ensureTransactionRunning(String description)
+    {
+        if (!isTransactionRunning()) {
+            throw new IllegalStateException("Not in ACID transaction but " + description);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AcidTransaction{" +
+                "operation=" + operation +
+                ", transactionId=" + transactionId +
+                '}';
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
@@ -132,6 +132,7 @@ public class BackgroundHiveSplitLoader
     private static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
 
     private final Table table;
+    private final AcidTransaction transaction;
     private final TupleDomain<? extends ColumnHandle> compactEffectivePredicate;
     private final DynamicFilter dynamicFilter;
     private final long dynamicFilteringProbeBlockingTimeoutMillis;
@@ -173,6 +174,7 @@ public class BackgroundHiveSplitLoader
 
     public BackgroundHiveSplitLoader(
             Table table,
+            AcidTransaction transaction,
             Iterable<HivePartitionMetadata> partitions,
             TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
             DynamicFilter dynamicFilter,
@@ -190,6 +192,7 @@ public class BackgroundHiveSplitLoader
             Optional<ValidWriteIdList> validWriteIds)
     {
         this.table = table;
+        this.transaction = transaction;
         this.compactEffectivePredicate = compactEffectivePredicate;
         this.dynamicFilter = dynamicFilter;
         this.dynamicFilteringProbeBlockingTimeoutMillis = dynamicFilteringProbeBlockingTimeout.toMillis();
@@ -395,7 +398,8 @@ public class BackgroundHiveSplitLoader
                         Optional.empty(),
                         getMaxInitialSplitSize(session),
                         isForceLocalScheduling(session),
-                        s3SelectPushdownEnabled);
+                        s3SelectPushdownEnabled,
+                        transaction);
                 lastResult = addSplitsToSource(targetSplits, splitFactory);
                 if (stopped) {
                     return COMPLETED_FUTURE;
@@ -434,7 +438,8 @@ public class BackgroundHiveSplitLoader
                 bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty(),
                 getMaxInitialSplitSize(session),
                 isForceLocalScheduling(session),
-                s3SelectPushdownEnabled);
+                s3SelectPushdownEnabled,
+                transaction);
 
         // To support custom input formats, we want to call getSplits()
         // on the input format to obtain file splits.

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
@@ -29,6 +29,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 
 import java.util.List;
 import java.util.Map;
@@ -314,5 +315,30 @@ public class HiveMetastoreClosure
     public Optional<String> getConfigValue(String name)
     {
         return delegate.getConfigValue(name);
+    }
+
+    public long allocateWriteId(String dbName, String tableName, long transactionId)
+    {
+        return delegate.allocateWriteId(dbName, tableName, transactionId);
+    }
+
+    public void acquireTableWriteLock(HiveIdentity identity, String queryId, long transactionId, String dbName, String tableName, DataOperationType operation)
+    {
+        delegate.acquireTableWriteLock(identity, queryId, transactionId, dbName, tableName, operation);
+    }
+
+    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+    {
+        delegate.updateTableWriteId(dbName, tableName, transactionId, writeId);
+    }
+
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+    {
+        delegate.alterPartitions(dbName, tableName, partitions, writeId);
+    }
+
+    public void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+    {
+        delegate.addDynamicPartitions(dbName, tableName, partitionNames, transactionId, writeId, operation);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -57,6 +57,7 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.plugin.hive.HiveColumnHandle.isRowIdColumnHandle;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
 import static io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMappingKind.EMPTY;
@@ -173,7 +174,7 @@ public class HivePageSource
                 coercers.add(Optional.empty());
             }
 
-            if (columnMapping.getKind() == EMPTY) {
+            if (columnMapping.getKind() == EMPTY || isRowIdColumnHandle(column)) {
                 prefilledValues[columnIndex] = null;
             }
             else if (columnMapping.getKind() == PREFILLED) {
@@ -240,6 +241,11 @@ public class HivePageSource
         this.coercers = coercers.build();
     }
 
+    public ConnectorPageSource getDelegate()
+    {
+        return delegate;
+    }
+
     @Override
     public long getCompletedBytes()
     {
@@ -286,6 +292,7 @@ public class HivePageSource
                         blocks.add(RunLengthEncodedBlock.create(types[fieldId], prefilledValues[fieldId], batchSize));
                         break;
                     case REGULAR:
+                    case SYNTHESIZED:
                         Block block = dataPage.getBlock(columnMapping.getIndex());
                         Optional<Function<Block, Block>> coercer = coercers.get(fieldId);
                         if (coercer.isPresent()) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
@@ -37,7 +37,8 @@ public interface HivePageSourceFactory
             Properties schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
-            Optional<AcidInfo> acidInfo);
+            Optional<AcidInfo> acidInfo,
+            AcidTransaction transaction);
 
     /**
      * A wrapper class for

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
@@ -195,7 +195,8 @@ public class HivePartitionManager
                 handle.getAnalyzePartitionValues(),
                 handle.getAnalyzeColumnNames(),
                 Optionals.combine(handle.getConstraintColumns(), columns,
-                        Sets::union));
+                        Sets::union),
+                handle.getTransaction());
     }
 
     public List<HivePartition> getOrLoadPartitions(SemiTransactionalHiveMetastore metastore, HiveIdentity identity, HiveTableHandle table)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplit.java
@@ -46,6 +46,7 @@ public class HiveSplit
     private final String table;
     private final String partitionName;
     private final OptionalInt bucketNumber;
+    private final int statementId;
     private final boolean forceLocalScheduling;
     private final TableToPartitionMapping tableToPartitionMapping;
     private final Optional<BucketConversion> bucketConversion;
@@ -66,6 +67,7 @@ public class HiveSplit
             @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys,
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("bucketNumber") OptionalInt bucketNumber,
+            @JsonProperty("statementId") int statementId,
             @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling,
             @JsonProperty("tableToPartitionMapping") TableToPartitionMapping tableToPartitionMapping,
             @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion,
@@ -99,6 +101,7 @@ public class HiveSplit
         this.partitionKeys = ImmutableList.copyOf(partitionKeys);
         this.addresses = ImmutableList.copyOf(addresses);
         this.bucketNumber = bucketNumber;
+        this.statementId = statementId;
         this.forceLocalScheduling = forceLocalScheduling;
         this.tableToPartitionMapping = tableToPartitionMapping;
         this.bucketConversion = bucketConversion;
@@ -177,6 +180,12 @@ public class HiveSplit
     public OptionalInt getBucketNumber()
     {
         return bucketNumber;
+    }
+
+    @JsonProperty
+    public int getStatementId()
+    {
+        return statementId;
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -218,6 +218,7 @@ public class HiveSplitManager
 
         HiveSplitLoader hiveSplitLoader = new BackgroundHiveSplitLoader(
                 table,
+                hiveTable.getTransaction(),
                 hivePartitions,
                 hiveTable.getCompactEffectivePredicate(),
                 dynamicFilter,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitSource.java
@@ -375,6 +375,7 @@ class HiveSplitSource
                         internalSplit.getPartitionKeys(),
                         block.getAddresses(),
                         internalSplit.getBucketNumber(),
+                        internalSplit.getStatementId(),
                         internalSplit.isForceLocalScheduling(),
                         internalSplit.getTableToPartitionMapping(),
                         internalSplit.getBucketConversion(),

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUpdatablePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveUpdatablePageSource.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.orc.OrcFileWriterFactory;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.RunLengthEncodedBlock;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.UpdatablePageSource;
+import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.plugin.hive.AcidSchema.ACID_COLUMN_NAMES;
+import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
+import static io.prestosql.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.prestosql.plugin.hive.util.ConfigurationUtils.toJobConf;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.hadoop.hive.ql.io.AcidUtils.OrcAcidVersion.writeVersionFile;
+import static org.apache.hadoop.hive.ql.io.AcidUtils.deleteDeltaSubdir;
+
+public class HiveUpdatablePageSource
+        implements UpdatablePageSource
+{
+    // The channel numbers of the child blocks in the RowBlock passed to deleteRows()
+    public static final int ORIGINAL_TRANSACTION_CHANNEL = 0;
+    public static final int ROW_ID_CHANNEL = 1;
+    public static final int BUCKET_CHANNEL = 2;
+    public static final int ACID_ROW_STRUCT_COLUMN_ID = 6;
+
+    // The bucketPath looks like .../delta_nnnnnnn_mmmmmmm_ssss/bucket_bbbbb(_aaaa)?
+    public static final Pattern BUCKET_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<dirStart>delta_[\\d]+_[\\d]+)_(?<statementId>[\\d]+)/(?<filename>bucket_(?<bucketNumber>[\\d]+)(?<attemptId>_[\\d]+)?)$");
+
+    private final HiveTableHandle hiveTable;
+    private final String partitionName;
+    private final ConnectorPageSource hivePageSource;
+    private final TypeManager typeManager;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final OrcFileWriterFactory orcFileWriterFactory;
+    private final Configuration configuration;
+    private final ConnectorSession session;
+    private final HiveType hiveRowType;
+    private final long writeId;
+    private final Properties hiveAcidSchema;
+    private final Path deleteDeltaDirectory;
+    private final String bucketFilename;
+
+    private Optional<FileWriter> writer = Optional.empty();
+    private boolean closed;
+
+    public HiveUpdatablePageSource(
+            HiveTableHandle hiveTableHandle,
+            String partitionName,
+            int statementId,
+            ConnectorPageSource hivePageSource,
+            TypeManager typeManager,
+            HdfsEnvironment hdfsEnvironment,
+            Path bucketPath,
+            OrcFileWriterFactory orcFileWriterFactory,
+            Configuration configuration,
+            ConnectorSession session,
+            HiveType hiveRowType)
+    {
+        this.hiveTable = requireNonNull(hiveTableHandle, "hiveTable is null");
+        this.partitionName = requireNonNull(partitionName, "partitionName is null");
+        this.hivePageSource = requireNonNull(hivePageSource, "hivePageSource is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.orcFileWriterFactory = requireNonNull(orcFileWriterFactory, "orcFileWriterFactory is null");
+        this.configuration = requireNonNull(configuration, "configuration is null");
+        this.session = requireNonNull(session, "session is null");
+        this.hiveRowType = requireNonNull(hiveRowType, "rowType is null");
+        checkArgument(hiveTableHandle.isInAcidTransaction(), "Not in a transaction; hiveTableHandle: " + hiveTableHandle);
+        this.writeId = hiveTableHandle.getWriteId();
+        this.hiveAcidSchema = AcidSchema.createAcidSchema(hiveRowType);
+        requireNonNull(bucketPath, "bucketPath is null");
+        Matcher matcher = BUCKET_PATH_MATCHER.matcher(bucketPath.toString());
+        checkArgument(matcher.matches(), "bucketPath doesn't have the required format: " + bucketPath);
+        this.bucketFilename = matcher.group("filename");
+        this.deleteDeltaDirectory = new Path(format("%s/%s", matcher.group("rootDir"), deleteDeltaSubdir(writeId, writeId, statementId)));
+    }
+
+    @Override
+    public void deleteRows(Block rowIds)
+    {
+        int positionCount = rowIds.getPositionCount();
+        List<Block> blocks = rowIds.getChildren();
+        checkArgument(blocks.size() == 3, "The rowId block should have 3 children, but has " + blocks.size());
+        Block[] blockArray = new Block[] {
+                RunLengthEncodedBlock.create(INTEGER, (long) DataOperationType.DELETE.getValue(), positionCount),
+                blocks.get(ORIGINAL_TRANSACTION_CHANNEL),
+                blocks.get(BUCKET_CHANNEL),
+                blocks.get(ROW_ID_CHANNEL),
+                RunLengthEncodedBlock.create(BIGINT, writeId, positionCount),
+                RunLengthEncodedBlock.create(hiveRowType.getType(typeManager), null, positionCount)
+        };
+        Page deletePage = new Page(blockArray);
+
+        lazyInitializeFileWriter();
+        checkArgument(writer.isPresent(), "writer not present");
+        writer.get().appendRows(deletePage);
+    }
+
+    private void lazyInitializeFileWriter()
+    {
+        if (writer.isEmpty()) {
+            Properties schemaCopy = new Properties();
+            schemaCopy.putAll(hiveAcidSchema);
+            writer = orcFileWriterFactory.createFileWriter(
+                    new Path(format("%s/%s", deleteDeltaDirectory, bucketFilename)),
+                    ACID_COLUMN_NAMES,
+                    fromHiveStorageFormat(ORC),
+                    schemaCopy,
+                    toJobConf(configuration),
+                    session,
+                    hiveTable.getTransaction());
+        }
+    }
+
+    private void createOrcAcidVersionFile()
+    {
+        try {
+            FileSystem fs = hdfsEnvironment.getFileSystem(new HdfsContext(session, hiveTable.getSchemaName()), deleteDeltaDirectory);
+            writeVersionFile(deleteDeltaDirectory, fs);
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Exception writing _orc_acid_version file for deltaDirectory " + deleteDeltaDirectory, e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        if (writer.isPresent()) {
+            writer.get().commit();
+            createOrcAcidVersionFile();
+            return completedFuture(ImmutableList.of(Slices.utf8Slice(partitionName)));
+        }
+        return completedFuture(ImmutableList.of());
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return hivePageSource.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return hivePageSource.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page page = hivePageSource.getNextPage();
+        if (page == null) {
+            close();
+            return null;
+        }
+        return page;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return hivePageSource.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        try {
+            hivePageSource.close();
+        }
+        catch (Exception e) {
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, e);
+        }
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -72,6 +72,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_READ_ONLY;
@@ -455,7 +456,8 @@ public class HiveWriterFactory
                     outputStorageFormat,
                     schema,
                     conf,
-                    session);
+                    session,
+                    NO_ACID_TRANSACTION);
             if (fileWriter.isPresent()) {
                 hiveFileWriter = fileWriter.get();
                 break;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/InternalHiveSplit.java
@@ -51,6 +51,7 @@ public class InternalHiveSplit
     private final List<InternalHiveBlock> blocks;
     private final String partitionName;
     private final OptionalInt bucketNumber;
+    private final int statementId;
     private final boolean splittable;
     private final boolean forceLocalScheduling;
     private final TableToPartitionMapping tableToPartitionMapping;
@@ -72,6 +73,7 @@ public class InternalHiveSplit
             List<HivePartitionKey> partitionKeys,
             List<InternalHiveBlock> blocks,
             OptionalInt bucketNumber,
+            int statementId,
             boolean splittable,
             boolean forceLocalScheduling,
             TableToPartitionMapping tableToPartitionMapping,
@@ -102,6 +104,7 @@ public class InternalHiveSplit
         this.partitionKeys = ImmutableList.copyOf(partitionKeys);
         this.blocks = ImmutableList.copyOf(blocks);
         this.bucketNumber = bucketNumber;
+        this.statementId = statementId;
         this.splittable = splittable;
         this.forceLocalScheduling = forceLocalScheduling;
         this.tableToPartitionMapping = tableToPartitionMapping;
@@ -158,6 +161,11 @@ public class InternalHiveSplit
     public OptionalInt getBucketNumber()
     {
         return bucketNumber;
+    }
+
+    public int getStatementId()
+    {
+        return statementId;
     }
 
     public boolean isSplittable()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
@@ -94,7 +94,8 @@ public class RcFileFileWriterFactory
             StorageFormat storageFormat,
             Properties schema,
             JobConf configuration,
-            ConnectorSession session)
+            ConnectorSession session,
+            AcidTransaction transaction)
     {
         if (!RCFileOutputFormat.class.getName().equals(storageFormat.getOutputFormat())) {
             return Optional.empty();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore;
 
+import io.prestosql.plugin.hive.AcidOperation;
 import io.prestosql.plugin.hive.HivePartition;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.PartitionStatistics;
@@ -22,6 +23,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 
 import java.util.List;
 import java.util.Map;
@@ -159,5 +161,30 @@ public interface HiveMetastore
     default Optional<String> getConfigValue(String name)
     {
         return Optional.empty();
+    }
+
+    default long allocateWriteId(String dbName, String tableName, long transactionId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void acquireTableWriteLock(HiveIdentity identity, String queryId, long transactionId, String dbName, String tableName, DataOperationType operation)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -23,6 +23,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.jmx.CacheStatsMBean;
 import io.airlift.units.Duration;
+import io.prestosql.plugin.hive.AcidOperation;
 import io.prestosql.plugin.hive.HivePartition;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.PartitionNotFoundException;
@@ -48,6 +49,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -941,6 +943,36 @@ public class CachingHiveMetastore
     private Set<HivePrivilegeInfo> loadTablePrivileges(String databaseName, String tableName, String tableOwner, Optional<HivePrincipal> principal)
     {
         return delegate.listTablePrivileges(databaseName, tableName, tableOwner, principal);
+    }
+
+    @Override
+    public long allocateWriteId(String dbName, String tableName, long transactionId)
+    {
+        return delegate.allocateWriteId(dbName, tableName, transactionId);
+    }
+
+    @Override
+    public void acquireTableWriteLock(HiveIdentity identity, String queryId, long transactionId, String dbName, String tableName, DataOperationType operation)
+    {
+        delegate.acquireTableWriteLock(identity, queryId, transactionId, dbName, tableName, operation);
+    }
+
+    @Override
+    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+    {
+        delegate.updateTableWriteId(dbName, tableName, transactionId, writeId);
+    }
+
+    @Override
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+    {
+        delegate.alterPartitions(dbName, tableName, partitions, writeId);
+    }
+
+    @Override
+    public void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+    {
+        delegate.addDynamicPartitions(dbName, tableName, partitionNames, transactionId, writeId, operation);
     }
 
     private static CacheBuilder<Object, Object> newCacheBuilder(OptionalLong expiresAfterWriteMillis, OptionalLong refreshMillis, long maximumSize, StatsRecording statsRecording)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.hive.metastore.thrift;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.prestosql.plugin.hive.AcidOperation;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -393,6 +394,34 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         return runWithHandle(() -> delegate.getDelegationToken(userName));
+    }
+
+    @Override
+    public long allocateWriteId(String dbName, String tableName, long transactionid)
+            throws TException
+    {
+        return runWithHandle(() -> delegate.allocateWriteId(dbName, tableName, transactionid));
+    }
+
+    @Override
+    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+            throws TException
+    {
+        runWithHandle(() -> delegate.updateTableWriteId(dbName, tableName, transactionId, writeId));
+    }
+
+    @Override
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterPartitions(dbName, tableName, partitions, writeId));
+    }
+
+    @Override
+    public void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+            throws TException
+    {
+        runWithHandle(() -> delegate.addDynamicPartitions(dbName, tableName, partitionNames, transactionId, writeId, operation));
     }
 
     private <T> T runWithHandle(ThrowingSupplier<T> supplier)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore.thrift;
 
+import io.prestosql.plugin.hive.AcidOperation;
 import io.prestosql.plugin.hive.HivePartition;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
@@ -26,6 +27,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
+import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -154,5 +156,30 @@ public interface ThriftMetastore
     default Optional<String> getConfigValue(String name)
     {
         return Optional.empty();
+    }
+
+    default long allocateWriteId(String dbName, String tableName, long transactionId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void acquireTableWriteLock(HiveIdentity identity, String queryId, long transactionId, String dbName, String tableName, DataOperationType operation)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.plugin.hive.metastore.thrift;
 
+import io.prestosql.plugin.hive.AcidOperation;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -178,5 +179,17 @@ public interface ThriftMetastoreClient
             throws TException;
 
     String getDelegationToken(String userName)
+            throws TException;
+
+    long allocateWriteId(String dbName, String tableName, long transactionId)
+            throws TException;
+
+    void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+            throws TException;
+
+    void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+            throws TException;
+
+    void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
             throws TException;
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -359,12 +359,20 @@ public final class ThriftMetastoreUtil
 
     public static org.apache.hadoop.hive.metastore.api.Partition toMetastoreApiPartition(Partition partition)
     {
+        return toMetastoreApiPartition(partition, Optional.empty());
+    }
+
+    public static org.apache.hadoop.hive.metastore.api.Partition toMetastoreApiPartition(Partition partition, Optional<Long> writeId)
+    {
         org.apache.hadoop.hive.metastore.api.Partition result = new org.apache.hadoop.hive.metastore.api.Partition();
         result.setDbName(partition.getDatabaseName());
         result.setTableName(partition.getTableName());
         result.setValues(partition.getValues());
         result.setSd(makeStorageDescriptor(partition.getTableName(), partition.getColumns(), partition.getStorage()));
         result.setParameters(partition.getParameters());
+        if (writeId.isPresent()) {
+            result.setWriteId(writeId.get());
+        }
         return result;
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcTypeToHiveTypeTranslator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcTypeToHiveTypeTranslator.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.orc;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.orc.metadata.ColumnMetadata;
+import io.prestosql.orc.metadata.OrcType;
+import io.prestosql.plugin.hive.HiveType;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.plugin.hive.HiveType.HIVE_BINARY;
+import static io.prestosql.plugin.hive.HiveType.HIVE_BOOLEAN;
+import static io.prestosql.plugin.hive.HiveType.HIVE_BYTE;
+import static io.prestosql.plugin.hive.HiveType.HIVE_DATE;
+import static io.prestosql.plugin.hive.HiveType.HIVE_DOUBLE;
+import static io.prestosql.plugin.hive.HiveType.HIVE_FLOAT;
+import static io.prestosql.plugin.hive.HiveType.HIVE_INT;
+import static io.prestosql.plugin.hive.HiveType.HIVE_LONG;
+import static io.prestosql.plugin.hive.HiveType.HIVE_SHORT;
+import static io.prestosql.plugin.hive.HiveType.HIVE_STRING;
+import static io.prestosql.plugin.hive.HiveType.HIVE_TIMESTAMP;
+import static io.prestosql.plugin.hive.HiveType.toHiveType;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getMapTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getStructTypeInfo;
+
+public final class OrcTypeToHiveTypeTranslator
+{
+    private OrcTypeToHiveTypeTranslator() {}
+
+    public static HiveType fromOrcTypeToHiveType(OrcType orcType, ColumnMetadata<OrcType> columnMetadata)
+    {
+        switch (orcType.getOrcTypeKind()) {
+            case BOOLEAN:
+                return HIVE_BOOLEAN;
+
+            case FLOAT:
+                return HIVE_FLOAT;
+
+            case DOUBLE:
+                return HIVE_DOUBLE;
+
+            case BYTE:
+                return HIVE_BYTE;
+
+            case DATE:
+                return HIVE_DATE;
+
+            case SHORT:
+                return HIVE_SHORT;
+
+            case INT:
+                return HIVE_INT;
+
+            case LONG:
+                return HIVE_LONG;
+
+            case DECIMAL:
+                checkArgument(orcType.getPrecision().isPresent(), "orcType.getPrecision() is not present");
+                checkArgument(orcType.getScale().isPresent(), "orcType.getScale() is not present");
+                return toHiveType(new DecimalTypeInfo(orcType.getPrecision().get(), orcType.getScale().get()));
+
+            case TIMESTAMP:
+                return HIVE_TIMESTAMP;
+
+            case BINARY:
+                return HIVE_BINARY;
+
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+                return HIVE_STRING;
+
+            case LIST: {
+                HiveType elementType = fromOrcTypeToHiveType(columnMetadata.get(orcType.getFieldTypeIndex(0)), columnMetadata);
+                return toHiveType(getListTypeInfo(elementType.getTypeInfo()));
+            }
+
+            case MAP: {
+                HiveType keyType = getHiveType(orcType, 0, columnMetadata);
+                HiveType elementType = getHiveType(orcType, 1, columnMetadata);
+                return toHiveType(getMapTypeInfo(keyType.getTypeInfo(), elementType.getTypeInfo()));
+            }
+
+            case STRUCT:
+                ImmutableList.Builder<TypeInfo> fieldTypeInfo = ImmutableList.builder();
+                for (int fieldId = 0; fieldId < orcType.getFieldCount(); fieldId++) {
+                    fieldTypeInfo.add(getHiveType(orcType, fieldId, columnMetadata).getTypeInfo());
+                }
+                return toHiveType(getStructTypeInfo(orcType.getFieldNames(), fieldTypeInfo.build()));
+
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    private static HiveType getHiveType(OrcType orcType, int index, ColumnMetadata<OrcType> columnMetadata)
+    {
+        return fromOrcTypeToHiveType(columnMetadata.get(orcType.getFieldTypeIndex(index)), columnMetadata);
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive.parquet;
 
 import io.prestosql.parquet.writer.ParquetSchemaConverter;
 import io.prestosql.parquet.writer.ParquetWriterOptions;
+import io.prestosql.plugin.hive.AcidTransaction;
 import io.prestosql.plugin.hive.FileWriter;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveFileWriterFactory;
@@ -67,7 +68,8 @@ public class ParquetFileWriterFactory
             StorageFormat storageFormat,
             Properties schema,
             JobConf conf,
-            ConnectorSession session)
+            ConnectorSession session,
+            AcidTransaction transaction)
     {
         if (!HiveSessionProperties.isParquetOptimizedWriterEnabled(session)) {
             return Optional.empty();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -25,6 +25,7 @@ import io.prestosql.parquet.predicate.Predicate;
 import io.prestosql.parquet.reader.MetadataReader;
 import io.prestosql.parquet.reader.ParquetReader;
 import io.prestosql.plugin.hive.AcidInfo;
+import io.prestosql.plugin.hive.AcidTransaction;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
@@ -123,7 +124,8 @@ public class ParquetPageSourceFactory
             Properties schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
-            Optional<AcidInfo> acidInfo)
+            Optional<AcidInfo> acidInfo,
+            AcidTransaction transaction)
     {
         if (!PARQUET_SERDE_CLASS_NAMES.contains(getDeserializerClassName(schema))) {
             return Optional.empty();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.prestosql.plugin.hive.AcidInfo;
+import io.prestosql.plugin.hive.AcidTransaction;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
@@ -108,7 +109,8 @@ public class RcFilePageSourceFactory
             Properties schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
-            Optional<AcidInfo> acidInfo)
+            Optional<AcidInfo> acidInfo,
+            AcidTransaction transaction)
     {
         RcFileEncoding rcFileEncoding;
         String deserializerClassName = getDeserializerClassName(schema);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -800,10 +800,13 @@ public abstract class AbstractTestHive
                 new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(
                 TYPE_MANAGER,
+                hiveConfig,
+                metastoreClient,
                 hdfsEnvironment,
                 getDefaultHivePageSourceFactories(hdfsEnvironment, hiveConfig),
                 getDefaultHiveRecordCursorProviders(hiveConfig, hdfsEnvironment),
-                new GenericHiveRecordCursorProvider(hdfsEnvironment, hiveConfig));
+                new GenericHiveRecordCursorProvider(hdfsEnvironment, hiveConfig),
+                Optional.empty());
     }
 
     protected HdfsConfiguration createTestHdfsConfiguration()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -83,6 +83,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
@@ -585,7 +586,8 @@ public abstract class AbstractTestHiveFileFormats
                 StorageFormat.fromHiveStorageFormat(storageFormat),
                 tableProperties,
                 jobConf,
-                session);
+                session,
+                NO_ACID_TRANSACTION);
 
         FileWriter hiveFileWriter = fileWriter.orElseThrow(() -> new IllegalArgumentException("fileWriterFactory"));
         hiveFileWriter.appendRows(page);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -235,10 +235,13 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(
                 TYPE_MANAGER,
+                config,
+                metastoreClient,
                 hdfsEnvironment,
                 getDefaultHivePageSourceFactories(hdfsEnvironment, config),
                 getDefaultHiveRecordCursorProviders(config, hdfsEnvironment),
-                new GenericHiveRecordCursorProvider(hdfsEnvironment, config));
+                new GenericHiveRecordCursorProvider(hdfsEnvironment, config),
+                Optional.empty());
 
         onSetupComplete();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -86,6 +86,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
 import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.getBucketNumber;
 import static io.prestosql.plugin.hive.BackgroundHiveSplitLoader.hasAttemptId;
@@ -473,6 +474,7 @@ public class TestBackgroundHiveSplitLoader
 
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = new BackgroundHiveSplitLoader(
                 SIMPLE_TABLE,
+                NO_ACID_TRANSACTION,
                 () -> new Iterator<>()
                 {
                     private boolean threw;
@@ -844,6 +846,7 @@ public class TestBackgroundHiveSplitLoader
 
         return new BackgroundHiveSplitLoader(
                 table,
+                NO_ACID_TRANSACTION,
                 hivePartitionMetadatas,
                 compactEffectivePredicate,
                 dynamicFilter,
@@ -874,6 +877,7 @@ public class TestBackgroundHiveSplitLoader
 
         return new BackgroundHiveSplitLoader(
                 SIMPLE_TABLE,
+                NO_ACID_TRANSACTION,
                 hivePartitionMetadatas,
                 TupleDomain.none(),
                 DynamicFilter.EMPTY,
@@ -898,6 +902,7 @@ public class TestBackgroundHiveSplitLoader
 
         return new BackgroundHiveSplitLoader(
                 SIMPLE_TABLE,
+                NO_ACID_TRANSACTION,
                 createPartitionMetadataWithOfflinePartitions(),
                 TupleDomain.all(),
                 DynamicFilter.EMPTY,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -70,6 +70,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveStorageFormat.AVRO;
 import static io.prestosql.plugin.hive.HiveStorageFormat.CSV;
 import static io.prestosql.plugin.hive.HiveStorageFormat.JSON;
@@ -927,7 +928,8 @@ public class TestHiveFileFormats
                 TableToPartitionMapping.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                NO_ACID_TRANSACTION);
 
         return pageSource.get();
     }
@@ -993,7 +995,8 @@ public class TestHiveFileFormats
                 TableToPartitionMapping.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                NO_ACID_TRANSACTION);
 
         assertTrue(pageSource.isPresent());
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -2855,7 +2855,7 @@ public class TestHiveIntegrationSmokeTest
             fail("expected exception");
         }
         catch (RuntimeException e) {
-            assertEquals(e.getMessage(), "This connector only supports delete where one or more partitions are deleted entirely");
+            assertEquals(e.getMessage(), "Deletes must match whole partitions for non-transactional tables");
         }
 
         assertQuery("SELECT * FROM test_metadata_delete", "SELECT orderkey, linenumber, linestatus FROM lineitem WHERE linestatus<>'O' AND linenumber<>3");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -189,7 +189,7 @@ public class TestHivePageSink
         File outputFile = getOnlyElement(files);
         long length = outputFile.length();
 
-        ConnectorPageSource pageSource = createPageSource(transaction, config, outputFile);
+        ConnectorPageSource pageSource = createPageSource(transaction, config, outputFile, metastore);
 
         List<Page> pages = new ArrayList<>();
         while (!pageSource.isFinished()) {
@@ -215,7 +215,7 @@ public class TestHivePageSink
         return resultBuilder.build();
     }
 
-    private static ConnectorPageSource createPageSource(HiveTransactionHandle transaction, HiveConfig config, File outputFile)
+    private static ConnectorPageSource createPageSource(HiveTransactionHandle transaction, HiveConfig config, File outputFile, HiveMetastore metastore)
     {
         Properties splitProperties = new Properties();
         splitProperties.setProperty(FILE_INPUT_FORMAT, config.getHiveStorageFormat().getInputFormat());
@@ -235,6 +235,7 @@ public class TestHivePageSink
                 ImmutableList.of(),
                 ImmutableList.of(),
                 OptionalInt.empty(),
+                0,
                 false,
                 TableToPartitionMapping.empty(),
                 Optional.empty(),
@@ -243,10 +244,13 @@ public class TestHivePageSink
         ConnectorTableHandle table = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), Optional.empty());
         HivePageSourceProvider provider = new HivePageSourceProvider(
                 TYPE_MANAGER,
+                config,
+                metastore,
                 HDFS_ENVIRONMENT,
                 getDefaultHivePageSourceFactories(HDFS_ENVIRONMENT, config),
                 getDefaultHiveRecordCursorProviders(config, HDFS_ENVIRONMENT),
-                new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT, config));
+                new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT, config),
+                Optional.empty());
         return provider.createPageSource(transaction, getHiveSession(config), split, table, ImmutableList.copyOf(getColumnHandles()), TupleDomain.all());
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplit.java
@@ -70,6 +70,7 @@ public class TestHiveSplit
                 partitionKeys,
                 addresses,
                 OptionalInt.empty(),
+                0,
                 true,
                 TableToPartitionMapping.mapColumnsByIndex(ImmutableMap.of(1, new HiveTypeName("string"))),
                 Optional.of(new HiveSplit.BucketConversion(

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveSplitSource.java
@@ -332,6 +332,7 @@ public class TestHiveSplitSource
                     ImmutableList.of(),
                     ImmutableList.of(new InternalHiveBlock(0, fileSize.toBytes(), ImmutableList.of())),
                     bucketNumber,
+                    0,
                     true,
                     false,
                     TableToPartitionMapping.empty(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -98,6 +98,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertBetweenInclusive;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.orc.OrcReader.MAX_BATCH_SIZE;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
@@ -503,7 +504,8 @@ public class TestOrcPageSourceMemoryTracking
                     TableToPartitionMapping.empty(),
                     Optional.empty(),
                     false,
-                    Optional.empty())
+                    Optional.empty(),
+                    NO_ACID_TRANSACTION)
                     .get();
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -68,6 +68,7 @@ import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
@@ -350,7 +351,8 @@ public enum FileFormat
                         createSchema(format, columnNames, columnTypes),
                         columnHandles,
                         TupleDomain.all(),
-                        Optional.empty());
+                        Optional.empty(),
+                        NO_ACID_TRANSACTION);
 
         checkState(readerPageSourceWithProjections.isPresent(), "readerPageSourceWithProjections is not present");
         checkState(readerPageSourceWithProjections.get().getProjectedReaderColumns().isEmpty(), "projection should not be required");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import io.prestosql.plugin.hive.AcidOperation;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
@@ -490,6 +491,34 @@ public class MockThriftMetastoreClient
 
     @Override
     public String getDelegationToken(String userName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long allocateWriteId(String dbName, String tableName, long transactionId)
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId)
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
+            throws TException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addDynamicPartitions(String dbName, String tableName, List<String> partitionNames, long transactionId, long writeId, AcidOperation operation)
+            throws TException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -47,6 +47,7 @@ import java.util.function.LongPredicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
@@ -196,7 +197,8 @@ public class TestOrcPageSourceFactory
                 createSchema(),
                 columnHandles,
                 tupleDomain,
-                acidInfo);
+                acidInfo,
+                NO_ACID_TRANSACTION);
 
         checkArgument(pageSourceWithProjections.isPresent());
         checkArgument(pageSourceWithProjections.get().getProjectedReaderColumns().isEmpty(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPredicates.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPredicates.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
 import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
@@ -223,7 +224,8 @@ public class TestOrcPredicates
                 TableToPartitionMapping.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                NO_ACID_TRANSACTION);
 
         assertTrue(pageSource.isPresent());
         return pageSource.get();

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
@@ -85,6 +85,7 @@ public class OrcRecordReader
     private final long totalRowCount;
     private final long splitLength;
     private final long maxBlockBytes;
+    private final ColumnMetadata<OrcType> orcTypes;
     private long currentPosition;
     private long currentStripePosition;
     private int currentBatchSize;
@@ -153,7 +154,7 @@ public class OrcRecordReader
         requireNonNull(fileStripes, "fileStripes is null");
         requireNonNull(stripeStats, "stripeStats is null");
         requireNonNull(orcDataSource, "orcDataSource is null");
-        requireNonNull(orcTypes, "types is null");
+        this.orcTypes = requireNonNull(orcTypes, "types is null");
         requireNonNull(decompressor, "decompressor is null");
         requireNonNull(legacyFileTimeZone, "legacyFileTimeZone is null");
         requireNonNull(userMetadata, "userMetadata is null");
@@ -322,6 +323,11 @@ public class OrcRecordReader
     public long getMaxCombinedBytesPerRow()
     {
         return maxCombinedBytesPerRow;
+    }
+
+    public ColumnMetadata<OrcType> getColumnTypes()
+    {
+        return orcTypes;
     }
 
     @Override

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/LongColumnWriter.java
@@ -235,4 +235,13 @@ public class LongColumnWriter
         rowGroupColumnStatistics.clear();
         statisticsBuilder = statisticsBuilderSupplier.get();
     }
+
+    @Override
+    public String toString()
+    {
+        return "LongColumnWriter{" +
+                "columnId=" + columnId +
+                ", type=" + type +
+                '}';
+    }
 }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestExternalHiveTable.java
@@ -126,7 +126,7 @@ public class TestExternalHiveTable
                 .hasRowsCount(3 * NATION_PARTITIONED_BY_REGIONKEY_NUMBER_OF_LINES_PER_SPLIT);
 
         assertThat(() -> onPresto().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME + " WHERE p_name IS NOT NULL"))
-                .failsWithMessage("This connector only supports delete where one or more partitions are deleted entirely");
+                .failsWithMessage("Deletes must match whole partitions for non-transactional tables");
 
         onPresto().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME + " WHERE p_regionkey = 1");
         assertThat(onPresto().executeQuery("SELECT * FROM " + EXTERNAL_TABLE_NAME))

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalDelete.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveTransactionalDelete.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import io.airlift.log.Logger;
+import io.prestosql.tests.hive.util.TemporaryHiveTable;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.tempto.assertions.QueryAssert.Row.row;
+import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
+import static io.prestosql.tests.TestGroups.HIVE_TRANSACTIONAL;
+import static io.prestosql.tests.hive.util.TemporaryHiveTable.randomTableSuffix;
+import static io.prestosql.tests.utils.QueryExecutors.onHive;
+import static io.prestosql.tests.utils.QueryExecutors.onPresto;
+import static java.lang.String.format;
+
+public class TestHiveTransactionalDelete
+        extends HiveProductTest
+{
+    private static final Logger log = Logger.get(TestHiveTransactionalDelete.class);
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveBasicDelete()
+    {
+        log.info("About to create table");
+        onHive().executeQuery("CREATE TABLE create_on_hive_basic_delete (column1 INT, column2 BIGINT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testBasicDelete("create_on_hive_basic_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoBasicDelete()
+    {
+        log.info("About to create table");
+        onPresto().executeQuery("CREATE TABLE create_on_presto_basic_delete (column1 INTEGER, column2 BIGINT) WITH (format = 'ORC', transactional = true)");
+        testBasicDelete("create_on_presto_basic_delete");
+    }
+
+    private void testBasicDelete(String tableName)
+    {
+        ensureTransactionalHive();
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
+        log.info("Deleting row 1 with hive");
+        onHive().executeQuery(format("DELETE FROM %s WHERE column2 = 100", tableName));
+        log.info("About to query row count");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column1 IN (2, 3, 4, 5)", tableName)))
+                .containsOnly(row(4));
+        log.info("About to perform first Presto delete");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column1 = 4", tableName));
+        log.info("Querying to verify first Presto delete worked");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column1 IN (2, 3, 5)", tableName)))
+                .containsOnly(row(3));
+        log.info("About to perform second Presto delete");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column1 < 3", tableName));
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column1 = 3", tableName)))
+                .containsOnly(row(1));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveMultiDelete()
+    {
+        onHive().executeQuery("CREATE TABLE create_on_hive_multi_delete (column1 INT, column2 BIGINT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testMultiDelete("create_on_hive_multi_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoMultiDelete()
+    {
+        onPresto().executeQuery("CREATE TABLE create_on_presto_multi_delete (column1 INT, column2 BIGINT) WITH (transactional = true)");
+        testMultiDelete("create_on_presto_multi_delete");
+    }
+
+    private void testMultiDelete(String tableName)
+    {
+        ensureTransactionalHive();
+        log.info("About to insert first set of rows");
+        onHive().executeQuery(format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
+        log.info("About to insert second set of rows");
+        onHive().executeQuery(format("INSERT INTO %s VALUES (6, 600), (7, 700), (8, 800), (9, 900), (10, 1000)", tableName));
+        log.info("About to have Hive delete row with column1 = 9");
+        onHive().executeQuery(format("DELETE FROM %s WHERE column1 = 9", tableName));
+        log.info("About to perform first Presto delete of row with column1 = 2 OR column1 = 3");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column1 = 2 OR column1 = 3", tableName));
+        log.info("Querying to verify that the Presto delete worked");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column1 IN (1, 4, 5, 6, 7, 8, 10)", tableName)))
+                .containsOnly(row(7));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveTransactionalMetadataDelete()
+    {
+        onHive().executeQuery("CREATE TABLE create_on_hive_transactional_metadata_delete (column2 BIGINT) PARTITIONED BY (column1 INT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testTransactionalMetadataDelete("create_on_hive_transactional_metadata_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoTransactionalMetadataDelete()
+    {
+        onPresto().executeQuery("CREATE TABLE create_on_presto_transactional_metadata_delete (column1 INT, column2 BIGINT) WITH (transactional = true, partitioned_by = ARRAY['column2'])");
+        testTransactionalMetadataDelete("create_on_presto_transactional_metadata_delete");
+    }
+
+    private void testTransactionalMetadataDelete(String tableName)
+    {
+        ensureTransactionalHive();
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s (column2, column1) VALUES %s, %s",
+                tableName,
+                makeInsertValues(1, 1, 20),
+                makeInsertValues(2, 1, 20)));
+
+        log.info("Deleting rows in Presto where column1 = 1");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column2 = 1", tableName));
+        log.info("Verifying that column1 = 1 rows are gone");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column2 = 1", tableName)))
+                .containsOnly(row(0));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveNonTransactionalMetadataDelete()
+    {
+        onHive().executeQuery("CREATE TABLE create_on_hive_non_transactional_metadata_delete (column2 BIGINT) PARTITIONED BY (column1 INT) STORED AS ORC");
+        testNonTransactionalMetadataDelete("create_on_hive_non_transactional_metadata_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoNonTransactionalMetadataDelete()
+    {
+        onPresto().executeQuery("CREATE TABLE create_on_presto_non_transactional_metadata_delete (column2 BIGINT, column1 INT) WITH (partitioned_by = ARRAY['column1'])");
+        testNonTransactionalMetadataDelete("create_on_presto_non_transactional_metadata_delete");
+    }
+
+    private void testNonTransactionalMetadataDelete(String tableName)
+    {
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s (column1, column2) VALUES %s, %s",
+                tableName,
+                makeInsertValues(1, 1, 20),
+                makeInsertValues(2, 1, 20)));
+
+        log.info("Deleting rows in Presto where column1 = 1");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column1 = 1", tableName));
+        log.info("Verifying that column1 = 1 rows are gone");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column1 = 1", tableName)))
+                .containsOnly(row(0));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveUnpartitionedDeleteAll()
+    {
+        onHive().executeQuery("CREATE TABLE test_unpartitioned_create_on_hive_delete_all (column1 INT, column2 BIGINT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testUnpartitionedDeleteAll("test_unpartitioned_create_on_hive_delete_all");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoUnpartitionedDeleteAll()
+    {
+        onPresto().executeQuery("CREATE TABLE test_unpartitioned_create_on_presto_delete_all (column1 INT, column2 BIGINT) WITH (transactional = true)");
+        testUnpartitionedDeleteAll("test_unpartitioned_create_on_presto_delete_all");
+    }
+
+    private void testUnpartitionedDeleteAll(String tableName)
+    {
+        ensureTransactionalHive();
+        onHive().executeQuery(format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
+        log.info("Deleting all rows in Presto");
+        onPresto().executeQuery("DELETE FROM " + tableName);
+        log.info("Verifying that all rows are gone");
+        assertThat(onPresto().executeQuery("SELECT COUNT(*) FROM " + tableName))
+                .containsOnly(row(0));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHiveMultiColumnDelete()
+    {
+        onHive().executeQuery("CREATE TABLE create_on_hive_multi_column_delete (column1 INT, column2 BIGINT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testMultiColumnDelete("create_on_hive_multi_column_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoMultiColumnDelete()
+    {
+        onPresto().executeQuery("CREATE TABLE create_on_presto_multi_column_delete (column1 INT, column2 BIGINT) WITH (transactional = true)");
+        testMultiColumnDelete("create_on_presto_multi_column_delete");
+    }
+
+    private void testMultiColumnDelete(String tableName)
+    {
+        ensureTransactionalHive();
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s VALUES (1, 100), (2, 200), (3, 300), (4, 400), (5, 500)", tableName));
+        String where = " WHERE column1 >= 2 AND column2 <= 400";
+        log.info("About to perform Presto delete of row %s", where);
+        onPresto().executeQuery(format("DELETE FROM %s %s", tableName, where));
+        log.info("Querying to verify that the Presto delete worked");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %S WHERE column1 IN (1, 5)", tableName)))
+                .containsOnly(row(2));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnHivePartitionAndRowsDelete()
+    {
+        onHive().executeQuery("CREATE TABLE create_on_hive_partition_and_rows_delete" +
+                " (column2 BIGINT) PARTITIONED BY (column1 INT) STORED AS ORC TBLPROPERTIES('transactional'='true')");
+        testPartitionAndRowsDelete("create_on_hive_partition_and_rows_delete");
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testCreateOnPrestoPartitionAndRowsDelete()
+    {
+        onPresto().executeQuery("CREATE TABLE create_on_presto_partition_and_rows_delete" +
+                " (column2 BIGINT, column1 INT) WITH (transactional = true, partitioned_by = ARRAY['column1'])");
+        testPartitionAndRowsDelete("create_on_presto_partition_and_rows_delete");
+    }
+
+    // Test cases with both a partition to drop and rows to delete
+    private void testPartitionAndRowsDelete(String tableName)
+    {
+        ensureTransactionalHive();
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s (column1, column2) VALUES (1, 100), (1, 200), (2, 300), (2, 400), (2, 500)", tableName));
+        String where = " WHERE column1 = 2 OR column2 = 200";
+        log.info("About to delete of rows %s", where);
+        onPresto().executeQuery(format("DELETE FROM %s %s", tableName, where));
+        assertThat(onPresto().executeQuery(format("SELECT column2 FROM %s", tableName)))
+                .containsOnly(row(100));
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testFailAcidBeforeHive3()
+    {
+        if (getHiveVersionMajor() >= 3) {
+            throw new SkipException("This tests behavior of ACID table before Hive 3 ");
+        }
+
+        try (TemporaryHiveTable table = TemporaryHiveTable.temporaryHiveTable("test_fail_acid_before_hive3_" + randomTableSuffix())) {
+            String tableName = table.getName();
+            onHive().executeQuery("" +
+                    "CREATE TABLE " + tableName + "(a bigint) " +
+                    "CLUSTERED BY(a) INTO 4 BUCKETS " +
+                    "STORED AS ORC " +
+                    "TBLPROPERTIES ('transactional'='true')");
+
+            assertThat(() -> onPresto().executeQuery("SELECT * FROM " + tableName))
+                    .failsWithMessage("Failed to open transaction. Transactional tables support requires Hive metastore version at least 3.0");
+        }
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL)
+    public void testPartitionedInsertAndRowLevelDelete()
+    {
+        ensureTransactionalHive();
+        String tableName = "transactional_row_delete";
+        onPresto().executeQuery(format("CREATE TABLE %s (column2 INT, column1 BIGINT) WITH (transactional = true, partitioned_by = ARRAY['column1'])", tableName));
+        log.info("About to insert rows");
+        onHive().executeQuery(format("INSERT INTO %s (column1, column2) VALUES %s, %s",
+                tableName,
+                makeInsertValues(1, 1, 20),
+                makeInsertValues(2, 1, 20)));
+        onHive().executeQuery(format("INSERT INTO %s (column1, column2) VALUES %s, %s",
+                tableName,
+                makeInsertValues(1, 21, 40),
+                makeInsertValues(2, 21, 40)));
+        log.info("Finished inserting rows");
+
+        log.info("Verifying that there are 40 rows with column2 > 10 AND column2 <= 30");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column2 > 10 AND column2 <= 30", tableName)))
+                .containsOnly(row(40));
+
+        log.info("Deleting rows in Presto where column2 > 10 AND column2 <= 30");
+        onPresto().executeQuery(format("DELETE FROM %s WHERE column2 > 10 AND column2 <= 30", tableName));
+        log.info("Finished delete");
+
+        log.info("Verifying that column2 > 10 AND column2 <= 30 rows are gone");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s WHERE column2 > 10 AND column2 <= 30", tableName)))
+                .containsOnly(row(0));
+
+        log.info("Verifying that there are 40 rows left");
+        assertThat(onPresto().executeQuery(format("SELECT COUNT(*) FROM %s", tableName)))
+                .containsOnly(row(40));
+
+        onPresto().executeQuery("DROP TABLE " + tableName);
+    }
+
+    private String makeInsertValues(int col1Value, int col2First, int col2Last)
+    {
+        checkArgument(col2First <= col2Last, "The first value %s must be less or equal to the last %s", col2First, col2Last);
+        return IntStream.rangeClosed(col2First, col2Last).mapToObj(i -> format("(%s, %s)", col1Value, i)).collect(Collectors.joining(", "));
+    }
+
+    private void ensureTransactionalHive()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
+        }
+    }
+
+    // A method used only during IDE test debugging to keep the docker containers alive
+    private void testUninterruptibly(Runnable runnable)
+    {
+        try {
+            runnable.run();
+        }
+        catch (Throwable e) {
+            log.error("Saw exception %s", e, e);
+            Uninterruptibles.sleepUninterruptibly(Duration.ofDays(1));
+        }
+        Uninterruptibles.sleepUninterruptibly(Duration.ofDays(1));
+    }
+}


### PR DESCRIPTION
This commit adds support for row-by-row delete for Hive ACID tables, and product tests that verify that row-by-row delete is working correctly for both partitioned and non-partitioned tables, and that metadata delete still works correctly in cases where the delete WHERE clause specifies all rows in a set of partitions and no other rows.  When the WHERE clause can't be satisfied by dropping partitions, row-by-row delete is used to delete all the rows.

Hive ACID uses the ORC format for data, and the Thrift Hive metastore format for metadata.  The work to support DELETE created much of the machinery needed for INSERT and UPDATE operations, and was concentrated in these areas:

- Plumbing the new methods required for any Hive ACID update operation through the many layers of Hive metastores, to ThriftHiveMetastoreClient. The first of those methods gets a new writeId for the delete_delta records to be written, and the second updates the table's writeId to be that deletion writeId.
- Adding a synthesized row__id column for the delete table scan, consisting of the originalWriteId, the rowId and the bucket for the deleted row.
- Creating the appropriate UpdatablePageSource to receive the rows to be deleted, and write the delete_delta files.

The only observable difference in data and metadata produced by the Presto Hive connector compared to running SQL in Hive itself is the column statistics for the delete delta ACID columns. The statistics written by Hive itself sets hasNull to false, and provides bytesOnDisk numbers.  The Presto implementation of ORC column statistics doesn't have those fields, and adding them would be an effort independent of the work in this commit.

It has been suggested that it may make more sense to delay merging this commit until Hive ACID INSERT works correctly, since DELETE without INSERT seems strange.  It appears to me that adding support for Hive ACID INSERT will go quickly because this commit created the metastore APIs needed for INSERT.

We have decided that for transactional tables, all deletes will be row-level deletes.  The discussion that led to this conclusion is tracked in issue #5035.