### PR TITLE
Fix compiler error for lambda parameter with non-letter

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
@@ -420,7 +420,7 @@ public final class BytecodeUtils
     public static BytecodeExpression invoke(Binding binding, String name)
     {
         // ensure that name doesn't have a special characters
-        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), name.replaceAll("[^(A-Za-z0-9_$)]", "_"), binding.getType());
+        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), name.replaceAll("[^A-Za-z0-9_$]", "_"), binding.getType());
     }
 
     public static BytecodeExpression invoke(Binding binding, BoundSignature signature)

--- a/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
@@ -420,12 +420,20 @@ public final class BytecodeUtils
     public static BytecodeExpression invoke(Binding binding, String name)
     {
         // ensure that name doesn't have a special characters
-        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), name.replaceAll("[^A-Za-z0-9_$]", "_"), binding.getType());
+        return invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(binding.getBindingId()), sanitizeName(name), binding.getType());
     }
 
     public static BytecodeExpression invoke(Binding binding, BoundSignature signature)
     {
         return invoke(binding, signature.getName());
+    }
+
+    /**
+     * Replace characters that are not safe to use in a JVM identifier.
+     */
+    public static String sanitizeName(String name)
+    {
+        return name.replaceAll("[^A-Za-z0-9_$]", "_");
     }
 
     public static BytecodeNode generateWrite(CallSiteBinder callSiteBinder, Scope scope, Variable wasNullVariable, Type type)

--- a/presto-main/src/main/java/io/prestosql/sql/gen/LambdaBytecodeGenerator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/LambdaBytecodeGenerator.java
@@ -122,7 +122,7 @@ public final class LambdaBytecodeGenerator
         for (int i = 0; i < lambdaExpression.getArguments().size(); i++) {
             Class<?> type = Primitives.wrap(lambdaExpression.getArgumentTypes().get(i).getJavaType());
             String argumentName = lambdaExpression.getArguments().get(i);
-            Parameter arg = arg("lambda_" + argumentName, type);
+            Parameter arg = arg("lambda_" + i + "_" + BytecodeUtils.sanitizeName(argumentName), type);
             parameters.add(arg);
             parameterMapBuilder.put(argumentName, new ParameterAndType(arg, type));
         }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestLambdaExpression.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestLambdaExpression.java
@@ -15,7 +15,6 @@ package io.prestosql.operator.scalar;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.prestosql.Session;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.RowType;
 import org.testng.annotations.BeforeClass;
@@ -39,12 +38,7 @@ public class TestLambdaExpression
 {
     public TestLambdaExpression()
     {
-        this(testSessionBuilder().setTimeZoneKey(getTimeZoneKey("Pacific/Kiritimati")).build());
-    }
-
-    private TestLambdaExpression(Session session)
-    {
-        super(session);
+        super(testSessionBuilder().setTimeZoneKey(getTimeZoneKey("Pacific/Kiritimati")).build());
     }
 
     @BeforeClass

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestLambdaExpression.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestLambdaExpression.java
@@ -55,6 +55,14 @@ public class TestLambdaExpression
     }
 
     @Test
