### PR TITLE
Product tests improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,5 +298,5 @@ jobs:
           rm -rf ~/.m2/repository
       - name: Product Tests
         run: |
-          presto-product-tests-launcher/bin/run-launcher suite run --suite ${{ matrix.suite }} --config ${{ matrix.config }} --no-bind
+          presto-product-tests-launcher/bin/run-launcher suite run --suite ${{ matrix.suite }} --config ${{ matrix.config }} --no-bind --logs-dir logs/
 

--- a/presto-product-tests-launcher/pom.xml
+++ b/presto-product-tests-launcher/pom.xml
@@ -33,6 +33,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Commands.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Commands.java
@@ -19,12 +19,13 @@ import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 final class Commands
 {
     private Commands() {}
 
-    public static void runCommand(List<Module> modules, Class<? extends Runnable> commandExecution)
+    public static int runCommand(List<Module> modules, Class<? extends Callable<Integer>> commandExecution)
     {
         Bootstrap app = new Bootstrap(
                 ImmutableList.<Module>builder()
@@ -36,7 +37,12 @@ final class Commands
                 .strictConfig()
                 .initialize();
 
-        injector.getInstance(commandExecution)
-                .run();
+        try {
+            return injector.getInstance(commandExecution)
+                    .call();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentList.java
@@ -21,6 +21,7 @@ import io.prestosql.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
 
 import javax.inject.Inject;
@@ -30,6 +31,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.concurrent.Callable;
 
 import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +42,7 @@ import static picocli.CommandLine.Command;
         description = "List environments",
         usageHelpAutoWidth = true)
 public final class EnvironmentList
-        implements Runnable
+        implements Callable<Integer>
 {
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit")
     public boolean usageHelpRequested;
@@ -53,9 +55,9 @@ public final class EnvironmentList
     }
 
     @Override
-    public void run()
+    public Integer call()
     {
-        runCommand(
+        return runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
                         .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
@@ -64,7 +66,7 @@ public final class EnvironmentList
     }
 
     public static class Execution
-            implements Runnable
+            implements Callable<Integer>
     {
         private final PrintStream out;
         private final EnvironmentFactory factory;
@@ -85,13 +87,15 @@ public final class EnvironmentList
         }
 
         @Override
-        public void run()
+        public Integer call()
         {
             out.println("Available environments: ");
             this.factory.list().forEach(out::println);
 
             out.println("\nAvailable environment configs: ");
             this.configFactory.listConfigs().forEach(out::println);
+
+            return ExitCode.OK;
         }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -20,6 +20,7 @@ import io.airlift.log.Logger;
 import io.prestosql.tests.product.launcher.Extensions;
 import io.prestosql.tests.product.launcher.LauncherModule;
 import io.prestosql.tests.product.launcher.docker.ContainerUtil;
+import io.prestosql.tests.product.launcher.env.DockerContainer;
 import io.prestosql.tests.product.launcher.env.Environment;
 import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentFactory;
@@ -115,6 +116,7 @@ public final class EnvironmentUp
         private final boolean debug;
         private final EnvironmentConfig environmentConfig;
         private final Optional<Path> logsDirBase;
+        private final DockerContainer.OutputMode outputMode;
 
         @Inject
         public Execution(EnvironmentFactory environmentFactory, EnvironmentConfig environmentConfig, EnvironmentOptions options, EnvironmentUpOptions environmentUpOptions)
@@ -125,6 +127,7 @@ public final class EnvironmentUp
             this.background = environmentUpOptions.background;
             this.environment = environmentUpOptions.environment;
             this.debug = options.debug;
+            this.outputMode = requireNonNull(options.output, "options.output is null");
             this.logsDirBase = requireNonNull(environmentUpOptions.logsDirBase, "environmentUpOptions.logsDirBase is null");
         }
 
@@ -135,6 +138,8 @@ public final class EnvironmentUp
             Environments.pruneEnvironment();
 
             Environment.Builder builder = environmentFactory.get(environment)
+                    .setContainerOutputMode(outputMode)
+                    .setLogsBaseDir(logsDirBase)
                     .removeContainer(TESTS);
 
             if (withoutPrestoMaster) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -26,7 +26,6 @@ import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 import io.prestosql.tests.product.launcher.env.EnvironmentFactory;
 import io.prestosql.tests.product.launcher.env.EnvironmentModule;
 import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
-import io.prestosql.tests.product.launcher.env.Environments;
 import io.prestosql.tests.product.launcher.env.common.Standard;
 import org.testcontainers.DockerClientFactory;
 import picocli.CommandLine.Command;
@@ -131,9 +130,6 @@ public final class EnvironmentUp
         @Override
         public Integer call()
         {
-            log.info("Pruning old environment(s)");
-            Environments.pruneEnvironment();
-
             Optional<Path> environmentLogPath = logsDirBase.map(dir -> dir.resolve(environment));
 
             Environment.Builder builder = environmentFactory.get(environment)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -38,6 +38,8 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
 import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.Mixin;
@@ -128,10 +130,10 @@ public final class EnvironmentUp
             Environments.pruneEnvironment();
 
             Environment.Builder builder = environmentFactory.get(environment)
-                    .removeContainer("tests");
+                    .removeContainer(TESTS);
 
             if (withoutPrestoMaster) {
-                builder.removeContainer("presto-master");
+                builder.removeContainer(COORDINATOR);
             }
 
             log.info("Creating environment '%s' with configuration %s", environment, environmentConfig);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.compose;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.logCopyingListener;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
 import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.Mixin;
@@ -142,9 +144,7 @@ public final class EnvironmentUp
             }
 
             Optional<Path> environmentLogPath = logsDirBase.map(dir -> dir.resolve(environment));
-            environmentLogPath.ifPresent(builder::exposeLogsInHostPath);
-
-            Environment environment = builder.build(loggingListener());
+            Environment environment = builder.build(compose(loggingListener(), logCopyingListener(environmentLogPath)));
             environment.start();
 
             if (background) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/EnvironmentUp.java
@@ -43,6 +43,7 @@ import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TEST
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.compose;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.logCopyingListener;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.statsPrintingListener;
 import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.Mixin;
 import static picocli.CommandLine.Option;
@@ -144,7 +145,11 @@ public final class EnvironmentUp
             }
 
             Optional<Path> environmentLogPath = logsDirBase.map(dir -> dir.resolve(environment));
-            Environment environment = builder.build(compose(loggingListener(), logCopyingListener(environmentLogPath)));
+            Environment environment = builder.build(compose(
+                    loggingListener(),
+                    logCopyingListener(environmentLogPath),
+                    statsPrintingListener()));
+
             environment.start();
 
             if (background) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Launcher.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Launcher.java
@@ -160,6 +160,7 @@ public class Launcher
                     {"product-tests.module", "presto-product-tests"},
                     {"server.module", "presto-server"},
                     {"server.name", "presto-server"},
+                    {"launcher.bin", "presto-product-tests-launcher/bin/run-launcher"},
             };
         }
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/OptionsPrinter.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/OptionsPrinter.java
@@ -93,6 +93,10 @@ public final class OptionsPrinter
             return null;
         }
 
