### PR TITLE
Remove unused WILDCARD_EXPRESSION

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -147,7 +147,6 @@ public class GlueHiveMetastore
 
     private static final String PUBLIC_ROLE_NAME = "public";
     private static final String DEFAULT_METASTORE_USER = "presto";
-    private static final String WILDCARD_EXPRESSION = "";
     private static final int BATCH_GET_PARTITION_MAX_PAGE_SIZE = 1000;
     private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
     private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 1000;


### PR DESCRIPTION
The [previous refactoring](https://github.com/prestosql/presto/pull/4748) around HiveMetastore API obsoleted the usage of WILDCARD_EXPRESSION in GlueHiveMetastore. We do not need `WILDCARD_EXPRESSION` anymore. 