### PR TITLE
Log Presto version on startup

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/Server.java
+++ b/presto-main/src/main/java/io/prestosql/server/Server.java
@@ -34,6 +34,7 @@ import io.airlift.log.LogJmxModule;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
 import io.airlift.tracetoken.TraceTokenModule;
+import io.prestosql.client.NodeVersion;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.eventlistener.EventListenerModule;
 import io.prestosql.execution.resourcegroups.ResourceGroupManager;
@@ -109,6 +110,7 @@ public class Server
         try {
             Injector injector = app.strictConfig().initialize();
 
+            log.info("Presto version: %s", injector.getInstance(NodeVersion.class).getVersion());
             logLocation(log, "Working directory", Paths.get("."));
             logLocation(log, "Etc directory", Paths.get("etc"));
 


### PR DESCRIPTION
Log Presto version on startup

Once presto.version configuration property is removed, Presto version is
not printed during the Presto startup.
