### PR TITLE
Variable precision timestamp support for Hive write operations

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -390,7 +390,7 @@ public class HiveMetadata
                 tableName.getTableName(),
                 table.get().getParameters(),
                 getPartitionKeyColumnHandles(table.get(), typeManager),
-                getRegularColumnHandles(table.get(), typeManager, getTimestampPrecision(session).getPrecision()),
+                getRegularColumnHandles(table.get(), typeManager, getTimestampPrecision(session)),
                 getHiveBucketHandle(session, table.get(), typeManager));
     }
 
@@ -566,7 +566,7 @@ public class HiveMetadata
 
         Function<HiveColumnHandle, ColumnMetadata> metadataGetter = columnMetadataGetter(table);
         ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
-        for (HiveColumnHandle columnHandle : hiveColumnHandles(table, typeManager, getTimestampPrecision(session).getPrecision())) {
+        for (HiveColumnHandle columnHandle : hiveColumnHandles(table, typeManager, getTimestampPrecision(session))) {
             columns.add(metadataGetter.apply(columnHandle));
         }
 
@@ -710,7 +710,7 @@ public class HiveMetadata
         SchemaTableName tableName = ((HiveTableHandle) tableHandle).getSchemaTableName();
         Table table = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), tableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));
-        return hiveColumnHandles(table, typeManager, getTimestampPrecision(session).getPrecision()).stream()
+        return hiveColumnHandles(table, typeManager, getTimestampPrecision(session)).stream()
                 .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
     }
 
@@ -1236,7 +1236,7 @@ public class HiveMetadata
         List<String> partitionColumnNames = partitionColumns.stream()
                 .map(Column::getName)
                 .collect(toImmutableList());
-        int timestampPrecision = getTimestampPrecision(session).getPrecision();
+        HiveTimestampPrecision timestampPrecision = getTimestampPrecision(session);
         List<HiveColumnHandle> hiveColumnHandles = hiveColumnHandles(table, typeManager, timestampPrecision);
         Map<String, Type> columnTypes = hiveColumnHandles.stream()
                 .filter(columnHandle -> !columnHandle.isHidden())
@@ -1568,7 +1568,7 @@ public class HiveMetadata
             }
         }
 
-        List<HiveColumnHandle> handles = hiveColumnHandles(table, typeManager, getTimestampPrecision(session).getPrecision()).stream()
+        List<HiveColumnHandle> handles = hiveColumnHandles(table, typeManager, getTimestampPrecision(session)).stream()
                 .filter(columnHandle -> !columnHandle.isHidden())
                 .collect(toList());
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
@@ -127,12 +127,12 @@ public final class HiveType
         return typeManager.getType(getTypeSignature());
     }
 
-    public Type getType(TypeManager typeManager, int timestampPrecision)
+    public Type getType(TypeManager typeManager, HiveTimestampPrecision timestampPrecision)
     {
         Type tentativeType = typeManager.getType(getTypeSignature());
         // TODO: handle timestamps in structural types (https://github.com/prestosql/presto/issues/5195)
         if (tentativeType instanceof TimestampType) {
-            return TimestampType.createTimestampType(timestampPrecision);
+            return TimestampType.createTimestampType(timestampPrecision.getPrecision());
         }
         return tentativeType;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -84,6 +84,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getCompressionCodec;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getInsertExistingPartitionsBehavior;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getTemporaryStagingDirectoryPath;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isTemporaryStagingDirectoryEnabled;
 import static io.prestosql.plugin.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getHiveSchema;
@@ -544,7 +545,7 @@ public class HiveWriterFactory
             }
 
             List<Type> types = dataColumns.stream()
-                    .map(column -> column.getHiveType().getType(typeManager))
+                    .map(column -> column.getHiveType().getType(typeManager, getTimestampPrecision(session).getPrecision()))
                     .collect(toImmutableList());
 
             Map<String, Integer> columnIndexes = new HashMap<>();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -545,7 +545,7 @@ public class HiveWriterFactory
             }
 
             List<Type> types = dataColumns.stream()