+        if (value == null) {
+            return null;
+        }
+
         if (value instanceof Optional) {
             if (((Optional<?>) value).isPresent()) {
                 return formatOption(((Optional<?>) value).get(), annotation);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/OptionsPrinter.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/OptionsPrinter.java
@@ -74,6 +74,10 @@ public final class OptionsPrinter
 
     private static String formatOption(Object value, Option annotation)
     {
+        if (annotation.hidden()) {
+            return null;
+        }
+
         if (value instanceof Boolean) {
             if ((boolean) value) {
                 return annotation.names()[0].replaceFirst("--no-", "--");

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
@@ -37,6 +37,7 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
@@ -155,6 +156,8 @@ public class SuiteDescribe
             testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments(environmentConfig);
             testRunOptions.testJar = testJar;
             testRunOptions.reportsDir = Paths.get(format("presto-product-tests/target/%s/%s/%s", suiteName, environmentConfig.getConfigName(), suiteTestRun.getEnvironmentName()));
+            testRunOptions.startupRetries = null;
+            testRunOptions.logsDirBase = Optional.empty();
             return testRunOptions;
         }
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
@@ -142,7 +142,7 @@ public class SuiteDescribe
 
             for (SuiteTestRun testRun : suite.getTestRuns(config)) {
                 TestRun.TestRunOptions runOptions = createTestRunOptions(suiteName, testRun, config);
-                out.println(format("\npresto-product-tests-launcher/bin/run-launcher test run %s\n", OptionsPrinter.format(environmentOptions, runOptions)));
+                out.println(format("\n%s run %s\n", environmentOptions.launcherBin, OptionsPrinter.format(environmentOptions, runOptions)));
             }
 
             return OK;

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteList.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.EnvironmentOptions;
 import io.prestosql.tests.product.launcher.suite.SuiteFactory;
 import io.prestosql.tests.product.launcher.suite.SuiteModule;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
 
 import javax.inject.Inject;
@@ -33,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.concurrent.Callable;
 
 import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static java.util.Objects.requireNonNull;
@@ -42,7 +44,7 @@ import static java.util.Objects.requireNonNull;
         description = "List tests suite",
         usageHelpAutoWidth = true)
 public final class SuiteList
-        implements Runnable
+        implements Callable<Integer>
 {
     private final Module additionalEnvironments;
     private final Module additionalSuites;
@@ -57,9 +59,9 @@ public final class SuiteList
     }
 
     @Override
-    public void run()
+    public Integer call()
     {
-        runCommand(
+        return runCommand(
                 ImmutableList.<Module>builder()
                         .add(new LauncherModule())
                         .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
@@ -69,7 +71,7 @@ public final class SuiteList
     }
 
     public static class Execution
-            implements Runnable
+            implements Callable<Integer>
     {
         private final PrintStream out;
         private final EnvironmentConfigFactory configFactory;
@@ -90,13 +92,15 @@ public final class SuiteList
         }
 
         @Override
-        public void run()
+        public Integer call()
         {
             out.println("Available suites: ");
             this.suiteFactory.listSuites().forEach(out::println);
 
             out.println("\nAvailable environment configs: ");
             this.configFactory.listConfigs().forEach(out::println);
+
+            return ExitCode.OK;
         }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
@@ -212,7 +212,7 @@ public class SuiteRun
         {
             log.info("Starting test run #%02d %s with config %s", runId, suiteTestRun, environmentConfig);
             TestRun.TestRunOptions testRunOptions = createTestRunOptions(runId, suiteName, suiteTestRun, environmentConfig, suiteRunOptions.logsDirBase);
-            log.info("Execute this test run using:\npresto-product-tests-launcher/bin/run-launcher test run %s", OptionsPrinter.format(environmentOptions, testRunOptions));
+            log.info("Execute this test run using:\n%s test run %s", environmentOptions.launcherBin, OptionsPrinter.format(environmentOptions, testRunOptions));
 
             Stopwatch stopwatch = Stopwatch.createStarted();
             Optional<Throwable> exception = runTest(environmentConfig, testRunOptions);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -45,6 +45,8 @@ import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static io.prestosql.tests.product.launcher.docker.ContainerUtil.exposePort;
 import static io.prestosql.tests.product.launcher.env.DockerContainer.cleanOrCreateHostPath;
 import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.compose;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.logCopyingListener;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.util.Objects.requireNonNull;
@@ -240,8 +242,7 @@ public final class TestRun
 
             environmentConfig.extendEnvironment(this.environment).ifPresent(extender -> extender.extendEnvironment(environment));
 
-            logsDirBase.ifPresent(environment::exposeLogsInHostPath);
-            return environment.build(loggingListener());
+            return environment.build(compose(loggingListener(), logCopyingListener(logsDirBase)));
         }
 
         private static Iterable<? extends String> reportsDirOptions(Path path)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -48,10 +48,7 @@ import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static io.prestosql.tests.product.launcher.docker.ContainerUtil.exposePort;
 import static io.prestosql.tests.product.launcher.env.DockerContainer.cleanOrCreateHostPath;
 import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
-import static io.prestosql.tests.product.launcher.env.EnvironmentListener.compose;
-import static io.prestosql.tests.product.launcher.env.EnvironmentListener.logCopyingListener;
-import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
-import static io.prestosql.tests.product.launcher.env.EnvironmentListener.statsPrintingListener;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.getStandardListeners;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.lang.StrictMath.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -248,10 +245,7 @@ public final class TestRun
 
             environmentConfig.extendEnvironment(this.environment).ifPresent(extender -> extender.extendEnvironment(environment));
 
-            return environment.build(compose(
-                    loggingListener(),
-                    logCopyingListener(logsDirBase),
-                    statsPrintingListener()));
+            return environment.build(getStandardListeners(logsDirBase));
         }
 
         private static Iterable<? extends String> reportsDirOptions(Path path)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -178,7 +178,7 @@ public final class TestRun
 
             if (!attach) {
                 log.info("Starting the environment '%s' with configuration %s", this.environment, environmentConfig);
-                environment.start(startupRetries);
+                environment.start();
             }
             else {
                 DockerContainer tests = environment.getContainer(TESTS);
@@ -196,6 +196,7 @@ public final class TestRun
             Environment.Builder environment = environmentFactory.get(this.environment)
                     .containerDependsOnRest(TESTS)
                     .setContainerOutputMode(outputMode)
+                    .setStartupRetries(startupRetries)
                     .setLogsBaseDir(logsDirBase);
 
             if (debug) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -48,6 +48,7 @@ import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TEST
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.compose;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.logCopyingListener;
 import static io.prestosql.tests.product.launcher.env.EnvironmentListener.loggingListener;
+import static io.prestosql.tests.product.launcher.env.EnvironmentListener.statsPrintingListener;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
@@ -242,7 +243,10 @@ public final class TestRun
 
             environmentConfig.extendEnvironment(this.environment).ifPresent(extender -> extender.extendEnvironment(environment));
 
-            return environment.build(compose(loggingListener(), logCopyingListener(logsDirBase)));
+            return environment.build(compose(
+                    loggingListener(),
+                    logCopyingListener(logsDirBase),
+                    statsPrintingListener()));
         }
 
         private static Iterable<? extends String> reportsDirOptions(Path path)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -116,7 +116,7 @@ public final class TestRun
         public Optional<Path> logsDirBase;
 
         @Option(names = "--startup-retries", paramLabel = "<retries>", description = "Environment startup retries " + DEFAULT_VALUE, defaultValue = "5")
-        public int startupRetries;
+        public Integer startupRetries = 5;
 
         @Parameters(paramLabel = "<argument>", description = "Test arguments")
         public List<String> testArguments;

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
@@ -172,7 +172,7 @@ public class DockerContainer
         log.info("Copying container %s logs to '%s'", logicalName, hostPath);
 
         Path hostLogPath = Paths.get(hostPath.toString(), logicalName);
-        cleanOrCreateHostPath(hostLogPath);
+        ensurePathExists(hostLogPath);
 
         for (String containerLogPath : logPaths) {
             try {
@@ -264,5 +264,14 @@ public class DockerContainer
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public enum OutputMode
+    {
+        PRINT,
+        DISCARD,
+        WRITE,
+        PRINT_WRITE,
+        /**/;
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
@@ -13,11 +13,15 @@
  */
 package io.prestosql.tests.product.launcher.env;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Statistics;
+import com.github.dockerjava.core.InvocationBuilder;
 import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.RecursiveDeleteOption;
 import io.airlift.log.Logger;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.SelinuxContext;
@@ -208,6 +212,18 @@ public class DockerContainer
         }
 
         return Stream.empty();
+    }
+
+    public Statistics getStats()
+    {
+        try (DockerClient client = DockerClientFactory.lazyClient()) {
+            InvocationBuilder.AsyncResultCallback<Statistics> callback = new InvocationBuilder.AsyncResultCallback<>();
+            client.statsCmd(getContainerId()).exec(callback);
+            return callback.awaitResult();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
@@ -33,7 +33,6 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -306,17 +305,6 @@ public final class Environment
             });
 
             return new Environment(name, containers, listener);
-        }
-
-        public Builder exposeLogsInHostPath(Path basePath)
-        {
-            log.info("Exposing environment '%s' logs in: '%s'", name, basePath);
-
-            return configureContainers(dockerContainer -> {
-                Path containerLogPath = basePath.resolve(dockerContainer.getLogicalName());
-                log.info("Exposing container '%s' logs in host directory '%s'", dockerContainer.getLogicalName(), containerLogPath);
-                dockerContainer.exposeLogsInHostPath(containerLogPath);
-            });
         }
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentContainers.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentContainers.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+public final class EnvironmentContainers
+{
+    public static final String PRESTO = "presto";
+    public static final String COORDINATOR = PRESTO + "-master";
+    public static final String WORKER = PRESTO + "-worker";
+    public static final String WORKER_NTH = WORKER + "-";
+    public static final String HADOOP = "hadoop-master";
+    public static final String TESTS = "tests";
+    public static final String LDAP = "ldapserver";
+
+    private EnvironmentContainers() {}
+
+    public static String worker(int number)
+    {
+        return WORKER_NTH + number;
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentDefaults.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentDefaults.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.tests.product.launcher.env;
 
-public class EnvironmentDefaults
+public final class EnvironmentDefaults
 {
     public static final String DOCKER_IMAGES_VERSION = "32";
     public static final String HADOOP_BASE_IMAGE = "prestodev/hdp2.6-hive";

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import io.airlift.log.Logger;
+
+import java.util.Arrays;
+
+public interface EnvironmentListener
+{
+    Logger log = Logger.get(EnvironmentListener.class);
+
+    default void environmentStarting(Environment environment)
+    {
+    }
+
+    default void environmentStarted(Environment environment)
+    {
+    }
+
+    default void environmentStopped(Environment environment)
+    {
+    }
+
+    default void environmentStopping(Environment environment)
+    {
+    }
+
+    default void containerStarting(DockerContainer container, InspectContainerResponse response)
+    {
+    }
+
+    default void containerStarted(DockerContainer container, InspectContainerResponse containerInfo)
+    {
+    }
+
+    default void containerStopping(DockerContainer container, InspectContainerResponse response)
+    {
+    }
+
+    default void containerStopped(DockerContainer container, InspectContainerResponse response)
+    {
+    }
+
+    static EnvironmentListener compose(EnvironmentListener... listeners)
+    {
+        return new EnvironmentListener()
+        {
+            @Override
+            public void environmentStarting(Environment environment)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.environmentStarting(environment));
+            }
+
+            @Override
+            public void environmentStarted(Environment environment)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.environmentStarted(environment));
+            }
+
+            @Override
+            public void environmentStopping(Environment environment)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.environmentStopping(environment));
+            }
+
+            @Override
+            public void environmentStopped(Environment environment)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.environmentStopped(environment));
+            }
+
+            @Override
+            public void containerStarting(DockerContainer container, InspectContainerResponse response)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.containerStarting(container, response));
+            }
+
+            @Override
+            public void containerStarted(DockerContainer container, InspectContainerResponse response)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.containerStarted(container, response));
+            }
+
+            @Override
+            public void containerStopping(DockerContainer container, InspectContainerResponse response)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.containerStopping(container, response));
+            }
+
+            @Override
+            public void containerStopped(DockerContainer container, InspectContainerResponse response)
+            {
+                Arrays.stream(listeners).forEach(listener -> listener.containerStopped(container, response));
+            }
+        };
+    }
+
+    static EnvironmentListener loggingListener()
+    {
+        return new EnvironmentListener()
+        {
+            @Override
+            public void environmentStarting(Environment environment)
+            {
+                log.info("Environment starting: %s", environment);
+            }
+
+            @Override
+            public void environmentStarted(Environment environment)
+            {
+                log.info("Environment started: %s", environment);
+            }
+
+            @Override
+            public void environmentStopping(Environment environment)
+            {
+                log.info("Environment stopping: %s", environment);
+            }
+
+            @Override
+            public void environmentStopped(Environment environment)
+            {
+                log.info("Environment stopped: %s", environment);
+            }
+
+            @Override
+            public void containerStarting(DockerContainer container, InspectContainerResponse response)
+            {
+                log.info("Container starting: %s", container);
+            }
+
+            @Override
+            public void containerStarted(DockerContainer container, InspectContainerResponse response)
+            {
+                log.info("Container started: %s", container);
+            }
+
+            @Override
+            public void containerStopping(DockerContainer container, InspectContainerResponse response)
+            {
+                log.info("Container stopping: %s", container);
+            }
+
+            @Override
+            public void containerStopped(DockerContainer container, InspectContainerResponse response)
+            {
+                log.info("Container stopped: %s", container);
+            }
+        };
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
@@ -16,7 +16,9 @@ package io.prestosql.tests.product.launcher.env;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import io.airlift.log.Logger;
 
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Optional;
 
 public interface EnvironmentListener
 {
@@ -160,5 +162,25 @@ public interface EnvironmentListener
                 log.info("Container stopped: %s", container);
             }
         };
