### PR TITLE
Fix parquet predicate pushdown for INT96 timestamp values

### DIFF
--- a/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/io/prestosql/parquet/TestTupleDomainParquetPredicate.java
@@ -361,16 +361,10 @@ public class TestTupleDomainParquetPredicate
         TimestampType timestampType = createTimestampType(3);
         assertEquals(getDomain(timestampType, 0, null, ID, column, true, UTC), all(timestampType));
         assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime, baseTime), ID, column, true, UTC), singleValue(timestampType, baseTime.toEpochMilli() * MICROSECONDS_PER_MILLISECOND));
+        // INT96 binary ranges ignored when min <> max
         assertEquals(
                 getDomain(timestampType, 10, timestampColumnStats(baseTime.minusSeconds(10), baseTime), ID, column, true, UTC),
-                create(ValueSet.ofRanges(range(timestampType, baseTime.minusSeconds(10).toEpochMilli() * MICROSECONDS_PER_MILLISECOND, true, baseTime.toEpochMilli() * MICROSECONDS_PER_MILLISECOND, true)), false));
-
-        // ignore corrupted statistics
-        assertEquals(getDomain(timestampType, 10, timestampColumnStats(baseTime.plusSeconds(10), baseTime), ID, column, false, UTC), create(ValueSet.all(timestampType), false));
-        // fail on corrupted statistics
-        assertThatExceptionOfType(ParquetCorruptionException.class)
-                .isThrownBy(() -> getDomain(timestampType, 10, timestampColumnStats(baseTime.plusSeconds(10), baseTime), ID, column, true, UTC))
-                .withMessageMatching("Corrupted statistics for column \"timestampColumn\" in Parquet file \"testFile\":.*");
+                create(ValueSet.all(timestampType), false));
     }
 
     private static BinaryStatistics timestampColumnStats(Instant minimum, Instant maximum)


### PR DESCRIPTION
Added in prestosql#4104, predicate pushdown for parquet INT96 timestamp values can result in incorrect results even when stats appear valid by checking min <= max. Parquet writers that produced statistics at all were comparing min and max values as BINARY which is oblivious to the semantics of how INT96 timestamps are encoded making them unusable.

Comparison of INT96 values for statistics was removed in [PARQUET-1065](https://issues.apache.org/jira/browse/PARQUET-1065) for all cases except when min == max, which would not be affected by the comparison issue or other byte order issues that existed with parquet BINARY types at the time. Any parquet file that contains INT96 statistics where min != max would have to have been written by an older parquet writer that compared the values incorrectly, making those statistics unusable.

This change disables parquet predicate pushdown on INT96 timestamps except for when all rows have the same value (min == max).