-                    .map(column -> column.getHiveType().getType(typeManager, getTimestampPrecision(session).getPrecision()))
+                    .map(column -> column.getHiveType().getType(typeManager, getTimestampPrecision(session)))
                     .collect(toImmutableList());
 
             Map<String, Integer> columnIndexes = new HashMap<>();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
@@ -48,6 +48,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
 import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.prestosql.plugin.hive.HiveMetadata.PRESTO_VERSION_NAME;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isRcfileOptimizedWriterValidate;
 import static io.prestosql.plugin.hive.rcfile.RcFilePageSourceFactory.createTextVectorEncoding;
 import static io.prestosql.plugin.hive.util.HiveUtil.getColumnNames;
@@ -122,7 +123,7 @@ public class RcFileFileWriterFactory
         // an index to rearrange columns in the proper order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RcFileFileWriterFactory.java
@@ -123,7 +123,7 @@ public class RcFileFileWriterFactory
         // an index to rearrange columns in the proper order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session)))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
@@ -45,6 +45,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.prestosql.plugin.hive.util.HiveUtil.getColumnNames;
 import static io.prestosql.plugin.hive.util.HiveUtil.getColumnTypes;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.createRecordWriter;
@@ -90,7 +91,7 @@ public class RecordFileWriter
         // existing tables may have columns in a different order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
                 .collect(toList());
 
         fieldCount = fileColumnNames.size();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/RecordFileWriter.java
@@ -91,7 +91,7 @@ public class RecordFileWriter
         // existing tables may have columns in a different order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session)))
                 .collect(toList());
 
         fieldCount = fileColumnNames.size();

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
@@ -149,7 +149,7 @@ public class OrcFileWriterFactory
         // an index to rearrange columns in the proper order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session)))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcFileWriterFactory.java
@@ -64,6 +64,7 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcOptimizedWrit
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcOptimizedWriterMinStripeSize;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcOptimizedWriterValidateMode;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcStringStatisticsLimit;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOrcOptimizedWriterValidate;
 import static io.prestosql.plugin.hive.acid.AcidSchema.ACID_COLUMN_NAMES;
 import static io.prestosql.plugin.hive.acid.AcidSchema.createAcidColumnPrestoTypes;
@@ -148,7 +149,7 @@ public class OrcFileWriterFactory
         // an index to rearrange columns in the proper order
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -92,7 +92,7 @@ public class ParquetFileWriterFactory
 
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session)))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.prestosql.plugin.hive.util.HiveUtil.getColumnNames;
 import static io.prestosql.plugin.hive.util.HiveUtil.getColumnTypes;
 import static java.util.Objects.requireNonNull;
@@ -91,7 +92,7 @@ public class ParquetFileWriterFactory
 
         List<String> fileColumnNames = getColumnNames(schema);
         List<Type> fileColumnTypes = getColumnTypes(schema).stream()
-                .map(hiveType -> hiveType.getType(typeManager))
+                .map(hiveType -> hiveType.getType(typeManager, getTimestampPrecision(session).getPrecision()))
                 .collect(toList());
 
         int[] fileInputColumnIndexes = fileColumnNames.stream()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -24,6 +24,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.HiveTimestampPrecision;
 import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.plugin.hive.util.FSDataInputStreamTail;
@@ -184,7 +185,7 @@ public class RcFilePageSourceFactory
 
         try {
             ImmutableMap.Builder<Integer, Type> readColumns = ImmutableMap.builder();
-            int timestampPrecision = getTimestampPrecision(session).getPrecision();
+            HiveTimestampPrecision timestampPrecision = getTimestampPrecision(session);
             for (HiveColumnHandle column : projectedReaderColumns) {
                 readColumns.put(column.getBaseHiveColumnIndex(), column.getHiveType().getType(typeManager, timestampPrecision));
             }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveBucketing.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.hive.HiveBucketHandle;
 import io.prestosql.plugin.hive.HiveBucketProperty;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveTableHandle;
+import io.prestosql.plugin.hive.HiveTimestampPrecision;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.Table;
@@ -184,7 +185,7 @@ public final class HiveBucketing
             return Optional.empty();
         }
 
