### PR TITLE
128 bit decimal improvements once more

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/DecimalCasts.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalCasts.java
@@ -223,7 +223,7 @@ public final class DecimalCasts
     public static Slice bigintToLongDecimal(long value, long precision, long scale, BigInteger tenToScale)
     {
         try {
-            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            Slice decimal = multiply(unscaledDecimal(tenToScale), value);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
                 throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
@@ -281,7 +281,7 @@ public final class DecimalCasts
     public static Slice integerToLongDecimal(long value, long precision, long scale, BigInteger tenToScale)
     {
         try {
-            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            Slice decimal = multiply(unscaledDecimal(tenToScale), value);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
                 throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
@@ -339,7 +339,7 @@ public final class DecimalCasts
     public static Slice smallintToLongDecimal(long value, long precision, long scale, BigInteger tenToScale)
     {
         try {
-            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            Slice decimal = multiply(unscaledDecimal(tenToScale), value);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
                 throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
@@ -397,7 +397,7 @@ public final class DecimalCasts
     public static Slice tinyintToLongDecimal(long value, long precision, long scale, BigInteger tenToScale)
     {
         try {
-            Slice decimal = multiply(unscaledDecimal(value), unscaledDecimal(tenToScale));
+            Slice decimal = multiply(unscaledDecimal(tenToScale), value);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
                 throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }

--- a/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
@@ -120,13 +120,32 @@ public final class DecimalOperators
     @UsedByGeneratedCode
     public static Slice addShortLongLong(long a, Slice b, int rescale, boolean left)
     {
-        return internalAddLongLongLong(unscaledDecimal(a), b, rescale, left);
+        return addLongShortLong(b, a, rescale, !left);
     }
 
     @UsedByGeneratedCode
-    public static Slice addLongShortLong(Slice a, long b, int rescale, boolean left)
+    public static Slice addLongShortLong(Slice a, long b, int rescale, boolean rescaleLeft)
     {
-        return internalAddLongLongLong(a, unscaledDecimal(b), rescale, left);
+        try {
+            Slice left;
+            Slice right;
+
+            if (rescaleLeft) {
+                left = rescale(a, rescale);
+                right = unscaledDecimal(b);
+            }
+            else {
+                left = rescale(b, rescale);
+                right = a;
+            }
+
+            add(left, right, left);
+            throwIfOverflows(left);
+            return left;
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow", e);
+        }
     }
 
     private static Slice internalAddLongLongLong(Slice a, Slice b, int rescale, boolean rescaleLeft)

--- a/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
@@ -28,7 +28,6 @@ import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.TypeSignature;
-import io.prestosql.spi.type.UnscaledDecimal128Arithmetic;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -296,7 +295,7 @@ public final class DecimalOperators
     public static Slice multiplyLongShortLong(Slice a, long b)
     {
         try {
-            Slice result = UnscaledDecimal128Arithmetic.multiply(a, b);
+            Slice result = multiply(a, b);
             throwIfOverflows(result);
             return result;
         }

--- a/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalOperators.java
@@ -28,7 +28,6 @@ import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.TypeSignature;
-import io.prestosql.spi.type.UnscaledDecimal128Arithmetic;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -45,10 +44,13 @@ import static io.prestosql.spi.function.OperatorType.SUBTRACT;
 import static io.prestosql.spi.type.Decimals.encodeUnscaledValue;
 import static io.prestosql.spi.type.Decimals.longTenToNth;
 import static io.prestosql.spi.type.TypeSignatureParameter.typeVariable;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.add;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.divideRoundUp;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.isZero;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.multiply;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.remainder;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.rescale;
+import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.subtract;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.throwIfOverflows;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 import static io.prestosql.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLong;
@@ -142,7 +144,7 @@ public final class DecimalOperators
                 right = a;
             }
 
-            UnscaledDecimal128Arithmetic.add(left, right, left);
+            add(left, right, left);
             throwIfOverflows(left);
             return left;
         }
@@ -214,11 +216,11 @@ public final class DecimalOperators
             Slice tmp = unscaledDecimal();
             if (rescaleLeft) {
                 rescale(a, rescale, tmp);
-                UnscaledDecimal128Arithmetic.subtract(tmp, b, tmp);
+                subtract(tmp, b, tmp);
             }
             else {
                 rescale(b, rescale, tmp);
-                UnscaledDecimal128Arithmetic.subtract(a, tmp, tmp);
+                subtract(a, tmp, tmp);
             }
             throwIfOverflows(tmp);
             return tmp;
@@ -267,7 +269,7 @@ public final class DecimalOperators
     public static Slice multiplyLongLongLong(Slice a, Slice b)
     {
         try {
-            Slice result = UnscaledDecimal128Arithmetic.multiply(a, b);
+            Slice result = multiply(a, b);
             throwIfOverflows(result);
             return result;
         }

--- a/presto-main/src/test/java/io/prestosql/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/BenchmarkDecimalOperators.java
@@ -73,14 +73,20 @@ import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
-import static java.util.stream.Collectors.toList;
 import static org.openjdk.jmh.annotations.Scope.Thread;
 
+/**
+ * This benchmark is known to produce non-deterministic results, because of the nature of JIT compiler.
+ * Using -Xbatch flag reduces the impact of this flaw while greatly increasing startup time.
+ */
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(3)
-@Warmup(iterations = 20, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = {
+        "-Xbatch",
+        "-server",
+})
+@Warmup(iterations = 30, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, timeUnit = TimeUnit.MILLISECONDS)
 public class BenchmarkDecimalOperators
 {
     private static final int PAGE_SIZE = 30000;
@@ -108,7 +114,7 @@ public class BenchmarkDecimalOperators
                 expression = "CAST(d1 AS BIGINT)";
             }
             else {
-                setDoubleMaxValue(Math.pow(9, Integer.valueOf(precision) - SCALE));
+                setDoubleMaxValue(Math.pow(9, Integer.parseInt(precision) - SCALE));
                 expression = format("CAST(d1 AS DECIMAL(%s, %d))", precision, SCALE);
             }
             generateRandomInputPage();
@@ -142,7 +148,7 @@ public class BenchmarkDecimalOperators
         @Setup
         public void setup()
         {
-            addSymbol("v1", createDecimalType(Integer.valueOf(precision), SCALE));
+            addSymbol("v1", createDecimalType(Integer.parseInt(precision), SCALE));
 
             String expression = "CAST(v1 AS DOUBLE)";
             generateRandomInputPage();
@@ -176,7 +182,7 @@ public class BenchmarkDecimalOperators
         @Setup
         public void setup()
         {
-            addSymbol("v1", createDecimalType(Integer.valueOf(precision), SCALE));
+            addSymbol("v1", createDecimalType(Integer.parseInt(precision), SCALE));
 
             String expression = "CAST(v1 AS VARCHAR)";
             generateRandomInputPage();
@@ -588,7 +594,7 @@ public class BenchmarkDecimalOperators
             for (int i = 0; i < PAGE_SIZE; i++) {
                 Object[] values = types.stream()
                         .map(this::generateRandomValue)
-                        .collect(toList()).toArray();
+                        .toArray();
 
                 buildPagesBuilder.row(values);
             }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
@@ -24,6 +24,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.prestosql.spi.type.Decimals.MAX_PRECISION;
 import static io.prestosql.spi.type.Decimals.longTenToNth;
 import static java.lang.Integer.toUnsignedLong;
+import static java.lang.Math.abs;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.fill;
 
@@ -587,7 +588,7 @@ public final class UnscaledDecimal128Arithmetic
         long l2 = toUnsignedLong(getInt(decimal, 2));
         long l3 = toUnsignedLong(getInt(decimal, 3));
 
-        long r0 = Math.abs(multiplier);
+        long r0 = abs(multiplier);
 
         long product;
 
@@ -1003,14 +1004,14 @@ public final class UnscaledDecimal128Arithmetic
     public static Slice divideRoundUp(long dividend, int dividendScaleFactor, long divisor)
     {
         return divideRoundUp(
-                Math.abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
-                Math.abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0);
+                abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
+                abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0);
     }
 
     public static Slice divideRoundUp(long dividend, int dividendScaleFactor, Slice divisor)
     {
         return divideRoundUp(
-                Math.abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
+                abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
                 getRawLong(divisor, 0), getRawLong(divisor, 1));
     }
 
@@ -1018,7 +1019,7 @@ public final class UnscaledDecimal128Arithmetic
     {
         return divideRoundUp(
                 getRawLong(dividend, 0), getRawLong(dividend, 1), dividendScaleFactor,
-                Math.abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0);
+                abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0);
     }
 
     public static Slice divideRoundUp(Slice dividend, int dividendScaleFactor, Slice divisor)
@@ -1114,14 +1115,14 @@ public final class UnscaledDecimal128Arithmetic
     public static Slice remainder(long dividend, int dividendScaleFactor, long divisor, int divisorScaleFactor)
     {
         return remainder(
-                Math.abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
-                Math.abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0, divisorScaleFactor);
+                abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
+                abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0, divisorScaleFactor);
     }
 
     public static Slice remainder(long dividend, int dividendScaleFactor, Slice divisor, int divisorScaleFactor)
     {
         return remainder(
-                Math.abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
+                abs(dividend), dividend < 0 ? SIGN_LONG_MASK : 0, dividendScaleFactor,
                 getRawLong(divisor, 0), getRawLong(divisor, 1), divisorScaleFactor);
     }
 
@@ -1129,7 +1130,7 @@ public final class UnscaledDecimal128Arithmetic
     {
         return remainder(
                 getRawLong(dividend, 0), getRawLong(dividend, 1), dividendScaleFactor,
-                Math.abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0, divisorScaleFactor);
+                abs(divisor), divisor < 0 ? SIGN_LONG_MASK : 0, divisorScaleFactor);
     }
 
     public static Slice remainder(Slice dividend, int dividendScaleFactor, Slice divisor, int divisorScaleFactor)

--- a/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
@@ -758,7 +758,7 @@ public final class UnscaledDecimal128Arithmetic
             accumulator = (accumulator >>> 32) + r3 * l0;
 
             z3 = accumulator & LOW_32_BITS;
-            z4 = (accumulator >>> 32) & LOW_32_BITS;
+            z4 = accumulator >>> 32;
         }
 
         if (l1 != 0) {
@@ -773,7 +773,7 @@ public final class UnscaledDecimal128Arithmetic
             accumulator = (accumulator >>> 32) + r3 * l1 + z4;
 
             z4 = accumulator & LOW_32_BITS;
-            z5 = (accumulator >>> 32) & LOW_32_BITS;
+            z5 = accumulator >>> 32;
         }
 
         if (l2 != 0) {
@@ -788,7 +788,7 @@ public final class UnscaledDecimal128Arithmetic
             accumulator = (accumulator >>> 32) + r3 * l2 + z5;
 
             z5 = accumulator & LOW_32_BITS;
-            z6 = (accumulator >>> 32) & LOW_32_BITS;
+            z6 = accumulator >>> 32;
         }
 
         if (l3 != 0) {
@@ -803,7 +803,7 @@ public final class UnscaledDecimal128Arithmetic
             accumulator = (accumulator >>> 32) + r3 * l3 + z6;
 
             z6 = accumulator & LOW_32_BITS;
-            z7 = (accumulator >>> 32) & LOW_32_BITS;
+            z7 = accumulator >>> 32;
         }
 
         left[0] = (int) z0;

--- a/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/UnscaledDecimal128Arithmetic.java
@@ -721,14 +721,16 @@ public final class UnscaledDecimal128Arithmetic
         pack(result, (int) z0, (int) z1, (int) z2, 0, leftNegative != rightNegative);
     }
 
-    public static void multiply256(Slice left, Slice right, Slice result)
+    /**
+     * This an unsigned operation. Supplying negative arguments will yield wrong results.
+     * Assumes left array length to be >= 8. However only first 4 int values are multiplied
+     */
+    static void multiply256Destructive(int[] left, Slice right)
     {
-        checkArgument(result.length() >= NUMBER_OF_LONGS * Long.BYTES * 2);
-
-        long l0 = toUnsignedLong(getInt(left, 0));
-        long l1 = toUnsignedLong(getInt(left, 1));
-        long l2 = toUnsignedLong(getInt(left, 2));
-        long l3 = toUnsignedLong(getInt(left, 3));
+        long l0 = toUnsignedLong(left[0]);
+        long l1 = toUnsignedLong(left[1]);
+        long l2 = toUnsignedLong(left[2]);
+        long l3 = toUnsignedLong(left[3]);
 
         long r0 = toUnsignedLong(getInt(right, 0));
         long r1 = toUnsignedLong(getInt(right, 1));
@@ -804,26 +806,27 @@ public final class UnscaledDecimal128Arithmetic
             z7 = (accumulator >>> 32) & LOW_32_BITS;
         }
 
-        setRawInt(result, 0, (int) z0);
-        setRawInt(result, 1, (int) z1);
-        setRawInt(result, 2, (int) z2);
-        setRawInt(result, 3, (int) z3);
-        setRawInt(result, 4, (int) z4);
-        setRawInt(result, 5, (int) z5);
-        setRawInt(result, 6, (int) z6);
-        setRawInt(result, 7, (int) z7);
+        left[0] = (int) z0;
+        left[1] = (int) z1;
+        left[2] = (int) z2;
+        left[3] = (int) z3;
+        left[4] = (int) z4;
+        left[5] = (int) z5;
+        left[6] = (int) z6;
+        left[7] = (int) z7;
     }
 
-    public static void multiply256(Slice left, long right, Slice result)
+    /**
+     * This an unsigned operation. Supplying negative arguments will yield wrong results.
+     * Assumes left array length to be >= 6. However only first 4 int values are multiplied
+     */
+    static void multiply256Destructive(int[] left, long right)
     {
-        checkArgument(result.length() >= NUMBER_OF_LONGS * Long.BYTES * 2);
+        long l0 = toUnsignedLong(left[0]);
+        long l1 = toUnsignedLong(left[1]);
+        long l2 = toUnsignedLong(left[2]);
+        long l3 = toUnsignedLong(left[3]);
 
-        long l0 = toUnsignedLong(getInt(left, 0));
-        long l1 = toUnsignedLong(getInt(left, 1));
-        long l2 = toUnsignedLong(getInt(left, 2));
-        long l3 = toUnsignedLong(getInt(left, 3));
-
-        right = abs(right);
         long r0 = right & LOW_32_BITS;
         long r1 = right >>> 32;
 
@@ -870,26 +873,24 @@ public final class UnscaledDecimal128Arithmetic
             z5 = accumulator >>> 32;
         }
 
-        setRawInt(result, 0, (int) z0);
-        setRawInt(result, 1, (int) z1);
-        setRawInt(result, 2, (int) z2);
-        setRawInt(result, 3, (int) z3);
-        setRawInt(result, 4, (int) z4);
-        setRawInt(result, 5, (int) z5);
-        setRawInt(result, 6, 0);
-        setRawInt(result, 7, 0);
+        left[0] = (int) z0;
+        left[1] = (int) z1;
+        left[2] = (int) z2;
+        left[3] = (int) z3;
+        left[4] = (int) z4;
+        left[5] = (int) z5;
     }
 
-    public static void multiply256(Slice left, int right, Slice result)
+    /**
+     * This an unsigned operation. Supplying negative arguments will yield wrong results.
+     * Assumes left array length to be >= 5. However only first 4 int values are multiplied
+     */
+    static void multiply256Destructive(int[] left, int r0)
     {
-        checkArgument(result.length() >= NUMBER_OF_LONGS * Long.BYTES * 2);
-
-        long l0 = toUnsignedLong(getInt(left, 0));
-        long l1 = toUnsignedLong(getInt(left, 1));
-        long l2 = toUnsignedLong(getInt(left, 2));
-        long l3 = toUnsignedLong(getInt(left, 3));
-
-        long r0 = abs(right);
+        long l0 = toUnsignedLong(left[0]);
+        long l1 = toUnsignedLong(left[1]);
+        long l2 = toUnsignedLong(left[2]);
+        long l3 = toUnsignedLong(left[3]);
 
         long z0;
         long z1;
@@ -913,14 +914,11 @@ public final class UnscaledDecimal128Arithmetic
         z3 = accumulator & LOW_32_BITS;
         z4 = accumulator >>> 32;
 
-        setRawInt(result, 0, (int) z0);
-        setRawInt(result, 1, (int) z1);
-        setRawInt(result, 2, (int) z2);
-        setRawInt(result, 3, (int) z3);
-        setRawInt(result, 4, (int) z4);
-        setRawInt(result, 5, 0);
-        setRawInt(result, 6, 0);
-        setRawInt(result, 7, 0);
+        left[0] = (int) z0;
+        left[1] = (int) z1;
+        left[2] = (int) z2;
+        left[3] = (int) z3;
+        left[4] = (int) z4;
     }
 
     public static int compare(Slice left, Slice right)
@@ -1400,8 +1398,7 @@ public final class UnscaledDecimal128Arithmetic
         dividend[3] = (highInt(dividendHigh) & ~SIGN_INT_MASK);
 
         if (dividendScaleFactor > 0) {
-            Slice sliceDividend = Slices.wrappedIntArray(dividend);
-            shiftLeftBy5Destructive(sliceDividend, dividendScaleFactor);
+            shiftLeftBy5Destructive(dividend, dividendScaleFactor);
             shiftLeftMultiPrecision(dividend, NUMBER_OF_INTS * 2, dividendScaleFactor);
         }
 
@@ -1412,8 +1409,7 @@ public final class UnscaledDecimal128Arithmetic
         divisor[3] = (highInt(divisorHigh) & ~SIGN_INT_MASK);
 
         if (divisorScaleFactor > 0) {
-            Slice sliceDivisor = Slices.wrappedIntArray(divisor);
-            shiftLeftBy5Destructive(sliceDivisor, divisorScaleFactor);
+            shiftLeftBy5Destructive(divisor, divisorScaleFactor);
             shiftLeftMultiPrecision(divisor, NUMBER_OF_INTS * 2, divisorScaleFactor);
         }
 
@@ -1429,18 +1425,18 @@ public final class UnscaledDecimal128Arithmetic
     }
 
     /**
-     * Value must be a 256-bit slice
+     * Value must have a length of 8
      */
