### PR TITLE
Support catalog props in FileSessionPropertyManager

### DIFF
--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -46,8 +46,12 @@ Match Rules
 * ``group`` (optional): regex to match against the fully qualified name of the resource group the query is
   routed to.
 
-* ``sessionProperties``: map with string keys and values. Each entry is a system or catalog property name and
+* ``sessionProperties``: map with string keys and values. Each entry is a system property name and
   corresponding value. Values must be specified as strings, no matter the actual data type.
+
+* ``catalogSessionProperties``: map with string keys and map with string keys and values as values.
+  Each entry is a catalog name and corresponding map of property names and value.
+  Values must be specified as strings, no matter the actual data type.
 
 Example
 -------
@@ -60,7 +64,7 @@ Consider the following set of requirements:
   limit of 1 hour (tighter than the constraint on ``global``).
 
 * All ETL queries (tagged with 'etl') are routed to subgroups under the ``global.pipeline`` group, and must be
-  configured with certain properties to control writer behavior.
+  configured with certain properties to control writer behavior as well as hive connector behavior.
 
 These requirements can be expressed with the following rules:
 
@@ -85,6 +89,11 @@ These requirements can be expressed with the following rules:
         "sessionProperties": {
           "scale_writers": "true",
           "writer_min_size": "1GB"
+        },
+        "catalogSessionProperties": {
+          "hive": {
+            "insert_existing_partitions_behavior": "overwrite"
+          }
         }
       }
     ]

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionMatchSpec.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionMatchSpec.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.session;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -42,7 +43,7 @@ public class SessionMatchSpec
     private final Set<String> clientTags;
     private final Optional<String> queryType;
     private final Optional<Pattern> resourceGroupRegex;
-    private final Map<String, String> sessionProperties;
+    private final SessionProperties sessionProperties;
 
     @JsonCreator
     public SessionMatchSpec(
@@ -51,7 +52,8 @@ public class SessionMatchSpec
             @JsonProperty("clientTags") Optional<List<String>> clientTags,
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("group") Optional<Pattern> resourceGroupRegex,
-            @JsonProperty("sessionProperties") Map<String, String> sessionProperties)
+            @JsonProperty("sessionProperties") Map<String, String> sessionProperties,
+            @JsonProperty("catalogSessionProperties") Map<String, Map<String, String>> catalogSessionProperties)
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
@@ -59,34 +61,41 @@ public class SessionMatchSpec
         this.clientTags = ImmutableSet.copyOf(clientTags.orElse(ImmutableList.of()));
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupRegex = requireNonNull(resourceGroupRegex, "resourceGroupRegex is null");
-        requireNonNull(sessionProperties, "sessionProperties is null");
-        this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
+        checkArgument(sessionProperties != null || catalogSessionProperties != null, "sessionProperties and catalogSessionProperties are null");
+        this.sessionProperties = new SessionProperties(
+                ImmutableMap.copyOf(nullToEmpty(sessionProperties)),
+                ImmutableMap.copyOf(nullToEmpty(catalogSessionProperties)));
     }
 
-    public Map<String, String> match(SessionConfigurationContext context)
+    private <K, V> Map<K, V> nullToEmpty(Map<K, V> map)
+    {
+        return Optional.ofNullable(map).orElseGet(ImmutableMap::of);
+    }
+
+    public SessionProperties match(SessionConfigurationContext context)
     {
         if (userRegex.isPresent() && !userRegex.get().matcher(context.getUser()).matches()) {
-            return ImmutableMap.of();
+            return SessionProperties.EMPTY;
         }
         if (sourceRegex.isPresent()) {
             String source = context.getSource().orElse("");
             if (!sourceRegex.get().matcher(source).matches()) {
-                return ImmutableMap.of();
+                return SessionProperties.EMPTY;
             }
         }
         if (!clientTags.isEmpty() && !context.getClientTags().containsAll(clientTags)) {
-            return ImmutableMap.of();
+            return SessionProperties.EMPTY;
         }
 
         if (queryType.isPresent()) {
             String contextQueryType = context.getQueryType().orElse("");
             if (!queryType.get().equalsIgnoreCase(contextQueryType)) {
-                return ImmutableMap.of();
+                return SessionProperties.EMPTY;
             }
         }
 
         if (resourceGroupRegex.isPresent() && !resourceGroupRegex.get().matcher(context.getResourceGroupId().toString()).matches()) {
-            return ImmutableMap.of();
+            return SessionProperties.EMPTY;
         }
 
         return sessionProperties;
@@ -122,10 +131,22 @@ public class SessionMatchSpec
         return resourceGroupRegex;
     }
 
-    @JsonProperty
-    public Map<String, String> getSessionProperties()
+    @JsonIgnore
+    public SessionProperties getAllSessionProperties()
     {
         return sessionProperties;
+    }
+
+    @JsonProperty("sessionProperties")
+    public Map<String, String> getSessionProperties()
+    {
+        return sessionProperties.getSystemProperties();
+    }
+
+    @JsonProperty("catalogSessionProperties")
+    public Map<String, Map<String, String>> getCatalogSessionProperties()
+    {
+        return sessionProperties.getCatalogsProperties();
     }
 
     public static class Mapper
