### PR TITLE
More Page getColumns refactors

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HashSemiJoinOperator.java
@@ -184,7 +184,7 @@ public class HashSemiJoinOperator
             // we know the exact size required for the block
             BlockBuilder blockBuilder = BOOLEAN.createFixedSizeBlockBuilder(inputPage.getPositionCount());
 
-            Page probeJoinPage = new Page(inputPage.getBlock(probeJoinChannel));
+            Page probeJoinPage = inputPage.getColumns(probeJoinChannel);
             Optional<Block> hashBlock = probeHashChannel.map(inputPage::getBlock);
 
             // update hashing strategy to use probe cursor

--- a/presto-main/src/main/java/io/prestosql/operator/SetBuilderOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SetBuilderOperator.java
@@ -18,7 +18,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.prestosql.operator.ChannelSet.ChannelSetBuilder;
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.sql.planner.plan.PlanNodeId;
@@ -122,8 +121,7 @@ public class SetBuilderOperator
 
     private final OperatorContext operatorContext;
     private final SetSupplier setSupplier;
-    private final int setChannel;
-    private final Optional<Integer> hashChannel;
+    private final int[] sourceChannels;
 
     private final ChannelSetBuilder channelSetBuilder;
 
@@ -142,9 +140,13 @@ public class SetBuilderOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.setSupplier = requireNonNull(setSupplier, "setProvider is null");
-        this.setChannel = setChannel;
 
-        this.hashChannel = requireNonNull(hashChannel, "hashChannel is null");
+        if (requireNonNull(hashChannel, "hashChannel is null").isPresent()) {
+            this.sourceChannels = new int[] {setChannel, hashChannel.get()};
+        }
+        else {
+            this.sourceChannels = new int[] {setChannel};
+        }
         // Set builder is has a single channel which goes in channel 0, if hash is present, add a hachBlock to channel 1
         Optional<Integer> channelSetHashChannel = hashChannel.isPresent() ? Optional.of(1) : Optional.empty();
         this.channelSetBuilder = new ChannelSetBuilder(
@@ -195,10 +197,7 @@ public class SetBuilderOperator
         requireNonNull(page, "page is null");
         checkState(!isFinished(), "Operator is already finished");
 
-        Block sourceBlock = page.getBlock(setChannel);
-        Page sourcePage = hashChannel.isPresent() ? new Page(sourceBlock, page.getBlock(hashChannel.get())) : new Page(sourceBlock);
-
-        unfinishedWork = channelSetBuilder.addPage(sourcePage);
+        unfinishedWork = channelSetBuilder.addPage(page.getColumns(sourceChannels));
         processUnfinishedWork();
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TopNRowNumberOperator.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.prestosql.memory.context.LocalMemoryContext;
 import io.prestosql.spi.Page;
-import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.SortOrder;
 import io.prestosql.spi.type.Type;
 import io.prestosql.sql.gen.JoinCompiler;
@@ -129,7 +128,7 @@ public class TopNRowNumberOperator
     private final OperatorContext operatorContext;
     private final LocalMemoryContext localUserMemoryContext;
 
-    private final List<Integer> outputChannels;
+    private final int[] outputChannels;
 
     private final GroupByHash groupByHash;
     private final GroupedTopNBuilder groupedTopNBuilder;
@@ -162,7 +161,7 @@ public class TopNRowNumberOperator
         if (generateRowNumber) {
             outputChannelsBuilder.add(outputChannels.size());
         }
-        this.outputChannels = outputChannelsBuilder.build();
+        this.outputChannels = Ints.toArray(outputChannelsBuilder.build());
 
         checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
 
@@ -253,13 +252,8 @@ public class TopNRowNumberOperator
 
         Page output = null;
         if (outputIterator.hasNext()) {
-            Page page = outputIterator.next();
             // rewrite to expected column ordering
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int i = 0; i < outputChannels.size(); i++) {
-                blocks[i] = page.getBlock(outputChannels.get(i));
-            }
-            output = new Page(blocks);
+            output = outputIterator.next().getColumns(outputChannels);
         }
         updateMemoryReservation();
         return output;

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/GenericAccumulatorFactory.java
@@ -565,14 +565,9 @@ public class GenericAccumulatorFactory
         @Override
         public void addInput(GroupByIdBlock groupIdsBlock, Page page)
         {
-            Block[] blocks = new Block[page.getChannelCount() + 1];
-            for (int i = 0; i < page.getChannelCount(); i++) {
-                blocks[i] = page.getBlock(i);
-            }
-            // Add group id block
-            blocks[page.getChannelCount()] = groupIdsBlock;
             groupCount = max(groupCount, groupIdsBlock.getGroupCount());
-            pagesIndex.addPage(new Page(blocks));
+            // Add group id block
+            pagesIndex.addPage(page.appendColumn(groupIdsBlock));
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/presto-main/src/main/java/io/prestosql/operator/index/UnloadedIndexKeyRecordSet.java
@@ -74,13 +74,8 @@ public class UnloadedIndexKeyRecordSet
         for (UpdateRequest request : requests) {
             Page page = request.getPage();
 
-            Block[] distinctBlocks = new Block[distinctChannels.length];
-            for (int i = 0; i < distinctBlocks.length; i++) {
-                distinctBlocks[i] = page.getBlock(distinctChannels[i]);
-            }
-
             // Move through the positions while advancing the cursors in lockstep
-            Work<GroupByIdBlock> work = groupByHash.getGroupIds(new Page(distinctBlocks));
+            Work<GroupByIdBlock> work = groupByHash.getGroupIds(page.getColumns(distinctChannels));
             boolean done = work.process();
             // TODO: this class does not yield wrt memory limit; enable it
             verify(done);

--- a/presto-spi/src/main/java/io/prestosql/spi/Page.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/Page.java
@@ -329,6 +329,11 @@ public final class Page
         return wrapBlocksWithoutCopy(length, blocks);
     }
 
+    public Page getColumns(int column)
+    {
+        return wrapBlocksWithoutCopy(positionCount, new Block[] {this.blocks[column]});
+    }
+
     public Page getColumns(int... columns)
     {
         requireNonNull(columns, "columns is null");


### PR DESCRIPTION
Two commits:
- Adds a single `int` overload to `Page#getColumns` to avoid creating a varargs array in that scenario
- Refactors more operator classes to use `Page#getColumns` where possible