### PR TITLE
Remove tested version information from user docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -7,8 +7,6 @@ external `PostgreSQL <https://www.postgresql.org/>`_ database. This can be used 
 different systems like PostgreSQL and Hive, or between different
 PostgreSQL instances.
 
-This connector is tested against PostgreSQL 12.4.
-
 Configuration
 -------------
 


### PR DESCRIPTION
The user does not know how to interpret such a sentence.
It can be read as "this is the supported version" or "this is the lowest
supported version", which was not the intention.