-        int timestampPrecision = getTimestampPrecision(session).getPrecision();
+        HiveTimestampPrecision timestampPrecision = getTimestampPrecision(session);
         Map<String, HiveColumnHandle> map = getRegularColumnHandles(table, typeManager, timestampPrecision).stream()
                 .collect(Collectors.toMap(HiveColumnHandle::getName, identity()));
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveTypeTranslator.java
@@ -18,6 +18,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.NamedTypeSignature;
+import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignatureParameter;
 import io.prestosql.spi.type.VarcharType;
@@ -49,7 +50,6 @@ import static io.prestosql.spi.type.DoubleType.DOUBLE;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
-import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TinyintType.TINYINT;
 import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.String.format;
@@ -113,7 +113,7 @@ public final class HiveTypeTranslator
         if (DATE.equals(type)) {
             return HIVE_DATE.getTypeInfo();
         }
-        if (TIMESTAMP_MILLIS.equals(type)) {
+        if (type instanceof TimestampType) {
             return HIVE_TIMESTAMP.getTypeInfo();
         }
         if (type instanceof DecimalType) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveUtil.java
@@ -27,6 +27,7 @@ import io.prestosql.hadoop.TextLineLengthLimitExceededException;
 import io.prestosql.orc.OrcWriterOptions;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HivePartitionKey;
+import io.prestosql.plugin.hive.HiveTimestampPrecision;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.avro.PrestoAvroSerDe;
 import io.prestosql.plugin.hive.metastore.Column;
@@ -819,7 +820,7 @@ public final class HiveUtil
         return partitionKey;
     }
 
-    public static List<HiveColumnHandle> hiveColumnHandles(Table table, TypeManager typeManager, int timestampPrecision)
+    public static List<HiveColumnHandle> hiveColumnHandles(Table table, TypeManager typeManager, HiveTimestampPrecision timestampPrecision)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
@@ -845,7 +846,7 @@ public final class HiveUtil
         return columns.build();
     }
 
-    public static List<HiveColumnHandle> getRegularColumnHandles(Table table, TypeManager typeManager, int timestampPrecision)
+    public static List<HiveColumnHandle> getRegularColumnHandles(Table table, TypeManager typeManager, HiveTimestampPrecision timestampPrecision)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -47,6 +47,7 @@ import io.prestosql.spi.type.DoubleType;
 import io.prestosql.spi.type.IntegerType;
 import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.SmallintType;
+import io.prestosql.spi.type.TimestampType;
 import io.prestosql.spi.type.TinyintType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.VarbinaryType;
@@ -695,7 +696,7 @@ public final class HiveWriteUtils
             return writableDateObjectInspector;
         }
 