-    private static void shiftLeftBy5Destructive(Slice value, int shift)
+    private static void shiftLeftBy5Destructive(int[] value, int shift)
     {
         if (shift <= MAX_POWER_OF_FIVE_INT) {
-            multiply256(value, POWERS_OF_FIVES_INT[shift], value);
+            multiply256Destructive(value, POWERS_OF_FIVES_INT[shift]);
         }
         else if (shift < MAX_POWER_OF_TEN_LONG) {
-            multiply256(value, POWERS_OF_FIVE_LONG[shift], value);
+            multiply256Destructive(value, POWERS_OF_FIVE_LONG[shift]);
         }
         else {
-            multiply256(value, POWERS_OF_FIVE[shift], value);
+            multiply256Destructive(value, POWERS_OF_FIVE[shift]);
         }
     }
 

--- a/presto-spi/src/test/java/io/prestosql/spi/type/TestUnscaledDecimal128Arithmetic.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/type/TestUnscaledDecimal128Arithmetic.java
@@ -99,29 +99,30 @@ public class TestUnscaledDecimal128Arithmetic
     @Test
     public void testRescale()
     {
-        assertEquals(rescale(unscaledDecimal(10), 0), unscaledDecimal(10L));
-        assertEquals(rescale(unscaledDecimal(10), -20), unscaledDecimal(0L));
-        assertEquals(rescale(unscaledDecimal(15), -1), unscaledDecimal(2));
-        assertEquals(rescale(unscaledDecimal(1050), -3), unscaledDecimal(1));
-        assertEquals(rescale(unscaledDecimal(15), 1), unscaledDecimal(150));
-        assertEquals(rescale(unscaledDecimal(-14), -1), unscaledDecimal(-1));
-        assertEquals(rescale(unscaledDecimal(-14), 1), unscaledDecimal(-140));
-        assertEquals(rescale(unscaledDecimal(0), 1), unscaledDecimal(0));
-        assertEquals(rescale(unscaledDecimal(5), -1), unscaledDecimal(1));
-        assertEquals(rescale(unscaledDecimal(10), 10), unscaledDecimal(100000000000L));
-        assertEquals(rescale(unscaledDecimal("150000000000000000000"), -20), unscaledDecimal(2));
-        assertEquals(rescale(unscaledDecimal("-140000000000000000000"), -20), unscaledDecimal(-1));
-        assertEquals(rescale(unscaledDecimal("50000000000000000000"), -20), unscaledDecimal(1));
-        assertEquals(rescale(unscaledDecimal("150500000000000000000"), -18), unscaledDecimal(151));
-        assertEquals(rescale(unscaledDecimal("-140000000000000000000"), -18), unscaledDecimal(-140));
-        assertEquals(rescale(unscaledDecimal(BigInteger.ONE.shiftLeft(63)), -18), unscaledDecimal(9L));
-        assertEquals(rescale(unscaledDecimal(BigInteger.ONE.shiftLeft(62)), -18), unscaledDecimal(5L));
-        assertEquals(rescale(unscaledDecimal(BigInteger.ONE.shiftLeft(62)), -19), unscaledDecimal(0L));
-        assertEquals(rescale(MAX_DECIMAL, -1), unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.divide(BigInteger.TEN).add(BigInteger.ONE)));
-        assertEquals(rescale(MIN_DECIMAL, -10), unscaledDecimal(MIN_DECIMAL_UNSCALED_VALUE.divide(BigInteger.valueOf(10000000000L)).subtract(BigInteger.ONE)));
-        assertEquals(rescale(unscaledDecimal(1), 37), unscaledDecimal("10000000000000000000000000000000000000"));
-        assertEquals(rescale(unscaledDecimal(-1), 37), unscaledDecimal("-10000000000000000000000000000000000000"));
-        assertEquals(rescale(unscaledDecimal("10000000000000000000000000000000000000"), -37), unscaledDecimal(1));
+        assertRescale(unscaledDecimal(10), 0, unscaledDecimal(10L));
+        assertRescale(unscaledDecimal(-10), 0, unscaledDecimal(-10L));
+        assertRescale(unscaledDecimal(10), -20, unscaledDecimal(0L));
+        assertRescale(unscaledDecimal(15), -1, unscaledDecimal(2));
+        assertRescale(unscaledDecimal(1050), -3, unscaledDecimal(1));
+        assertRescale(unscaledDecimal(15), 1, unscaledDecimal(150));
+        assertRescale(unscaledDecimal(-14), -1, unscaledDecimal(-1));
+        assertRescale(unscaledDecimal(-14), 1, unscaledDecimal(-140));
+        assertRescale(unscaledDecimal(0), 1, unscaledDecimal(0));
+        assertRescale(unscaledDecimal(5), -1, unscaledDecimal(1));
+        assertRescale(unscaledDecimal(10), 10, unscaledDecimal(100000000000L));
+        assertRescale(unscaledDecimal("150000000000000000000"), -20, unscaledDecimal(2));
+        assertRescale(unscaledDecimal("-140000000000000000000"), -20, unscaledDecimal(-1));
+        assertRescale(unscaledDecimal("50000000000000000000"), -20, unscaledDecimal(1));
+        assertRescale(unscaledDecimal("150500000000000000000"), -18, unscaledDecimal(151));
+        assertRescale(unscaledDecimal("-140000000000000000000"), -18, unscaledDecimal(-140));
+        assertRescale(unscaledDecimal(BigInteger.ONE.shiftLeft(63)), -18, unscaledDecimal(9L));
+        assertRescale(unscaledDecimal(BigInteger.ONE.shiftLeft(62)), -18, unscaledDecimal(5L));
+        assertRescale(unscaledDecimal(BigInteger.ONE.shiftLeft(62)), -19, unscaledDecimal(0L));
+        assertRescale(MAX_DECIMAL, -1, unscaledDecimal(MAX_DECIMAL_UNSCALED_VALUE.divide(BigInteger.TEN).add(BigInteger.ONE)));
+        assertRescale(MIN_DECIMAL, -10, unscaledDecimal(MIN_DECIMAL_UNSCALED_VALUE.divide(BigInteger.valueOf(10000000000L)).subtract(BigInteger.ONE)));
+        assertRescale(unscaledDecimal(1), 37, unscaledDecimal("10000000000000000000000000000000000000"));
+        assertRescale(unscaledDecimal(-1), 37, unscaledDecimal("-10000000000000000000000000000000000000"));
+        assertRescale(unscaledDecimal("10000000000000000000000000000000000000"), -37, unscaledDecimal(1));
     }
 
     @Test
