### PR TITLE
Improve message Access Denied: insufficient view owner privileges

### DIFF
--- a/presto-main/src/main/java/io/prestosql/security/ViewAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/ViewAccessControl.java
@@ -14,6 +14,8 @@
 package io.prestosql.security;
 
 import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.Identity;
 import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
@@ -21,6 +23,8 @@ import io.prestosql.spi.type.Type;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
+import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
 import static java.util.Objects.requireNonNull;
 
 public class ViewAccessControl
@@ -42,25 +46,25 @@ public class ViewAccessControl
         // In SQL, views are special in that they execute with permissions of the owner.
         // This means that the owner of the view is effectively granting permissions to the user running the query,
         // and thus must have the equivalent of the SQL standard "GRANT ... WITH GRANT OPTION".
-        delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
     }
 
     @Override
     public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
     {
-        delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
     }
 
     @Override
     public void checkCanExecuteFunction(SecurityContext context, String functionName)
     {
-        delegate.checkCanGrantExecuteFunctionPrivilege(context, functionName, invoker, false);
+        wrapAccessDeniedException(() -> delegate.checkCanGrantExecuteFunctionPrivilege(context, functionName, invoker, false));
     }
 
     @Override
     public void checkCanGrantExecuteFunctionPrivilege(SecurityContext context, String functionName, Identity grantee, boolean grantOption)
     {
-        delegate.checkCanGrantExecuteFunctionPrivilege(context, functionName, grantee, grantOption);
+        wrapAccessDeniedException(() -> delegate.checkCanGrantExecuteFunctionPrivilege(context, functionName, grantee, grantOption));
     }
 
     @Override
@@ -73,5 +77,18 @@ public class ViewAccessControl
     public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
         return delegate.getColumnMasks(context, tableName, columnName, type);
+    }
+
+    private static void wrapAccessDeniedException(Runnable runnable)
+    {
+        try {
+            runnable.run();
+        }
+        catch (AccessDeniedException e) {
+            String prefix = AccessDeniedException.PREFIX;
+            verify(e.getMessage().startsWith(prefix));
+            String msg = e.getMessage().substring(prefix.length());
+            throw new PrestoException(PERMISSION_DENIED, prefix + "View owner does not have sufficient privileges: " + msg, e);
+        }
     }
 }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestSqlStandardAccessControlChecks.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestSqlStandardAccessControlChecks.java
