### PR TITLE
Allow to use camel case environment name

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfigFactory.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentConfigFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.tests.product.launcher.env.Environments.canonicalName;
 
 public class EnvironmentConfigFactory
 {
@@ -34,6 +35,7 @@ public class EnvironmentConfigFactory
 
     public EnvironmentConfig getConfig(String configName)
     {
+        configName = canonicalName(configName);
         checkArgument(configurations.containsKey(configName), "No environment config with name '%s'. Those do exist, however: %s", configName, listConfigs());
         return configurations.get(configName);
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentFactory.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.tests.product.launcher.env.Environments.canonicalName;
 import static java.util.Objects.requireNonNull;
 
 public final class EnvironmentFactory
@@ -35,6 +36,7 @@ public final class EnvironmentFactory
 
     public Environment.Builder get(String environmentName, EnvironmentConfig config)
     {
+        environmentName = canonicalName(environmentName);
         checkArgument(environmentProviders.containsKey(environmentName), "No environment with name '%s'. Those do exist, however: %s", environmentName, list());
         return environmentProviders.get(environmentName)
                 .createEnvironment(environmentName, config);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environments.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environments.java
@@ -109,11 +109,25 @@ public final class Environments
 
     public static String nameForClass(Class<? extends EnvironmentProvider> clazz)
     {
-        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName());
+        return canonicalName(clazz);
     }
 
     public static String nameForConfigClass(Class<? extends EnvironmentConfig> clazz)
     {
-        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, clazz.getSimpleName());
+        return canonicalName(clazz);
+    }
+
+    private static String canonicalName(Class<?> clazz)
+    {
+        return canonicalName(clazz.getSimpleName());
+    }
+
+    /**
+     * Converts camel case name to hyphenated. Returns input if the name is already hyphenated.
+     */
+    public static String canonicalName(String name)
+    {
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, name)
+                .replaceAll("-+", "-");
     }
 }

--- a/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/env/TestEnvironments.java
+++ b/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/env/TestEnvironments.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import org.testng.annotations.Test;
+
+import static io.prestosql.tests.product.launcher.env.Environments.canonicalName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestEnvironments
+{
+    @Test
+    public void testCanonicalName()
+    {
+        assertThat(canonicalName("ala")).isEqualTo("ala");
+        assertThat(canonicalName("Ala")).isEqualTo("ala");
+        assertThat(canonicalName("DuzaAla")).isEqualTo("duza-ala");
+        assertThat(canonicalName("duza-ala")).isEqualTo("duza-ala");
+        assertThat(canonicalName("duza-Ala")).isEqualTo("duza-ala");
+        assertThat(canonicalName("duza----Ala")).isEqualTo("duza-ala");
+    }
+}


### PR DESCRIPTION
Allow to use camel case environment name

This is useful when you want to simply copy an environment class name.
