### PR TITLE
Refactor dynamic filtering configs

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueries.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveDistributedJoinQueries.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.Session;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.operator.OperatorStats;
 import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.testing.AbstractTestJoinQueries;
@@ -38,7 +39,7 @@ public class TestHiveDistributedJoinQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        verify(new FeaturesConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
+        verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
         return HiveQueryRunner.builder()
                 .setInitialTables(getTables())
                 .build();

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -16,6 +16,7 @@ package io.prestosql;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.QueryManagerConfig;
 import io.prestosql.execution.TaskManagerConfig;
 import io.prestosql.memory.MemoryManagerConfig;
@@ -117,11 +118,9 @@ public final class SystemSessionProperties
     public static final String PREDICATE_PUSHDOWN_USE_TABLE_PROPERTIES = "predicate_pushdown_use_table_properties";
     public static final String LATE_MATERIALIZATION = "late_materialization";
     public static final String ENABLE_DYNAMIC_FILTERING = "enable_dynamic_filtering";
+    public static final String ENABLE_LARGE_DYNAMIC_FILTERS = "enable_large_dynamic_filters";
     public static final String QUERY_MAX_MEMORY_PER_NODE = "query_max_memory_per_node";
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE = "query_max_total_memory_per_node";
-    public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
-    public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
-    public static final String DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER = "dynamic_filtering_range_row_limit_per_driver";
     public static final String IGNORE_DOWNSTREAM_PREFERENCES = "ignore_downstream_preferences";
     public static final String ITERATIVE_COLUMN_PRUNING = "iterative_rule_based_column_pruning";
     public static final String REQUIRED_WORKERS_COUNT = "required_workers_count";
@@ -133,7 +132,7 @@ public final class SystemSessionProperties
 
     public SystemSessionProperties()
     {
-        this(new QueryManagerConfig(), new TaskManagerConfig(), new MemoryManagerConfig(), new FeaturesConfig(), new NodeMemoryConfig());
+        this(new QueryManagerConfig(), new TaskManagerConfig(), new MemoryManagerConfig(), new FeaturesConfig(), new NodeMemoryConfig(), new DynamicFilterConfig());
     }
 
     @Inject
@@ -142,7 +141,8 @@ public final class SystemSessionProperties
             TaskManagerConfig taskManagerConfig,
             MemoryManagerConfig memoryManagerConfig,
             FeaturesConfig featuresConfig,
-            NodeMemoryConfig nodeMemoryConfig)
+            NodeMemoryConfig nodeMemoryConfig,
+            DynamicFilterConfig dynamicFilterConfig)
     {
         sessionProperties = ImmutableList.of(
                 stringProperty(
@@ -527,7 +527,12 @@ public final class SystemSessionProperties
                 booleanProperty(
                         ENABLE_DYNAMIC_FILTERING,
                         "Enable dynamic filtering",
-                        featuresConfig.isEnableDynamicFiltering(),
+                        dynamicFilterConfig.isEnableDynamicFiltering(),
+                        false),
+                booleanProperty(
+                        ENABLE_LARGE_DYNAMIC_FILTERS,
+                        "Enable collection of large dynamic filters",
+                        dynamicFilterConfig.isEnableLargeDynamicFilters(),
                         false),
                 dataSizeProperty(
                         QUERY_MAX_MEMORY_PER_NODE,
@@ -539,21 +544,6 @@ public final class SystemSessionProperties
                         "Maximum amount of total memory a query can use per node",
                         nodeMemoryConfig.getMaxQueryTotalMemoryPerNode(),
                         true),
-                integerProperty(
-                        DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT,
-                        "Experimental: maximum number of build-side rows to be collected for dynamic filtering per-driver",
-                        featuresConfig.getDynamicFilteringMaxPerDriverRowCount(),
-                        false),
-                dataSizeProperty(
-                        DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE,
-                        "Experimental: maximum number of bytes to be collected for dynamic filtering per-driver",
-                        featuresConfig.getDynamicFilteringMaxPerDriverSize(),
-                        false),
-                integerProperty(
-                        DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER,
-                        "Maximum number of build-side rows per driver up to which min and max values will be collected for dynamic filtering",
-                        featuresConfig.getDynamicFilteringRangeRowLimitPerDriver(),
-                        false),
                 booleanProperty(
                         IGNORE_DOWNSTREAM_PREFERENCES,
                         "Ignore Parent's PreferredProperties in AddExchange optimizer",
@@ -992,6 +982,11 @@ public final class SystemSessionProperties
         return session.getSystemProperty(ENABLE_DYNAMIC_FILTERING, Boolean.class);
     }
 
+    public static boolean isEnableLargeDynamicFilters(Session session)
+    {
+        return session.getSystemProperty(ENABLE_LARGE_DYNAMIC_FILTERS, Boolean.class);
+    }
+
     public static DataSize getQueryMaxMemoryPerNode(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_MEMORY_PER_NODE, DataSize.class);
@@ -1000,21 +995,6 @@ public final class SystemSessionProperties
     public static DataSize getQueryMaxTotalMemoryPerNode(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, DataSize.class);
-    }
-
-    public static int getDynamicFilteringMaxPerDriverRowCount(Session session)
-    {
-        return session.getSystemProperty(DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT, Integer.class);
-    }
-
-    public static DataSize getDynamicFilteringMaxPerDriverSize(Session session)
-    {
-        return session.getSystemProperty(DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE, DataSize.class);
-    }
-
-    public static int getDynamicFilteringRangeRowLimitPerDriver(Session session)
-    {
-        return session.getSystemProperty(DYNAMIC_FILTERING_RANGE_ROW_LIMIT_PER_DRIVER, Integer.class);
     }
 
     public static boolean ignoreDownStreamPreferences(Session session)

--- a/presto-main/src/main/java/io/prestosql/execution/DynamicFilterConfig.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DynamicFilterConfig.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@DefunctConfig({
+        "dynamic-filtering-max-per-driver-row-count",
+        "experimental.dynamic-filtering-max-per-driver-row-count",
+        "dynamic-filtering-max-per-driver-size",
+        "experimental.dynamic-filtering-max-per-driver-size",
+        "dynamic-filtering-range-row-limit-per-driver"
+})
+public class DynamicFilterConfig
+{
+    private boolean enableDynamicFiltering = true;
+    private boolean enableLargeDynamicFilters;
+    private Duration dynamicFilteringRefreshInterval = new Duration(200, MILLISECONDS);
+
+    private int smallBroadcastMaxDistinctValuesPerDriver = 100;
+    private DataSize smallBroadcastMaxSizePerDriver = DataSize.of(10, KILOBYTE);
+    private int smallBroadcastRangeRowLimitPerDriver;
+    private int smallPartitionedMaxDistinctValuesPerDriver = 100;
+    private DataSize smallPartitionedMaxSizePerDriver = DataSize.of(10, KILOBYTE);
+    private int smallPartitionedRangeRowLimitPerDriver;
+
+    private int largeBroadcastMaxDistinctValuesPerDriver = 5_000;
+    private DataSize largeBroadcastMaxSizePerDriver = DataSize.of(500, KILOBYTE);
+    private int largeBroadcastRangeRowLimitPerDriver = 50_000;
+    private int largePartitionedMaxDistinctValuesPerDriver = 500;
+    private DataSize largePartitionedMaxSizePerDriver = DataSize.of(50, KILOBYTE);
+    private int largePartitionedRangeRowLimitPerDriver = 5_000;
+
+    public boolean isEnableDynamicFiltering()
+    {
+        return enableDynamicFiltering;
+    }
+
+    @Config("enable-dynamic-filtering")
+    @LegacyConfig("experimental.enable-dynamic-filtering")
+    public DynamicFilterConfig setEnableDynamicFiltering(boolean enableDynamicFiltering)
+    {
+        this.enableDynamicFiltering = enableDynamicFiltering;
+        return this;
+    }
+
+    public boolean isEnableLargeDynamicFilters()
+    {
+        return enableLargeDynamicFilters;
+    }
+
+    @Config("enable-large-dynamic-filters")
+    public DynamicFilterConfig setEnableLargeDynamicFilters(boolean enableLargeDynamicFilters)
+    {
+        this.enableLargeDynamicFilters = enableLargeDynamicFilters;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    @MaxDuration("10s")
+    @NotNull
+    public Duration getDynamicFilteringRefreshInterval()
+    {
+        return dynamicFilteringRefreshInterval;
+    }
+
+    @Config("experimental.dynamic-filtering-refresh-interval")
+    public DynamicFilterConfig setDynamicFilteringRefreshInterval(Duration dynamicFilteringRefreshInterval)
+    {
+        this.dynamicFilteringRefreshInterval = dynamicFilteringRefreshInterval;
+        return this;
+    }
+
+    @Min(0)
+    public int getSmallBroadcastMaxDistinctValuesPerDriver()
+    {
+        return smallBroadcastMaxDistinctValuesPerDriver;
+    }
+
+    @Config("dynamic-filtering.small-broadcast.max-distinct-values-per-driver")
+    public DynamicFilterConfig setSmallBroadcastMaxDistinctValuesPerDriver(int smallBroadcastMaxDistinctValuesPerDriver)
+    {
+        this.smallBroadcastMaxDistinctValuesPerDriver = smallBroadcastMaxDistinctValuesPerDriver;
+        return this;
+    }
+
+    @MaxDataSize("1MB")
+    public DataSize getSmallBroadcastMaxSizePerDriver()
+    {
+        return smallBroadcastMaxSizePerDriver;
+    }
+
+    @Config("dynamic-filtering.small-broadcast.max-size-per-driver")
+    public DynamicFilterConfig setSmallBroadcastMaxSizePerDriver(DataSize smallBroadcastMaxSizePerDriver)
+    {
+        this.smallBroadcastMaxSizePerDriver = smallBroadcastMaxSizePerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getSmallBroadcastRangeRowLimitPerDriver()
+    {
+        return smallBroadcastRangeRowLimitPerDriver;
+    }
+
+    @Config("dynamic-filtering.small-broadcast.range-row-limit-per-driver")
+    public DynamicFilterConfig setSmallBroadcastRangeRowLimitPerDriver(int smallBroadcastRangeRowLimitPerDriver)
+    {
+        this.smallBroadcastRangeRowLimitPerDriver = smallBroadcastRangeRowLimitPerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getSmallPartitionedMaxDistinctValuesPerDriver()
+    {
+        return smallPartitionedMaxDistinctValuesPerDriver;
+    }
+
+    @Config("dynamic-filtering.small-partitioned.max-distinct-values-per-driver")
+    public DynamicFilterConfig setSmallPartitionedMaxDistinctValuesPerDriver(int smallPartitionedMaxDistinctValuesPerDriver)
+    {
+        this.smallPartitionedMaxDistinctValuesPerDriver = smallPartitionedMaxDistinctValuesPerDriver;
+        return this;
+    }
+
+    @MaxDataSize("1MB")
+    public DataSize getSmallPartitionedMaxSizePerDriver()
+    {
+        return smallPartitionedMaxSizePerDriver;
+    }
+
+    @Config("dynamic-filtering.small-partitioned.max-size-per-driver")
+    public DynamicFilterConfig setSmallPartitionedMaxSizePerDriver(DataSize smallPartitionedMaxSizePerDriver)
+    {
+        this.smallPartitionedMaxSizePerDriver = smallPartitionedMaxSizePerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getSmallPartitionedRangeRowLimitPerDriver()
+    {
+        return smallPartitionedRangeRowLimitPerDriver;
+    }
+
+    @Config("dynamic-filtering.small-partitioned.range-row-limit-per-driver")
+    public DynamicFilterConfig setSmallPartitionedRangeRowLimitPerDriver(int smallPartitionedRangeRowLimitPerDriver)
+    {
+        this.smallPartitionedRangeRowLimitPerDriver = smallPartitionedRangeRowLimitPerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getLargeBroadcastMaxDistinctValuesPerDriver()
+    {
+        return largeBroadcastMaxDistinctValuesPerDriver;
+    }
+
+    @Config("dynamic-filtering.large-broadcast.max-distinct-values-per-driver")
+    public DynamicFilterConfig setLargeBroadcastMaxDistinctValuesPerDriver(int largeBroadcastMaxDistinctValuesPerDriver)
+    {
+        this.largeBroadcastMaxDistinctValuesPerDriver = largeBroadcastMaxDistinctValuesPerDriver;
+        return this;
+    }
+
+    @MaxDataSize("50MB")
+    public DataSize getLargeBroadcastMaxSizePerDriver()
+    {
+        return largeBroadcastMaxSizePerDriver;
+    }
+
+    @Config("dynamic-filtering.large-broadcast.max-size-per-driver")
+    public DynamicFilterConfig setLargeBroadcastMaxSizePerDriver(DataSize largeBroadcastMaxSizePerDriver)
+    {
+        this.largeBroadcastMaxSizePerDriver = largeBroadcastMaxSizePerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getLargeBroadcastRangeRowLimitPerDriver()
+    {
+        return largeBroadcastRangeRowLimitPerDriver;
+    }
+
+    @Config("dynamic-filtering.large-broadcast.range-row-limit-per-driver")
+    public DynamicFilterConfig setLargeBroadcastRangeRowLimitPerDriver(int largeBroadcastRangeRowLimitPerDriver)
+    {
+        this.largeBroadcastRangeRowLimitPerDriver = largeBroadcastRangeRowLimitPerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getLargePartitionedMaxDistinctValuesPerDriver()
+    {
+        return largePartitionedMaxDistinctValuesPerDriver;
+    }
+
+    @Config("dynamic-filtering.large-partitioned.max-distinct-values-per-driver")
+    public DynamicFilterConfig setLargePartitionedMaxDistinctValuesPerDriver(int largePartitionedMaxDistinctValuesPerDriver)
+    {
+        this.largePartitionedMaxDistinctValuesPerDriver = largePartitionedMaxDistinctValuesPerDriver;
+        return this;
+    }
+
+    @MaxDataSize("5MB")
+    public DataSize getLargePartitionedMaxSizePerDriver()
+    {
+        return largePartitionedMaxSizePerDriver;
+    }
+
+    @Config("dynamic-filtering.large-partitioned.max-size-per-driver")
+    public DynamicFilterConfig setLargePartitionedMaxSizePerDriver(DataSize largePartitionedMaxSizePerDriver)
+    {
+        this.largePartitionedMaxSizePerDriver = largePartitionedMaxSizePerDriver;
+        return this;
+    }
+
+    @Min(0)
+    public int getLargePartitionedRangeRowLimitPerDriver()
+    {
+        return largePartitionedRangeRowLimitPerDriver;
+    }
+
+    @Config("dynamic-filtering.large-partitioned.range-row-limit-per-driver")
+    public DynamicFilterConfig setLargePartitionedRangeRowLimitPerDriver(int largePartitionedRangeRowLimitPerDriver)
+    {
+        this.largePartitionedRangeRowLimitPerDriver = largePartitionedRangeRowLimitPerDriver;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 import io.prestosql.Session;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.SqlQueryExecution;
 import io.prestosql.execution.StageState;
 import io.prestosql.operator.JoinUtils;
@@ -35,7 +36,6 @@ import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Ranges;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.sql.DynamicFilters;
-import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.sql.planner.PlanFragment;
 import io.prestosql.sql.planner.SubPlan;
 import io.prestosql.sql.planner.Symbol;
@@ -95,9 +95,9 @@ public class DynamicFilterService
     private final Map<QueryId, DynamicFilterContext> dynamicFilterContexts = new ConcurrentHashMap<>();
 
     @Inject
-    public DynamicFilterService(FeaturesConfig featuresConfig)
+    public DynamicFilterService(DynamicFilterConfig dynamicFilterConfig)
     {
-        this.dynamicFilteringRefreshInterval = requireNonNull(featuresConfig, "featuresConfig is null").getDynamicFilteringRefreshInterval();
+        this.dynamicFilteringRefreshInterval = requireNonNull(dynamicFilterConfig, "dynamicFilterConfig is null").getDynamicFilteringRefreshInterval();
     }
 
     @PostConstruct

--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -38,6 +38,7 @@ import io.prestosql.connector.ConnectorManager;
 import io.prestosql.connector.system.SystemConnectorModule;
 import io.prestosql.dispatcher.DispatchManager;
 import io.prestosql.event.SplitMonitor;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
 import io.prestosql.execution.ExecutionFailureInfo;
 import io.prestosql.execution.ExplainAnalyzeContext;
@@ -436,6 +437,9 @@ public class ServerMainModule
         newExporter(binder).export(SpillerFactory.class).withGeneratedName();
         binder.bind(LocalSpillManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(NodeSpillConfig.class);
+
+        // Dynamic Filtering
+        configBinder(binder).bindConfig(DynamicFilterConfig.class);
 
         // dispatcher
         // TODO remove dispatcher fromm ServerMainModule, and bind dependent components only on coordinators

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -23,8 +23,6 @@ import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
-import io.airlift.units.MaxDuration;
-import io.airlift.units.MinDuration;
 import io.prestosql.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import io.prestosql.operator.aggregation.histogram.HistogramGroupImplementation;
 import io.prestosql.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
@@ -43,7 +41,6 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.prestosql.sql.analyzer.RegexLibrary.JONI;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -134,11 +131,6 @@ public class FeaturesConfig
     private boolean iterativeRuleBasedColumnPruning = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
-    private boolean enableDynamicFiltering = true;
-    private int dynamicFilteringMaxPerDriverRowCount = 100;
-    private DataSize dynamicFilteringMaxPerDriverSize = DataSize.of(10, KILOBYTE);
-    private Duration dynamicFilteringRefreshInterval = new Duration(200, MILLISECONDS);
-    private int dynamicFilteringRangeRowLimitPerDriver;
 
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
     private int filterAndProjectMinOutputPageRowCount = 256;
@@ -739,74 +731,6 @@ public class FeaturesConfig
     public FeaturesConfig setSpillMaxUsedSpaceThreshold(double spillMaxUsedSpaceThreshold)
     {
         this.spillMaxUsedSpaceThreshold = spillMaxUsedSpaceThreshold;
-        return this;
-    }
-
-    public boolean isEnableDynamicFiltering()
-    {
-        return enableDynamicFiltering;
-    }
-
-    @Config("enable-dynamic-filtering")
-    @LegacyConfig("experimental.enable-dynamic-filtering")
-    public FeaturesConfig setEnableDynamicFiltering(boolean value)
-    {
-        this.enableDynamicFiltering = value;
-        return this;
-    }
-
-    public int getDynamicFilteringMaxPerDriverRowCount()
-    {
-        return dynamicFilteringMaxPerDriverRowCount;
-    }
-
-    @Config("dynamic-filtering-max-per-driver-row-count")
-    @LegacyConfig("experimental.dynamic-filtering-max-per-driver-row-count")
-    public FeaturesConfig setDynamicFilteringMaxPerDriverRowCount(int dynamicFilteringMaxPerDriverRowCount)
-    {
-        this.dynamicFilteringMaxPerDriverRowCount = dynamicFilteringMaxPerDriverRowCount;
-        return this;
-    }
-
-    @MaxDataSize("1MB")
-    public DataSize getDynamicFilteringMaxPerDriverSize()
-    {
-        return dynamicFilteringMaxPerDriverSize;
-    }
-
-    @Config("dynamic-filtering-max-per-driver-size")
-    @LegacyConfig("experimental.dynamic-filtering-max-per-driver-size")
-    public FeaturesConfig setDynamicFilteringMaxPerDriverSize(DataSize dynamicFilteringMaxPerDriverSize)
-    {
-        this.dynamicFilteringMaxPerDriverSize = dynamicFilteringMaxPerDriverSize;
-        return this;
-    }
-
-    @MinDuration("1ms")
-    @MaxDuration("10s")
-    @NotNull
-    public Duration getDynamicFilteringRefreshInterval()
-    {
-        return dynamicFilteringRefreshInterval;
-    }
-
-    @Config("experimental.dynamic-filtering-refresh-interval")
-    public FeaturesConfig setDynamicFilteringRefreshInterval(Duration dynamicFilteringRefreshInterval)
-    {
-        this.dynamicFilteringRefreshInterval = dynamicFilteringRefreshInterval;
-        return this;
-    }
-
-    public int getDynamicFilteringRangeRowLimitPerDriver()
-    {
-        return dynamicFilteringRangeRowLimitPerDriver;
-    }
-
-    @Config("dynamic-filtering-range-row-limit-per-driver")
-    @ConfigDescription("Maximum number of build-side rows per driver up to which min and max values will be collected for dynamic filtering")
-    public FeaturesConfig setDynamicFilteringRangeRowLimitPerDriver(int dynamicFilteringRangeRowLimitPerDriver)
-    {
-        this.dynamicFilteringRangeRowLimitPerDriver = dynamicFilteringRangeRowLimitPerDriver;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -51,6 +51,7 @@ import io.prestosql.execution.DataDefinitionTask;
 import io.prestosql.execution.DeallocateTask;
 import io.prestosql.execution.DropTableTask;
 import io.prestosql.execution.DropViewTask;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.Lifespan;
 import io.prestosql.execution.NodeTaskMap;
 import io.prestosql.execution.PrepareTask;
@@ -311,7 +312,7 @@ public class LocalQueryRunner
 
         this.metadata = new MetadataManager(
                 featuresConfig,
-                new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new NodeMemoryConfig())),
+                new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new NodeMemoryConfig(), new DynamicFilterConfig())),
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new ColumnPropertyManager(),
@@ -728,7 +729,8 @@ public class LocalQueryRunner
                 new PagesIndex.TestingFactory(false),
                 joinCompiler,
                 new LookupJoinOperators(),
-                new OrderingCompiler());
+                new OrderingCompiler(),
+                new DynamicFilterConfig());
 
         // plan query
         StageExecutionDescriptor stageExecutionDescriptor = subplan.getFragment().getStageExecutionDescriptor();

--- a/presto-main/src/test/java/io/prestosql/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TaskTestUtils.java
@@ -142,7 +142,8 @@ public final class TaskTestUtils
                 new PagesIndex.TestingFactory(false),
                 new JoinCompiler(metadata),
                 new LookupJoinOperators(),
-                new OrderingCompiler());
+                new OrderingCompiler(),
+                new DynamicFilterConfig());
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/io/prestosql/execution/TestDynamicFilterConfig.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestDynamicFilterConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class TestDynamicFilterConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DynamicFilterConfig.class)
+                .setEnableDynamicFiltering(true)
+                .setDynamicFilteringRefreshInterval(new Duration(200, MILLISECONDS))
+                .setEnableLargeDynamicFilters(false)
+                .setSmallBroadcastMaxDistinctValuesPerDriver(100)
+                .setSmallBroadcastMaxSizePerDriver(DataSize.of(10, KILOBYTE))
+                .setSmallBroadcastRangeRowLimitPerDriver(0)
+                .setSmallPartitionedMaxDistinctValuesPerDriver(100)
+                .setSmallPartitionedMaxSizePerDriver(DataSize.of(10, KILOBYTE))
+                .setSmallPartitionedRangeRowLimitPerDriver(0)
+                .setLargeBroadcastMaxDistinctValuesPerDriver(5000)
+                .setLargeBroadcastMaxSizePerDriver(DataSize.of(500, KILOBYTE))
+                .setLargeBroadcastRangeRowLimitPerDriver(50_000)
+                .setLargePartitionedMaxDistinctValuesPerDriver(500)
+                .setLargePartitionedMaxSizePerDriver(DataSize.of(50, KILOBYTE))
+                .setLargePartitionedRangeRowLimitPerDriver(5_000));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("enable-dynamic-filtering", "false")
+                .put("enable-large-dynamic-filters", "true")
+                .put("experimental.dynamic-filtering-refresh-interval", "300ms")
+                .put("dynamic-filtering.small-broadcast.max-distinct-values-per-driver", "256")
+                .put("dynamic-filtering.small-broadcast.max-size-per-driver", "64kB")
+                .put("dynamic-filtering.small-broadcast.range-row-limit-per-driver", "10000")
+                .put("dynamic-filtering.small-partitioned.max-distinct-values-per-driver", "256")
+                .put("dynamic-filtering.small-partitioned.max-size-per-driver", "64kB")
+                .put("dynamic-filtering.small-partitioned.range-row-limit-per-driver", "10000")
+                .put("dynamic-filtering.large-broadcast.max-distinct-values-per-driver", "256")
+                .put("dynamic-filtering.large-broadcast.max-size-per-driver", "64kB")
+                .put("dynamic-filtering.large-broadcast.range-row-limit-per-driver", "100000")
+                .put("dynamic-filtering.large-partitioned.max-distinct-values-per-driver", "256")
+                .put("dynamic-filtering.large-partitioned.max-size-per-driver", "64kB")
+                .put("dynamic-filtering.large-partitioned.range-row-limit-per-driver", "100000")
+                .build();
+
+        DynamicFilterConfig expected = new DynamicFilterConfig()
+                .setEnableDynamicFiltering(false)
+                .setDynamicFilteringRefreshInterval(new Duration(300, MILLISECONDS))
+                .setEnableLargeDynamicFilters(true)
+                .setSmallBroadcastMaxDistinctValuesPerDriver(256)
+                .setSmallBroadcastMaxSizePerDriver(DataSize.of(64, KILOBYTE))
+                .setSmallBroadcastRangeRowLimitPerDriver(10000)
+                .setSmallPartitionedMaxDistinctValuesPerDriver(256)
+                .setSmallPartitionedMaxSizePerDriver(DataSize.of(64, KILOBYTE))
+                .setSmallPartitionedRangeRowLimitPerDriver(10000)
+                .setLargeBroadcastMaxDistinctValuesPerDriver(256)
+                .setLargeBroadcastMaxSizePerDriver(DataSize.of(64, KILOBYTE))
+                .setLargeBroadcastRangeRowLimitPerDriver(100000)
+                .setLargePartitionedMaxDistinctValuesPerDriver(256)
+                .setLargePartitionedMaxSizePerDriver(DataSize.of(64, KILOBYTE))
+                .setLargePartitionedRangeRowLimitPerDriver(100000);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/io/prestosql/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -21,6 +21,7 @@ import io.airlift.units.Duration;
 import io.prestosql.client.NodeVersion;
 import io.prestosql.connector.CatalogName;
 import io.prestosql.cost.StatsAndCosts;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.MockRemoteTaskFactory;
 import io.prestosql.execution.MockRemoteTaskFactory.MockRemoteTask;
 import io.prestosql.execution.NodeTaskMap;
@@ -45,7 +46,6 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.split.ConnectorAwareSplitSource;
 import io.prestosql.split.SplitSource;
 import io.prestosql.sql.DynamicFilters;
-import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.sql.planner.Partitioning;
 import io.prestosql.sql.planner.PartitioningScheme;
 import io.prestosql.sql.planner.PlanFragment;
@@ -331,7 +331,7 @@ public class TestSourcePartitionedScheduler
                     Iterables.getOnlyElement(plan.getSplitSources().values()),
                     new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                     2,
-                    new DynamicFilterService(new FeaturesConfig()),
+                    new DynamicFilterService(new DynamicFilterConfig()),
                     () -> false);
             scheduler.schedule();
         }).hasErrorCode(NO_NODES_AVAILABLE);
@@ -405,7 +405,7 @@ public class TestSourcePartitionedScheduler
                 Iterables.getOnlyElement(plan.getSplitSources().values()),
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 500,
-                new DynamicFilterService(new FeaturesConfig()),
+                new DynamicFilterService(new DynamicFilterConfig()),
                 () -> false);
 
         // the queues of 3 running nodes should be full