+    }
+
+    static EnvironmentListener logCopyingListener(Optional<Path> logBaseDir)
+    {
+        if (logBaseDir.isEmpty()) {
+            return noop();
+        }
+
+        return new EnvironmentListener() {
+            @Override
+            public void containerStopping(DockerContainer container, InspectContainerResponse response)
+            {
+                container.copyLogsToHostPath(logBaseDir.get());
+            }
+        };
+    }
+
+    static EnvironmentListener noop()
+    {
+        return new EnvironmentListener() {};
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -37,6 +37,9 @@ public final class EnvironmentOptions
     @Option(names = "--debug", description = "Open Java debug ports")
     public boolean debug;
 
+    @Option(names = "--output", description = "Container output handling mode: ${COMPLETION-CANDIDATES} " + DEFAULT_VALUE, defaultValue = "PRINT")
+    public DockerContainer.OutputMode output;
+
     @Option(names = "--launcher-bin", paramLabel = "<launcher bin>", description = "Launcher bin path (used to display run commands)", defaultValue = "${launcher.bin}", hidden = true)
     public String launcherBin;
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -15,6 +15,7 @@ package io.prestosql.tests.product.launcher.env;
 
 import java.io.File;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static picocli.CommandLine.Option;
 
 public final class EnvironmentOptions
@@ -27,7 +28,7 @@ public final class EnvironmentOptions
     @Option(names = "--server-package", paramLabel = "<package>", description = "Path to Presto server package " + DEFAULT_VALUE, defaultValue = "${server.module}/target/${server.name}-${project.version}.tar.gz")
     public File serverPackage;
 
-    @Option(names = "--without-presto", description = "Do not start presto-master")
+    @Option(names = "--without-presto", description = "Do not start " + COORDINATOR)
     public boolean withoutPrestoMaster;
 
     @Option(names = "--no-bind", description = "Bind ports on localhost", negatable = true)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentOptions.java
@@ -37,6 +37,9 @@ public final class EnvironmentOptions
     @Option(names = "--debug", description = "Open Java debug ports")
     public boolean debug;
 
+    @Option(names = "--launcher-bin", paramLabel = "<launcher bin>", description = "Launcher bin path (used to display run commands)", defaultValue = "${launcher.bin}", hidden = true)
+    public String launcherBin;
+
     public static EnvironmentOptions empty()
     {
         return new EnvironmentOptions();

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
@@ -25,6 +25,8 @@ import javax.inject.Inject;
 
 import java.time.Duration;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -57,9 +59,9 @@ public final class Hadoop
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
-        builder.addContainer("hadoop-master", createHadoopMaster());
+        builder.addContainer(createHadoopMaster());
 
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive_with_external_writes.properties")), CONTAINER_PRESTO_HIVE_WITH_EXTERNAL_WRITES_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
@@ -68,7 +70,7 @@ public final class Hadoop
     @SuppressWarnings("resource")
     private DockerContainer createHadoopMaster()
     {
-        DockerContainer container = new DockerContainer(hadoopBaseImage + ":" + hadoopImagesVersion)
+        DockerContainer container = new DockerContainer(hadoopBaseImage + ":" + hadoopImagesVersion, HADOOP)
                 // TODO HIVE_PROXY_PORT:1180
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath()), "/docker/presto-product-tests")
                 .withExposedLogPaths("/var/log/hadoop-yarn", "/var/log/hadoop-hdfs", "/var/log/hive")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kafka.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kafka.java
@@ -40,14 +40,13 @@ public class Kafka
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
-        builder.addContainer("zookeeper", createZookeeper());
-        builder.addContainer("kafka", createKafka());
+        builder.addContainers(createZookeeper(), createKafka());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createZookeeper()
     {
-        DockerContainer container = new DockerContainer("confluentinc/cp-zookeeper:" + CONFLUENT_VERSION)
+        DockerContainer container = new DockerContainer("confluentinc/cp-zookeeper:" + CONFLUENT_VERSION, "zookeeper")
                 .withEnv("ZOOKEEPER_CLIENT_PORT", "2181")
                 .withEnv("ZOOKEEPER_TICK_TIME", "2000")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
@@ -61,7 +60,7 @@ public class Kafka
     @SuppressWarnings("resource")
     private DockerContainer createKafka()
     {
-        DockerContainer container = new DockerContainer("confluentinc/cp-kafka:" + CONFLUENT_VERSION)
+        DockerContainer container = new DockerContainer("confluentinc/cp-kafka:" + CONFLUENT_VERSION, "kafka")
                 .withEnv("KAFKA_BROKER_ID", "1")
                 .withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181")
                 .withEnv("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://kafka:9092")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kerberos.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kerberos.java
@@ -20,6 +20,9 @@ import io.prestosql.tests.product.launcher.testcontainers.PortBinder;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.util.Objects.requireNonNull;
@@ -50,19 +53,18 @@ public class Kerberos
     public void extendEnvironment(Environment.Builder builder)
     {
         String dockerImageName = hadoopBaseImage + "-kerberized:" + hadoopImagesVersion;
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container.setDockerImageName(dockerImageName);
             portBinder.exposePort(container, 88);
         });
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container.setDockerImageName(dockerImageName);
             portBinder.exposePort(container, 7778);
             container
-                    .withNetworkAliases("presto-master.docker.cluster")
                     .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                     .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/kerberos/config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES);
         });