-        if (type.equals(TIMESTAMP_MILLIS)) {
+        if (type instanceof TimestampType) {
             return writableTimestampObjectInspector;
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -123,7 +123,6 @@ import static org.testng.Assert.fail;
 public class TestBackgroundHiveSplitLoader
 {
     private static final int BUCKET_COUNT = 2;
-    private static final int TIMESTAMP_PRECISION = 3;
 
     private static final String SAMPLE_PATH = "hdfs://VOL1:9000/db_name/table_name/000000_0";
     private static final String SAMPLE_PATH_FILTERED = "hdfs://VOL1:9000/db_name/table_name/000000_1";
@@ -322,7 +321,7 @@ public class TestBackgroundHiveSplitLoader
                 PARTITIONED_TABLE,
                 Optional.of(
                         new HiveBucketHandle(
-                                getRegularColumnHandles(PARTITIONED_TABLE, TYPE_MANAGER, TIMESTAMP_PRECISION),
+                                getRegularColumnHandles(PARTITIONED_TABLE, TYPE_MANAGER, HiveTimestampPrecision.MILLISECONDS),
                                 BUCKETING_V1,
                                 BUCKET_COUNT,
                                 BUCKET_COUNT)));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileFormats.java
@@ -292,13 +292,8 @@ public class TestHiveFileFormats
     public void testOrc(int rowCount, long fileSizePadding)
             throws Exception
     {
-        // Hive binary writers are broken for timestamps
-        List<TestColumn> testColumns = TEST_COLUMNS.stream()
-                .filter(TestHiveFileFormats::withoutTimestamps)
-                .collect(toImmutableList());
-
         assertThatFileFormat(ORC)
-                .withColumns(testColumns)
+                .withColumns(TEST_COLUMNS)
                 .withRowsCount(rowCount)
                 .withFileSizePadding(fileSizePadding)
                 .isReadableByPageSource(new OrcPageSourceFactory(new OrcReaderOptions(), HDFS_ENVIRONMENT, STATS, UTC));

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -770,7 +770,7 @@ public final class MetadataManager
     {
         CatalogName catalogName = tableHandle.getCatalogName();
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
-        catalogMetadata.getMetadata().finishStatisticsCollection(session.toConnectorSession(), tableHandle.getConnectorHandle(), computedStatistics);
+        catalogMetadata.getMetadata().finishStatisticsCollection(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), computedStatistics);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
@@ -27,6 +27,7 @@ import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.CharType;
+import io.prestosql.spi.type.LongTimestamp;
 import io.prestosql.spi.type.MapType;
 import io.prestosql.spi.type.RowType;
 import io.prestosql.spi.type.SqlDate;
@@ -294,7 +295,12 @@ public class MaterializedResult
         }
         else if (type instanceof TimestampType) {
             long micros = ((SqlTimestamp) value).getEpochMicros();
-            type.writeLong(blockBuilder, micros);
+            if (((TimestampType) type).getPrecision() <= TimestampType.MAX_SHORT_PRECISION) {
+                type.writeLong(blockBuilder, micros);
+            }
+            else {
+                type.writeObject(blockBuilder, new LongTimestamp(micros, ((SqlTimestamp) value).getPicosOfMicros()));
+            }
         }
         else if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             long millisUtc = ((SqlTimestampWithTimeZone) value).getMillisUtc();

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -316,15 +316,6 @@ public class TimestampColumnWriter
         statisticsBuilder = statisticsBuilderSupplier.get();
     }
 
-    private void writeTimestampMillis(Block block)
-    {
-        for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
-                writeMillis(type.getLong(block, i));
-            }
-        }
-    }
-
     private void writeTimestampMicros(Block block)
     {
         for (int i = 0; i < block.getPositionCount(); i++) {

--- a/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/writer/TimestampColumnWriter.java
@@ -354,6 +354,7 @@ public class TimestampColumnWriter
                 long seconds = timestamp.getEpochMicros() / MICROSECONDS_PER_SECOND;
                 long microsFraction = floorMod(timestamp.getEpochMicros(), MICROSECONDS_PER_SECOND);
                 long nanosFraction = (microsFraction * NANOSECONDS_PER_MICROSECOND) +
+                        // no rounding since the the data has nanosecond precision, at most
                         (timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND);
 
                 long millis = floorDiv(timestamp.getEpochMicros(), MICROSECONDS_PER_MILLISECOND);

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -151,7 +151,6 @@ import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
 import static io.prestosql.spi.type.Varchars.truncateToLength;
 import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static io.prestosql.testing.TestingConnectorSession.SESSION;
-import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_ALL_COLUMNS;
@@ -837,7 +836,7 @@ public class OrcTester
                 actualValue = SqlTimestampWithTimeZone.newInstance(3, timestamp.toEpochMilli(), 0, UTC_KEY);
             }
             else if (type.equals(TIMESTAMP_TZ_MICROS)) {
-                int picosOfMilli = toIntExact(roundDiv(timestamp.getNanos(), NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_MICROSECOND);
+                int picosOfMilli = roundDiv(timestamp.getNanos(), NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_MICROSECOND;
                 actualValue = SqlTimestampWithTimeZone.newInstance(3, timestamp.toEpochMilli(), picosOfMilli, UTC_KEY);
             }
             else if (type.equals(TIMESTAMP_TZ_NANOS)) {
@@ -1041,7 +1040,7 @@ public class OrcTester
         }
         if (type.equals(TIMESTAMP_TZ_MILLIS) || type.equals(TIMESTAMP_TZ_MICROS) || type.equals(TIMESTAMP_TZ_NANOS)) {
             SqlTimestampWithTimeZone timestamp = (SqlTimestampWithTimeZone) value;
-            int nanosOfMilli = toIntExact(roundDiv(timestamp.getPicosOfMilli(), PICOSECONDS_PER_NANOSECOND));
+            int nanosOfMilli = roundDiv(timestamp.getPicosOfMilli(), PICOSECONDS_PER_NANOSECOND);
             return Timestamp.ofEpochMilli(timestamp.getEpochMillis(), nanosOfMilli);
         }
         if (type instanceof DecimalType) {

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveStorageFormats.java
@@ -331,47 +331,220 @@ public class TestHiveStorageFormats
         onHive().executeQuery("DROP TABLE " + tableName);
     }
 
-    @Test(dataProvider = "storageFormatsWithNanosecondPrecision", groups = STORAGE_FORMATS)
-    public void testTimestamp(StorageFormat storageFormat)
+    @Test(dataProvider = "storageFormatsWithNanosecondPrecision")
+    public void testTimestampCreatedFromHive(StorageFormat storageFormat)
             throws Exception
+    {
+        String tableName = "test_timestamp_" + storageFormat.getName().toLowerCase(Locale.ENGLISH);
+        setupTimestampData(tableName, storageFormat);
+        // write precision is not relevant here, as Hive always uses nanos
+        List<TimestampAndPrecision> data = ImmutableList.of(
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.123",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.123",
+                                "NANOSECONDS", "1967-01-02 12:34:56.123")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.123",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.1234",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.1234",
+                                "NANOSECONDS", "1967-01-02 12:34:56.1234")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.1234",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.1234",
+                                "NANOSECONDS", "2020-01-02 12:34:56.1234")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.1236",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.124",
+                                "MICROSECONDS", "1967-01-02 12:34:56.1236",
+                                "NANOSECONDS", "1967-01-02 12:34:56.1236")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.1236",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.124",
+                                "MICROSECONDS", "2020-01-02 12:34:56.1236",
+                                "NANOSECONDS", "2020-01-02 12:34:56.1236")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.123456",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.123456",
+                                "NANOSECONDS", "1967-01-02 12:34:56.123456")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.123456",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123456",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123456")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.1234564",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.123456",
+                                "NANOSECONDS", "1967-01-02 12:34:56.1234564")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.1234564",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123456",
+                                "NANOSECONDS", "2020-01-02 12:34:56.1234564")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.1234567",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.123457",
+                                "NANOSECONDS", "1967-01-02 12:34:56.1234567")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.1234567",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123457",
+                                "NANOSECONDS", "2020-01-02 12:34:56.1234567")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "1967-01-02 12:34:56.123456789",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "1967-01-02 12:34:56.123",
+                                "MICROSECONDS", "1967-01-02 12:34:56.123457",
+                                "NANOSECONDS", "1967-01-02 12:34:56.123456789")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.123456789",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123457",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123456789")));
+
+        // insert records one by one so that we have one file per record, which allows us to exercise predicate push-down in Parquet
+        // (which only works when the value range has a min = max)
+        for (TimestampAndPrecision entry : data) {
+            onHive().executeQuery(format("INSERT INTO %s VALUES (%s, '%s')", tableName, entry.getId(), entry.getWriteValue()));
+        }
+
+        runTimestampQueries(tableName, data);
+    }
+
+    @Test(dataProvider = "storageFormatsWithNanosecondPrecision")
+    public void testTimestampCreatedFromPresto(StorageFormat storageFormat)
+            throws Exception
+    {
+        String tableName = "test_timestamp_" + storageFormat.getName().toLowerCase(Locale.ENGLISH);
+        setupTimestampData(tableName, storageFormat);
+
+        List<TimestampAndPrecision> data = ImmutableList.of(
+                new TimestampAndPrecision(
+                        "MILLISECONDS",
+                        "2020-01-02 12:34:56.123",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123")),
+                new TimestampAndPrecision(
+                        "MILLISECONDS",
+                        "2020-01-02 12:34:56.1234",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123")),
+                new TimestampAndPrecision(
+                        "MILLISECONDS",
+                        "2020-01-02 12:34:56.1236",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.124",
+                                "MICROSECONDS", "2020-01-02 12:34:56.124",
+                                "NANOSECONDS", "2020-01-02 12:34:56.124")),
+                new TimestampAndPrecision(
+                        "MICROSECONDS",
+                        "2020-01-02 12:34:56.123456",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123456",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123456")),
+                new TimestampAndPrecision(
+                        "MICROSECONDS",
+                        "2020-01-02 12:34:56.1234564",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123456",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123456")),
+                new TimestampAndPrecision(
+                        "MICROSECONDS",
+                        "2020-01-02 12:34:56.1234567",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123457",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123457")),
+                new TimestampAndPrecision(
+                        "NANOSECONDS",
+                        "2020-01-02 12:34:56.123456789",
+                        ImmutableMap.of(
+                                "MILLISECONDS", "2020-01-02 12:34:56.123",
+                                "MICROSECONDS", "2020-01-02 12:34:56.123457",
+                                "NANOSECONDS", "2020-01-02 12:34:56.123456789")));
+
+        for (TimestampAndPrecision entry : data) {
+            // insert timestamps with different precisions
+            setSessionProperty(onPresto().getConnection(), "hive.timestamp_precision", entry.getPrecision());
+            // insert records one by one so that we have one file per record, which allows us to exercise predicate push-down in Parquet
+            // (which only works when the value range has a min = max)
+            onPresto().executeQuery(format("INSERT INTO %s VALUES (%s, TIMESTAMP'%s')", tableName, entry.getId(), entry.getWriteValue()));
+        }
+
+        runTimestampQueries(tableName, data);
+    }
+
+    private void setupTimestampData(String tableName, StorageFormat storageFormat)
     {
         // only admin user is allowed to change session properties
         Connection connection = onPresto().getConnection();
         setAdminRole(connection);
         setSessionProperties(connection, storageFormat);
 
-        String tableName = "test_timestamp_" + storageFormat.getName().toLowerCase(Locale.ENGLISH);
         onPresto().executeQuery("DROP TABLE IF EXISTS " + tableName);
-
         onPresto().executeQuery(format("CREATE TABLE %s (id BIGINT, ts TIMESTAMP) WITH (%s)", tableName, storageFormat.getStoragePropertiesAsSql()));
-        List<TimestampAndPrecision> data = ImmutableList.of(
-                new TimestampAndPrecision(1, "MILLISECONDS", "2020-01-02 12:34:56.123", "2020-01-02 12:34:56.123"),
-                new TimestampAndPrecision(2, "MILLISECONDS", "2020-01-02 12:34:56.1234", "2020-01-02 12:34:56.123"),
-                new TimestampAndPrecision(3, "MILLISECONDS", "2020-01-02 12:34:56.1236", "2020-01-02 12:34:56.124"),
-                new TimestampAndPrecision(4, "MICROSECONDS", "2020-01-02 12:34:56.123456", "2020-01-02 12:34:56.123456"),
-                new TimestampAndPrecision(5, "MICROSECONDS", "2020-01-02 12:34:56.1234564", "2020-01-02 12:34:56.123456"),
-                new TimestampAndPrecision(6, "MICROSECONDS", "2020-01-02 12:34:56.1234567", "2020-01-02 12:34:56.123457"),
-                new TimestampAndPrecision(7, "NANOSECONDS", "2020-01-02 12:34:56.123456789", "2020-01-02 12:34:56.123456789"));
+    }
 