@@ -444,7 +444,7 @@ public class TestSourcePartitionedScheduler
                 Iterables.getOnlyElement(plan.getSplitSources().values()),
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 400,
-                new DynamicFilterService(new FeaturesConfig()),
+                new DynamicFilterService(new DynamicFilterConfig()),
                 () -> true);
 
         // the queues of 3 running nodes should be full
@@ -468,7 +468,7 @@ public class TestSourcePartitionedScheduler
         NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap));
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         dynamicFilterService.registerQuery(
                 QUERY_ID,
                 ImmutableList::of,
@@ -544,7 +544,7 @@ public class TestSourcePartitionedScheduler
                 splitSource,
                 placementPolicy,
                 splitBatchSize,
-                new DynamicFilterService(new FeaturesConfig()),
+                new DynamicFilterService(new DynamicFilterConfig()),
                 () -> false);
     }
 

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -48,9 +48,6 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
-import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverRowCount;
-import static io.prestosql.SystemSessionProperties.getDynamicFilteringMaxPerDriverSize;
-import static io.prestosql.SystemSessionProperties.getDynamicFilteringRangeRowLimitPerDriver;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -89,9 +86,9 @@ public class BenchmarkDynamicFilterSourceOperator
                     new PlanNodeId("joinNodeId"),
                     (tupleDomain -> {}),
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel(new DynamicFilterId("0"), BIGINT, 0)),
-                    getDynamicFilteringMaxPerDriverRowCount(TEST_SESSION),
-                    getDynamicFilteringMaxPerDriverSize(TEST_SESSION),
-                    getDynamicFilteringRangeRowLimitPerDriver(TEST_SESSION));
+                    100,
+                    DataSize.ofBytes(Long.MAX_VALUE),
+                    0);
         }
 
         @TearDown

