### PR TITLE
Expand 'Table does not exists' message when tableHandle is empty

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -1212,7 +1212,7 @@ class StatementAnalyzer
                 if (!metadata.schemaExists(session, new CatalogSchemaName(name.getCatalogName(), name.getSchemaName()))) {
                     throw semanticException(SCHEMA_NOT_FOUND, table, "Schema '%s' does not exist", name.getSchemaName());
                 }
-                throw semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", name);
+                throw semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist or is not accessible", name);
             }
             TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle.get());
             Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle.get());


### PR DESCRIPTION
Added 'or is not accessible' since some connectors may disallow access which results in empty table handle