-        // insert records one by one so that we have one file per record, which allows us to exercise predicate push-down in Parquet
-        // (which only works when the value range has a min = max)
+    private void runTimestampQueries(String tableName, List<TimestampAndPrecision> data)
+            throws SQLException
+    {
         for (TimestampAndPrecision entry : data) {
-            onHive().executeQuery(format("INSERT INTO %s VALUES (%s, '%s')", tableName, entry.getId(), entry.getValue()));
-        }
-
-        for (TimestampAndPrecision entry : data) {
-            setSessionProperty(connection, "hive.timestamp_precision", entry.getPrecision());
-            assertThat(onPresto().executeQuery(format("SELECT ts FROM %s WHERE id = %s", tableName, entry.getId())))
-                    .containsOnly(row(Timestamp.valueOf(entry.getRoundedValue())));
-            assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts = TIMESTAMP'%s'", tableName, entry.getId(), entry.getRoundedValue())))
-                    .containsOnly(row(entry.getId()));
-            if (entry.isRoundedUp()) {
-                assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts > TIMESTAMP'%s'", tableName, entry.getId(), entry.getValue())))
+            for (String precision : List.of("MILLISECONDS", "MICROSECONDS", "NANOSECONDS")) {
+                setSessionProperty(onPresto().getConnection(), "hive.timestamp_precision", precision);
+                assertThat(onPresto().executeQuery(format("SELECT ts FROM %s WHERE id = %s", tableName, entry.getId())))
+                        .containsOnly(row(Timestamp.valueOf(entry.getReadValues(precision))));
+                assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts = TIMESTAMP'%s'", tableName, entry.getId(), entry.getReadValues(precision))))
                         .containsOnly(row(entry.getId()));
-            }
-            if (entry.isRoundedDown()) {
-                assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts < TIMESTAMP'%s'", tableName, entry.getId(), entry.getValue())))
-                        .containsOnly(row(entry.getId()));
+                if (entry.isRoundedUp(precision)) {
+                    assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts > TIMESTAMP'%s'", tableName, entry.getId(), entry.getWriteValue())))
+                            .containsOnly(row(entry.getId()));
+                }
+                if (entry.isRoundedDown(precision)) {
+                    assertThat(onPresto().executeQuery(format("SELECT id FROM %s WHERE id = %s AND ts < TIMESTAMP'%s'", tableName, entry.getId(), entry.getWriteValue())))
+                            .containsOnly(row(entry.getId()));
+                }
             }
         }
         onPresto().executeQuery("DROP TABLE " + tableName);
@@ -503,17 +676,21 @@ public class TestHiveStorageFormats
 
     private static class TimestampAndPrecision
     {
+        private static int counter;
         private final int id;
+        // precision used when writing the data
         private final String precision;
-        private final String value;
-        private final String roundedValue;
+        // inserted value
+        private final String writeValue;
+        // expected values to be read back at various precisions
+        private final Map<String, String> readValues;
 
-        public TimestampAndPrecision(int id, String precision, String value, String roundedValue)
+        public TimestampAndPrecision(String precision, String writeValue, Map<String, String> readValues)
         {
-            this.id = id;
+            this.id = counter++;
             this.precision = precision;
-            this.value = value;
-            this.roundedValue = roundedValue;
+            this.writeValue = writeValue;
+            this.readValues = readValues;
         }
 
         public int getId()
@@ -526,29 +703,29 @@ public class TestHiveStorageFormats
             return precision;
         }
 
-        public String getValue()
+        public String getWriteValue()
         {
-            return value;
+            return writeValue;
         }
 
-        public String getRoundedValue()
+        public String getReadValues(String precision)
         {
-            return roundedValue;
+            return readValues.get(precision);
         }
 
-        private int roundingSign()
+        private int roundingSign(String precision)
         {
-            return Timestamp.valueOf(roundedValue).compareTo(Timestamp.valueOf(value));
+            return Timestamp.valueOf(readValues.get(precision)).compareTo(Timestamp.valueOf(writeValue));
         }
 
-        public boolean isRoundedUp()
+        public boolean isRoundedUp(String precision)
         {
-            return roundingSign() > 0;
+            return roundingSign(precision) > 0;
         }
 
-        public boolean isRoundedDown()
+        public boolean isRoundedDown(String precision)
         {
-            return roundingSign() < 0;
+            return roundingSign(precision) < 0;
         }
     }
 }

