### PR TITLE
Deprecate isCharType, isVarcharType

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
@@ -25,6 +25,10 @@ public final class Chars
 {
     private Chars() {}
 
+    /**
+     * @deprecated Use {@code type instanceof CharType} instead.
+     */
+    @Deprecated
     public static boolean isCharType(Type type)
     {
         return type instanceof CharType;

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
@@ -24,6 +24,10 @@ public final class Varchars
 {
     private Varchars() {}
 
+    /**
+     * @deprecated Use {@code type instanceof VarcharType} instead.
+     */
+    @Deprecated
     public static boolean isVarcharType(Type type)
     {
         return type instanceof VarcharType;


### PR DESCRIPTION
There is no way of preventing `instanceof VarcharType` and we do no try
to discourage that. For consistency of the code base, let's standardize
on (unavoidable) `instanceof` and depart from using a method to check
that.

Note also we do not have such methods for some other parametric types,
e.g.  timestamps, decimals, arrays.