### PR TITLE
Reduce size of serialized Range (and TupleDomain)

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/RangeJsonSerde.java
+++ b/presto-main/src/main/java/io/prestosql/server/RangeJsonSerde.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.predicate.Marker;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.type.Type;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static io.prestosql.spi.predicate.Marker.Bound.EXACTLY;
+
+public class RangeJsonSerde
+{
+    private RangeJsonSerde() {}
+
+    public static class Serializer
+            extends JsonSerializer<Range>
+    {
+        @Override
+        public void serialize(Range range, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+                throws IOException
+        {
+            jsonGenerator.writeNumber(range.isSingleValue() ? 1 : 0);
+            if (range.isSingleValue()) {
+                serializerProvider.findValueSerializer(Type.class).serialize(range.getType(), jsonGenerator, serializerProvider);
+                serializerProvider.findValueSerializer(Block.class).serialize(range.getLow().getValueBlock().get(), jsonGenerator, serializerProvider);
+                return;
+            }
+
+            JsonSerializer<Object> markerSerializer = serializerProvider.findValueSerializer(Marker.class);
+            markerSerializer.serialize(range.getLow(), jsonGenerator, serializerProvider);
+            markerSerializer.serialize(range.getHigh(), jsonGenerator, serializerProvider);
+        }
+    }
+
+    public static class Deserializer
+            extends JsonDeserializer<Range>
+    {
+        @Override
+        public Range deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException
+        {
+            boolean isSingleValue = jsonParser.getByteValue() == 1;
+            jsonParser.nextToken();
+            if (isSingleValue) {
+                Type type = deserializationContext.readValue(jsonParser, Type.class);
+                jsonParser.nextToken();
+                Block block = deserializationContext.readValue(jsonParser, Block.class);
+                Marker marker = new Marker(type, Optional.of(block), EXACTLY);
+                return new Range(marker, marker);
+            }
+
+            Marker low = deserializationContext.readValue(jsonParser, Marker.class);
+            jsonParser.nextToken();
+            Marker high = deserializationContext.readValue(jsonParser, Marker.class);
+            return new Range(low, high);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -97,6 +97,7 @@ import io.prestosql.spi.PageIndexerFactory;
 import io.prestosql.spi.PageSorter;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockEncodingSerde;
+import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
 import io.prestosql.spiller.FileSingleStreamSpillerFactory;
@@ -410,6 +411,10 @@ public class ServerMainModule
         // block encodings
         jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
         jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+
+        // range encoding
+        jsonBinder(binder).addSerializerBinding(Range.class).to(RangeJsonSerde.Serializer.class);
+        jsonBinder(binder).addDeserializerBinding(Range.class).to(RangeJsonSerde.Deserializer.class);
 
         // thread visualizer
         jaxrsBinder(binder).bind(ThreadResource.class);

--- a/presto-main/src/test/java/io/prestosql/server/TestRangeJsonSerde.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestRangeJsonSerde.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.ObjectMapperProvider;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.TestingBlockEncodingSerde;
+import io.prestosql.spi.block.TestingBlockJsonSerde;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.type.TestingTypeDeserializer;
+import io.prestosql.spi.type.TestingTypeManager;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestRangeJsonSerde
+{
+    @Test
+    public void testRangeJsonSerde()
+            throws JsonProcessingException
+    {
+        TestingTypeManager typeManager = new TestingTypeManager();
+        TestingBlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();
+
+        ObjectMapper mapper = new ObjectMapperProvider().get()
+                .registerModule(new SimpleModule()
+                        .addSerializer(Range.class, new RangeJsonSerde.Serializer())
+                        .addDeserializer(Range.class, new RangeJsonSerde.Deserializer())
+                        .addDeserializer(Type.class, new TestingTypeDeserializer(typeManager))
+                        .addSerializer(Block.class, new TestingBlockJsonSerde.Serializer(blockEncodingSerde))
+                        .addDeserializer(Block.class, new TestingBlockJsonSerde.Deserializer(blockEncodingSerde)));
+
+        Range singleValueRange = Range.equal(BIGINT, 1L);
+        Range range = Range.range(BIGINT, 12L, true, 42L, true);
+        Range unboundedRange = Range.greaterThan(BIGINT, 123L);
+        String serializedRanges = mapper.writeValueAsString(ImmutableList.of(singleValueRange, range, unboundedRange, singleValueRange));
+        assertEquals(serializedRanges, "[" +
+                "1,\"bigint\",\"CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA\"," +
+                "0,{\"type\":\"bigint\",\"valueBlock\":\"CgAAAExPTkdfQVJSQVkBAAAAAAwAAAAAAAAA\",\"bound\":\"EXACTLY\"},{\"type\":\"bigint\",\"valueBlock\":\"CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA\",\"bound\":\"EXACTLY\"}," +
+                "0,{\"type\":\"bigint\",\"valueBlock\":\"CgAAAExPTkdfQVJSQVkBAAAAAHsAAAAAAAAA\",\"bound\":\"ABOVE\"},{\"type\":\"bigint\",\"bound\":\"BELOW\"}," +
+                "1,\"bigint\",\"CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA\"]");
+        assertEquals(mapper.readValue(serializedRanges, new TypeReference<List<Range>>() {}), ImmutableList.of(singleValueRange, range, unboundedRange, singleValueRange));
+    }
+}


### PR DESCRIPTION
Size of serialized discrete range is reduced by ~4 times (see test)