--- a/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -23,8 +23,10 @@ import io.prestosql.testing.TestingTaskContext;
 import io.prestosql.tpch.LineItem;
 import io.prestosql.tpch.LineItemGenerator;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
@@ -54,10 +56,11 @@ import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
 
 @State(Scope.Thread)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(3)
-@Warmup(iterations = 20, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 20, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 15, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 15, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
 public class BenchmarkDynamicFilterSourceOperator
 {
     private static final int TOTAL_POSITIONS = 1_000_000;
@@ -65,8 +68,11 @@ public class BenchmarkDynamicFilterSourceOperator
     @State(Scope.Thread)
     public static class BenchmarkContext
     {
-        @Param({"32", "256", "1024"})
-        private String positionsPerPage = "32";
+        @Param({"32", "1024"})
+        private int positionsPerPage = 32;
+
+        @Param({"100,0", "500,5000", "5000,50000"})
+        private String collectionLimits = "100,0";
 
         private ExecutorService executor;
         private ScheduledExecutorService scheduledExecutor;
@@ -79,16 +85,20 @@ public class BenchmarkDynamicFilterSourceOperator
             executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
             scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
 
-            pages = createInputPages(Integer.valueOf(positionsPerPage));
+            pages = createInputPages(positionsPerPage);
+
+            String[] limits = collectionLimits.split(",", 2);
+            int maxDistinctValuesCount = Integer.parseInt(limits[0]);
+            int minMaxCollectionLimit = Integer.parseInt(limits[1]);
 
             operatorFactory = new DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory(
                     1,
                     new PlanNodeId("joinNodeId"),
                     (tupleDomain -> {}),
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel(new DynamicFilterId("0"), BIGINT, 0)),
-                    100,
+                    maxDistinctValuesCount,
                     DataSize.ofBytes(Long.MAX_VALUE),
-                    0);
+                    minMaxCollectionLimit);
         }
 
         @TearDown

