### PR TITLE
Remove FloatingPointEquality warning no longer valid

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
@@ -287,7 +287,6 @@ public class ExpressionInterpreter
         return visitor.process(expression, inputs);
     }
 
-    @SuppressWarnings("FloatingPointEquality")
     private class Visitor
             extends AstVisitor<Object, Object>
     {


### PR DESCRIPTION
ExpressionInterpreter no longer compares the long variables. We can get rid of the warning from the class.

Ref: https://github.com/prestosql/presto/commit/34e25649e84f1c074d04a430628dda4ef920894e