### PR TITLE
Remove deprecated type methods

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -100,7 +100,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -872,7 +871,7 @@ public abstract class BaseJdbcClient
     @Override
     public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             String dataType;
             if (varcharType.isUnbounded()) {

--- a/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHolePageSourceProvider.java
+++ b/presto-blackhole/src/main/java/io/prestosql/plugin/blackhole/BlackHolePageSourceProvider.java
@@ -49,7 +49,6 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.type.Decimals.encodeScaledValue;
 import static io.prestosql.spi.type.Decimals.isLongDecimal;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.math.BigDecimal.ZERO;
 import static java.util.Objects.requireNonNull;
 
@@ -105,7 +104,7 @@ public final class BlackHolePageSourceProvider
 
         Slice slice;
         // do not exceed varchar limit
-        if (isVarcharType(type) && !((VarcharType) type).isUnbounded()) {
+        if (type instanceof VarcharType && !((VarcharType) type).isUnbounded()) {
             slice = constantSlice.slice(0, Math.min(((VarcharType) type).getBoundedLength(), constantSlice.length()));
         }
         else if (isLongDecimal(type)) {

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPageSink.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraPageSink.java
@@ -26,6 +26,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.ConnectorPageSink;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -57,7 +58,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -161,7 +161,7 @@ public class CassandraPageSink
         else if (TIMESTAMP_TZ_MILLIS.equals(type)) {
             values.add(new Timestamp(unpackMillisUtc(type.getLong(block, position))));
         }
-        else if (isVarcharType(type)) {
+        else if (type instanceof VarcharType) {
             values.add(type.getSlice(block, position).toStringUtf8());
         }
         else if (VARBINARY.equals(type)) {

--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
@@ -34,6 +34,7 @@ import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
+import io.prestosql.spi.type.VarcharType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -54,7 +55,6 @@ import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
@@ -492,7 +492,7 @@ public enum CassandraType
         if (type.equals(RealType.REAL)) {
             return FLOAT;
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return TEXT;
         }
         if (type.equals(DateType.DATE)) {

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraConnector.java
@@ -35,6 +35,7 @@ import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.testing.TestingConnectorContext;
 import io.prestosql.testing.TestingConnectorSession;
 import org.testng.annotations.AfterClass;
@@ -62,7 +63,6 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
@@ -228,7 +228,7 @@ public class TestCassandraConnector
                 else if (REAL.equals(type)) {
                     cursor.getLong(columnIndex);
                 }
-                else if (isVarcharType(type) || VARBINARY.equals(type)) {
+                else if (type instanceof VarcharType || VARBINARY.equals(type)) {
                     try {
                         cursor.getSlice(columnIndex);
                     }

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/ElasticsearchLoader.java
@@ -19,6 +19,7 @@ import io.prestosql.client.QueryData;
 import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.testing.AbstractTestingPrestoClient;
 import io.prestosql.testing.ResultsSession;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -40,7 +41,6 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
@@ -128,7 +128,7 @@ public class ElasticsearchLoader
                 return null;
             }
 
-            if (type == BOOLEAN || type == DATE || isVarcharType(type)) {
+            if (type == BOOLEAN || type == DATE || type instanceof VarcharType) {
                 return value;
             }
             if (type == BIGINT) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursor.java
@@ -19,9 +19,11 @@ import io.prestosql.hadoop.TextLineLengthLimitExceededException;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.RecordCursor;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.Date;
@@ -62,7 +64,6 @@ import static io.prestosql.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.prestosql.plugin.hive.util.SerDeUtils.getBlockObject;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.rescale;
@@ -74,7 +75,6 @@ import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.max;
@@ -362,10 +362,10 @@ public class GenericHiveRecordCursor<K, V extends Writable>
 
     private static Slice trimStringToCharacterLimits(Type type, Slice value)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return truncateToLength(value, type);
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             return truncateToLengthAndTrimSpaces(value, type);
         }
         return value;
@@ -512,10 +512,10 @@ public class GenericHiveRecordCursor<K, V extends Writable>
         else if (DOUBLE.equals(type)) {
             parseDoubleColumn(column);
         }
-        else if (isVarcharType(type) || VARBINARY.equals(type)) {
+        else if (type instanceof VarcharType || VARBINARY.equals(type)) {
             parseStringColumn(column);
         }
-        else if (isCharType(type)) {
+        else if (type instanceof CharType) {
             parseStringColumn(column);
         }
         else if (isStructuralType(hiveTypes[column])) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -35,6 +35,7 @@ import io.prestosql.spi.block.LazyBlockLoader;
 import io.prestosql.spi.block.RowBlock;
 import io.prestosql.spi.block.RunLengthEncodedBlock;
 import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.Type;
@@ -97,7 +98,6 @@ import static io.prestosql.spi.block.ColumnarMap.toColumnarMap;
 import static io.prestosql.spi.block.ColumnarRow.toColumnarRow;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.isLongDecimal;
@@ -109,7 +109,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -205,10 +204,10 @@ public class HivePageSource
                 else if (type.equals(DOUBLE)) {
                     prefilledValue = doublePartitionKey(columnValue, name);
                 }
-                else if (isVarcharType(type)) {
+                else if (type instanceof VarcharType) {
                     prefilledValue = varcharPartitionKey(columnValue, name, type);
                 }
-                else if (isCharType(type)) {
+                else if (type instanceof CharType) {
                     prefilledValue = charPartitionKey(columnValue, name, type);
                 }
                 else if (type.equals(DATE)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursor.java
@@ -19,8 +19,10 @@ import io.prestosql.plugin.hive.HivePageSourceProvider.ColumnMapping;
 import io.prestosql.plugin.hive.util.HiveUtil;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.RecordCursor;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.joda.time.DateTimeZone;
 
 import java.util.List;
@@ -44,7 +46,6 @@ import static io.prestosql.plugin.hive.util.HiveUtil.varcharPartitionKey;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.isLongDecimal;
@@ -56,7 +57,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -132,10 +132,10 @@ public class HiveRecordCursor
                 else if (DOUBLE.equals(type)) {
                     doubles[columnIndex] = doublePartitionKey(columnValue, name);
                 }
-                else if (isVarcharType(type)) {
+                else if (type instanceof VarcharType) {
                     slices[columnIndex] = varcharPartitionKey(columnValue, name, type);
                 }
-                else if (isCharType(type)) {
+                else if (type instanceof CharType) {
                     slices[columnIndex] = charPartitionKey(columnValue, name, type);
                 }
                 else if (DATE.equals(type)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -43,10 +43,12 @@ import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.security.SelectedRole;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.hadoop.hive.metastore.api.BinaryColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -120,7 +122,6 @@ import static io.prestosql.spi.statistics.ColumnStatisticType.NUMBER_OF_TRUE_VAL
 import static io.prestosql.spi.statistics.ColumnStatisticType.TOTAL_SIZE_IN_BYTES;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
@@ -129,7 +130,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Math.round;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -967,7 +967,7 @@ public final class ThriftMetastoreUtil
             // TODO https://github.com/prestosql/presto/issues/37 support non-legacy TIMESTAMP
             return ImmutableSet.of(MIN_VALUE, MAX_VALUE, NUMBER_OF_DISTINCT_VALUES, NUMBER_OF_NON_NULL_VALUES);
         }
-        if (isVarcharType(type) || isCharType(type)) {
+        if (type instanceof VarcharType || type instanceof CharType) {
             // TODO Collect MIN,MAX once it is used by the optimizer
             return ImmutableSet.of(NUMBER_OF_NON_NULL_VALUES, NUMBER_OF_DISTINCT_VALUES, TOTAL_SIZE_IN_BYTES, MAX_VALUE_SIZE_IN_BYTES);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -43,9 +43,11 @@ import io.prestosql.spi.statistics.ColumnStatistics;
 import io.prestosql.spi.statistics.DoubleRange;
 import io.prestosql.spi.statistics.Estimate;
 import io.prestosql.spi.statistics.TableStatistics;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -74,7 +76,6 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.getPartitionStatist
 import static io.prestosql.plugin.hive.HiveSessionProperties.isIgnoreCorruptedStatistics;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isStatisticsEnabled;
 import static io.prestosql.spi.type.BigintType.BIGINT;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.isLongDecimal;
 import static io.prestosql.spi.type.Decimals.isShortDecimal;
@@ -83,7 +84,6 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isNaN;
 import static java.lang.Double.parseDouble;
@@ -521,7 +521,7 @@ public class MetastoreHiveStatisticsProvider
 
     private static boolean hasDataSize(Type type)
     {
-        return isVarcharType(type) || isCharType(type);
+        return type instanceof VarcharType || type instanceof CharType;
     }
 
     private static int getSize(NullableValue nullableValue)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -143,7 +143,6 @@ import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.trimTrailingSpaces;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
@@ -154,7 +153,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Byte.parseByte;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.floatToRawIntBits;
@@ -519,8 +517,8 @@ public final class HiveUtil
                 DOUBLE.equals(type) ||
                 DATE.equals(type) ||
                 TIMESTAMP_MILLIS.equals(type) ||
-                isVarcharType(type) ||
-                isCharType(type);
+                type instanceof VarcharType ||
+                type instanceof CharType;
     }
 
     public static NullableValue parsePartitionValue(String partitionName, String value, Type type)
@@ -632,14 +630,14 @@ public final class HiveUtil
             return NullableValue.of(DOUBLE, doublePartitionKey(value, partitionName));
         }
 
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             if (isNull) {
                 return NullableValue.asNull(type);
             }
             return NullableValue.of(type, varcharPartitionKey(value, partitionName, type));
         }
 
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             if (isNull) {
                 return NullableValue.asNull(type);
             }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -112,7 +112,6 @@ import static io.prestosql.plugin.hive.util.HiveUtil.isArrayType;
 import static io.prestosql.plugin.hive.util.HiveUtil.isMapType;
 import static io.prestosql.plugin.hive.util.HiveUtil.isRowType;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
@@ -689,7 +688,7 @@ public final class HiveWriteUtils
             }
         }
 
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             CharType charType = (CharType) type;
             int charLength = charType.getLength();
             return getPrimitiveWritableObjectInspector(getCharTypeInfo(charLength));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -112,6 +112,7 @@ import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.SqlVarbinary;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.gen.JoinCompiler;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.MaterializedRow;
@@ -248,7 +249,6 @@ import static io.prestosql.spi.security.PrincipalType.USER;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
@@ -263,7 +263,6 @@ import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.MaterializedResult.materializeSourceDataStream;
 import static io.prestosql.testing.QueryAssertions.assertEqualsIgnoreOrder;
@@ -1347,7 +1346,7 @@ public abstract class AbstractTestHive
                         columnStatistics.getDistinctValuesCount().isUnknown(),
                         "unknown distinct values count for " + columnName);
 
-                if (isVarcharType(columnType)) {
+                if (columnType instanceof VarcharType) {
                     assertFalse(
                             columnStatistics.getDataSize().isUnknown(),
                             "unknown data size for " + columnName);
@@ -4529,7 +4528,7 @@ public abstract class AbstractTestHive
                 else if (REAL.equals(column.getType())) {
                     assertInstanceOf(value, Float.class);
                 }
-                else if (isVarcharType(column.getType())) {
+                else if (column.getType() instanceof VarcharType) {
                     assertInstanceOf(value, String.class);
                 }
                 else if (isCharType(column.getType())) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -103,6 +103,7 @@ import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.statistics.ColumnStatistics;
 import io.prestosql.spi.statistics.TableStatistics;
 import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.NamedTypeSignature;
 import io.prestosql.spi.type.RowFieldName;
@@ -4531,7 +4532,7 @@ public abstract class AbstractTestHive
                 else if (column.getType() instanceof VarcharType) {
                     assertInstanceOf(value, String.class);
                 }
-                else if (isCharType(column.getType())) {
+                else if (column.getType() instanceof CharType) {
                     assertInstanceOf(value, String.class);
                 }
                 else if (VARBINARY.equals(column.getType())) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileFormats.java
@@ -37,6 +37,7 @@ import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlVarbinary;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.MaterializedRow;
 import org.apache.hadoop.conf.Configuration;
@@ -98,7 +99,6 @@ import static io.prestosql.plugin.hive.util.SerDeUtils.serializeObject;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
@@ -108,7 +108,6 @@ import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.MaterializedResult.materializeSourceDataStream;
 import static io.prestosql.testing.StructuralTestUtil.arrayBlockOf;
@@ -705,7 +704,7 @@ public abstract class AbstractTestHiveFileFormats
         if (DOUBLE.equals(type)) {
             return cursor.getDouble(field);
         }
-        if (isVarcharType(type) || isCharType(type) || VARBINARY.equals(type)) {
+        if (type instanceof VarcharType || type instanceof CharType || VARBINARY.equals(type)) {
             return cursor.getSlice(field);
         }
         if (DateType.DATE.equals(type)) {

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/ParquetTester.java
@@ -114,7 +114,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -516,7 +515,7 @@ public class ParquetTester
             DecimalType decimalType = (DecimalType) type;
             return new SqlDecimal((BigInteger) fieldFromCursor, decimalType.getPrecision(), decimalType.getScale());
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return new String(((Slice) fieldFromCursor).getBytes(), UTF_8);
         }
         if (VARBINARY.equals(type)) {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergPageSource.java
@@ -53,7 +53,6 @@ import static io.prestosql.spi.type.TimeType.TIME_MICROS;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.parseFloat;
@@ -221,7 +220,7 @@ public class IcebergPageSource
             if (type.equals(TIMESTAMP_TZ_MICROS)) {
                 return timestampTzFromMicros(parseLong(valueString), timeZoneKey);
             }
-            if (isVarcharType(type)) {
+            if (type instanceof VarcharType) {
                 Slice value = utf8Slice(valueString);
                 VarcharType varcharType = (VarcharType) type;
                 if (!varcharType.isUnbounded() && SliceUtf8.countCodePoints(value) > varcharType.getBoundedLength()) {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/PartitionTransforms.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.block.Block;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.iceberg.PartitionField;
 import org.joda.time.DateTimeField;
 import org.joda.time.chrono.ISOChronology;
@@ -53,7 +54,6 @@ import static io.prestosql.spi.type.Timestamps.MILLISECONDS_PER_HOUR;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Integer.parseInt;
 import static java.lang.Math.floorDiv;
 import static java.util.Objects.requireNonNull;
@@ -148,7 +148,7 @@ public final class PartitionTransforms
             if (type.equals(TIMESTAMP_TZ_MICROS)) {
                 return new ColumnTransform(INTEGER, block -> bucketTimestampWithTimeZone(block, count));
             }
-            if (isVarcharType(type)) {
+            if (type instanceof VarcharType) {
                 return new ColumnTransform(INTEGER, block -> bucketVarchar(block, count));
             }
             if (type.equals(VARBINARY)) {
@@ -174,7 +174,7 @@ public final class PartitionTransforms
                 DecimalType decimal = (DecimalType) type;
                 return new ColumnTransform(type, block -> truncateLongDecimal(decimal, block, width));
             }
-            if (isVarcharType(type)) {
+            if (type instanceof VarcharType) {
                 return new ColumnTransform(VARCHAR, block -> truncateVarchar(block, width));
             }
             if (type.equals(VARBINARY)) {

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -28,6 +28,8 @@ import io.prestosql.spi.type.TimeWithTimeZoneType;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarbinaryType;
+import io.prestosql.spi.type.VarcharType;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -41,7 +43,6 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.VarbinaryType.isVarbinaryType;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -99,7 +100,7 @@ public abstract class AbstractRowEncoder
         else if (type instanceof VarcharType) {
             appendString(type.getSlice(block, position).toStringUtf8());
         }
-        else if (isVarbinaryType(type)) {
+        else if (type instanceof VarbinaryType) {
             appendByteBuffer(type.getSlice(block, position).toByteBuffer());
         }
         else if (type == DATE) {

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/AbstractRowEncoder.java
@@ -42,7 +42,6 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.isVarbinaryType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -97,7 +96,7 @@ public abstract class AbstractRowEncoder
         else if (type == REAL) {
             appendFloat(intBitsToFloat(toIntExact(type.getLong(block, position))));
         }
-        else if (isVarcharType(type)) {
+        else if (type instanceof VarcharType) {
             appendString(type.getSlice(block, position).toStringUtf8());
         }
         else if (isVarbinaryType(type)) {

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/avro/AvroRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/avro/AvroRowEncoder.java
@@ -18,6 +18,7 @@ import io.prestosql.plugin.kafka.encoder.AbstractRowEncoder;
 import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -36,7 +37,6 @@ import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -70,7 +70,7 @@ public class AvroRowEncoder
 
     private boolean isSupportedType(Type type)
     {
-        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof VarcharType || SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/csv/CsvRowEncoder.java
@@ -19,6 +19,7 @@ import io.prestosql.plugin.kafka.encoder.AbstractRowEncoder;
 import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,7 +37,6 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 
 public class CsvRowEncoder
@@ -63,7 +63,7 @@ public class CsvRowEncoder
 
     private boolean isSupportedType(Type type)
     {
-        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof VarcharType || SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/JsonRowEncoder.java
@@ -31,6 +31,7 @@ import io.prestosql.spi.type.SqlTimestamp;
 import io.prestosql.spi.type.SqlTimestampWithTimeZone;
 import io.prestosql.spi.type.TimeType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -49,7 +50,6 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -101,7 +101,7 @@ public class JsonRowEncoder
 
     private boolean isSupportedType(Type type)
     {
-        return isVarcharType(type) ||
+        return type instanceof VarcharType ||
                 SUPPORTED_PRIMITIVE_TYPES.contains(type) ||
                 isSupportedTemporalType(type);
     }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/raw/RawRowEncoder.java
@@ -19,6 +19,7 @@ import io.prestosql.plugin.kafka.encoder.AbstractRowEncoder;
 import io.prestosql.plugin.kafka.encoder.EncoderColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +40,6 @@ import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 
@@ -90,7 +90,7 @@ public class RawRowEncoder
         this.columnMappings = this.columnHandles.stream().map(ColumnMapping::new).collect(toImmutableList());
 
         for (ColumnMapping mapping : this.columnMappings) {
-            if (mapping.getLength() != mapping.getFieldType().getSize() && !isVarcharType(mapping.getType())) {
+            if (mapping.getLength() != mapping.getFieldType().getSize() && ! (mapping.getType() instanceof VarcharType)) {
                 throw new IndexOutOfBoundsException(format(
                         "Mapping length '%s' is not equal to expected length '%s' for column '%s'",
                         mapping.getLength(),
@@ -198,7 +198,7 @@ public class RawRowEncoder
             else if (columnType == DOUBLE) {
                 checkFieldTypeOneOf(fieldType, columnName, columnType, FieldType.DOUBLE, FieldType.FLOAT);
             }
-            else if (isVarcharType(columnType)) {
+            else if (columnType instanceof VarcharType) {
                 checkFieldTypeOneOf(fieldType, columnName, columnType, FieldType.BYTE);
             }
         }
@@ -246,7 +246,7 @@ public class RawRowEncoder
 
     private static boolean isSupportedType(Type type)
     {
-        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof VarcharType || SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 
     @Override

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/raw/RawRowEncoder.java
@@ -90,7 +90,7 @@ public class RawRowEncoder
         this.columnMappings = this.columnHandles.stream().map(ColumnMapping::new).collect(toImmutableList());
 
         for (ColumnMapping mapping : this.columnMappings) {
-            if (mapping.getLength() != mapping.getFieldType().getSize() && ! (mapping.getType() instanceof VarcharType)) {
+            if (mapping.getLength() != mapping.getFieldType().getSize() && !(mapping.getType() instanceof VarcharType)) {
                 throw new IndexOutOfBoundsException(format(
                         "Mapping length '%s' is not equal to expected length '%s' for column '%s'",
                         mapping.getLength(),

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
@@ -22,7 +22,6 @@ import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
-import io.prestosql.spi.type.Varchars;
 import io.prestosql.testing.AbstractTestingPrestoClient;
 import io.prestosql.testing.ResultsSession;
 import org.apache.kafka.clients.producer.KafkaProducer;

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/util/KafkaLoader.java
@@ -21,6 +21,7 @@ import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.spi.type.Varchars;
 import io.prestosql.testing.AbstractTestingPrestoClient;
 import io.prestosql.testing.ResultsSession;
@@ -127,7 +128,7 @@ public class KafkaLoader
                 return null;
             }
 
-            if (BOOLEAN.equals(type) || Varchars.isVarcharType(type)) {
+            if (BOOLEAN.equals(type) || type instanceof VarcharType) {
                 return value;
             }
             if (BIGINT.equals(type)) {

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduPageSink.java
@@ -25,6 +25,7 @@ import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.SqlDate;
 import io.prestosql.spi.type.SqlDecimal;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduSession;
 import org.apache.kudu.client.KuduTable;
@@ -53,7 +54,6 @@ import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.truncateEpochMicrosToMillis;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -165,7 +165,7 @@ public class KuduPageSink
         else if (DOUBLE.equals(type)) {
             row.addDouble(destChannel, type.getDouble(block, position));
         }
-        else if (isVarcharType(type)) {
+        else if (type instanceof VarcharType) {
             Type originalType = originalColumnTypes.get(destChannel);
             if (DATE.equals(originalType)) {
                 SqlDate date = (SqlDate) originalType.getObjectValue(connectorSession, block, position);

--- a/presto-main/src/main/java/io/prestosql/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/jdbc/ColumnJdbcTable.java
@@ -75,7 +75,6 @@ import static io.prestosql.metadata.MetadataListing.listTables;
 import static io.prestosql.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
@@ -86,7 +85,6 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.type.TypeUtils.getDisplayLabel;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -356,10 +354,10 @@ public class ColumnJdbcTable
         if (type instanceof DecimalType) {
             return Types.DECIMAL;
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return Types.VARCHAR;
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             return Types.CHAR;
         }
         if (type.equals(VARBINARY)) {
@@ -409,10 +407,10 @@ public class ColumnJdbcTable
         if (type.equals(DOUBLE)) {
             return 53; // IEEE 754
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return ((VarcharType) type).getLength().orElse(VarcharType.UNBOUNDED_LENGTH);
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             return ((CharType) type).getLength();
         }
         if (type.equals(VARBINARY)) {
@@ -470,10 +468,10 @@ public class ColumnJdbcTable
 
     private static Integer charOctetLength(Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return ((VarcharType) type).getLength().orElse(VarcharType.UNBOUNDED_LENGTH);
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             return ((CharType) type).getLength();
         }
         if (type.equals(VARBINARY)) {

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
@@ -34,6 +34,7 @@ import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.sql.tree.QualifiedName;
 
 import java.lang.invoke.MethodHandle;
@@ -55,7 +56,6 @@ import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentC
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.decodeUnscaledValue;
@@ -68,7 +68,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.type.DateTimes.PICOSECONDS_PER_NANOSECOND;
 import static io.prestosql.type.DateTimes.toLocalDateTime;
 import static io.prestosql.type.DateTimes.toZonedDateTime;
@@ -130,8 +129,8 @@ public final class FormatFunction
                 type instanceof TimeType ||
                 isShortDecimal(type) ||
                 isLongDecimal(type) ||
-                isVarcharType(type) ||
-                isCharType(type)) {
+                type instanceof VarcharType ||
+                type instanceof CharType) {
             return;
         }
 
@@ -228,10 +227,10 @@ public final class FormatFunction
             int scale = ((DecimalType) type).getScale();
             return (session, block) -> new BigDecimal(decodeUnscaledValue(type.getSlice(block, position)), scale);
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return (session, block) -> type.getSlice(block, position).toStringUtf8();
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             CharType charType = (CharType) type;
             return (session, block) -> padSpaces(type.getSlice(block, position), charType).toStringUtf8();
         }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -157,7 +157,6 @@ import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWit
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.sql.NodeUtils.getSortItemsFromOrderBy;
 import static io.prestosql.sql.analyzer.Analyzer.verifyNoAggregateWindowOrGroupingFunctions;
 import static io.prestosql.sql.analyzer.ExpressionTreeUtils.extractLocation;
@@ -1093,7 +1092,7 @@ public class ExpressionAnalyzer
                     .map(expression -> process(expression, context))
                     .collect(toImmutableList());
 
-            if (!isVarcharType(arguments.get(0))) {
+            if (!(arguments.get(0) instanceof VarcharType)) {
                 throw semanticException(TYPE_MISMATCH, node.getArguments().get(0), "Type of first argument to format() must be VARCHAR (actual: %s)", arguments.get(0));
             }
 

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoPageSink.java
@@ -42,6 +42,7 @@ import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignatureParameter;
 import io.prestosql.spi.type.VarbinaryType;
+import io.prestosql.spi.type.VarcharType;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.bson.types.ObjectId;
@@ -68,7 +69,6 @@ import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.toIntExact;
@@ -153,7 +153,7 @@ public class MongoPageSink
         if (type.equals(DoubleType.DOUBLE)) {
             return type.getDouble(block, position);
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return type.getSlice(block, position).toStringUtf8();
         }
         if (type instanceof CharType) {

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -94,7 +94,6 @@ import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLI
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.math.RoundingMode.UNNECESSARY;
@@ -267,7 +266,7 @@ public class MySqlClient
         if (VARBINARY.equals(type)) {
             return WriteMapping.sliceMapping("mediumblob", varbinaryWriteFunction());
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             String dataType;
             if (varcharType.isUnbounded()) {

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -82,7 +82,6 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackZoneKey;
@@ -102,7 +101,6 @@ import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.max;
@@ -444,7 +442,7 @@ public class OracleClient
     @Override
     public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             String dataType;
             VarcharType varcharType = (VarcharType) type;
             if (varcharType.isUnbounded() || varcharType.getBoundedLength() > ORACLE_VARCHAR2_MAX_CHARS) {
@@ -455,7 +453,7 @@ public class OracleClient
             }
             return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             String dataType;
             if (((CharType) type).getLength() > ORACLE_CHAR_MAX_CHARS) {
                 dataType = "nclob";

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -25,6 +25,7 @@ import io.prestosql.orc.metadata.statistics.RangeStatistics;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.ValueSet;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.LongTimestamp;
@@ -44,7 +45,6 @@ import java.util.function.Function;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.prestosql.spi.type.DateTimeEncoding.unpackMillisUtc;
@@ -66,7 +66,6 @@ import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLI
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
@@ -244,10 +243,10 @@ public class TupleDomainOrcPredicate
         else if (isLongDecimal(type) && columnStatistics.getDecimalStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getDecimalStatistics(), value -> encodeUnscaledValue(rescale(value, (DecimalType) type).unscaledValue()));
         }
-        else if (isCharType(type) && columnStatistics.getStringStatistics() != null) {
+        else if (type instanceof CharType && columnStatistics.getStringStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getStringStatistics(), value -> truncateToLengthAndTrimSpaces(value, type));
         }
-        else if (isVarcharType(type) && columnStatistics.getStringStatistics() != null) {
+        else if (type instanceof VarcharType && columnStatistics.getStringStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getStringStatistics());
         }
         else if (type instanceof DateType && columnStatistics.getDateStatistics() != null) {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/SliceColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/SliceColumnReader.java
@@ -40,10 +40,8 @@ import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT
 import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.prestosql.orc.reader.ReaderUtils.verifyStreamType;
 import static io.prestosql.spi.type.Chars.byteCountWithoutTrailingSpace;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.VarbinaryType.isVarbinaryType;
 import static io.prestosql.spi.type.Varchars.byteCount;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.util.Objects.requireNonNull;
 
 public class SliceColumnReader
@@ -65,7 +63,7 @@ public class SliceColumnReader
         this.column = requireNonNull(column, "column is null");
 
         int maxCodePointCount = getMaxCodePointCount(type);
-        boolean charType = isCharType(type);
+        boolean charType = type instanceof CharType;
         directReader = new SliceDirectColumnReader(column, maxCodePointCount, charType);
         dictionaryReader = new SliceDictionaryColumnReader(column, systemMemoryContext.newLocalMemoryContext(SliceColumnReader.class.getSimpleName()), maxCodePointCount, charType);
     }
@@ -118,11 +116,11 @@ public class SliceColumnReader
 
     private static int getMaxCodePointCount(Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             return varcharType.isUnbounded() ? -1 : varcharType.getBoundedLength();
         }
-        if (isCharType(type)) {
+        if (type instanceof CharType) {
             return ((CharType) type).getLength();
         }
         if (isVarbinaryType(type)) {

--- a/presto-orc/src/main/java/io/prestosql/orc/reader/SliceColumnReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/reader/SliceColumnReader.java
@@ -40,7 +40,6 @@ import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT
 import static io.prestosql.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static io.prestosql.orc.reader.ReaderUtils.verifyStreamType;
 import static io.prestosql.spi.type.Chars.byteCountWithoutTrailingSpace;
-import static io.prestosql.spi.type.VarbinaryType.isVarbinaryType;
 import static io.prestosql.spi.type.Varchars.byteCount;
 import static java.util.Objects.requireNonNull;
 
@@ -123,7 +122,7 @@ public class SliceColumnReader
         if (type instanceof CharType) {
             return ((CharType) type).getLength();
         }
-        if (isVarbinaryType(type)) {
+        if (type instanceof VarbinaryType) {
             return -1;
         }
         throw new IllegalArgumentException("Unsupported encoding " + type.getDisplayName());

--- a/presto-parquet/src/main/java/io/prestosql/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/predicate/TupleDomainParquetPredicate.java
@@ -30,6 +30,7 @@ import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.statistics.BinaryStatistics;
 import org.apache.parquet.column.statistics.BooleanStatistics;
@@ -60,7 +61,6 @@ import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -226,7 +226,7 @@ public class TupleDomainParquetPredicate
             return createDomain(type, hasNullValue, parquetDoubleStatistics);
         }
 
-        if (isVarcharType(type) && statistics instanceof BinaryStatistics) {
+        if (type instanceof VarcharType && statistics instanceof BinaryStatistics) {
             BinaryStatistics binaryStatistics = (BinaryStatistics) statistics;
             Slice minSlice = Slices.wrappedBuffer(binaryStatistics.genericGetMin().getBytes());
             Slice maxSlice = Slices.wrappedBuffer(binaryStatistics.genericGetMax().getBytes());
@@ -357,7 +357,7 @@ public class TupleDomainParquetPredicate
             return Domain.union(domains);
         }
 
-        if (isVarcharType(type) && columnDescriptor.getPrimitiveType().getPrimitiveTypeName() == PrimitiveTypeName.BINARY) {
+        if (type instanceof VarcharType && columnDescriptor.getPrimitiveType().getPrimitiveTypeName() == PrimitiveTypeName.BINARY) {
             List<Domain> domains = new ArrayList<>();
             for (int i = 0; i < dictionarySize; i++) {
                 domains.add(Domain.singleValue(type, Slices.wrappedBuffer(dictionary.decodeToBinary(i).getBytes())));

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/BinaryColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/BinaryColumnReader.java
@@ -16,14 +16,14 @@ package io.prestosql.parquet.reader;
 import io.airlift.slice.Slice;
 import io.prestosql.parquet.RichColumnDescriptor;
 import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import org.apache.parquet.io.api.Binary;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.truncateToLengthAndTrimSpaces;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 
 public class BinaryColumnReader
@@ -46,10 +46,10 @@ public class BinaryColumnReader
             else {
                 value = wrappedBuffer(binary.getBytes());
             }
-            if (isVarcharType(type)) {
+            if (type instanceof VarcharType) {
                 value = truncateToLength(value, type);
             }
-            if (isCharType(type)) {
+            if (type instanceof CharType) {
                 value = truncateToLengthAndTrimSpaces(value, type);
             }
             type.writeSlice(blockBuilder, value);

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/TypeUtils.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/TypeUtils.java
@@ -40,7 +40,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.Decimals.decodeUnscaledValue;
 import static io.prestosql.spi.type.Decimals.encodeScaledValue;
@@ -52,7 +51,6 @@ import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.TypeUtils.readNativeValue;
 import static io.prestosql.spi.type.TypeUtils.writeNativeValue;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -68,7 +66,7 @@ public final class TypeUtils
 
     public static String getArrayElementPhoenixTypeName(ConnectorSession session, PhoenixClient client, Type elementType)
     {
-        if (isVarcharType(elementType)) {
+        if (elementType instanceof VarcharType) {
             return "VARCHAR";
         }
 

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/TypeUtils.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/TypeUtils.java
@@ -70,7 +70,7 @@ public final class TypeUtils
             return "VARCHAR";
         }
 
-        if (isCharType(elementType)) {
+        if (elementType instanceof CharType) {
             return "CHAR";
         }
 

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorBucketFunction.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorBucketFunction.java
@@ -19,6 +19,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.connector.BucketFunction;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.util.List;
 
@@ -26,7 +27,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 
 public class RaptorBucketFunction
         implements BucketFunction
@@ -70,7 +70,7 @@ public class RaptorBucketFunction
         if (type.equals(INTEGER)) {
             return intHashFunction();
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return varcharHashFunction();
         }
         throw new PrestoException(NOT_SUPPORTED, "Bucketing is supported for bigint, integer and varchar, not " + type.getDisplayName());

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/PreparedStatementBuilder.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/systemtables/PreparedStatementBuilder.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -41,7 +42,6 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.sql.ResultSet.CONCUR_READ_ONLY;
@@ -266,7 +266,7 @@ public final class PreparedStatementBuilder
         if (type.equals(BOOLEAN)) {
             return Types.BOOLEAN;
         }
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return Types.VARCHAR;
         }
         if (type.equals(VARBINARY)) {

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
@@ -50,7 +50,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_USER_ERROR;
-
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/avro/AvroColumnDecoder.java
@@ -50,7 +50,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_USER_ERROR;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
+
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;
@@ -123,7 +123,7 @@ public class AvroColumnDecoder
 
     private boolean isSupportedPrimitive(Type type)
     {
-        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof VarcharType || SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 
     public FieldValueProvider decodeField(GenericRecord avroRecord)

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvColumnDecoder.java
@@ -19,6 +19,7 @@ import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -31,7 +32,6 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +70,7 @@ public class CsvColumnDecoder
 
     private static boolean isSupportedType(Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return true;
         }
         if (ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type)) {

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/DefaultJsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/DefaultJsonFieldDecoder.java
@@ -20,6 +20,7 @@ import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.decoder.DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPORTED;
@@ -29,7 +30,6 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static java.lang.Double.parseDouble;
 import static java.lang.Long.parseLong;
@@ -78,7 +78,7 @@ public class DefaultJsonFieldDecoder
 
     private boolean isSupportedType(Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return true;
         }
         if (ImmutableList.of(
@@ -183,7 +183,7 @@ public class DefaultJsonFieldDecoder
         {
             String textValue = value.isValueNode() ? value.asText() : value.toString();
             Slice slice = utf8Slice(textValue);
-            if (isVarcharType(columnHandle.getType())) {
+            if (columnHandle.getType() instanceof VarcharType) {
                 slice = truncateToLength(slice, columnHandle.getType());
             }
             return slice;

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/raw/RawColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/raw/RawColumnDecoder.java
@@ -22,6 +22,7 @@ import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.StandardErrorCode;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.spi.type.Varchars;
 
 import java.nio.ByteBuffer;
@@ -41,7 +42,6 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -107,7 +107,7 @@ public class RawColumnDecoder
                 end = OptionalInt.of(parseInt(mappingMatcher.group(2)));
             }
             else {
-                if (!isVarcharType(columnType)) {
+                if (!(columnType instanceof VarcharType)) {
                     end = OptionalInt.of(start + fieldType.getSize());
                 }
                 else {
@@ -141,11 +141,11 @@ public class RawColumnDecoder
             if (columnType == DOUBLE) {
                 checkFieldTypeOneOf(fieldType, columnName, FieldType.DOUBLE, FieldType.FLOAT);
             }
-            if (isVarcharType(columnType)) {
+            if (columnType instanceof VarcharType) {
                 checkFieldTypeOneOf(fieldType, columnName, FieldType.BYTE);
             }
 
-            if (!isVarcharType(columnType)) {
+            if (!(columnType instanceof VarcharType)) {
                 checkArgument(end.isEmpty() || end.getAsInt() - start == fieldType.getSize(),
                         "Bytes mapping for column '%s' does not match dataFormat '%s'; expected %s bytes but got %s",
                         columnName,
@@ -160,7 +160,7 @@ public class RawColumnDecoder
 
     private static boolean isSupportedType(Type type)
     {
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             return true;
         }
         if (ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type)) {

--- a/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
+++ b/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
@@ -22,7 +22,6 @@ import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarcharType;
-import io.prestosql.spi.type.Varchars;
 import io.prestosql.testing.AbstractTestingPrestoClient;
 import io.prestosql.testing.ResultsSession;
 import io.prestosql.util.DateTimeUtils;

--- a/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
+++ b/presto-redis/src/test/java/io/prestosql/plugin/redis/util/RedisLoader.java
@@ -21,6 +21,7 @@ import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
 import io.prestosql.spi.type.Varchars;
 import io.prestosql.testing.AbstractTestingPrestoClient;
 import io.prestosql.testing.ResultsSession;
@@ -150,7 +151,7 @@ public class RedisLoader
                 return null;
             }
 
-            if (BOOLEAN.equals(type) || Varchars.isVarcharType(type)) {
+            if (BOOLEAN.equals(type) || type instanceof VarcharType) {
                 return value;
             }
             if (BIGINT.equals(type)) {

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
@@ -25,15 +25,6 @@ public final class Chars
 {
     private Chars() {}
 
-    /**
-     * @deprecated Use {@code type instanceof CharType} instead.
-     */
-    @Deprecated
-    public static boolean isCharType(Type type)
-    {
-        return type instanceof CharType;
-    }
-
     public static Slice padSpaces(Slice slice, CharType charType)
     {
         requireNonNull(charType, "charType is null");
@@ -89,7 +80,7 @@ public final class Chars
     public static Slice truncateToLengthAndTrimSpaces(Slice slice, Type type)
     {
         requireNonNull(type, "type is null");
-        if (!isCharType(type)) {
+        if (!(type instanceof CharType)) {
             throw new IllegalArgumentException("type must be the instance of CharType");
         }
         return truncateToLengthAndTrimSpaces(slice, CharType.class.cast(type));

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Chars.java
@@ -25,6 +25,15 @@ public final class Chars
 {
     private Chars() {}
 
+    /**
+     * @deprecated Use {@code type instanceof CharType} instead.
+     */
+    @Deprecated
+    public static boolean isCharType(Type type)
+    {
+        return type instanceof CharType;
+    }
+
     public static Slice padSpaces(Slice slice, CharType charType)
     {
         requireNonNull(charType, "charType is null");

--- a/presto-spi/src/main/java/io/prestosql/spi/type/VarbinaryType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/VarbinaryType.java
@@ -28,15 +28,6 @@ public final class VarbinaryType
         super(new TypeSignature(StandardTypes.VARBINARY), Slice.class);
     }
 
-    /**
-     * @deprecated Use {@code type instanceof VarbinaryType} instead.
-     */
-    @Deprecated
-    public static boolean isVarbinaryType(Type type)
-    {
-        return type instanceof VarbinaryType;
-    }
-
     @Override
     public boolean isComparable()
     {

--- a/presto-spi/src/main/java/io/prestosql/spi/type/VarbinaryType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/VarbinaryType.java
@@ -28,6 +28,15 @@ public final class VarbinaryType
         super(new TypeSignature(StandardTypes.VARBINARY), Slice.class);
     }
 
+    /**
+     * @deprecated Use {@code type instanceof VarbinaryType} instead.
+     */
+    @Deprecated
+    public static boolean isVarbinaryType(Type type)
+    {
+        return type instanceof VarbinaryType;
+    }
+
     @Override
     public boolean isComparable()
     {

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
@@ -24,19 +24,10 @@ public final class Varchars
 {
     private Varchars() {}
 
-    /**
-     * @deprecated Use {@code type instanceof VarcharType} instead.
-     */
-    @Deprecated
-    public static boolean isVarcharType(Type type)
-    {
-        return type instanceof VarcharType;
-    }
-
     public static Slice truncateToLength(Slice slice, Type type)
     {
         requireNonNull(type, "type is null");
-        if (!isVarcharType(type)) {
+        if (!(type instanceof VarcharType)) {
             throw new IllegalArgumentException("type must be the instance of VarcharType");
         }
         return truncateToLength(slice, VarcharType.class.cast(type));

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Varchars.java
@@ -24,6 +24,15 @@ public final class Varchars
 {
     private Varchars() {}
 
+    /**
+     * @deprecated Use {@code type instanceof VarcharType} instead.
+     */
+    @Deprecated
+    public static boolean isVarcharType(Type type)
+    {
+        return type instanceof VarcharType;
+    }
+
     public static Slice truncateToLength(Slice slice, Type type)
     {
         requireNonNull(type, "type is null");

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -55,7 +55,6 @@ import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharWriteFuncti
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
@@ -150,7 +149,7 @@ public class SqlServerClient
             return WriteMapping.booleanMapping("bit", booleanWriteFunction());
         }
 
-        if (isVarcharType(type)) {
+        if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             String dataType;
             if (varcharType.isUnbounded() || varcharType.getBoundedLength() > 4000) {

--- a/presto-testing/src/main/java/io/prestosql/testing/H2QueryRunner.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/H2QueryRunner.java
@@ -65,7 +65,6 @@ import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.plugin.tpch.TpchRecordSet.createTpchRecordSet;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.Chars.padSpaces;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
@@ -76,7 +75,6 @@ import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
-import static io.prestosql.spi.type.Varchars.isVarcharType;
 import static io.prestosql.tpch.TpchTable.CUSTOMER;
 import static io.prestosql.tpch.TpchTable.LINE_ITEM;
 import static io.prestosql.tpch.TpchTable.NATION;
@@ -281,7 +279,7 @@ public class H2QueryRunner
                         row.add(jsonParse(utf8Slice(stringValue)).toStringUtf8());
                     }
                 }
-                else if (isVarcharType(type)) {
+                else if (type instanceof VarcharType) {
                     String stringValue = resultSet.getString(i);
                     if (resultSet.wasNull()) {
                         row.add(null);
@@ -290,7 +288,7 @@ public class H2QueryRunner
                         row.add(stringValue);
                     }
                 }
-                else if (isCharType(type)) {
+                else if (type instanceof CharType) {
                     String stringValue = resultSet.getString(i);
                     if (resultSet.wasNull()) {
                         row.add(null);

--- a/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/TestingPrestoClient.java
@@ -22,6 +22,7 @@ import io.prestosql.client.QueryStatusInfo;
 import io.prestosql.client.Warning;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
@@ -57,7 +58,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
-import static io.prestosql.spi.type.Chars.isCharType;
 import static io.prestosql.spi.type.DateType.DATE;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
@@ -210,7 +210,7 @@ public class TestingPrestoClient
         else if (type instanceof VarcharType) {
             return value;
         }
-        else if (isCharType(type)) {
+        else if (type instanceof CharType) {
             return value;
         }
         else if (VARBINARY.equals(type)) {


### PR DESCRIPTION
Implements #5212 
As descbribed [here](https://github.com/prestosql/presto/issues/5212), we need to remove deprecated methods which validate instance types of `Varchar`, `Char` and `VarBinary` and use default method `instanceof`.