--- a/presto-main/src/test/java/io/prestosql/server/TestDynamicFilterService.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestDynamicFilterService.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.Session;
 import io.prestosql.cost.StatsAndCosts;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.StageId;
 import io.prestosql.execution.StageState;
 import io.prestosql.execution.TaskId;
@@ -30,7 +31,6 @@ import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.predicate.ValueSet;
 import io.prestosql.sql.DynamicFilters;
-import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.sql.planner.Partitioning;
 import io.prestosql.sql.planner.PartitioningHandle;
 import io.prestosql.sql.planner.PartitioningScheme;
@@ -91,7 +91,7 @@ public class TestDynamicFilterService
     @Test
     public void testDynamicFilterSummaryCompletion()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId = new DynamicFilterId("df");
         QueryId queryId = new QueryId("query");
         StageId stageId = new StageId(queryId, 0);
@@ -158,7 +158,7 @@ public class TestDynamicFilterService
     @Test
     public void testDynamicFilter()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId1 = new DynamicFilterId("df1");
         DynamicFilterId filterId2 = new DynamicFilterId("df2");
         DynamicFilterId filterId3 = new DynamicFilterId("df3");
@@ -353,7 +353,7 @@ public class TestDynamicFilterService
     @Test
     public void testShortCircuitOnAllTupleDomain()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId1 = new DynamicFilterId("df1");
         Expression df1 = expression("DF_SYMBOL1");
 