@@ -145,7 +166,8 @@ public class SessionMatchSpec
                     Optional.ofNullable(resultSet.getString("client_tags")).map(tag -> Splitter.on(",").splitToList(tag)),
                     Optional.ofNullable(resultSet.getString("query_type")),
                     Optional.ofNullable(resultSet.getString("group_regex")).map(Pattern::compile),
-                    sessionProperties);
+                    sessionProperties,
+                    ImmutableMap.of());
         }
 
         private static Map<String, String> getProperties(Optional<String> names, Optional<String> values)

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionProperties.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/SessionProperties.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.session;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class SessionProperties
+{
+    static final SessionProperties EMPTY = new SessionProperties(ImmutableMap.of(), ImmutableMap.of());
+    private final Map<String, String> systemProperties;
+    private final Map<String, Map<String, String>> catalogsProperties;
+
+    public SessionProperties(
+            Map<String, String> systemProperties,
+            Map<String, Map<String, String>> catalogsProperties)
+    {
+        this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
+        this.catalogsProperties = ImmutableMap.copyOf(requireNonNull(catalogsProperties, "catalogsProperties is null"));
+    }
+
+    public Map<String, String> getSystemProperties()
+    {
+        return systemProperties;
+    }
+
+    public Map<String, Map<String, String>> getCatalogsProperties()
+    {
+        return catalogsProperties;
+    }
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
@@ -49,7 +49,7 @@ public class DbSessionPropertyManager
         // later properties override earlier properties
         Map<String, String> combinedProperties = new HashMap<>();
         for (SessionMatchSpec sessionMatchSpec : sessionMatchSpecs) {
-            combinedProperties.putAll(sessionMatchSpec.match(context));
+            combinedProperties.putAll(sessionMatchSpec.match(context).getSystemProperties());
         }
 
         return ImmutableMap.copyOf(combinedProperties);

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/db/TestDbSessionPropertyManager.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.session.db;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.session.AbstractTestSessionPropertyManager;
 import io.prestosql.plugin.session.SessionMatchSpec;
+import io.prestosql.plugin.session.SessionProperties;
 import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import io.prestosql.spi.session.SessionConfigurationContext;
 import org.testng.annotations.AfterClass;
@@ -82,14 +83,14 @@ public class TestDbSessionPropertyManager
     }
 
     @Override
-    protected void assertProperties(Map<String, String> properties, SessionMatchSpec... specs)
+    protected void assertProperties(SessionProperties sessionProperties, SessionMatchSpec... specs)
     {
         insertSpecs(specs);
         long failureCountBefore = specsProvider.getDbLoadFailures().getTotalCount();
         specsProvider.refresh();
         long failureCountAfter = specsProvider.getDbLoadFailures().getTotalCount();
         assertEquals(failureCountAfter, failureCountBefore, "specs refresh should not fail");
-        assertEquals(manager.getSystemSessionProperties(CONTEXT), properties);
+        assertEquals(manager.getSystemSessionProperties(CONTEXT), sessionProperties.getSystemProperties());
     }
 
     private void insertSpecs(SessionMatchSpec[] specs)

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
@@ -17,13 +17,13 @@ package io.prestosql.plugin.session.file;
 import io.airlift.testing.TempFile;
 import io.prestosql.plugin.session.AbstractTestSessionPropertyManager;
 import io.prestosql.plugin.session.SessionMatchSpec;
+import io.prestosql.plugin.session.SessionProperties;
 import io.prestosql.spi.session.SessionPropertyConfigurationManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Map;
 
 import static io.prestosql.plugin.session.file.FileSessionPropertyManager.CODEC;
 import static org.testng.Assert.assertEquals;
@@ -32,14 +32,15 @@ public class TestFileSessionPropertyManager
         extends AbstractTestSessionPropertyManager
 {
     @Override
-    protected void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+    protected void assertProperties(SessionProperties sessionProperties, SessionMatchSpec... spec)
             throws IOException
     {
         try (TempFile tempFile = new TempFile()) {
             Path configurationFile = tempFile.path();
             Files.write(configurationFile, CODEC.toJsonBytes(Arrays.asList(spec)));
             SessionPropertyConfigurationManager manager = new FileSessionPropertyManager(new FileSessionPropertyManagerConfig().setConfigFile(configurationFile.toFile()));
-            assertEquals(manager.getSystemSessionProperties(CONTEXT), properties);
+            assertEquals(manager.getSystemSessionProperties(CONTEXT), sessionProperties.getSystemProperties());
+            assertEquals(manager.getCatalogSessionProperties(CONTEXT), sessionProperties.getCatalogsProperties());
         }
     }
 }


### PR DESCRIPTION
Remark: this implementation made the choice to not change SessionPropertyConfigurationManager API however it would make sense to change it
from 
```
    Map<String, String> getSystemSessionProperties(SessionConfigurationContext context);
    Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context);
```
to
```
 SessionProperties getSessionProperties(SessionConfigurationContext context);
```
I can implement the API change in a dedicated PR if an experienced Presto developer confirm it's worth breaking the API