### PR TITLE
Add support for precision for TIMESTAMP in Postgresql type mapping

### DIFF
--- a/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
@@ -261,7 +261,7 @@ public class MaterializedResult
             type.writeLong(blockBuilder, ((Number) value).byteValue());
         }
         else if (REAL.equals(type)) {
-            type.writeLong(blockBuilder, (long) floatToRawIntBits(((Number) value).floatValue()));
+            type.writeLong(blockBuilder, floatToRawIntBits(((Number) value).floatValue()));
         }
         else if (DOUBLE.equals(type)) {
             type.writeDouble(blockBuilder, ((Number) value).doubleValue());

--- a/presto-main/src/main/java/io/prestosql/testing/TestngUtils.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestngUtils.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.testing;
 
+import org.testng.annotations.DataProvider;
+
 import java.util.ArrayList;
 import java.util.stream.Collector;
 
@@ -30,5 +32,11 @@ public final class TestngUtils
                     return left;
                 },
                 builder -> builder.toArray(new Object[][] {}));
+    }
+
+    @DataProvider
+    public static Object[][] trueFalse()
+    {
+        return new Object[][] {{true}, {false}};
     }
 }

--- a/presto-main/src/main/java/io/prestosql/type/DateTimes.java
+++ b/presto-main/src/main/java/io/prestosql/type/DateTimes.java
@@ -161,9 +161,9 @@ public final class DateTimes
         return floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND);
     }
 
-    public static long toEpochMicros(long epochMillis, int fraction)
+    public static long toEpochMicros(long epochMillis, int picosOfMilli)
     {
-        return scaleEpochMillisToMicros(epochMillis) + fraction / 1_000_000;
+        return scaleEpochMillisToMicros(epochMillis) + picosOfMilli / 1_000_000;
     }
 
     public static long round(long value, int magnitude)

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -262,7 +262,7 @@ public class MySqlClient
         }
         if (TIMESTAMP_MILLIS.equals(type)) {
             // TODO use `timestampWriteFunction`
-            return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp());
+            return WriteMapping.longMapping("datetime", timestampWriteFunctionUsingSqlTimestamp(TIMESTAMP_MILLIS));
         }
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("mediumblob", varbinaryWriteFunction());

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -20,11 +20,9 @@ import io.prestosql.testing.sql.JdbcSqlExecutor;
 import io.prestosql.testing.sql.TestTable;
 import io.prestosql.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.Test;
 
 import static io.prestosql.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 
