### PR TITLE
Support Domain Expressions for GlueHiveMetastore

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePartitionManager.java
@@ -122,7 +122,7 @@ public class HivePartitionManager
                     .collect(toImmutableList());
         }
         else {
-            List<String> partitionNames = getFilteredPartitionNames(metastore, identity, tableName, partitionColumns, effectivePredicate);
+            List<String> partitionNames = getFilteredPartitionNames(metastore, identity, tableName, partitionColumns, compactEffectivePredicate);
             partitionsIterable = () -> partitionNames.stream()
                     // Apply extra filters which could not be done by getFilteredPartitionNames
                     .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, partitionTypes, effectivePredicate, predicate))
@@ -241,7 +241,7 @@ public class HivePartitionManager
         return true;
     }
 
-    private List<String> getFilteredPartitionNames(SemiTransactionalHiveMetastore metastore, HiveIdentity identity, SchemaTableName tableName, List<HiveColumnHandle> partitionKeys, TupleDomain<ColumnHandle> effectivePredicate)
+    private List<String> getFilteredPartitionNames(SemiTransactionalHiveMetastore metastore, HiveIdentity identity, SchemaTableName tableName, List<HiveColumnHandle> partitionKeys, TupleDomain<HiveColumnHandle> effectivePredicate)
     {
         List<String> columnNames = partitionKeys.stream()
                 .map(HiveColumnHandle::getName)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -13,73 +13,202 @@
  */
 package io.prestosql.plugin.hive.metastore.glue;
 
-import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import io.prestosql.plugin.hive.HiveType;
-import io.prestosql.plugin.hive.metastore.Column;
-import io.prestosql.spi.PrestoException;
+import io.prestosql.plugin.hive.metastore.MetastoreUtil;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Marker;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.predicate.ValueSet;
+import io.prestosql.spi.type.CharType;
+import io.prestosql.spi.type.DateType;
+import io.prestosql.spi.type.TimestampType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
-import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 
 public final class GlueExpressionUtil
 {
-    private static final Joiner JOINER = Joiner.on(" AND ");
+    static final String NULL_STRING = "__HIVE_DEFAULT_PARTITION__";
+    static final int GLUE_EXPRESSION_CHAR_LIMIT = 2048;
+
     private static final Set<String> QUOTED_TYPES = ImmutableSet.of("string", "char", "varchar", "date", "timestamp", "binary", "varbinary");
+    private static final String CONJUNCT_SEPARATOR = " AND ";
+    private static final Joiner CONJUNCT_JOINER = Joiner.on(CONJUNCT_SEPARATOR);
+    private static final String DISJUNCT_SEPARATOR = " OR ";
+    private static final Joiner DISJUNCT_JOINER = Joiner.on(DISJUNCT_SEPARATOR);
 
     private GlueExpressionUtil() {}
 
-    /**
-     * Build an expression string used for partition filtering in {@link GetPartitionsRequest}
-     * <pre>
-     * Ex: partition keys: ['a', 'b']
-     *     partition values: ['1', '2']
-     *     expression: (a='1') AND (b='2')
-     *
-     * Partial specification ex:
-     *      partition values: ['', '2']
-     *      expression: (b='2')
-     * </pre>
-     *
-     * @param partitionKeys List of partition keys to filter on
-     * @param partitionValues Full or partial list of partition values to filter on. Keys without filter should be empty string.
-     */
-    public static String buildGlueExpression(List<Column> partitionKeys, List<String> partitionValues)
+    private static boolean isQuotedType(Type type)
     {
-        if (partitionValues == null || partitionValues.isEmpty()) {
-            return null;
+        return QUOTED_TYPES.contains(type.getTypeSignature().getBase());
+    }
+
+    private static String valueToString(Type type, Object value)
+    {
+        String s = MetastoreUtil.sqlScalarToString(type, value, NULL_STRING);
+
+        return isQuotedType(type) ? "'" + s + "'" : s;
+    }
+
+    private static boolean canConvertSqlTypeToStringForGlue(Type type, boolean assumeCanonicalPartitionKeys)
+    {
+        return !(type instanceof TimestampType) && !(type instanceof DateType) && (type instanceof CharType || type instanceof VarcharType || assumeCanonicalPartitionKeys);
+    }
+
+    /**
+     * @return a valid glue expression <= {@link  GlueExpressionUtil#GLUE_EXPRESSION_CHAR_LIMIT}. A return value of "" means a valid glue expression could not be created, or
+     * {@link TupleDomain#all()} was passed in as an argument
+     */
+    public static String buildGlueExpression(List<String> columnNames, TupleDomain<String> partitionKeysFilter, boolean assumeCanonicalPartitionKeys)
+    {
+        return buildGlueExpression(columnNames, partitionKeysFilter, assumeCanonicalPartitionKeys, GLUE_EXPRESSION_CHAR_LIMIT);
+    }
+
+    public static String buildGlueExpression(
+            List<String> columnNames, TupleDomain<String> partitionKeysFilter, boolean assumeCanonicalPartitionKeys, int expressionLengthLimit)
+    {
+        // this should have been handled by callers
+        checkState(!partitionKeysFilter.isNone());
+        if (partitionKeysFilter.isAll()) {
+            // glue handles both null and "" as a tautology
+            return "";
         }
 
-        if (partitionKeys == null || partitionValues.size() != partitionKeys.size()) {
-            throw new PrestoException(HIVE_METASTORE_ERROR, "Incorrect number of partition values: " + partitionValues);
-        }
+        List<String> perColumnExpressions = new ArrayList<>();
+        int expressionLength = 0;
+        Map<String, Domain> domains = partitionKeysFilter.getDomains().get();
+        for (String columnName : columnNames) {
+            Domain domain = domains.get(columnName);
+            if (domain != null) {
+                Optional<String> columnExpression = buildGlueExpressionForSingleDomain(columnName, domain, assumeCanonicalPartitionKeys);
+                if (columnExpression.isPresent()) {
+                    int newExpressionLength = expressionLength;
+                    if (expressionLength > 0) {
+                        newExpressionLength += CONJUNCT_SEPARATOR.length();
+                    }
 
-        List<String> predicates = new LinkedList<>();
-        for (int i = 0; i < partitionValues.size(); i++) {
-            if (!Strings.isNullOrEmpty(partitionValues.get(i))) {
-                predicates.add(buildPredicate(partitionKeys.get(i), partitionValues.get(i)));
+                    newExpressionLength += columnExpression.get().length();
+
+                    if (newExpressionLength > expressionLengthLimit) {
+                        continue;
+                    }
+
+                    perColumnExpressions.add(columnExpression.get());
+                    expressionLength = newExpressionLength;
+                }
             }
         }
 
-        return JOINER.join(predicates);
+        return Joiner.on(CONJUNCT_SEPARATOR).join(perColumnExpressions);
     }
 
-    private static String buildPredicate(Column partitionKey, String value)
+    /**
+     * Converts domain to a valid glue expression per
+     * https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-partitions.html#aws-glue-api-catalog-partitions-GetPartitions
+     *
+     * @return optional glue-compatible expression. if empty, either tye type of the {@link Domain} cannot be converted to a string, or the filter is {@link Domain#all}
+     */
+    @VisibleForTesting
+    static Optional<String> buildGlueExpressionForSingleDomain(String columnName, Domain domain, boolean assumeCanonicalPartitionKeys)
     {
-        if (isQuotedType(partitionKey.getType())) {
-            return format("(%s='%s')", partitionKey.getName(), value);
+        ValueSet valueSet = domain.getValues();
+
+        if (domain.isAll() || !canConvertSqlTypeToStringForGlue(domain.getType(), assumeCanonicalPartitionKeys)) {
+            // if the type can't be converted or Domain.all()
+            return Optional.empty();
         }
-        return format("(%s=%s)", partitionKey.getName(), value);
-    }
 
-    private static boolean isQuotedType(HiveType type)
-    {
-        return QUOTED_TYPES.contains(type.getTypeSignature().getBase());
+        if (domain.getValues().isAll()) {
+            return Optional.of(format("(%s <> '%s')", columnName, NULL_STRING));
+        }
+
+        // null must be allowed for this case since callers must filter Domain.none() out
+        if (domain.getValues().isNone()) {
+            return Optional.of(format("(%s = '%s')", columnName, NULL_STRING));
+        }
+
+        List<String> disjuncts = new ArrayList<>();
+        List<String> singleValues = new ArrayList<>();
+        for (Range range : valueSet.getRanges().getOrderedRanges()) {
+            checkState(!range.isAll()); // Already checked
+            if (range.isSingleValue()) {
+                Marker rangeLow = range.getLow();
+                singleValues.add(valueToString(rangeLow.getType(), rangeLow.getValue()));
+            }
+            else {
+                List<String> rangeConjuncts = new ArrayList<>();
+                if (!range.getLow().isLowerUnbounded()) {
+                    Marker rangeLow = range.getLow();
+                    switch (range.getLow().getBound()) {
+                        case ABOVE:
+                            rangeConjuncts.add(format(
+                                    "%s > %s",
+                                    columnName,
+                                    valueToString(rangeLow.getType(), rangeLow.getValue())));
+                            break;
+                        case EXACTLY:
+                            rangeConjuncts.add(format(
+                                    "%s >= %s",
+                                    columnName,
+                                    valueToString(rangeLow.getType(), rangeLow.getValue())));
+                            break;
+                        case BELOW:
+                            throw new IllegalArgumentException("Low marker should never use BELOW bound");
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                    }
+                }
+                if (!range.getHigh().isUpperUnbounded()) {
+                    Marker rangeHigh = range.getHigh();
+                    switch (range.getHigh().getBound()) {
+                        case ABOVE:
+                            throw new IllegalArgumentException("High marker should never use ABOVE bound");
+                        case EXACTLY:
+                            rangeConjuncts.add(format(
+                                    "%s <= %s",
+                                    columnName,
+                                    valueToString(rangeHigh.getType(), rangeHigh.getValue())));
+                            break;
+                        case BELOW:
+                            rangeConjuncts.add(format(
+                                    "%s < %s",
+                                    columnName,
+                                    valueToString(rangeHigh.getType(), rangeHigh.getValue())));
+                            break;
+                        default:
+                            throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                    }
+                }
+                // If rangeConjuncts is null, then the range was ALL, which should already have been checked for by callers
+                checkState(!rangeConjuncts.isEmpty());
+                disjuncts.add("(" + CONJUNCT_JOINER.join(rangeConjuncts) + ")");
+            }
+        }
+
+        if (singleValues.size() == 1) {
+            String equalsTest = format("(%s = %s)", columnName, getOnlyElement(singleValues));
+            disjuncts.add(equalsTest);
+        }
+        else if (singleValues.size() > 1) {
+            String values = Joiner.on(", ").join(singleValues);
+            String inClause = format("(%s in (%s))", columnName, values);
+
+            disjuncts.add(inClause);
+        }
+
+        return Optional.of("(" + DISJUNCT_JOINER.join(disjuncts) + ")");
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveLocal.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveLocal.java
@@ -55,7 +55,7 @@ public abstract class AbstractTestHiveLocal
 
     protected abstract HiveMetastore createMetastore(File tempDir);
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void initialize()
     {
         tempDir = Files.createTempDir();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/PartitionFilterBuilder.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/PartitionFilterBuilder.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore.glue;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.predicate.ValueSet;
+import io.prestosql.spi.type.BigintType;
+import io.prestosql.spi.type.DateType;
+import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.IntegerType;
+import io.prestosql.spi.type.SmallintType;
+import io.prestosql.spi.type.TinyintType;
+import io.prestosql.spi.type.VarcharType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class PartitionFilterBuilder
+{
+    public static final int DECIMAL_TYPE_PRECISION = 10;
+    public static final int DECIMAL_TYPE_SCALE = 5;
+    public static final DecimalType DECIMAL_TYPE = DecimalType.createDecimalType(DECIMAL_TYPE_PRECISION, DECIMAL_TYPE_SCALE);
+
+    private final Map<String, Domain> domains = new HashMap<>();
+
+    public PartitionFilterBuilder addStringValues(String columnName, String... values)
+    {
+        List<Slice> blockValues = Arrays.stream(values).map(Slices::utf8Slice).collect(toImmutableList());
+        Domain domain = Domain.multipleValues(VarcharType.VARCHAR, blockValues);
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addBigintValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(BigintType.BIGINT, Arrays.asList(values));
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addIntegerValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(IntegerType.INTEGER, Arrays.asList(values));
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addSmallintValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(SmallintType.SMALLINT, Arrays.asList(values));
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addTinyintValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(TinyintType.TINYINT, Arrays.asList(values));
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addDecimalValues(String columnName, String... values)
+    {
+        checkArgument(values.length > 0);
+        List<Long> encodedValues = Arrays.stream(values)
+                .map(PartitionFilterBuilder::decimalOf)
+                .collect(toImmutableList());
+        Domain domain = Domain.multipleValues(DECIMAL_TYPE, encodedValues);
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addDateValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(DateType.DATE, Arrays.asList(values));
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addRanges(String columnName, Range range, Range... ranges)
+    {
+        ValueSet values = ValueSet.ofRanges(range, ranges);
+        Domain domain = Domain.create(values, false);
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public PartitionFilterBuilder addDomain(String columnName, Domain domain)
+    {
+        domains.compute(columnName, (k, v) -> v == null ? domain : v.union(domain));
+        return this;
+    }
+
+    public TupleDomain<String> build()
+    {
+        ImmutableMap<String, Domain> domains = ImmutableMap.copyOf(this.domains);
+        TupleDomain<String> stringTupleDomain = TupleDomain.withColumnDomains(domains);
+        return stringTupleDomain;
+    }
+
+    public static Long decimalOf(double value)
+    {
+        BigDecimal bigDecimalValue = new BigDecimal(value)
+                .setScale(DECIMAL_TYPE_SCALE, RoundingMode.UP);
+        return bigDecimalValue.unscaledValue().longValue();
+    }
+
+    public static Long decimalOf(String value)
+    {
+        BigDecimal bigDecimalValue = new BigDecimal(value)
+                .setScale(DECIMAL_TYPE_SCALE, RoundingMode.UP);
+        return bigDecimalValue.unscaledValue().longValue();
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
@@ -16,70 +16,208 @@ package io.prestosql.plugin.hive.metastore.glue;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.metastore.Column;
-import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.VarcharType;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Optional;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.plugin.hive.metastore.glue.GlueExpressionUtil.buildGlueExpression;
+import static io.prestosql.plugin.hive.metastore.glue.GlueExpressionUtil.buildGlueExpressionForSingleDomain;
+import static io.prestosql.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 public class TestGlueExpressionUtil
 {
-    private static final List<Column> PARTITION_KEYS = ImmutableList.of(
-            getColumn("name", "string"),
-            getColumn("birthday", "date"),
-            getColumn("age", "int"));
-
     private static Column getColumn(String name, String type)
     {
         return new Column(name, HiveType.valueOf(type), Optional.empty());
     }
 
     @Test
-    public void testBuildExpression()
+    public void testBuildGlueExpressionDomainEqualsSingleValue()
     {
-        List<String> partitionValues = ImmutableList.of("foo", "2018-01-02", "99");
-        String expression = buildGlueExpression(PARTITION_KEYS, partitionValues);
-        assertEquals(expression, "(name='foo') AND (birthday='2018-01-02') AND (age=99)");
-
-        partitionValues = ImmutableList.of("foo", "2018-01-02", "");
-        expression = buildGlueExpression(PARTITION_KEYS, partitionValues);
-        assertEquals(expression, "(name='foo') AND (birthday='2018-01-02')");
+        Domain domain = Domain.singleValue(VarcharType.VARCHAR, utf8Slice("2020-01-01"));
+        Optional<String> foo = buildGlueExpressionForSingleDomain("foo", domain, true);
+        assertEquals(foo.get(), "((foo = '2020-01-01'))");
     }
 
     @Test
-    public void testBuildExpressionFromPartialSpecification()
+    public void testBuildGlueExpressionTupleDomainEqualsSingleValue()
     {
-        List<String> partitionValues = ImmutableList.of("", "2018-01-02", "");
-        String expression = buildGlueExpression(PARTITION_KEYS, partitionValues);
-        assertEquals(expression, "(birthday='2018-01-02')");
-
-        partitionValues = ImmutableList.of("foo", "", "99");
-        expression = buildGlueExpression(PARTITION_KEYS, partitionValues);
-        assertEquals(expression, "(name='foo') AND (age=99)");
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addStringValues("col2", "2020-02-20")
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
+        assertEquals(expression, "((col1 = '2020-01-01')) AND ((col2 = '2020-02-20'))");
     }
 
     @Test
-    public void testBuildExpressionNullOrEmptyValues()
+    public void testBuildGlueExpressionTupleDomainEqualsAndInClause()
     {
-        assertNull(buildGlueExpression(PARTITION_KEYS, ImmutableList.of()));
-        assertNull(buildGlueExpression(PARTITION_KEYS, null));
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addStringValues("col2", "2020-02-20", "2020-02-28")
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
+        assertEquals(expression, "((col1 = '2020-01-01')) AND ((col2 in ('2020-02-20', '2020-02-28')))");
     }
 
-    @Test(expectedExceptions = PrestoException.class)
-    public void testBuildExpressionInvalidPartitionValueListSize()
+    @Test
+    public void testBuildGlueExpressionTupleDomainExtraDomain()
     {
-        List<String> partitionValues = ImmutableList.of("foo", "2017-01-02", "99", "extra");
-        buildGlueExpression(PARTITION_KEYS, partitionValues);
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addStringValues("col2", "2020-02-20", "2020-02-28")
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, "((col1 = '2020-01-01'))");
     }
 
-    @Test(expectedExceptions = PrestoException.class)
-    public void testBuildExpressionNullPartitionKeys()
+    @Test
+    public void testBuildGlueExpressionTupleDomainRange()
     {
-        List<String> partitionValues = ImmutableList.of("foo", "2018-01-02", "99");
-        buildGlueExpression(null, partitionValues);
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .addRanges("col2", Range.greaterThan(BIGINT, 100L))
+                .addRanges("col2", Range.lessThan(BIGINT, 0L))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
+        assertEquals(expression, "((col1 = '2020-01-01')) AND ((col2 < 0) OR (col2 > 100))");
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainEqualAndRangeLong()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addBigintValues("col1", 3L)
+                .addRanges("col1", Range.greaterThan(BIGINT, 100L))
+                .addRanges("col1", Range.lessThan(BIGINT, 0L))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, "((col1 < 0) OR (col1 > 100) OR (col1 = 3))");
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainEqualAndRangeString()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01", "2020-01-31")
+                .addRanges("col1", Range.range(VarcharType.VARCHAR, utf8Slice("2020-03-01"), true, utf8Slice("2020-03-31"), true))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, "((col1 >= '2020-03-01' AND col1 <= '2020-03-31') OR (col1 in ('2020-01-01', '2020-01-31')))");
+    }
+
+    @Test
+    public void testBuildGlueExpressionExtraColumn()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "2020-01-01")
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
+        assertEquals(expression, "((col1 = '2020-01-01'))");
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainIsNull()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addDomain("col1", Domain.onlyNull(VarcharType.VARCHAR))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("(col1 = '%s')", GlueExpressionUtil.NULL_STRING));
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainNotNull()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addDomain("col1", Domain.notNull(VarcharType.VARCHAR))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("(col1 <> '%s')", GlueExpressionUtil.NULL_STRING));
+    }
+
+    @Test
+    public void testBuildGlueExpressionMaxLengthNone()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "x".repeat(101))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true, 100);
+        assertEquals(expression, "");
+    }
+
+    @Test
+    public void testBuildGlueExpressionMaxLengthOneColumn()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues("col1", "x".repeat(5))
+                .addStringValues("col2", "x".repeat(25))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true, 20);
+        assertEquals(expression, "((col1 = 'xxxxx'))");
+    }
+
+    @Test
+    public void testBuildGlueExpressionTupleDomainAll()
+    {
+        String expression = buildGlueExpression(ImmutableList.of("col1"), TupleDomain.all(), true);
+        assertEquals(expression, "");
+    }
+
+    @Test
+    public void testDecimalConverstion()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addDecimalValues("col1", "10.134")
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, "((col1 = 10.13400))");
+    }
+
+    @Test
+    public void testBigintConversion()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addBigintValues("col1", Long.MAX_VALUE)
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("((col1 = %d))", Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testIntegerConversion()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addIntegerValues("col1", Long.valueOf(Integer.MAX_VALUE))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("((col1 = %d))", Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testSmallintConversion()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addIntegerValues("col1", Long.valueOf(Short.MAX_VALUE))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("((col1 = %d))", Short.MAX_VALUE));
+    }
+
+    @Test
+    public void testTinyintConversion()
+    {
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addIntegerValues("col1", Long.valueOf(Byte.MAX_VALUE))
+                .build();
+        String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
+        assertEquals(expression, String.format("((col1 = %d))", Byte.MAX_VALUE));
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -16,20 +16,45 @@ package io.prestosql.plugin.hive.metastore.glue;
 import com.google.common.collect.ImmutableList;
 import io.airlift.concurrent.BoundedExecutor;
 import io.prestosql.plugin.hive.AbstractTestHiveLocal;
+import io.prestosql.plugin.hive.HiveMetastoreClosure;
+import io.prestosql.plugin.hive.HiveTestUtils;
+import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
+import io.prestosql.plugin.hive.metastore.Table;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.BigintType;
+import io.prestosql.spi.type.DateType;
+import io.prestosql.spi.type.IntegerType;
+import io.prestosql.spi.type.SmallintType;
+import io.prestosql.spi.type.TinyintType;
+import io.prestosql.spi.type.VarcharType;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.plugin.hive.HiveStorageFormat.ORC;
 import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.prestosql.plugin.hive.metastore.glue.PartitionFilterBuilder.DECIMAL_TYPE;
+import static io.prestosql.plugin.hive.metastore.glue.PartitionFilterBuilder.decimalOf;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
 import static java.util.Locale.ENGLISH;
 import static java.util.UUID.randomUUID;
+import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
@@ -44,10 +69,59 @@ public class TestHiveGlueMetastore
         extends AbstractTestHiveLocal
 {
     private static final HiveIdentity HIVE_CONTEXT = new HiveIdentity(SESSION);
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS = ImmutableList.<ColumnMetadata>builder()
+            .add(new ColumnMetadata("id", BigintType.BIGINT))
+            .build();
+    private static final String PARTITION_KEY = "part_key_1";
+    private static final String PARTITION_KEY2 = "part_key_2";
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, VarcharType.VARCHAR))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_TWO_KEYS = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, VarcharType.VARCHAR))
+            .add(new ColumnMetadata(PARTITION_KEY2, BigintType.BIGINT))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_TINYINT = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, TinyintType.TINYINT))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_SMALLINT = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, SmallintType.SMALLINT))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_INTEGER = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, IntegerType.INTEGER))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_BIGINT = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, BigintType.BIGINT))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_DECIMAL = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, DECIMAL_TYPE))
+            .build();
+    private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS_PARTITIONED_DATE = ImmutableList.<ColumnMetadata>builder()
+            .addAll(CREATE_TABLE_COLUMNS)
+            .add(new ColumnMetadata(PARTITION_KEY, DateType.DATE))
+            .build();
+    private static final List<String> VARCHAR_PARTITION_VALUES = ImmutableList.of("2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01");
 
     public TestHiveGlueMetastore()
     {
         super("test_glue" + randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void initialize()
+    {
+        super.initialize();
+        // uncomment to get extra AWS debug information
+//        Logging logging = Logging.initialize();
+//        logging.setLevel("com.amazonaws.request", Level.DEBUG);
     }
 
     @Override
@@ -55,6 +129,7 @@ public class TestHiveGlueMetastore
     {
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
         glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());
+        glueConfig.setAssumeCanonicalPartitionKeys(true);
 
         Executor executor = new BoundedExecutor(this.executor, 10);
         return new GlueHiveMetastore(HDFS_ENVIRONMENT, glueConfig, new DisabledGlueColumnStatisticsProvider(), executor, Optional.empty());
@@ -108,12 +183,13 @@ public class TestHiveGlueMetastore
             throws Exception
     {
         try {
-            createDummyPartitionedTable(tablePartitionFormat, CREATE_TABLE_COLUMNS_PARTITIONED);
+            SchemaTableName tableName = temporaryTable("get_partitions");
+            createDummyPartitionedTable(tableName, CREATE_TABLE_COLUMNS_PARTITIONED);
             HiveMetastore metastoreClient = getMetastoreClient();
             Optional<List<String>> partitionNames = metastoreClient.getPartitionNamesByFilter(
                     HIVE_CONTEXT,
-                    tablePartitionFormat.getSchemaName(),
-                    tablePartitionFormat.getTableName(),
+                    tableName.getSchemaName(),
+                    tableName.getTableName(),
                     ImmutableList.of("ds"), TupleDomain.all());
             assertTrue(partitionNames.isPresent());
             assertEquals(partitionNames.get(), ImmutableList.of("ds=2016-01-01", "ds=2016-01-02"));
@@ -144,5 +220,584 @@ public class TestHiveGlueMetastore
         long initialFailureCount = stats.getGetDatabase().getTotalFailures().getTotalCount();
         assertThrows(() -> getMetastoreClient().getDatabase(null));
         assertEquals(stats.getGetDatabase().getTotalFailures().getTotalCount(), initialFailureCount + 1);
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterVarChar()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "2020-01-01")
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(VarcharType.VARCHAR, utf8Slice("2020-02-01")))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(VarcharType.VARCHAR, utf8Slice("2020-02-01"), true, utf8Slice("2020-03-01"), true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(VarcharType.VARCHAR, utf8Slice("2020-03-01")))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "2020-01-01", "2020-02-01")
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(VarcharType.VARCHAR, utf8Slice("2020-03-01")))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                VARCHAR_PARTITION_VALUES,
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("2020-01-01"),
+                        ImmutableList.of("2020-03-01", "2020-04-01"),
+                        ImmutableList.of("2020-02-01", "2020-03-01"),
+                        ImmutableList.of("2020-03-01", "2020-04-01"),
+                        ImmutableList.of("2020-01-01", "2020-02-01"),
+                        ImmutableList.of("2020-01-01", "2020-02-01"),
+                        ImmutableList.of("2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterBigInt()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addBigintValues(PARTITION_KEY, 1000L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(BigintType.BIGINT, 100L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(BigintType.BIGINT, 100L, true, 1000L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(BigintType.BIGINT, 100L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addBigintValues(PARTITION_KEY, 1L, 1000000L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(BigintType.BIGINT, 1000L))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_BIGINT,
+                PARTITION_KEY,
+                ImmutableList.of("1", "100", "1000", "1000000"),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("1000"),
+                        ImmutableList.of("1000", "1000000"),
+                        ImmutableList.of("100", "1000"),
+                        ImmutableList.of("100", "1000", "1000000"),
+                        ImmutableList.of("1", "1000000"),
+                        ImmutableList.of("1", "100"),
+                        ImmutableList.of("1", "100", "1000", "1000000")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterInteger()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addIntegerValues(PARTITION_KEY, 1000L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(IntegerType.INTEGER, 100L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(IntegerType.INTEGER, 100L, true, 1000L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(IntegerType.INTEGER, 100L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addIntegerValues(PARTITION_KEY, 1L, 1000000L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(IntegerType.INTEGER, 1000L))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_INTEGER,
+                PARTITION_KEY,
+                ImmutableList.of("1", "100", "1000", "1000000"),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("1000"),
+                        ImmutableList.of("1000", "1000000"),
+                        ImmutableList.of("100", "1000"),
+                        ImmutableList.of("100", "1000", "1000000"),
+                        ImmutableList.of("1", "1000000"),
+                        ImmutableList.of("1", "100"),
+                        ImmutableList.of("1", "100", "1000", "1000000")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterSmallInt()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addSmallintValues(PARTITION_KEY, 1000L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(SmallintType.SMALLINT, 100L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(SmallintType.SMALLINT, 100L, true, 1000L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(SmallintType.SMALLINT, 100L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addSmallintValues(PARTITION_KEY, 1L, 10000L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(SmallintType.SMALLINT, 1000L))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_SMALLINT,
+                PARTITION_KEY,
+                ImmutableList.of("1", "100", "1000", "10000"),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("1000"),
+                        ImmutableList.of("1000", "10000"),
+                        ImmutableList.of("100", "1000"),
+                        ImmutableList.of("100", "1000", "10000"),
+                        ImmutableList.of("1", "10000"),
+                        ImmutableList.of("1", "100"),
+                        ImmutableList.of("1", "100", "1000", "10000")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterTinyInt()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addTinyintValues(PARTITION_KEY, 127L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(TinyintType.TINYINT, 10L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(TinyintType.TINYINT, 10L, true, 100L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(TinyintType.TINYINT, 10L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addTinyintValues(PARTITION_KEY, 1L, 127L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(TinyintType.TINYINT, 100L))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_TINYINT,
+                PARTITION_KEY,
+                ImmutableList.of("1", "10", "100", "127"),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("127"),
+                        ImmutableList.of("100", "127"),
+                        ImmutableList.of("10", "100"),
+                        ImmutableList.of("10", "100", "127"),
+                        ImmutableList.of("1", "127"),
+                        ImmutableList.of("1", "10"),
+                        ImmutableList.of("1", "10", "100", "127")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterTinyIntNegatives()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addTinyintValues(PARTITION_KEY, -128L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(TinyintType.TINYINT, 0L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(TinyintType.TINYINT, 0L, true, 50L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(TinyintType.TINYINT, 0L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addTinyintValues(PARTITION_KEY, 0L, -128L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(TinyintType.TINYINT, 0L))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_TINYINT,
+                PARTITION_KEY,
+                ImmutableList.of("-128", "0", "50", "100"),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of("-128"),
+                        ImmutableList.of("100", "50"),
+                        ImmutableList.of("0", "50"),
+                        ImmutableList.of("0", "100", "50"),
+                        ImmutableList.of("-128", "0"),
+                        ImmutableList.of("-128"),
+                        ImmutableList.of("-128", "0", "100", "50")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterDecimal()
+            throws Exception
+    {
+        String value1 = "1.000";
+        String value2 = "10.134";
+        String value3 = "25.111";
+        String value4 = "30.333";
+
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addDecimalValues(PARTITION_KEY, value1)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(DECIMAL_TYPE, decimalOf(value2)))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(DECIMAL_TYPE, decimalOf(value2), true, decimalOf(value3), true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(DECIMAL_TYPE, decimalOf(value3)))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addDecimalValues(PARTITION_KEY, value1, value4)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(DECIMAL_TYPE, decimalOf("25.5")))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_DECIMAL,
+                PARTITION_KEY,
+                ImmutableList.of(value1, value2, value3, value4),
+                ImmutableList.of(singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of(value1),
+                        ImmutableList.of(value3, value4),
+                        ImmutableList.of(value2, value3),
+                        ImmutableList.of(value3, value4),
+                        ImmutableList.of(value1, value4),
+                        ImmutableList.of(value1, value2, value3),
+                        ImmutableList.of(value1, value2, value3, value4)));
+    }
+
+    // we don't presently know how to properly convert a Date type into a string that is compatible with Glue.
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterDate()
+            throws Exception
+    {
+        TupleDomain<String> singleEquals = new PartitionFilterBuilder()
+                .addDateValues(PARTITION_KEY, 18000L)
+                .build();
+        TupleDomain<String> greaterThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThan(DateType.DATE, 19000L))
+                .build();
+        TupleDomain<String> betweenInclusive = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.range(DateType.DATE, 19000L, true, 20000L, true))
+                .build();
+        TupleDomain<String> greaterThanOrEquals = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(DateType.DATE, 19000L))
+                .build();
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addDateValues(PARTITION_KEY, 18000L, 21000L)
+                .build();
+        TupleDomain<String> lessThan = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.lessThan(DateType.DATE, 20000L))
+                .build();
+        // we are unable to convert Date to a string format that Glue will accept, so it should translate to the wildcard in all cases. Commented out results are
+        // what we expect if we are able to do a proper conversion
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_DATE,
+                PARTITION_KEY,
+                ImmutableList.of("18000", "19000", "20000", "21000"),
+                ImmutableList.of(
+                        singleEquals, greaterThan, betweenInclusive, greaterThanOrEquals, inClause, lessThan, TupleDomain.all()),
+                ImmutableList.of(
+//                        ImmutableList.of("18000"),
+//                        ImmutableList.of("20000", "21000"),
+//                        ImmutableList.of("19000", "20000"),
+//                        ImmutableList.of("19000", "20000", "21000"),
+//                        ImmutableList.of("18000", "21000"),
+//                        ImmutableList.of("18000", "19000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000"),
+                        ImmutableList.of("18000", "19000", "20000", "21000")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterTwoPartitionKeys()
+            throws Exception
+    {
+        TupleDomain<String> equalsFilter = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "2020-03-01")
+                .addBigintValues(PARTITION_KEY2, 300L)
+                .build();
+        TupleDomain<String> rangeFilter = new PartitionFilterBuilder()
+                .addRanges(PARTITION_KEY, Range.greaterThanOrEqual(VarcharType.VARCHAR, utf8Slice("2020-02-01")))
+                .addRanges(PARTITION_KEY2, Range.greaterThan(BigintType.BIGINT, 200L))
+                .build();
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_TWO_KEYS,
+                ImmutableList.of(PARTITION_KEY, PARTITION_KEY2),
+                ImmutableList.of(
+                        PartitionValues.make("2020-01-01", "100"),
+                        PartitionValues.make("2020-02-01", "200"),
+                        PartitionValues.make("2020-03-01", "300"),
+                        PartitionValues.make("2020-04-01", "400")),
+                ImmutableList.of(equalsFilter, rangeFilter, TupleDomain.all()),
+                ImmutableList.of(
+                        ImmutableList.of(PartitionValues.make("2020-03-01", "300")),
+                        ImmutableList.of(
+                                PartitionValues.make("2020-03-01", "300"),
+                                PartitionValues.make("2020-04-01", "400")),
+                        ImmutableList.of(
+                                PartitionValues.make("2020-01-01", "100"),
+                                PartitionValues.make("2020-02-01", "200"),
+                                PartitionValues.make("2020-03-01", "300"),
+                                PartitionValues.make("2020-04-01", "400"))));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterMaxLengthWildcard()
+            throws Exception
+    {
+        // this filter string will exceed the 2048 char limit set by glue, and we expect the filter to revert to the wildcard
+        TupleDomain<String> filter = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "x".repeat(2048))
+                .build();
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                VARCHAR_PARTITION_VALUES,
+                ImmutableList.of(filter),
+                ImmutableList.of(
+                        ImmutableList.of("2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterTwoPartitionKeysPartialQuery()
+            throws Exception
+    {
+        // we expect the second constraint to still be present and provide filtering
+        TupleDomain<String> equalsFilter = new PartitionFilterBuilder()
+                .addStringValues(PARTITION_KEY, "x".repeat(2048))
+                .addBigintValues(PARTITION_KEY2, 300L)
+                .build();
+
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_TWO_KEYS,
+                ImmutableList.of(PARTITION_KEY, PARTITION_KEY2),
+                ImmutableList.of(
+                        PartitionValues.make("2020-01-01", "100"),
+                        PartitionValues.make("2020-02-01", "200"),
+                        PartitionValues.make("2020-03-01", "300"),
+                        PartitionValues.make("2020-04-01", "400")),
+                ImmutableList.of(equalsFilter),
+                ImmutableList.of(ImmutableList.of(PartitionValues.make("2020-03-01", "300"))));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterNone()
+            throws Exception
+    {
+        // test both a global none and that with a single column none, and a valid domain with none()
+        TupleDomain<String> noneFilter = new PartitionFilterBuilder()
+                .addDomain(PARTITION_KEY, Domain.none(VarcharType.VARCHAR))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                VARCHAR_PARTITION_VALUES,
+                ImmutableList.of(TupleDomain.none(), noneFilter),
+                ImmutableList.of(ImmutableList.of(), ImmutableList.of()));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterNotNull()
+            throws Exception
+    {
+        TupleDomain<String> notNullFilter = new PartitionFilterBuilder()
+                .addDomain(PARTITION_KEY, Domain.notNull(VarcharType.VARCHAR))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                VARCHAR_PARTITION_VALUES,
+                ImmutableList.of(notNullFilter),
+                ImmutableList.of(ImmutableList.of("2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01")));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterIsNull()
+            throws Exception
+    {
+        TupleDomain<String> isNullFilter = new PartitionFilterBuilder()
+                .addDomain(PARTITION_KEY, Domain.onlyNull(VarcharType.VARCHAR))
+                .build();
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                VARCHAR_PARTITION_VALUES,
+                ImmutableList.of(isNullFilter),
+                ImmutableList.of(ImmutableList.of()));
+    }
+
+    @Test(groups = "get-partitions-by-filter")
+    public void testGetPartitionsFilterIsNullWithValue()
+            throws Exception
+    {
+        TupleDomain<String> isNullFilter = new PartitionFilterBuilder()
+                .addDomain(PARTITION_KEY, Domain.onlyNull(VarcharType.VARCHAR))
+                .build();
+        List<String> partitionList = new ArrayList<>();
+        partitionList.add(null);
+        doGetPartitionsFilterTest(
+                CREATE_TABLE_COLUMNS_PARTITIONED_VARCHAR,
+                PARTITION_KEY,
+                partitionList,
+                ImmutableList.of(isNullFilter),
+                ImmutableList.of(ImmutableList.of(GlueExpressionUtil.NULL_STRING)));
+    }
+
+    private void doGetPartitionsFilterTest(
+            List<ColumnMetadata> columnMetadata,
+            String partitionColumnName,
+            List<String> partitionStringValues,
+            List<TupleDomain<String>> filterList,
+            List<List<String>> expectedSingleValueList)
+            throws Exception
+    {
+        List<PartitionValues> partitionValuesList = partitionStringValues.stream()
+                .map(PartitionValues::make)
+                .collect(toImmutableList());
+        List<List<PartitionValues>> expectedPartitionValuesList = expectedSingleValueList.stream()
+                .map(expectedValue -> expectedValue.stream()
+                        .map(PartitionValues::make)
+                        .collect(toImmutableList()))
+                .collect(toImmutableList());
+        doGetPartitionsFilterTest(columnMetadata, ImmutableList.of(partitionColumnName), partitionValuesList, filterList, expectedPartitionValuesList);
+    }
+
+    /**
+     * @param filterList should be same sized list as expectedValuesList
+     * @param expectedValuesList
+     * @throws Exception
+     */
+    private void doGetPartitionsFilterTest(
+            List<ColumnMetadata> columnMetadata,
+            List<String> partitionColumnNames,
+            List<PartitionValues> partitionValues,
+            List<TupleDomain<String>> filterList,
+            List<List<PartitionValues>> expectedValuesList)
+            throws Exception
+    {
+        try (CloseableSchamaTableName closeableTableName = new CloseableSchamaTableName(temporaryTable(("get_partitions")))) {
+            SchemaTableName tableName = closeableTableName.getSchemaTableName();
+            createDummyPartitionedTable(tableName, columnMetadata, partitionColumnNames, partitionValues);
+            HiveMetastore metastoreClient = getMetastoreClient();
+
+            for (int i = 0; i < filterList.size(); i++) {
+                TupleDomain<String> filter = filterList.get(i);
+                List<PartitionValues> expectedValues = expectedValuesList.get(i);
+                List<String> expectedResults = expectedValues.stream()
+                        .map(expectedPartitionValues -> makePartName(partitionColumnNames, expectedPartitionValues.getValues()))
+                        .collect(toImmutableList());
+
+                Optional<List<String>> partitionNames = metastoreClient.getPartitionNamesByFilter(
+                        HIVE_CONTEXT,
+                        tableName.getSchemaName(),
+                        tableName.getTableName(),
+                        partitionColumnNames,
+                        filter);
+                assertTrue(partitionNames.isPresent());
+                assertEquals(
+                        partitionNames.get(),
+                        expectedResults,
+                        String.format("lists \nactual: %s\nexpected: %s\nmismatch for filter %s (input index %d)\n", partitionNames.get(), expectedResults, filter, i));
+            }
+        }
+    }
+
+    private void createDummyPartitionedTable(SchemaTableName tableName, List<ColumnMetadata> columns, List<String> partitionColumnNames, List<PartitionValues> partitionValues)
+            throws Exception
+    {
+        doCreateEmptyTable(tableName, ORC, columns, partitionColumnNames);
+
+        HiveMetastoreClosure metastoreClient = new HiveMetastoreClosure(getMetastoreClient());
+        HiveIdentity identity = new HiveIdentity(HiveTestUtils.SESSION);
+        Table table = metastoreClient.getTable(identity, tableName.getSchemaName(), tableName.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(tableName));
+        List<PartitionWithStatistics> partitions = new ArrayList<>();
+        List<String> partitionNames = new ArrayList<>();
+        partitionValues.stream()
+                .map(partitionValue -> makePartName(partitionColumnNames, partitionValue.values))
+                .forEach(
+                        partitionName -> {
+                            partitions.add(new PartitionWithStatistics(createDummyPartition(table, partitionName), partitionName, PartitionStatistics.empty()));
+                            partitionNames.add(partitionName);
+                        });
+        metastoreClient.addPartitions(identity, tableName.getSchemaName(), tableName.getTableName(), partitions);
+        partitionNames.forEach(
+                partitionName -> metastoreClient.updatePartitionStatistics(
+                        identity, tableName.getSchemaName(), tableName.getTableName(), partitionName, currentStatistics -> EMPTY_TABLE_STATISTICS));
+    }
+
+    private class CloseableSchamaTableName
+            implements AutoCloseable
+    {
+        private final SchemaTableName schemaTableName;
+
+        private CloseableSchamaTableName(SchemaTableName schemaTableName)
+        {
+            this.schemaTableName = schemaTableName;
+        }
+
+        public SchemaTableName getSchemaTableName()
+        {
+            return schemaTableName;
+        }
+
+        @Override
+        public void close()
+        {
+            dropTable(schemaTableName);
+        }
+    }
+
+    // container class for readability. Each value is one for a partitionKey, in order they appear in the schema
+    private static class PartitionValues
+    {
+        private final List<String> values;
+
+        private static PartitionValues make(String... values)
+        {
+            return new PartitionValues(Arrays.asList(values));
+        }
+
+        private static PartitionValues make(List<String> values)
+        {
+            return new PartitionValues(values);
+        }
+
+        private PartitionValues(List<String> values)
+        {
+            this.values = values;
+        }
+
+        public List<String> getValues()
+        {
+            return values;
+        }
     }
 }


### PR DESCRIPTION
This work adds support that converts expressions on partition columns
into valid glue expresions to improve performance. The Domain for each
partition column is converted, if possible, into a glue expression
per 

https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-partitions.html#aws-glue-api-catalog-partitions-GetPartitions

The implementation is best-effort and may still return more partitions for the caller to filter out (HivePartitionManager)

#611