### PR TITLE
Coerce strings to boolean

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/BooleanDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/BooleanDecoder.java
@@ -44,6 +44,17 @@ public class BooleanDecoder
         else if (value instanceof Boolean) {
             BOOLEAN.writeBoolean(output, (Boolean) value);
         }
+        else if (value instanceof String) {
+            if (value.equals("true")) {
+                BOOLEAN.writeBoolean(output, true);
+            }
+            else if (value.equals("false") || value.equals("")) {
+                BOOLEAN.writeBoolean(output, false);
+            }
+            else {
+                throw new PrestoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as BOOLEAN: %s", path, value));
+            }
+        }
         else {
             throw new PrestoException(TYPE_MISMATCH, format("Expected a boolean value for field %s of type BOOLEAN: %s [%s]", path, value, value.getClass().getSimpleName()));
         }

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
@@ -393,6 +393,55 @@ public abstract class BaseElasticsearchSmokeTest
     }
 
     @Test
+    public void testBoolean()
+            throws IOException
+    {
+        String indexName = "booleans";
+
+        @Language("JSON")
+        String mappings = "" +
+                "{" +
+                "  \"properties\": { " +
+                "    \"boolean_column\":   { \"type\": \"boolean\" }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", true)
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", "true")
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", false)
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", "false")
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", "")
+                .build());
+
+        MaterializedResult rows = computeActual("SELECT boolean_column FROM booleans");
+
+        MaterializedResult expected = resultBuilder(getSession(), rows.getTypes())
+                .row(true)
+                .row(true)
+                .row(false)
+                .row(false)
+                .row(false)
+                .build();
+
+        assertEquals(rows.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
     public void testCoercions()
             throws IOException
     {


### PR DESCRIPTION
Elasticsearch allows the following strings as values for boolean fields: "true", "false", ""