+    public void testParameterName()
+    {
+        // parameter which is not valid identifier in Java
+        String nonLetters = "a.b c; d ' \n \\n \"";
+        assertFunction("apply(5, " + quote(nonLetters) + " -> " + quote(nonLetters) + " * 2)", INTEGER, 10);
+    }
+
+    @Test
     public void testNull()
     {
         assertFunction("apply(3, x -> x + 1)", INTEGER, 4);
@@ -157,5 +165,10 @@ public class TestLambdaExpression
         assertFunction("apply(ARRAY['abc', NULL, '123'], x -> x[2] IS NULL)", BOOLEAN, true);
         assertFunction("apply(ARRAY['abc', NULL, '123'], x -> x[2])", createVarcharType(3), null);
         assertFunction("apply(MAP(ARRAY['abc', 'def'], ARRAY[123, 456]), x -> map_keys(x))", new ArrayType(createVarcharType(3)), ImmutableList.of("abc", "def"));
+    }
+
+    private static String quote(String identifier)
+    {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
@@ -40,26 +40,26 @@ public class TestLambdaExpressions
     public void testDuplicateLambdaExpressions()
     {
         assertThat(assertions.query("" +
-                        "SELECT cardinality(filter(a, x -> x > 0)) " +
-                        "FROM (VALUES " +
-                        "   ARRAY[1,2,3], " +
-                        "   ARRAY[0,1,2]," +
-                        "   ARRAY[0,0,0]" +
-                        ") AS t(a) " +
-                        "GROUP BY cardinality(filter(a, x -> x > 0))" +
-                        "ORDER BY cardinality(filter(a, x -> x > 0))"))
+                "SELECT cardinality(filter(a, x -> x > 0)) " +
+                "FROM (VALUES " +
+                "   ARRAY[1,2,3], " +
+                "   ARRAY[0,1,2]," +
+                "   ARRAY[0,0,0]" +
+                ") AS t(a) " +
+                "GROUP BY cardinality(filter(a, x -> x > 0))" +
+                "ORDER BY cardinality(filter(a, x -> x > 0))"))
                 .matches("VALUES BIGINT '0', BIGINT '2', BIGINT '3'");
 
         // same type
         assertThat(assertions.query("" +
-                        "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
-                        "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10, 20, 30])) t(a, b)"))
+                "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
+                "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10, 20, 30])) t(a, b)"))
                 .matches("VALUES ROW(ARRAY[2, 3, 4], ARRAY[11, 21, 31])");
 
         // different type
         assertThat(assertions.query("" +
-                        "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
-                        "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10e0, 20e0, 30e0])) t(a, b)"))
+                "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
+                "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10e0, 20e0, 30e0])) t(a, b)"))
                 .matches("VALUES ROW(ARRAY[2, 3, 4], ARRAY[11e0, 21e0, 31e0])");
     }
 
@@ -68,14 +68,14 @@ public class TestLambdaExpressions
     {
         // same argument name
         assertThat(assertions.query("" +
-                        "SELECT transform(a, x -> transform(ARRAY[x], x -> x + 1)) " +
-                        "FROM (VALUES ARRAY[1, 2, 3]) t(a)"))
+                "SELECT transform(a, x -> transform(ARRAY[x], x -> x + 1)) " +
+                "FROM (VALUES ARRAY[1, 2, 3]) t(a)"))
                 .matches("VALUES ARRAY[ARRAY[2], ARRAY[3], ARRAY[4]]");
 
         // different argument name
         assertThat(assertions.query("" +
-                        "SELECT transform(a, x -> transform(ARRAY[x], y -> y + 1)) " +
-                        "FROM (VALUES ARRAY[1, 2, 3]) t(a)"))
+                "SELECT transform(a, x -> transform(ARRAY[x], y -> y + 1)) " +
+                "FROM (VALUES ARRAY[1, 2, 3]) t(a)"))
                 .matches("VALUES ARRAY[ARRAY[2], ARRAY[3], ARRAY[4]]");
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
@@ -64,6 +64,20 @@ public class TestLambdaExpressions
     }
 
     @Test
+    public void testParameterName()
+    {
+        // lambda may be using parameter which is not valid identifier in Java
+        assertThat(assertions.query("" +
+                "WITH t AS ( " +
+                "    SELECT count(*) AS \"a.b c; d\" FROM (VALUES (42)) " +
+                "    UNION ALL " +
+                "    SELECT * FROM (VALUES (77)) v(\"a.b c; d\") " +
+                ") " +
+                "SELECT transform(ARRAY[1], x -> x + \"a.b c; d\") FROM t"))
+                .matches("VALUES ARRAY[BIGINT '2'], ARRAY[BIGINT '78']");
+    }
+
+    @Test
     public void testNestedLambda()
     {
         // same argument name


### PR DESCRIPTION
Fix a generated code error when lambda parameter contains a character
that is not part of a valid Java identifier.

Fixes https://github.com/prestosql/presto/issues/5085