@@ -402,7 +402,7 @@ public class TestDynamicFilterService
     @Test
     public void testReplicatedDynamicFilter()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId1 = new DynamicFilterId("df1");
         Expression df1 = expression("DF_SYMBOL1");
         QueryId queryId = new QueryId("query");
@@ -473,7 +473,7 @@ public class TestDynamicFilterService
     @Test
     public void testDynamicFilterCancellation()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId = new DynamicFilterId("df");
         Expression df1 = expression("DF_SYMBOL1");
         QueryId queryId = new QueryId("query");
@@ -521,7 +521,7 @@ public class TestDynamicFilterService
     @Test
     public void testIsAwaitable()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId1 = new DynamicFilterId("df1");
         DynamicFilterId filterId2 = new DynamicFilterId("df2");
         Expression symbol = new Symbol("symbol").toSymbolReference();
@@ -557,7 +557,7 @@ public class TestDynamicFilterService
     @Test
     public void testMultipleColumnMapping()
     {
-        DynamicFilterService dynamicFilterService = new DynamicFilterService(new FeaturesConfig());
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(new DynamicFilterConfig());
         DynamicFilterId filterId1 = new DynamicFilterId("df1");
         Expression df1 = expression("DF_SYMBOL1");
         Expression df2 = expression("DF_SYMBOL2");

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -20,6 +20,7 @@ import io.prestosql.SystemSessionProperties;
 import io.prestosql.connector.CatalogName;
 import io.prestosql.connector.informationschema.InformationSchemaConnector;
 import io.prestosql.connector.system.SystemConnector;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.execution.QueryManagerConfig;
 import io.prestosql.execution.TaskManagerConfig;
 import io.prestosql.execution.warnings.WarningCollector;
@@ -763,7 +764,8 @@ public class TestAnalyzer
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
                 new FeaturesConfig().setMaxGroupingSets(2048),
-                new NodeMemoryConfig()))).build();
+                new NodeMemoryConfig(),
+                new DynamicFilterConfig()))).build();
         analyze(session, "SELECT a, b, c, d, e, f, g, h, i, j, k, SUM(l)" +
                 "FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))\n" +
                 "t (a, b, c, d, e, f, g, h, i, j, k, l)\n" +

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -36,7 +36,6 @@ import static io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType.BROA
 import static io.prestosql.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static io.prestosql.sql.analyzer.RegexLibrary.JONI;
 import static io.prestosql.sql.analyzer.RegexLibrary.RE2J;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -110,11 +109,6 @@ public class TestFeaturesConfig
                 .setLateMaterializationEnabled(false)
                 .setSkipRedundantSort(true)
                 .setPredicatePushdownUseTableProperties(true)
-                .setEnableDynamicFiltering(true)
-                .setDynamicFilteringMaxPerDriverRowCount(100)
-                .setDynamicFilteringMaxPerDriverSize(DataSize.of(10, KILOBYTE))
-                .setDynamicFilteringRefreshInterval(new Duration(200, MILLISECONDS))
-                .setDynamicFilteringRangeRowLimitPerDriver(0)
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
                 .setIterativeRuleBasedColumnPruning(true));
