### PR TITLE
Add from_iso8601_timestamp_nanos operation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -91,6 +91,21 @@ Date and Time Functions
         SELECT from_iso8601_timestamp('2020-05-11T11:15:05.055+01:00');
         -- 2020-05-11 11:15:05.055 +01:00
 
+.. function:: from_iso8601_timestamp_nanos(string) -> timestamp(9) with time zone
+
+    Parses the ISO 8601 formatted date ``string``, optionally with time and time
+    zone, into a ``timestamp(9) with time zone``. The time defaults to
+    ``00:00:00.000000000``, and the time zone defaults to the session time zone::
+
+        SELECT from_iso8601_timestamp('2020-05-11');
+        -- 2020-05-11 00:00:00.000000000 America/Vancouver
+
+        SELECT from_iso8601_timestamp('2020-05-11T11:15:05');
+        -- 2020-05-11 11:15:05.000000000 America/Vancouver
+
+        SELECT from_iso8601_timestamp('2020-05-11T11:15:05.123456789+01:00');
+        -- 2020-05-11 11:15:05.123456789 +01:00
+
 .. function:: from_iso8601_date(string) -> date
 
     Parses the ISO 8601 formatted date ``string`` into a ``date``. The date can


### PR DESCRIPTION
This addresses the nanos use case of https://github.com/prestosql/presto/issues/5037

If this approach looks reasonable to you @dain @electrum @martint happy to update this with the micros version as well, or we can do that in a separate PR