-@Test
 public class TestPostgreSqlDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -36,7 +36,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-@Test
 public class TestPostgreSqlIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1090,14 +1090,6 @@ public class TestPostgreSqlTypeMapping
     @Test(dataProvider = "trueFalse", dataProviderClass = TestngUtils.class)
     public void testTimestampWithTimeZone(boolean insertWithPresto)
     {
-        DataSetup dataSetup;
-        if (insertWithPresto) {
-            dataSetup = prestoCreateAsSelect("test_timestamp_with_time_zone");
-        }
-        else {
-            dataSetup = postgresCreateAndInsert("tpch.test_timestamp_with_time_zone");
-        }
-
         DataTypeTest tests = DataTypeTest.create(true);
         for (int precision : List.of(3, 6)) {
             // test all standard cases with precision 3 and 6 to make sure the long and short TIMESTAMP WITH TIME ZONE
@@ -1141,7 +1133,12 @@ public class TestPostgreSqlTypeMapping
         tests.addRoundTrip(timestampWithTimeZoneDataType(5, insertWithPresto), ZonedDateTime.of(2012, 1, 2, 3, 4, 5, 123_450_000, kathmandu));
         tests.addRoundTrip(timestampWithTimeZoneDataType(6, insertWithPresto), ZonedDateTime.of(2012, 1, 2, 3, 4, 5, 123_456_000, kathmandu));
 
-        tests.execute(getQueryRunner(), dataSetup);
+        if (insertWithPresto) {
+            tests.execute(getQueryRunner(), prestoCreateAsSelect("test_timestamp_with_time_zone"));
+        }
+        else {
+            tests.execute(getQueryRunner(), postgresCreateAndInsert("tpch.test_timestamp_with_time_zone"));
+        }
     }
 
     @Test
@@ -1156,14 +1153,6 @@ public class TestPostgreSqlTypeMapping
     @Test(dataProvider = "trueFalse", dataProviderClass = TestngUtils.class)
     public void testArrayTimestampWithTimeZone(boolean insertWithPresto)
     {
-        DataSetup dataSetup;
-        if (insertWithPresto) {
-            dataSetup = prestoCreateAsSelect(sessionWithArrayAsArray(), "test_array_timestamp_with_time_zone");
-        }
-        else {
-            dataSetup = postgresCreateAndInsert("tpch.test_array_timestamp_with_time_zone");
-        }
-
         DataTypeTest tests = DataTypeTest.create();
         for (int precision : List.of(3, 6)) {
             // test all standard cases with precision 3 and 6 to make sure the long and short TIMESTAMP WITH TIME ZONE
@@ -1196,7 +1185,12 @@ public class TestPostgreSqlTypeMapping
         tests.addRoundTrip(arrayOfTimestampWithTimeZoneDataType(5, insertWithPresto), asList(ZonedDateTime.of(2012, 1, 2, 3, 4, 5, 123_450_000, kathmandu)));
         tests.addRoundTrip(arrayOfTimestampWithTimeZoneDataType(6, insertWithPresto), asList(ZonedDateTime.of(2012, 1, 2, 3, 4, 5, 123_456_000, kathmandu)));
 
-        tests.execute(getQueryRunner(), sessionWithArrayAsArray(), dataSetup);
+        if (insertWithPresto) {
+            tests.execute(getQueryRunner(), sessionWithArrayAsArray(), prestoCreateAsSelect(sessionWithArrayAsArray(), "test_array_timestamp_with_time_zone"));
+        }
+        else {
+            tests.execute(getQueryRunner(), sessionWithArrayAsArray(), postgresCreateAndInsert("tpch.test_array_timestamp_with_time_zone"));
+        }
     }
 
     @Test

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1045,24 +1045,18 @@ public class TestPostgreSqlTypeMapping
                 .addRoundTrip(dataType, asList(beforeEpoch))
                 .addRoundTrip(dataType, asList(afterEpoch))
                 .addRoundTrip(dataType, asList(timeDoubledInJvmZone))
-                .addRoundTrip(dataType, asList(timeDoubledInVilnius));
-
-        addArrayTimestampTestIfSupported(tests, dataType, epoch);
-        addArrayTimestampTestIfSupported(tests, dataType, timeGapInJvmZone1);
-        addArrayTimestampTestIfSupported(tests, dataType, timeGapInJvmZone2);
-        addArrayTimestampTestIfSupported(tests, dataType, timeGapInVilnius);
-        addArrayTimestampTestIfSupported(tests, dataType, timeGapInKathmandu);
+                .addRoundTrip(dataType, asList(timeDoubledInVilnius))
+                .addRoundTrip(dataType, asList(epoch))
+                .addRoundTrip(dataType, asList(timeGapInJvmZone1))
+                .addRoundTrip(dataType, asList(timeGapInJvmZone2))
+                .addRoundTrip(dataType, asList(timeGapInVilnius))
+                .addRoundTrip(dataType, asList(timeGapInKathmandu));
 
         Session session = Session.builder(sessionWithArrayAsArray())
                 .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
                 .build();
 
         tests.execute(getQueryRunner(), session, dataSetup);
-    }
-
-    private void addArrayTimestampTestIfSupported(DataTypeTest tests, DataType<List<LocalDateTime>> dataType, LocalDateTime dateTime)
-    {
-        tests.addRoundTrip(dataType, asList(dateTime));
     }
 
     @DataProvider

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.testing.AbstractTestQueryFramework;
 import io.prestosql.testing.QueryRunner;
 import io.prestosql.testing.TestingSession;
+import io.prestosql.testing.TestngUtils;
 import io.prestosql.testing.datatype.CreateAndInsertDataSetup;
 import io.prestosql.testing.datatype.CreateAndPrestoInsertDataSetup;
 import io.prestosql.testing.datatype.CreateAsSelectDataSetup;
@@ -1086,7 +1087,7 @@ public class TestPostgreSqlTypeMapping
         };
     }
 