@@ -162,7 +162,7 @@ public class TestSqlStandardAccessControlChecks
 
         // Charlie still cannot access view because Bob does not have SELECT WITH GRANT OPTION
         assertThat(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: View owner 'bob' cannot create view that selects from default.%s", tableName));
+                .failsWithMessage(format("Access Denied: View owner does not have sufficient privileges: View owner 'bob' cannot create view that selects from default.%s", tableName));
 
         // Give Bob SELECT WITH GRANT OPTION on the underlying table
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM bob", tableName));

--- a/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/AccessDeniedException.java
@@ -26,9 +26,11 @@ import static java.lang.String.format;
 public class AccessDeniedException
         extends PrestoException
 {
+    public static final String PREFIX = "Access Denied: ";
+
     public AccessDeniedException(String message)
     {
-        super(PERMISSION_DENIED, "Access Denied: " + message);
+        super(PERMISSION_DENIED, PREFIX + message);
     }
 
     public static void denyImpersonateUser(String originalUser, String newUser)

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -1062,7 +1062,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
         assertAccessDenied(
                 "SELECT * FROM " + columnAccessViewName,
-                "View owner 'test_view_access_owner' cannot create view that selects from .*.orders.*",
+                "View owner does not have sufficient privileges: View owner 'test_view_access_owner' cannot create view that selects from \\w+.\\w+.orders\\w*",
                 privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify the view owner can select from the view even without special view creation privileges
@@ -1095,7 +1095,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
         assertAccessDenied(
                 "SELECT * FROM " + nestedViewName,
-                "View owner 'test_nested_view_access_owner' cannot create view that selects from .*.test_view_column_access.*",
+                "View owner does not have sufficient privileges: View owner 'test_nested_view_access_owner' cannot create view that selects from \\w+.\\w+.test_view_column_access\\w*",
                 privilege(nestedViewOwnerSession.getUser(), columnAccessViewName, CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view
@@ -1150,7 +1150,7 @@ public abstract class AbstractTestDistributedQueries
 
         assertAccessDenied(
                 "SELECT * FROM " + functionAccessViewName,
-                "'test_view_access_owner' cannot grant 'abs' execution to user '\\w*'",
+                "View owner does not have sufficient privileges: 'test_view_access_owner' cannot grant 'abs' execution to user '\\w*'",
                 privilege(viewOwnerSession.getUser(), "abs", GRANT_EXECUTE_FUNCTION));
 
         // verify executing from a view over a function does not require the session user to have execute privileges on the underlying function

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -30,7 +30,6 @@ import io.prestosql.execution.warnings.WarningCollector;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.operator.OperatorStats;
 import io.prestosql.spi.QueryId;
-import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType;
@@ -66,18 +65,16 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.sql.ParsingUtil.createParsingOptions;
 import static io.prestosql.sql.SqlFormatter.formatSql;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 public abstract class AbstractTestQueryFramework
 {
@@ -276,6 +273,11 @@ public abstract class AbstractTestQueryFramework
 
     protected void assertAccessAllowed(Session session, @Language("SQL") String sql, TestingPrivilege... deniedPrivileges)
     {
+        executeExclusively(session, sql, deniedPrivileges);
+    }
+
+    private void executeExclusively(Session session, @Language("SQL") String sql, TestingPrivilege[] deniedPrivileges)
+    {
         executeExclusively(() -> {
             try {
                 queryRunner.getAccessControl().deny(deniedPrivileges);
@@ -298,19 +300,14 @@ public abstract class AbstractTestQueryFramework
             @Language("RegExp") String exceptionsMessageRegExp,
             TestingPrivilege... deniedPrivileges)
     {
-        executeExclusively(() -> {
-            try {
-                queryRunner.getAccessControl().deny(deniedPrivileges);
-                queryRunner.execute(session, sql);
-                fail("Expected " + AccessDeniedException.class.getSimpleName());
-            }
-            catch (RuntimeException e) {
-                assertExceptionMessage(sql, e, ".*Access Denied: " + exceptionsMessageRegExp);
-            }
-            finally {
-                queryRunner.getAccessControl().reset();
-            }
-        });
+        assertException(session, sql, ".*Access Denied: " + exceptionsMessageRegExp, deniedPrivileges);
+    }
+
+    private void assertException(Session session, @Language("SQL") String sql, @Language("RegExp") String exceptionsMessageRegExp, TestingPrivilege[] deniedPrivileges)
+    {
+        assertThatThrownBy(() -> executeExclusively(session, sql, deniedPrivileges))
+                .as("Query: " + sql)
+                .hasMessageMatching(exceptionsMessageRegExp);
     }
 
     protected void assertTableColumnNames(String tableName, String... columnNames)
@@ -321,13 +318,6 @@ public abstract class AbstractTestQueryFramework
                 .map(row -> (String) row.getField(0))
                 .collect(toImmutableList());
         assertEquals(actual, expected);
-    }
-
-    private static void assertExceptionMessage(String sql, Exception exception, @Language("RegExp") String regex)
-    {
-        if (!nullToEmpty(exception.getMessage()).matches(regex)) {
-            fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
-        }
     }
 
     protected MaterializedResult computeExpected(@Language("SQL") String sql, List<? extends Type> resultTypes)


### PR DESCRIPTION
If a user A creates a view and user B wants to access the view and then user A loses access to the original data then B should not be able to access data in the view.
If B gets and access denied, they are told whether it's because they don't have access to the view or if the view creator doesn't have access to the underlying data.
This PR is only about enhancing information in the error message.