### PR TITLE
Clamp BackgroundHiveSplitLoader concurrency to usable parallelism

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
@@ -196,6 +196,7 @@ public class BackgroundHiveSplitLoader
         this.typeManager = typeManager;
         this.tableBucketInfo = tableBucketInfo;
         this.loaderConcurrency = loaderConcurrency;
+        checkArgument(loaderConcurrency > 0, "loaderConcurrency must be > 0, found: %s", loaderConcurrency);
         this.session = session;
         this.hdfsEnvironment = hdfsEnvironment;
         this.namenodeStats = namenodeStats;


### PR DESCRIPTION
Avoids allocation a greater level of concurrency to split loading than can actually be used based on the number of partititions being loaded. The effective usable concurrency in split loading can be significantly lower than the configured split loader concurrency value when the number of partitions scanned is small, since split loading is single threaded within each partition anyway. This makes it feasible to configure a much higher concurrency value than before without overcommitting threads to loading tasks unnecessarily.