### PR TITLE
Fix JDBC driver compatibility regarding TIME WITH TIME ZONE

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -86,7 +86,7 @@ abstract class AbstractPrestoResultSet
     private static final Pattern TIME_PATTERN = Pattern.compile("(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?");
     private static final Pattern TIME_WITH_TIME_ZONE_PATTERN = Pattern.compile("" +
             "(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?" +
-            "(?<offsetHour>[+-]\\d\\d):(?<offsetMinute>\\d\\d)");
+            "[ ]?(?<offsetHour>[+-]\\d\\d):(?<offsetMinute>\\d\\d)");
 
     private static final long[] POWERS_OF_TEN = {
             1L,


### PR DESCRIPTION
Recent changes around making TIMESTAMP type variadic broke JDBC wire
compatibility between Presto JDBC Driver 341 and older versions of
Presto.
Presto up to 340 encoded TIMESTAMP WITH TIME ZONE value with space
between time part and timezone part. With 341 this space is gone.

This change allows parsing both versions.