### PR TITLE
Reuse Marker object

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/predicate/Range.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/predicate/Range.java
@@ -81,7 +81,8 @@ public final class Range
 
     public static Range equal(Type type, Object value)
     {
-        return new Range(Marker.exactly(type, value), Marker.exactly(type, value));
+        Marker marker = Marker.exactly(type, value);
+        return new Range(marker, marker);
     }
 
     public static Range range(Type type, Object low, boolean lowInclusive, Object high, boolean highInclusive)


### PR DESCRIPTION
This improves TupleDomain performance
and reduces retained memory.

Tested using:
```
    @Test
    public void testLargeDomain()
    {
        SortedRangeSet[] sets = new SortedRangeSet[100];
        for (int i = 0; i < sets.length; ++i) {
            ImmutableList.Builder<Range> ranges = ImmutableList.builder();
            for (int j = 0; j < 100_000; ++j) {
                ranges.add(Range.equal(BIGINT, (long) j));
            }
            sets[i] = SortedRangeSet.copyOf(BIGINT, ranges.build());
        }
        System.err.println(sets.length);
    }
```
Rough performance before is 6.6s vs 5.1s after

Retained size before:
![obraz](https://user-images.githubusercontent.com/5989165/93589087-a075fe80-f9ac-11ea-8332-fc0522375ca4.png)

2880MB (36x vs raw data size of 80MB)

Retained size after:
![obraz](https://user-images.githubusercontent.com/5989165/93589106-a5d34900-f9ac-11ea-8c25-3b3e2627c83b.png)

1760MB (22x vs raw data size)