### PR TITLE
Make DynamicFilter future resilient to cancel

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
@@ -67,6 +67,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
 import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.prestosql.spi.connector.DynamicFilter.EMPTY;
@@ -217,7 +218,7 @@ public class DynamicFilterService
                     return NOT_BLOCKED;
                 }
 
-                return toCompletableFuture(whenAnyComplete(undoneFutures));
+                return unmodifiableFuture(toCompletableFuture(whenAnyComplete(undoneFutures)));
             }
 
             @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalDynamicFiltersCollector.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalDynamicFiltersCollector.java
@@ -38,6 +38,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
 import static io.prestosql.sql.DynamicFilters.Descriptor;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -145,7 +146,7 @@ class LocalDynamicFiltersCollector
         @Override
         public synchronized CompletableFuture<?> isBlocked()
         {
-            return isBlocked;
+            return unmodifiableFuture(isBlocked);
         }
 
         @Override


### PR DESCRIPTION
Cancelling CompletableFuture returned by DynamicFilter#isBlocked
should not affect dynamic filter collection. If cancellation of
a future from a consumer of DynamicFilter is allowed to propgate
into DynamicFilterService or LocalDynamicFiltersCollector,
then it will prevent the completion of collection of that
dynamic filter and it's usage by other consumers.