### PR TITLE
Remove some unnecessary usage of Number

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -198,7 +198,7 @@ public final class HiveSessionProperties
                         orcWriterConfig.getValidationPercentage(),
                         false,
                         value -> {
-                            double doubleValue = ((Number) value).doubleValue();
+                            double doubleValue = (double) value;
                             if (doubleValue < 0.0 || doubleValue > 100.0) {
                                 throw new PrestoException(
                                         INVALID_SESSION_PROPERTY,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/IonSqlQueryBuilder.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/IonSqlQueryBuilder.java
@@ -15,6 +15,8 @@ package io.prestosql.plugin.hive;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;
@@ -38,6 +40,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -216,19 +219,19 @@ public class IonSqlQueryBuilder
     private static String valueToQuery(Type type, Object value)
     {
         if (type.equals(BIGINT)) {
-            return String.valueOf(((Number) value).longValue());
+            return String.valueOf((long) value);
         }
         if (type.equals(INTEGER)) {
-            return String.valueOf(((Number) value).intValue());
+            return String.valueOf(toIntExact((long) value));
         }
         if (type.equals(SMALLINT)) {
-            return String.valueOf(((Number) value).shortValue());
+            return String.valueOf(Shorts.checkedCast((long) value));
         }
         if (type.equals(TINYINT)) {
-            return String.valueOf(((Number) value).byteValue());
+            return String.valueOf(SignedBytes.checkedCast((long) value));
         }
         if (type.equals(BOOLEAN)) {
-            return String.valueOf(value);
+            return String.valueOf((boolean) value);
         }
         if (type.equals(DATE)) {
             return "`" + FORMATTER.print(DAYS.toMillis((long) value)) + "`";

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -131,7 +131,7 @@ public final class IcebergSessionProperties
                         orcWriterConfig.getValidationPercentage(),
                         false,
                         value -> {
-                            double doubleValue = ((Number) value).doubleValue();
+                            double doubleValue = (double) value;
                             if (doubleValue < 0.0 || doubleValue > 100.0) {
                                 throw new PrestoException(INVALID_SESSION_PROPERTY, format(
                                         "%s must be between 0.0 and 100.0 inclusive: %s",

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -40,7 +40,6 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
-import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -195,7 +194,7 @@ public final class SystemSessionProperties
                 new PropertyMetadata<>(
                         TASK_WRITER_COUNT,
                         "Default number of local parallel table writer jobs per worker",
-                        BIGINT,
+                        INTEGER,
                         Integer.class,
                         taskManagerConfig.getWriterCount(),
                         false,
@@ -229,7 +228,7 @@ public final class SystemSessionProperties
                 new PropertyMetadata<>(
                         TASK_CONCURRENCY,
                         "Default number of local parallel jobs per worker",
-                        BIGINT,
+                        INTEGER,
                         Integer.class,
                         taskManagerConfig.getTaskConcurrency(),
                         false,
@@ -319,7 +318,7 @@ public final class SystemSessionProperties
                 new PropertyMetadata<>(
                         MAX_REORDERED_JOINS,
                         "The maximum number of joins to reorder as one group in cost-based join reordering",
-                        BIGINT,
+                        INTEGER,
                         Integer.class,
                         featuresConfig.getMaxReorderedJoins(),
                         false,

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -43,7 +43,6 @@ import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static java.lang.Math.min;
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
 
 public final class SystemSessionProperties
 {
@@ -323,7 +322,7 @@ public final class SystemSessionProperties
                         featuresConfig.getMaxReorderedJoins(),
                         false,
                         value -> {
-                            int intValue = ((Number) requireNonNull(value, "value is null")).intValue();
+                            int intValue = (int) value;
                             if (intValue < 2) {
                                 throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be greater than or equal to 2: %s", MAX_REORDERED_JOINS, intValue));
                             }
@@ -901,7 +900,7 @@ public final class SystemSessionProperties
 
     private static int validateValueIsPowerOfTwo(Object value, String property)
     {
-        int intValue = ((Number) requireNonNull(value, "value is null")).intValue();
+        int intValue = (int) value;
         if (Integer.bitCount(intValue) != 1) {
             throw new PrestoException(
                     INVALID_SESSION_PROPERTY,
@@ -925,7 +924,7 @@ public final class SystemSessionProperties
             return null;
         }
 
-        int intValue = ((Number) value).intValue();
+        int intValue = (int) value;
         if (intValue < lowerBoundIncluded) {
             throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be equal or greater than %s", property, lowerBoundIncluded));
         }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestRecursiveCte.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestRecursiveCte.java
@@ -33,7 +33,7 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.window;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
 
-public class TestRecursiveCTE
+public class TestRecursiveCte
         extends BasePlanTest
 {
     @Override

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestRecursiveCte.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestRecursiveCte.java
@@ -21,7 +21,7 @@ import static io.prestosql.SystemSessionProperties.getMaxRecursionDepth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestRecursiveCTE
+public class TestRecursiveCte
 {
     private QueryAssertions assertions;
 

--- a/presto-pinot/src/main/java/io/prestosql/pinot/PinotSessionProperties.java
+++ b/presto-pinot/src/main/java/io/prestosql/pinot/PinotSessionProperties.java
@@ -116,9 +116,9 @@ public class PinotSessionProperties
                         pinotConfig.getSegmentsPerSplit(),
                         false,
                         value -> {
-                            int ret = ((Number) value).intValue();
-                            checkArgument(ret > 0, "Number of segments per split must be more than zero");
-                            return ret;
+                            int intValue = (int) value;
+                            checkArgument(intValue > 0, "Number of segments per split must be more than zero");
+                            return intValue;
                         },
                         object -> object));
     }


### PR DESCRIPTION
Using `Number` for dealing with Presto values can mask subtle issues.
It is better to use explicit data conversions.