-    @Test(dataProvider = "testTimestampWithTimeZoneDataProvider")
+    @Test(dataProvider = "trueFalse", dataProviderClass = TestngUtils.class)
     public void testTimestampWithTimeZone(boolean insertWithPresto)
     {
         DataSetup dataSetup;
@@ -1152,7 +1153,7 @@ public class TestPostgreSqlTypeMapping
                 "Unsupported column type: timestamp\\(7\\) with time zone");
     }
 
-    @Test(dataProvider = "testTimestampWithTimeZoneDataProvider")
+    @Test(dataProvider = "trueFalse", dataProviderClass = TestngUtils.class)
     public void testArrayTimestampWithTimeZone(boolean insertWithPresto)
     {
         DataSetup dataSetup;
@@ -1196,15 +1197,6 @@ public class TestPostgreSqlTypeMapping
         tests.addRoundTrip(arrayOfTimestampWithTimeZoneDataType(6, insertWithPresto), asList(ZonedDateTime.of(2012, 1, 2, 3, 4, 5, 123_456_000, kathmandu)));
 
         tests.execute(getQueryRunner(), sessionWithArrayAsArray(), dataSetup);
-    }
-
-    @DataProvider
-    public Object[][] testTimestampWithTimeZoneDataProvider()
-    {
-        return new Object[][] {
-                {true},
-                {false},
-        };
     }
 
     @Test

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -110,7 +110,6 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-@Test
 public class TestPostgreSqlTypeMapping
         extends AbstractTestQueryFramework
 {

--- a/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
@@ -253,7 +253,7 @@ public class TestingPrestoClient
         else if (type instanceof RowType) {
             List<Type> fieldTypes = type.getTypeParameters();
             Collection<?> values = ((Map<?, ?>) value).values();
-            return dataToRow(fieldTypes).apply(new ArrayList(values));
+            return dataToRow(fieldTypes).apply(new ArrayList<>(values));
         }
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/DataType.java
@@ -33,6 +33,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.io.BaseEncoding.base16;
 import static io.prestosql.spi.type.CharType.createCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
@@ -40,6 +41,7 @@ import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.spi.type.TimestampType.createTimestampType;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.type.JsonType.JSON;
 import static java.lang.String.format;
@@ -191,6 +193,25 @@ public class DataType<T>
                 "timestamp",
                 TIMESTAMP_MILLIS,
                 DateTimeFormatter.ofPattern("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss.SSS''")::format,
+                identity());
+    }
+
+    public static DataType<LocalDateTime> timestampDataType(int precision)
+    {
+        // This code does not support precision > 9, due to limitations of DateTimeFormatter. For now it is not needed as
+        // none of currently supported JDBC databases supports precision over 9.
+        checkArgument(precision >= 0 && precision <= 9, "Unsupported precision: %s", precision);
+        DateTimeFormatter dateTimeFormatter;
+        if (precision == 0) {
+            dateTimeFormatter = DateTimeFormatter.ofPattern("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss''");
+        }
+        else {
+            dateTimeFormatter = DateTimeFormatter.ofPattern(format("'TIMESTAMP '''yyyy-MM-dd HH:mm:ss.%s''", "n".repeat(precision)));
+        }
+        return dataType(
+                format("timestamp(%s)", precision),
+                createTimestampType(precision),
+                dateTimeFormatter::format,
                 identity());
     }
 


### PR DESCRIPTION
Replaces https://github.com/prestosql/presto/pull/4570