### PR TITLE
Fix standard mapping for char exceeding allowed length

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -79,7 +79,6 @@ import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.UNNECESSARY;
@@ -503,9 +502,13 @@ public final class StandardColumnMappings
 
             case Types.CHAR:
             case Types.NCHAR:
-                // TODO this is wrong, we're going to construct malformed Slice representation if source > charLength
-                int charLength = min(columnSize, CharType.MAX_LENGTH);
-                return Optional.of(charColumnMapping(createCharType(charLength)));
+                if (columnSize > CharType.MAX_LENGTH) {
+                    if (columnSize > VarcharType.MAX_LENGTH) {
+                        return Optional.of(varcharColumnMapping(createUnboundedVarcharType()));
+                    }
+                    return Optional.of(varcharColumnMapping(createVarcharType(columnSize)));
+                }
+                return Optional.of(charColumnMapping(createCharType(columnSize)));
 
             case Types.VARCHAR:
             case Types.NVARCHAR:

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -189,11 +189,11 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testVarbinary()
     {
-        varbinaryTestCases(varbinaryDataType())
-                .execute(getQueryRunner(), prestoCreateAsSelect("test_varbinary"));
-
         varbinaryTestCases(byteaDataType())
                 .execute(getQueryRunner(), postgresCreateAndInsert("tpch.test_varbinary"));
+
+        varbinaryTestCases(varbinaryDataType())
+                .execute(getQueryRunner(), prestoCreateAsSelect("test_varbinary"));
     }
 
     private DataTypeTest varbinaryTestCases(DataType<byte[]> varbinaryDataType)
@@ -1220,9 +1220,10 @@ public class TestPostgreSqlTypeMapping
     public void testJson()
     {
         jsonTestCases(jsonDataType())
-                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_json"));
-        jsonTestCases(jsonDataType())
                 .execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_json"));
+
+        jsonTestCases(jsonDataType())
+                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_json"));
     }
 
     @Test
@@ -1272,10 +1273,10 @@ public class TestPostgreSqlTypeMapping
     public void testUuid()
     {
         uuidTestCases(uuidDataType())
-                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_uuid"));
+                .execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_uuid"));
 
         uuidTestCases(uuidDataType())
-                .execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_uuid"));
+                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_uuid"));
     }
 
     private DataTypeTest uuidTestCases(DataType<java.util.UUID> uuidDataType)
@@ -1299,21 +1300,21 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testReal()
     {
-        singlePrecisionFloatingPointTests(realDataType())
-                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_real"));
-
         singlePrecisionFloatingPointTests(postgreSqlRealDataType())
                 .execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_real"));
+
+        singlePrecisionFloatingPointTests(realDataType())
+                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_real"));
     }
 
     @Test
     public void testDouble()
     {
-        doublePrecisionFloatingPointTests(doubleDataType())
-                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_double"));
-
         doublePrecisionFloatingPointTests(postgreSqlDoubleDataType())
                 .execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_double"));
+
+        doublePrecisionFloatingPointTests(doubleDataType())
+                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_double"));
     }
 
     private static DataTypeTest singlePrecisionFloatingPointTests(DataType<Float> floatType)


### PR DESCRIPTION
Various editorial fixes in `TestPostgreSqlTypeMapping` and mapping fix for very long char types.