-        builder.configureContainer("tests", container -> {
+        builder.configureContainer(TESTS, container -> {
             container.setDockerImageName(dockerImageName);
             container.withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/tempto/tempto-configuration-for-docker-kerberos.yaml")), CONTAINER_TEMPTO_PROFILE_CONFIG);
         });

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/KerberosKms.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/KerberosKms.java
@@ -19,6 +19,9 @@ import io.prestosql.tests.product.launcher.env.EnvironmentConfig;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -44,7 +47,7 @@ public class KerberosKms
         // TODO (https://github.com/prestosql/presto/issues/1652) create images with HDP and KMS
         String dockerImageName = "prestodev/cdh5.15-hive-kerberized-kms:" + hadoopImagesVersion;
 
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container.setDockerImageName(dockerImageName);
             container
                     .withCopyFileToContainer(
@@ -52,9 +55,9 @@ public class KerberosKms
                             "/etc/hadoop-kms/conf/core-site.xml");
         });
 
-        builder.configureContainer("presto-master", container -> container.setDockerImageName(dockerImageName));
+        builder.configureContainer(COORDINATOR, container -> container.setDockerImageName(dockerImageName));
 
-        builder.configureContainer("tests", container -> {
+        builder.configureContainer(TESTS, container -> {
             container.setDockerImageName(dockerImageName);
             container.withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/tempto/tempto-configuration-for-docker-kerberos-kms.yaml")), CONTAINER_TEMPTO_PROFILE_CONFIG);
         });

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigEnvBased.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigEnvBased.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.PRESTO;
 import static java.lang.System.getenv;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -89,8 +90,8 @@ public class ConfigEnvBased
     @Override
     public Optional<EnvironmentExtender> extendEnvironment(String environmentName)
     {
-        return Optional.of((builder -> builder.configureContainers((containerName, container) -> {
-            if (containerName.startsWith("presto-")) {
+        return Optional.of((builder -> builder.configureContainers(container -> {
+            if (container.getLogicalName().startsWith(PRESTO)) {
                 String hadoopInitScript = getenv("HADOOP_PRESTO_INIT_SCRIPT");
 
                 if (!Strings.isNullOrEmpty(hadoopInitScript)) {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigHdp3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/configs/ConfigHdp3.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.PRESTO;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -50,8 +51,8 @@ public class ConfigHdp3
     @Override
     public Optional<EnvironmentExtender> extendEnvironment(String environmentName)
     {
-        return Optional.of((builder -> builder.configureContainers((containerName, container) -> {
-            if (containerName.startsWith("presto-")) {
+        return Optional.of((builder -> builder.configureContainers(container -> {
+            if (container.getLogicalName().startsWith(PRESTO)) {
                 container.withCopyFileToContainer(forHostPath(
                         // HDP3's handling of timestamps is incompatible with previous versions of Hive (see https://issues.apache.org/jira/browse/HIVE-21002);
                         // in order for Presto to deal with the differences, we must set catalog properties for Parquet and RCFile

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/Multinode.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 
 import java.io.File;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.WORKER;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
@@ -62,19 +64,19 @@ public final class Multinode
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-master-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                     .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-master-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES);
         });
 
-        builder.addContainer("presto-worker", createPrestoWorker());
+        builder.addContainer(createPrestoWorker());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createPrestoWorker()
     {
-        return createPrestoContainer(dockerFiles, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
+        return createPrestoContainer(dockerFiles, serverPackage, "prestodev/centos7-oj11:" + imagesVersion, WORKER)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/MultinodeHiveCaching.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 
 import java.io.File;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.worker;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_CONFIG_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
@@ -64,7 +66,7 @@ public final class MultinodeHiveCaching
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-master-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-master-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_NON_CACHED_PROPERTIES)
@@ -78,7 +80,7 @@ public final class MultinodeHiveCaching
     @SuppressWarnings("resource")
     private void createPrestoWorker(Environment.Builder builder, int workerNumber)
     {
-        builder.addContainer("presto-worker-" + workerNumber, createPrestoContainer(dockerFiles, serverPackage, "prestodev/centos7-oj11:" + imagesVersion)
+        builder.addContainer(createPrestoContainer(dockerFiles, serverPackage, "prestodev/centos7-oj11:" + imagesVersion, worker(workerNumber))
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-jvm.config")), CONTAINER_PRESTO_JVM_CONFIG)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode/multinode-worker-config.properties")), CONTAINER_PRESTO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_PRESTO_HIVE_NON_CACHED_PROPERTIES)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeCassandra.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeCassandra.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 
 import java.time.Duration;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -53,15 +54,15 @@ public final class SinglenodeCassandra
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.addContainer("cassandra", createCassandra());
+        builder.addContainer(createCassandra());
 
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-cassandra/cassandra.properties")), CONTAINER_PRESTO_CASSANDRA_PROPERTIES));
     }
 
     private DockerContainer createCassandra()
     {
-        DockerContainer container = new DockerContainer("cassandra:3.9")
+        DockerContainer container = new DockerContainer("cassandra:3.9", "cassandra")
                 .withEnv("HEAP_NEWSIZE", "128M")
                 .withEnv("MAX_HEAP_SIZE", "512M")
                 .withCommand(

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdfsImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdfsImpersonation.java
@@ -23,6 +23,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -44,7 +45,7 @@ public final class SinglenodeHdfsImpersonation
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hdfs-impersonation/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hdfs-impersonation/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdp3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHdp3.java
@@ -24,6 +24,8 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -50,13 +52,13 @@ public class SinglenodeHdp3
     {
         String dockerImageName = "prestodev/hdp3.1-hive:" + hadoopImagesVersion;
 
-        builder.configureContainer("hadoop-master", dockerContainer -> {
+        builder.configureContainer(HADOOP, dockerContainer -> {
             dockerContainer.setDockerImageName(dockerImageName);
             dockerContainer.withCreateContainerCmdModifier(createContainerCmd ->
                     createContainerCmd.withEntrypoint(ImmutableList.of(("/docker/presto-product-tests/conf/environment/singlenode-hdp3/hadoop-entrypoint.sh"))));
         });
 
-        builder.configureContainer("tests", dockerContainer -> {
+        builder.configureContainer(TESTS, dockerContainer -> {
             dockerContainer.withCopyFileToContainer(
                     forHostPath(dockerFiles.getDockerFilesHostPath("conf/tempto/tempto-configuration-for-hive3.yaml")),
                     CONTAINER_TEMPTO_PROFILE_CONFIG);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHiveImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHiveImpersonation.java
@@ -23,6 +23,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -44,7 +45,7 @@ public final class SinglenodeHiveImpersonation
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hive-impersonation/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hive-impersonation/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKafka.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKafka.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -44,7 +45,7 @@ public final class SinglenodeKafka
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(
                         forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kafka/kafka.properties")),
                         CONTAINER_PRESTO_ETC + "/catalog/kafka.properties"));

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonation.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -45,7 +46,7 @@ public final class SinglenodeKerberosHdfsImpersonation
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationCrossRealm.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationCrossRealm.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +47,7 @@ public final class SinglenodeKerberosHdfsImpersonationCrossRealm
     @SuppressWarnings("resource")
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties")),

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationWithDataProtection.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationWithDataProtection.java
@@ -24,6 +24,8 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +48,7 @@ public final class SinglenodeKerberosHdfsImpersonationWithDataProtection
     @SuppressWarnings("resource")
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/core-site.xml")),
@@ -56,7 +58,7 @@ public final class SinglenodeKerberosHdfsImpersonationWithDataProtection
                             "/etc/hadoop/conf/hdfs-site.xml");
         });
 
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties")),

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationWithWireEncryption.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsImpersonationWithWireEncryption.java
@@ -24,6 +24,8 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +48,7 @@ public final class SinglenodeKerberosHdfsImpersonationWithWireEncryption
     @SuppressWarnings("resource")
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/core-site.xml")),
@@ -56,7 +58,7 @@ public final class SinglenodeKerberosHdfsImpersonationWithWireEncryption
                             "/etc/hadoop/conf/hdfs-site.xml");
         });
 
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties")),

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsNoImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHdfsNoImpersonation.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -45,7 +46,7 @@ public final class SinglenodeKerberosHdfsNoImpersonation
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hdfs-no-impersonation/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHiveImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosHiveImpersonation.java
@@ -24,6 +24,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -45,7 +46,7 @@ public final class SinglenodeKerberosHiveImpersonation
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hive-impersonation/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-hive-impersonation/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosKmsHdfsImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosKmsHdfsImpersonation.java
@@ -25,6 +25,8 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -47,7 +49,7 @@ public final class SinglenodeKerberosKmsHdfsImpersonation
     @SuppressWarnings("resource")
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-kms-hdfs-impersonation/kms-acls.xml")),
@@ -57,7 +59,7 @@ public final class SinglenodeKerberosKmsHdfsImpersonation
                             "/etc/hive/conf/hiveserver2-site.xml");
         });
 
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties")),

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosKmsHdfsNoImpersonation.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeKerberosKmsHdfsNoImpersonation.java
@@ -25,6 +25,7 @@ import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
 import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -47,7 +48,7 @@ public final class SinglenodeKerberosKmsHdfsNoImpersonation
     @SuppressWarnings("resource")
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withCopyFileToContainer(
                             forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties")),

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeMysql.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeMysql.java
@@ -26,6 +26,7 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -51,18 +52,18 @@ public final class SinglenodeMysql
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(
                         forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-mysql/mysql.properties")),
                         CONTAINER_PRESTO_ETC + "/catalog/mysql.properties"));
 
-        builder.addContainer("mysql", createMySql());
+        builder.addContainer(createMySql());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createMySql()
     {
-        DockerContainer container = new DockerContainer("mysql:5.7")
+        DockerContainer container = new DockerContainer("mysql:5.7", "mysql")
                 .withEnv("MYSQL_USER", "test")
                 .withEnv("MYSQL_PASSWORD", "test")
                 .withEnv("MYSQL_ROOT_PASSWORD", "test")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodePostgresql.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodePostgresql.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -52,19 +53,19 @@ public final class SinglenodePostgresql
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(
                         forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-postgresql/postgresql.properties")),
                         CONTAINER_PRESTO_ETC + "/catalog/postgresql.properties"));
 
-        builder.addContainer("postgresql", createPostgreSql());
+        builder.addContainer(createPostgreSql());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createPostgreSql()
     {
         // Use the oldest supported PostgreSQL version
-        DockerContainer container = new DockerContainer("postgres:9.5")
+        DockerContainer container = new DockerContainer("postgres:9.5", "postgresql")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_DB", "test")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeSqlserver.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeSqlserver.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 
 import javax.inject.Inject;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -51,18 +52,18 @@ public final class SinglenodeSqlserver
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> container
+        builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(
                         forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-sqlserver/sqlserver.properties")),
                         CONTAINER_PRESTO_ETC + "/catalog/sqlserver.properties"));
 
-        builder.addContainer("sqlserver", createSqlServer());
+        builder.addContainer(createSqlServer());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createSqlServer()
     {
-        DockerContainer container = new DockerContainer("microsoft/mssql-server-linux:2017-CU13")
+        DockerContainer container = new DockerContainer("microsoft/mssql-server-linux:2017-CU13", "sqlserver")
                 .withEnv("ACCEPT_EULA", "Y")
                 .withEnv("SA_PASSWORD", "SQLServerPass1")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoKerberosHives.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoKerberosHives.java
@@ -38,6 +38,8 @@ import java.time.Duration;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -85,7 +87,7 @@ public final class TwoKerberosHives
     {
         String keytabsHostDirectory = createKeytabsHostDirectory().toString();
 
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container
                     .withFileSystemBind(keytabsHostDirectory, "/etc/presto/conf", READ_WRITE)
 
@@ -110,14 +112,14 @@ public final class TwoKerberosHives
                             CONTAINER_PRESTO_ETC + "/catalog/iceberg2.properties");
         });
 
-        builder.configureContainer("hadoop-master", container -> {
+        builder.configureContainer(HADOOP, container -> {
             container
                     .withFileSystemBind(keytabsHostDirectory, "/presto_keytabs", READ_WRITE)
                     .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withEntrypoint(ImmutableList.of(
                             "/docker/presto-product-tests/conf/environment/two-kerberos-hives/hadoop-master-entrypoint.sh")));
         });
 
-        builder.addContainer("hadoop-master-2", createHadoopMaster2(keytabsHostDirectory));
+        builder.addContainer(createHadoopMaster2(keytabsHostDirectory));
     }
 
     private Path createKeytabsHostDirectory()
@@ -136,7 +138,7 @@ public final class TwoKerberosHives
     @SuppressWarnings("resource")
     private DockerContainer createHadoopMaster2(String keytabsHostDirectory)
     {
-        DockerContainer container = new DockerContainer(hadoopBaseImage + "-kerberized-2:" + hadoopImagesVersion)
+        DockerContainer container = new DockerContainer(hadoopBaseImage + "-kerberized-2:" + hadoopImagesVersion, HADOOP + "-2")
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath()), "/docker/presto-product-tests")
                 .withFileSystemBind(keytabsHostDirectory, "/presto_keytabs", READ_WRITE)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withEntrypoint(ImmutableList.of(

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoMixedHives.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/TwoMixedHives.java
@@ -29,6 +29,8 @@ import javax.inject.Inject;
 
 import java.time.Duration;
 
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.HADOOP;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -64,7 +66,7 @@ public final class TwoMixedHives
     @Override
     protected void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer("presto-master", container -> {
+        builder.configureContainer(COORDINATOR, container -> {
             container.withCopyFileToContainer(
                     forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/two-mixed-hives/hive1.properties")),
                     CONTAINER_PRESTO_ETC + "/catalog/hive1.properties");
@@ -79,13 +81,13 @@ public final class TwoMixedHives
                     CONTAINER_PRESTO_ETC + "/catalog/iceberg2.properties");
         });
 
-        builder.addContainer("hadoop-master-2", createHadoopMaster2());
+        builder.addContainer(createHadoopMaster2());
     }
 
     @SuppressWarnings("resource")
     private DockerContainer createHadoopMaster2()
     {
-        DockerContainer container = new DockerContainer(hadoopBaseImage + ":" + hadoopImagesVersion)
+        DockerContainer container = new DockerContainer(hadoopBaseImage + ":" + hadoopImagesVersion, HADOOP + "-2")
                 .withCopyFileToContainer(
                         forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/two-mixed-hives/hadoop-master-2/core-site.xml")),
                         "/etc/hadoop/conf/core-site.xml")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite1.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite1.java
@@ -30,14 +30,6 @@ public class Suite1
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
-            /**
-             * presto-product-tests-launcher/bin/run-launcher test run \
-             *     --environment multinode \
-             *     -- \
-             *     -x big_query,storage_formats,profile_specific_tests,tpcds,hive_compression,"${DISTRO_SKIP_GROUP}" \
-             *     -e "${DISTRO_SKIP_TEST}" \
-             *     || suite_exit_code=1
-             */
             testOnEnvironment(Multinode.class)
                     .withExcludedGroups("big_query", "storage_formats", "profile_specific_tests", "tpcds", "hive_compression")
                     .build());

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite2.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite2.java
@@ -33,44 +33,10 @@ public class Suite2
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode \
-                 *     -- -g hdfs_no_impersonation,hive_compression -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(Singlenode.class).withGroups("hdfs_no_impersonation", "hive_compression").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hdfs-no-impersonation \
-                 *     -- -g storage_formats,hdfs_no_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHdfsNoImpersonation.class).withGroups("storage_formats", "hdfs_no_impersonation").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-hdfs-impersonation \
-                 *     -- -g storage_formats,cli,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeHdfsImpersonation.class).withGroups("storage_formats", "cli", "hdfs_impersonation").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hdfs-impersonation \
-                 *     -- -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHdfsImpersonation.class).withGroups("storage_formats", "cli", "hdfs_impersonation", "authorization", "hive_file_header").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode \
-                 *     -- -g hive_with_external_writes -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(Singlenode.class).withGroups("hive_with_external_writes").build());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite3.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite3.java
@@ -33,43 +33,15 @@ public class Suite3
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment multinode-tls \
-                 *     -- -g smoke,cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(MultinodeTls.class)
                         .withGroups("smoke", "cli", "group-by", "join", "tls")
                         .build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment multinode-tls-kerberos \
-                 *     -- -g cli,group-by,join,tls -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(MultinodeTlsKerberos.class)
                         .withGroups("cli", "group-by", "join", "tls")
                         .build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hdfs-impersonation-with-wire-encryption \
-                 *     -- -g storage_formats,cli,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHdfsImpersonationWithWireEncryption.class)
                         .withGroups("storage_formats", "cli", "hdfs_impersonation,authorization")
                         .build(),
-
-                /**
-                 * # Smoke run af a few tests in environment with dfs.data.transfer.protection=true. Arbitrary tests which access HDFS data were chosen.
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hdfs-impersonation-with-data-protection \
-                 *     -- -t TestHiveStorageFormats.testOrcTableCreatedInPresto,TestHiveCreateTable.testCreateTable  -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHdfsImpersonationWithDataProtection.class)
                         .withTests("TestHiveStorageFormats.testOrcTableCreatedInPresto", "TestHiveCreateTable.testCreateTable")
                         .build());

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite5.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite5.java
@@ -32,28 +32,8 @@ public class Suite5
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-hive-impersonation \
-                 *     -- -g storage_formats,hdfs_impersonation -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeHiveImpersonation.class).withGroups("storage_formats", "hdfs_impersonation").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hive-impersonation \
-                 *     -- -g storage_formats,hdfs_impersonation,authorization -x "${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHiveImpersonation.class).withGroups("storage_formats", "hdfs_impersonation", "authorization").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment multinode-hive-caching \
-                 *     -- -g hive_caching,storage_formats -x iceberg,"${DISTRO_SKIP_GROUP}" -e "${DISTRO_SKIP_TEST}" \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(MultinodeHiveCaching.class)
                         .withGroups("hive_caching", "storage_formats")
                         .withExcludedGroups("iceberg")

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite6NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite6NonGeneric.java
@@ -40,66 +40,12 @@ public class Suite6NonGeneric
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
-                /**
-                 * Uses hadoop, but it irrelevant from these tests' perspective.
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-ldap \
-                 *     -- -g ldap \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeLdap.class).withGroups("ldap").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-ldap-insecure \
-                 *     -- -g ldap \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeLdapInsecure.class).withGroups("ldap").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-ldap-referrals \
-                 *     -- -g ldap \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeLdapReferrals.class).withGroups("ldap").build(),
-
-                /**
-                 * We have docker images with KMS on CDH only. TODO (https://github.com/prestosql/presto/issues/1652) create images with HDP and KMS
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-kms-hdfs-no-impersonation \
-                 *     -- -g storage_formats \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosKmsHdfsNoImpersonation.class).withGroups("storage_formats").build(),
-
-                /**
-                 * We have docker images with KMS on CDH only. TODO (https://github.com/prestosql/presto/issues/1652) create images with HDP and KMS
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-kms-hdfs-impersonation \
-                 *     -- -g storage_formats \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosKmsHdfsImpersonation.class).withGroups("storage_formats").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-cassandra \
-                 *     -- -g cassandra \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeCassandra.class).withGroups("cassandra").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kafka \
-                 *     -- -g kafka \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKafka.class).withGroups("kafka").build());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
@@ -41,76 +41,13 @@ public class Suite7NonGeneric
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
-                /**
-                 * Does not use hadoop
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-mysql \
-                 *     -- -g mysql \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeMysql.class).withGroups("mysql").build(),
-
-                /**
-                 * Does not use hadoop
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-postgresql \
-                 *     -- -g postgresql \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodePostgresql.class).withGroups("postgresql").build(),
-
-                /**
-                 * Does not use hadoop
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-sqlserver \
-                 *     -- -g sqlserver \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeSqlserver.class).withGroups("sqlserver").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-spark-iceberg \
-                 *     -- -g iceberg -x storage_formats \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeSparkIceberg.class).withGroups("iceberg").withExcludedGroups("storage_formats").build(),
-
-                /**
-                 * Environment not set up on CDH. (TODO run on HDP 2.6 and HDP 3.1)
-                 *
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-kerberos-hdfs-impersonation-cross-realm \
-                 *     -- -g storage_formats,cli,hdfs_impersonation \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeKerberosHdfsImpersonationCrossRealm.class).withGroups("storage_formats", "cli", "hdfs_impersonation").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment two-mixed-hives \
-                 *     -- -g two_hives \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(TwoMixedHives.class).withGroups("two_hives").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment two-kerberos-hives \
-                 *     -- -g two_hives \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(TwoKerberosHives.class).withGroups("two_hives").build(),
-
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *     --environment singlenode-ldap-bind-dn \
-                 *     -- -g ldap \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeLdapBindDn.class).withGroups("ldap").build());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite8NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite8NonGeneric.java
@@ -34,12 +34,6 @@ public class Suite8NonGeneric
         verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
-                /**
-                 * presto-product-tests-launcher/bin/run-launcher test run \
-                 *    --environment singlenode-hdp3 \
-                 *     -- -g hdp3_only,hive_transactional \
-                 *     || suite_exit_code=1
-                 */
                 testOnEnvironment(SinglenodeHdp3.class).withGroups("hdp3_only", "hive_transactional").build());
     }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/SuiteTpcds.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/SuiteTpcds.java
@@ -30,12 +30,6 @@ public class SuiteTpcds
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
         return ImmutableList.of(
-            /**
-             * presto-product-tests-launcher/bin/run-launcher test run \
-             *     --environment multinode \
-             *     -- -g tpcds -x "${DISTRO_SKIP_GROUP}" -e sql_tests.testcases.tpcds.q72,"${DISTRO_SKIP_TEST}" \
-             *     || suite_exit_code=1
-             */
             testOnEnvironment(Multinode.class)
                     .withGroups("tpcds")
                     // TODO: Results for q72 need to be fixed. https://github.com/prestosql/presto/issues/4564

--- a/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/cli/TestOptionsPrinter.java
+++ b/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/cli/TestOptionsPrinter.java
@@ -110,6 +110,9 @@ public class TestOptionsPrinter
         @Option(names = "--value", paramLabel = "<value>", description = "Test optional value")
         public Optional<String> value;
 
+        @Option(names = "--hidden", hidden = true)
+        public String hiddenOption = "hidden-value";
+
         public OptionalFields(String value)
         {
             this.value = Optional.ofNullable(value);


### PR DESCRIPTION
This PR introduces the following product tests improvements:

* adds logging of the container and environment lifecycle events (starting, started, stopping, stopped)
* refactor codebase to use common, const container names
* adds printing of container stats (cpu/mem/network/pids) before it's stopped
* refactors picocli's Commands to use Callable<Integer> and make exit codes explicit
* adds 4 distinct container output handling modes (DISCARD, PRINT, WRITE, PRINT_WRITE)