@@ -188,11 +182,6 @@ public class TestFeaturesConfig
                 .put("experimental.late-materialization.enabled", "true")
                 .put("optimizer.skip-redundant-sort", "false")
                 .put("optimizer.predicate-pushdown-use-table-properties", "false")
-                .put("enable-dynamic-filtering", "false")
-                .put("dynamic-filtering-max-per-driver-row-count", "256")
-                .put("dynamic-filtering-max-per-driver-size", "64kB")
-                .put("experimental.dynamic-filtering-refresh-interval", "300ms")
-                .put("dynamic-filtering-range-row-limit-per-driver", "10000")
                 .put("optimizer.ignore-downstream-preferences", "true")
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
@@ -263,11 +252,6 @@ public class TestFeaturesConfig
                 .setLateMaterializationEnabled(true)
                 .setSkipRedundantSort(false)
                 .setPredicatePushdownUseTableProperties(false)
-                .setEnableDynamicFiltering(false)
-                .setDynamicFilteringMaxPerDriverRowCount(256)
-                .setDynamicFilteringMaxPerDriverSize(DataSize.of(64, KILOBYTE))
-                .setDynamicFilteringRefreshInterval(new Duration(300, MILLISECONDS))
-                .setDynamicFilteringRangeRowLimitPerDriver(10000)
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
                 .setIterativeRuleBasedColumnPruning(false);

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
@@ -108,7 +108,7 @@ public class TestShowQueries
     {
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page_row_c%'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(115)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(96)))");
     }
 
     @Test
@@ -120,7 +120,7 @@ public class TestShowQueries
                 .hasMessage("Escape string must be a single character");
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page$_row$_c%' ESCAPE '$'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(115)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(96)))");
     }
 
     @Test

--- a/presto-tests/src/test/java/io/prestosql/tests/TestJoinQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestJoinQueries.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.tests;
 
-import io.prestosql.sql.analyzer.FeaturesConfig;
+import io.prestosql.execution.DynamicFilterConfig;
 import io.prestosql.testing.AbstractTestJoinQueries;
 import io.prestosql.testing.QueryRunner;
 import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
@@ -31,7 +31,7 @@ public class TestJoinQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        verify(new FeaturesConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
+        verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
         return TpchQueryRunnerBuilder.builder().build();
     }
 


### PR DESCRIPTION
Moved dynamic filtering related configs to DynamicFilterConfig.
Added enable-large-dynamic-filters to allow collection of
large dynamic filters.
Removed existing configs dynamic-filtering-max-per-driver-row-count,
dynamic-filtering-max-per-driver-size,
dynamic-filtering-range-row-limit-per-driver and their session
properties. These are replaced by new properties based on
join distribution type and value of enable_large_dynamic_filters.