--- a/presto-rcfile/src/main/java/io/prestosql/rcfile/TimestampHolder.java
+++ b/presto-rcfile/src/main/java/io/prestosql/rcfile/TimestampHolder.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.rcfile;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.type.LongTimestamp;
+import io.prestosql.spi.type.TimestampType;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.function.BiFunction;
+
+import static io.prestosql.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.prestosql.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+
+public final class TimestampHolder
+{
+    private final long seconds;
+    private final int nanosOfSecond;
+
+    public TimestampHolder(long epochMicros, int picosOfMicro)
+    {
+        this.seconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        long picosOfSecond = (long) floorMod(epochMicros, MICROSECONDS_PER_SECOND) * PICOSECONDS_PER_MICROSECOND + picosOfMicro;
+
+        // no rounding since the the data has nanosecond precision, at most
+        this.nanosOfSecond = toIntExact(picosOfSecond / PICOSECONDS_PER_NANOSECOND);
+    }
+
+    public long getSeconds()
+    {
+        return seconds;
+    }
+
+    public int getNanosOfSecond()
+    {
+        return nanosOfSecond;
+    }
+
+    public LocalDateTime toLocalDateTime()
+    {
+        return LocalDateTime.ofEpochSecond(seconds, nanosOfSecond, ZoneOffset.UTC);
+    }
+
+    public static BiFunction<Block, Integer, TimestampHolder> getFactory(TimestampType type)
+    {
+        if (type.isShort()) {
+            return (block, position) -> new TimestampHolder(type.getLong(block, position), 0);
+        }
+        else {
+            return (block, position) -> {
+                LongTimestamp longTimestamp = (LongTimestamp) type.getObject(block, position);
+                return new TimestampHolder(longTimestamp.getEpochMicros(), longTimestamp.getPicosOfMicro());
+            };
+        }
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimestamp.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/SqlTimestamp.java
@@ -28,7 +28,6 @@ import static io.prestosql.spi.type.Timestamps.round;
 import static io.prestosql.spi.type.Timestamps.roundDiv;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public final class SqlTimestamp
@@ -152,7 +151,7 @@ public final class SqlTimestamp
         long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
         int microOfSecond = floorMod(epochMicros, MICROSECONDS_PER_SECOND);
         int nanoOfSecond = (microOfSecond * NANOSECONDS_PER_MICROSECOND) +
-                toIntExact(roundDiv(picosOfMicros, PICOSECONDS_PER_NANOSECOND));
+                roundDiv(picosOfMicros, PICOSECONDS_PER_NANOSECOND);
         return LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, ZoneOffset.UTC);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/Timestamps.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/Timestamps.java
@@ -102,6 +102,12 @@ public class Timestamps
         return POWERS_OF_TEN[toPrecision - fromPrecision];
     }
 
+    @SuppressWarnings("NumericCastThatLosesPrecision")
+    public static int roundDiv(int value, long factor)
+    {
+        return (int) roundDiv((long) value, factor);
+    }
+
     public static long roundDiv(long value, long factor)
     {
         if (factor <= 0) {


### PR DESCRIPTION
Write path for timestamps now honors the precision specified in the Hive config (or session).  Stats collection is only supported for millisecond precision; when a higher precision is specified, timestamp columns will be ignored for the purpose of collecting stats.  The limitation will be addressed when https://github.com/prestosql/presto/issues/5170 is implemented.