@@ -800,6 +801,15 @@ public class TestUnscaledDecimal128Arithmetic
         }
         if (!isShort(a) && isShort(b)) {
             assertEquals(unscaledDecimal(result), multiply(unscaledDecimal(a), b.longValue()));
+        }
+    }
+
+    private static void assertRescale(Slice decimal, int rescale, Slice expected)
+    {
+        assertEquals(rescale(decimal, rescale), expected);
+        if (isShort(unscaledDecimalToBigInteger(decimal))) {
+            Slice actual = rescale(unscaledDecimalToUnscaledLong(decimal), rescale);
+            assertEquals(expected, actual);
         }
     }
 }


### PR DESCRIPTION
Another batch of 128-bit decimal optimizations

Benchmarks (BenchmarkDecimalOperators class):
Benchmark   | throughput before | throughput after
-|-|-
s2 + l2 | 557 | 705
l1 + l2 | 571 | 601
l1 + l2 + l3 + l4 | 240 | 262
s2 + l3 + l1 + s4 | 251 | 307
s2 + lz3 + lz1 + s4 | 230 | 285
s1 / s3 | 265 | 334
s2 / l1 | 391 | 497
l1 / s2 | 279 | 354
s3 / l1 | 224 | 294
l2 / l3 | 186 | 222
l2 / l4 / l4 / l4 | 113 | 128
l2 / s4 / s4 / s4 | 110 | 140
s2 % l2 | 443 | 578
l3 % s3 | 272 | 358
s4 % l3 | 320 | 379
l2 % l3 | 260 | 299
l2 % l3 % l4 % l1 | 91 | 113
s3 * s4 | 586 | 1153
l2 * s2 | 716 | 855
l2 * s2 * s5 * s6 | 329 | 448
s1 * l2 | 713 | 865

