### PR TITLE
Allow PortBinder to work on GenericContainer

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/docker/ContainerUtil.java
@@ -20,8 +20,9 @@ import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Network;
-import io.prestosql.tests.product.launcher.env.DockerContainer;
+import com.google.common.collect.ImmutableList;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
 
 import java.util.List;
 import java.util.function.Function;
@@ -75,9 +76,9 @@ public final class ContainerUtil
                 .exec();
     }
 
-    public static void exposePort(DockerContainer container, int port)
+    public static void exposePort(GenericContainer container, int port)
     {
         container.addExposedPort(port);
-        container.withFixedExposedPort(port, port);
+        container.setPortBindings(ImmutableList.builder().addAll(container.getPortBindings()).add(String.format("%d:%d/tcp", port, port)).build());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/testcontainers/PortBinder.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/testcontainers/PortBinder.java
@@ -14,8 +14,8 @@
 package io.prestosql.tests.product.launcher.testcontainers;
 
 import io.prestosql.tests.product.launcher.docker.ContainerUtil;
-import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import org.testcontainers.containers.GenericContainer;
 
 import javax.inject.Inject;
 
@@ -31,7 +31,12 @@ public class PortBinder
         this.bindPorts = requireNonNull(environmentOptions, "environmentOptions is null").bindPorts;
     }
 
-    public void exposePort(DockerContainer container, int port)
+    public PortBinder(boolean bindPorts)
+    {
+        this.bindPorts = bindPorts;
+    }
+
+    public void exposePort(GenericContainer container, int port)
     {
         if (bindPorts) {
             ContainerUtil.exposePort(container, port);


### PR DESCRIPTION
This will allow sharing container setup code with integration tests.