### PR TITLE
Interpret string as varchar in hive views

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/TypeSignatureTranslator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/TypeSignatureTranslator.java
@@ -102,8 +102,9 @@ public class TypeSignatureTranslator
     {
         ImmutableList.Builder<TypeSignatureParameter> parameters = ImmutableList.builder();
 
-        if (type.getName().getValue().equalsIgnoreCase(StandardTypes.VARCHAR) && type.getArguments().isEmpty()) {
+        if ((type.getName().getValue().equalsIgnoreCase(StandardTypes.VARCHAR) || type.getName().getValue().equalsIgnoreCase(StandardTypes.STRING)) && type.getArguments().isEmpty()) {
             // We treat VARCHAR specially because currently, the unbounded VARCHAR type is modeled in the system as a VARCHAR(n) with a "magic" length
+            // We treat String of Hive as VARCHAR
             // TODO: Eventually, we should split the types into VARCHAR and VARCHAR(n)
             return VarcharType.VARCHAR.getTypeSignature();
         }

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestTypeSignatureTranslator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestTypeSignatureTranslator.java
@@ -98,4 +98,13 @@ public class TestTypeSignatureTranslator
     {
         assertRoundTrip("ROW(x BIGINT, y DOUBLE PRECISION, z ROW(m array<bigint>,n map<double,varchar>))");
     }
+
+    @Test
+    public void testStringToVarchar()
+    {
+        assertThat(type("varchar"))
+                .ignoringLocation()
+                .withComparatorForType(Comparator.comparing(identifier -> identifier.getValue().toLowerCase(Locale.ENGLISH)), Identifier.class)
+                .isEqualTo(toDataType(toTypeSignature(SQL_PARSER.createType("string"))));
+    }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
@@ -44,6 +44,7 @@ public final class StandardTypes
     public static final String GEOMETRY = "Geometry";
     public static final String BING_TILE = "BingTile";
     public static final String UUID = "uuid";
+    public static final String STRING = "string";
 
     private StandardTypes() {}
 }


### PR DESCRIPTION
Currently PrestoSQL do not support Hive views when the view define a cast with String.
As TypeSignatureTranslator 'treat VARCHAR specially because currently, the unbounded VARCHAR type is modeled in the system as a VARCHAR(n) with a "magic" length', it's can also treat String as an unbound VARCHAR.