### PR TITLE
Use ordinary compare for picos value

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestamp.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestamp.java
@@ -74,7 +74,7 @@ public final class LongTimestamp
         if (value != 0) {
             return value;
         }
-        return Integer.compareUnsigned(picosOfMicro, other.picosOfMicro);
+        return Integer.compare(picosOfMicro, other.picosOfMicro);
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampType.java
@@ -91,7 +91,7 @@ class LongTimestampType
         if (value != 0) {
             return value;
         }
-        return Integer.compareUnsigned(leftFraction, rightFraction);
+        return Integer.compare(leftFraction, rightFraction);
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZone.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZone.java
@@ -97,6 +97,6 @@ public final class LongTimestampWithTimeZone
         if (value != 0) {
             return value;
         }
-        return Integer.compareUnsigned(picosOfMilli, other.picosOfMilli);
+        return Integer.compare(picosOfMilli, other.picosOfMilli);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZoneType.java
@@ -95,7 +95,7 @@ class LongTimestampWithTimeZoneType
         if (value != 0) {
             return value;
         }
-        return Integer.compareUnsigned(leftFraction, rightFraction);
+        return Integer.compare(leftFraction, rightFraction);
     }
 
     @Override


### PR DESCRIPTION
The value does not overflow signed integer, so `compareUnsigned` is not
necessary.