### PR TITLE
Extract re-usable abstractions from hive projection pushdown

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursorProvider.java
@@ -35,7 +35,7 @@ import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -82,7 +82,7 @@ public class GenericHiveRecordCursorProvider
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + path, e);
         }
 
-        Optional<ReaderProjections> projectedReaderColumns = projectBaseColumns(columns);
+        Optional<ReaderColumns> projectedReaderColumns = projectBaseColumns(columns);
 
         RecordCursor cursor = hdfsEnvironment.doAs(session.getUser(), () -> {
             RecordReader<?, ?> recordReader = HiveUtil.createRecordReader(
@@ -92,7 +92,7 @@ public class GenericHiveRecordCursorProvider
                     length,
                     schema,
                     projectedReaderColumns
-                            .map(ReaderProjections::getReaderColumns)
+                            .map(ReaderColumns::get)
                             .orElse(columns));
 
             return new GenericHiveRecordCursor<>(
@@ -102,7 +102,7 @@ public class GenericHiveRecordCursorProvider
                     length,
                     schema,
                     projectedReaderColumns
-                            .map(ReaderProjections::getReaderColumns)
+                            .map(ReaderColumns::get)
                             .orElse(columns));
         });
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/GenericHiveRecordCursorProvider.java
@@ -35,9 +35,10 @@ import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
+import static io.prestosql.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class GenericHiveRecordCursorProvider
         implements HiveRecordCursorProvider
@@ -82,7 +83,13 @@ public class GenericHiveRecordCursorProvider
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + path, e);
         }
 
-        Optional<ReaderColumns> projectedReaderColumns = projectBaseColumns(columns);
+        Optional<ReaderColumns> projections = projectBaseColumns(columns);
+        List<HiveColumnHandle> readerColumns = projections
+                .map(ReaderColumns::get)
+                .map(columnHandles -> columnHandles.stream()
+                        .map(HiveColumnHandle.class::cast)
+                        .collect(toUnmodifiableList()))
+                .orElse(columns);
 
         RecordCursor cursor = hdfsEnvironment.doAs(session.getUser(), () -> {
             RecordReader<?, ?> recordReader = HiveUtil.createRecordReader(
@@ -91,9 +98,7 @@ public class GenericHiveRecordCursorProvider
                     start,
                     length,
                     schema,
-                    projectedReaderColumns
-                            .map(ReaderColumns::get)
-                            .orElse(columns));
+                    readerColumns);
 
             return new GenericHiveRecordCursor<>(
                     configuration,
@@ -101,12 +106,10 @@ public class GenericHiveRecordCursorProvider
                     genericRecordReader(recordReader),
                     length,
                     schema,
-                    projectedReaderColumns
-                            .map(ReaderColumns::get)
-                            .orElse(columns));
+                    readerColumns);
         });
 
-        return Optional.of(new ReaderRecordCursorWithProjections(cursor, projectedReaderColumns));
+        return Optional.of(new ReaderRecordCursorWithProjections(cursor, projections));
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceFactory.java
@@ -14,7 +14,6 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.plugin.hive.acid.AcidTransaction;
-import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.TupleDomain;
 import org.apache.hadoop.conf.Configuration;
@@ -25,11 +24,9 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
-import static java.util.Objects.requireNonNull;
-
 public interface HivePageSourceFactory
 {
-    Optional<ReaderPageSourceWithProjections> createPageSource(
+    Optional<ReaderPageSource> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -43,39 +40,4 @@ public interface HivePageSourceFactory
             OptionalInt bucketNumber,
             boolean originalFile,
             AcidTransaction transaction);
-
-    /**
-     * A wrapper class for
-     * - delegate reader page source and
-     * - projection information for columns to be returned by the delegate
-     * <p>
-     * Empty {@param projectedReaderColumns} indicates that the delegate page source reads the exact same columns provided to
-     * it in {@link HivePageSourceFactory#createPageSource}
-     */
-    class ReaderPageSourceWithProjections
-    {
-        private final ConnectorPageSource connectorPageSource;
-        private final Optional<ReaderProjections> projectedReaderColumns;
-
-        public ReaderPageSourceWithProjections(ConnectorPageSource connectorPageSource, Optional<ReaderProjections> projectedReaderColumns)
-        {
-            this.connectorPageSource = requireNonNull(connectorPageSource, "connectorPageSource is null");
-            this.projectedReaderColumns = requireNonNull(projectedReaderColumns, "projectedReaderColumns is null");
-        }
-
-        public ConnectorPageSource getConnectorPageSource()
-        {
-            return connectorPageSource;
-        }
-
-        public Optional<ReaderProjections> getProjectedReaderColumns()
-        {
-            return projectedReaderColumns;
-        }
-
-        public static ReaderPageSourceWithProjections noProjectionAdaptation(ConnectorPageSource connectorPageSource)
-        {
-            return new ReaderPageSourceWithProjections(connectorPageSource, Optional.empty());
-        }
-    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -19,7 +19,6 @@ import io.prestosql.orc.metadata.ColumnMetadata;
 import io.prestosql.orc.metadata.OrcColumnId;
 import io.prestosql.orc.metadata.OrcType;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider.ReaderRecordCursorWithProjections;
 import io.prestosql.plugin.hive.HiveSplit.BucketConversion;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
@@ -240,7 +239,7 @@ public class HivePageSourceProvider
         for (HivePageSourceFactory pageSourceFactory : pageSourceFactories) {
             List<HiveColumnHandle> desiredColumns = toColumnHandles(regularAndInterimColumnMappings, true, typeManager);
 
-            Optional<ReaderPageSourceWithProjections> readerWithProjections = pageSourceFactory.createPageSource(
+            Optional<ReaderPageSource> readerWithProjections = pageSourceFactory.createPageSource(
                     configuration,
                     session,
                     path,
@@ -256,9 +255,9 @@ public class HivePageSourceProvider
                     transaction);
 
             if (readerWithProjections.isPresent()) {
-                ConnectorPageSource pageSource = readerWithProjections.get().getConnectorPageSource();
+                ConnectorPageSource pageSource = readerWithProjections.get().get();
 
-                Optional<ReaderProjections> readerProjections = readerWithProjections.get().getProjectedReaderColumns();
+                Optional<ReaderProjections> readerProjections = readerWithProjections.get().getReaderColumns();
                 Optional<ReaderProjectionsAdapter> adapter = Optional.empty();
                 if (readerProjections.isPresent()) {
                     adapter = Optional.of(new ReaderProjectionsAdapter(desiredColumns, readerProjections.get()));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -257,7 +257,7 @@ public class HivePageSourceProvider
             if (readerWithProjections.isPresent()) {
                 ConnectorPageSource pageSource = readerWithProjections.get().get();
 
-                Optional<ReaderProjections> readerProjections = readerWithProjections.get().getReaderColumns();
+                Optional<ReaderColumns> readerProjections = readerWithProjections.get().getReaderColumns();
                 Optional<ReaderProjectionsAdapter> adapter = Optional.empty();
                 if (readerProjections.isPresent()) {
                     adapter = Optional.of(new ReaderProjectionsAdapter(desiredColumns, readerProjections.get()));
@@ -292,7 +292,7 @@ public class HivePageSourceProvider
 
             if (readerWithProjections.isPresent()) {
                 RecordCursor delegate = readerWithProjections.get().getRecordCursor();
-                Optional<ReaderProjections> projections = readerWithProjections.get().getProjectedReaderColumns();
+                Optional<ReaderColumns> projections = readerWithProjections.get().getProjectedReaderColumns();
 
                 if (projections.isPresent()) {
                     ReaderProjectionsAdapter projectionsAdapter = new ReaderProjectionsAdapter(desiredColumns, projections.get());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSourceProvider.java
@@ -13,6 +13,9 @@
  */
 package io.prestosql.plugin.hive;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.orc.metadata.ColumnMetadata;
@@ -44,10 +47,12 @@ import org.apache.hadoop.fs.Path;
 
 import javax.inject.Inject;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
@@ -260,7 +265,7 @@ public class HivePageSourceProvider
                 Optional<ReaderColumns> readerProjections = readerWithProjections.get().getReaderColumns();
                 Optional<ReaderProjectionsAdapter> adapter = Optional.empty();
                 if (readerProjections.isPresent()) {
-                    adapter = Optional.of(new ReaderProjectionsAdapter(desiredColumns, readerProjections.get()));
+                    adapter = Optional.of(hiveProjectionsAdapter(desiredColumns, readerProjections.get()));
                 }
 
                 return Optional.of(new HivePageSource(
@@ -295,7 +300,7 @@ public class HivePageSourceProvider
                 Optional<ReaderColumns> projections = readerWithProjections.get().getProjectedReaderColumns();
 
                 if (projections.isPresent()) {
-                    ReaderProjectionsAdapter projectionsAdapter = new ReaderProjectionsAdapter(desiredColumns, projections.get());
+                    ReaderProjectionsAdapter projectionsAdapter = hiveProjectionsAdapter(desiredColumns, projections.get());
                     delegate = new HiveReaderProjectionsAdaptingRecordCursor(delegate, projectionsAdapter);
                 }
 
@@ -337,6 +342,37 @@ public class HivePageSourceProvider
         }
         Optional<HiveBucketFilter> hiveBucketFilter = getHiveBucketFilter(hiveTable, dynamicFilter.getCurrentPredicate());
         return hiveBucketFilter.map(filter -> !filter.getBucketsToKeep().contains(hiveSplit.getBucketNumber().getAsInt())).orElse(false);
+    }
+
+    private static ReaderProjectionsAdapter hiveProjectionsAdapter(List<HiveColumnHandle> expectedColumns, ReaderColumns readColumns)
+    {
+        return new ReaderProjectionsAdapter(
+                expectedColumns.stream().map(ColumnHandle.class::cast).collect(toImmutableList()),
+                readColumns,
+                column -> ((HiveColumnHandle) column).getType(),
+                HivePageSourceProvider::getProjection);
+    }
+
+    @VisibleForTesting
+    static List<Integer> getProjection(ColumnHandle expected, ColumnHandle read)
+    {
+        HiveColumnHandle expectedColumn = (HiveColumnHandle) expected;
+        HiveColumnHandle readColumn = (HiveColumnHandle) read;
+
+        checkArgument(expectedColumn.getBaseColumn().equals(readColumn.getBaseColumn()), "reader column is not valid for expected column");
+
+        List<Integer> expectedDereferences = expectedColumn.getHiveColumnProjectionInfo()
+                .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                .orElse(ImmutableList.of());
+
+        List<Integer> readerDereferences = readColumn.getHiveColumnProjectionInfo()
+                .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                .orElse(ImmutableList.of());
+
+        checkArgument(readerDereferences.size() <= expectedDereferences.size(), "Field returned by the reader should include expected field");
+        checkArgument(expectedDereferences.subList(0, readerDereferences.size()).equals(readerDereferences), "Field returned by the reader should be a prefix of expected field");
+
+        return expectedDereferences.subList(readerDereferences.size(), expectedDereferences.size());
     }
 
     public static class ColumnMapping
@@ -639,6 +675,152 @@ public class HivePageSourceProvider
         public int getBucketToKeep()
         {
             return bucketToKeep;
+        }
+    }
+
+    /**
+     * Creates a mapping between the input {@param columns} and base columns if required.
+     */
+    public static Optional<ReaderColumns> projectBaseColumns(List<HiveColumnHandle> columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        // No projection is required if all columns are base columns
+        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<ColumnHandle> projectedColumns = ImmutableList.builder();
+        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
+        Map<Integer, Integer> mappedHiveColumnIndices = new HashMap<>();
+        int projectedColumnCount = 0;
+
+        for (HiveColumnHandle column : columns) {
+            int hiveColumnIndex = column.getBaseHiveColumnIndex();
+            Integer mapped = mappedHiveColumnIndices.get(hiveColumnIndex);
+
+            if (mapped == null) {
+                projectedColumns.add(column.getBaseColumn());
+                mappedHiveColumnIndices.put(hiveColumnIndex, projectedColumnCount);
+                outputColumnMapping.add(projectedColumnCount);
+                projectedColumnCount++;
+            }
+            else {
+                outputColumnMapping.add(mapped);
+            }
+        }
+
+        return Optional.of(new ReaderColumns(projectedColumns.build(), outputColumnMapping.build()));
+    }
+
+    /**
+     * Creates a set of sufficient columns for the input projected columns and prepares a mapping between the two. For example,
+     * if input {@param columns} include columns "a.b" and "a.b.c", then they will be projected from a single column "a.b".
+     */
+    public static Optional<ReaderColumns> projectSufficientColumns(List<HiveColumnHandle> columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
+            return Optional.empty();
+        }
+
+        ImmutableBiMap.Builder<DereferenceChain, HiveColumnHandle> dereferenceChainsBuilder = ImmutableBiMap.builder();
+
+        for (HiveColumnHandle column : columns) {
+            List<Integer> indices = column.getHiveColumnProjectionInfo()
+                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
+                    .orElse(ImmutableList.of());
+
+            DereferenceChain dereferenceChain = new DereferenceChain(column.getBaseColumnName(), indices);
+            dereferenceChainsBuilder.put(dereferenceChain, column);
+        }
+
+        BiMap<DereferenceChain, HiveColumnHandle> dereferenceChains = dereferenceChainsBuilder.build();
+
+        List<ColumnHandle> sufficientColumns = new ArrayList<>();
+        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
+
+        Map<DereferenceChain, Integer> pickedColumns = new HashMap<>();
+
+        // Pick a covering column for every column
+        for (HiveColumnHandle columnHandle : columns) {
+            DereferenceChain column = dereferenceChains.inverse().get(columnHandle);
+            List<DereferenceChain> orderedPrefixes = column.getOrderedPrefixes();
+            DereferenceChain chosenColumn = null;
+
+            // Shortest existing prefix is chosen as the input.
+            for (DereferenceChain prefix : orderedPrefixes) {
+                if (dereferenceChains.containsKey(prefix)) {
+                    chosenColumn = prefix;
+                    break;
+                }
+            }
+
+            checkState(chosenColumn != null, "chosenColumn is null");
+            int inputBlockIndex;
+
+            if (pickedColumns.containsKey(chosenColumn)) {
+                // Use already picked column
+                inputBlockIndex = pickedColumns.get(chosenColumn);
+            }
+            else {
+                // Add a new column for the reader
+                sufficientColumns.add(dereferenceChains.get(chosenColumn));
+                pickedColumns.put(chosenColumn, sufficientColumns.size() - 1);
+                inputBlockIndex = sufficientColumns.size() - 1;
+            }
+
+            outputColumnMapping.add(inputBlockIndex);
+        }
+
+        return Optional.of(new ReaderColumns(sufficientColumns, outputColumnMapping.build()));
+    }
+
+    private static class DereferenceChain
+    {
+        private final String name;
+        private final List<Integer> indices;
+
+        public DereferenceChain(String name, List<Integer> indices)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.indices = ImmutableList.copyOf(requireNonNull(indices, "indices is null"));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DereferenceChain that = (DereferenceChain) o;
+            return Objects.equals(name, that.name) &&
+                    Objects.equals(indices, that.indices);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, indices);
+        }
+
+        /**
+         * Get Prefixes of this Dereference chain in increasing order of lengths
+         */
+        public List<DereferenceChain> getOrderedPrefixes()
+        {
+            ImmutableList.Builder<DereferenceChain> prefixes = ImmutableList.builder();
+
+            for (int prefixLen = 0; prefixLen <= indices.size(); prefixLen++) {
+                prefixes.add(new DereferenceChain(name, indices.subList(0, prefixLen)));
+            }
+
+            return prefixes.build();
         }
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveRecordCursorProvider.java
@@ -52,9 +52,9 @@ public interface HiveRecordCursorProvider
     class ReaderRecordCursorWithProjections
     {
         private final RecordCursor recordCursor;
-        private final Optional<ReaderProjections> projectedReaderColumns;
+        private final Optional<ReaderColumns> projectedReaderColumns;
 
-        public ReaderRecordCursorWithProjections(RecordCursor recordCursor, Optional<ReaderProjections> projectedReaderColumns)
+        public ReaderRecordCursorWithProjections(RecordCursor recordCursor, Optional<ReaderColumns> projectedReaderColumns)
         {
             this.recordCursor = requireNonNull(recordCursor, "recordCursor is null");
             this.projectedReaderColumns = requireNonNull(projectedReaderColumns, "projectedReaderColumns is null");
@@ -65,7 +65,7 @@ public interface HiveRecordCursorProvider
             return recordCursor;
         }
 
-        public Optional<ReaderProjections> getProjectedReaderColumns()
+        public Optional<ReaderColumns> getProjectedReaderColumns()
         {
             return projectedReaderColumns;
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderColumns.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderColumns.java
@@ -32,14 +32,14 @@ import static java.util.Objects.requireNonNull;
  * Stores a mapping of the projected columns required by {@link HivePageSource} to the columns supplied by format-specific
  * page sources or record cursors.
  */
-public class ReaderProjections
+public class ReaderColumns
 {
     // columns to be read by the reader (ordered)
     private final List<HiveColumnHandle> readerColumns;
     // indices for mapping expected hive column handles to the reader's column handles
     private final List<Integer> readerBlockIndices;
 
-    private ReaderProjections(List<HiveColumnHandle> readerColumns, List<Integer> readerBlockIndices)
+    private ReaderColumns(List<HiveColumnHandle> readerColumns, List<Integer> readerBlockIndices)
     {
         this.readerColumns = ImmutableList.copyOf(requireNonNull(readerColumns, "readerColumns is null"));
 
@@ -50,7 +50,7 @@ public class ReaderProjections
     /**
      * For a column required by the {@link HivePageSource}, returns the column read by the delegate page source or record cursor.
      */
-    public HiveColumnHandle readerColumnForHiveColumnAt(int index)
+    public HiveColumnHandle getForColumnAt(int index)
     {
         checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is not valid");
         int readerIndex = readerBlockIndices.get(index);
@@ -60,7 +60,7 @@ public class ReaderProjections
     /**
      * For a channel expected by {@link HivePageSource}, returns the channel index in the underlying page source or record cursor.
      */
-    public int readerColumnPositionForHiveColumnAt(int index)
+    public int getPositionForColumnAt(int index)
     {
         checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is invalid");
         return readerBlockIndices.get(index);
@@ -69,7 +69,7 @@ public class ReaderProjections
     /**
      * returns the actual list of columns being read by underlying page source or record cursor in order.
      */
-    public List<HiveColumnHandle> getReaderColumns()
+    public List<HiveColumnHandle> get()
     {
         return readerColumns;
     }
@@ -77,7 +77,7 @@ public class ReaderProjections
     /**
      * Creates a mapping between the input {@param columns} and base columns if required.
      */
-    public static Optional<ReaderProjections> projectBaseColumns(List<HiveColumnHandle> columns)
+    public static Optional<ReaderColumns> projectBaseColumns(List<HiveColumnHandle> columns)
     {
         requireNonNull(columns, "columns is null");
 
@@ -106,14 +106,14 @@ public class ReaderProjections
             }
         }
 
-        return Optional.of(new ReaderProjections(projectedColumns.build(), outputColumnMapping.build()));
+        return Optional.of(new ReaderColumns(projectedColumns.build(), outputColumnMapping.build()));
     }
 
     /**
      * Creates a set of sufficient columns for the input projected columns and prepares a mapping between the two. For example,
      * if input {@param columns} include columns "a.b" and "a.b.c", then they will be projected from a single column "a.b".
      */
-    public static Optional<ReaderProjections> projectSufficientColumns(List<HiveColumnHandle> columns)
+    public static Optional<ReaderColumns> projectSufficientColumns(List<HiveColumnHandle> columns)
     {
         requireNonNull(columns, "columns is null");
 
@@ -170,7 +170,7 @@ public class ReaderProjections
             outputColumnMapping.add(inputBlockIndex);
         }
 
-        return Optional.of(new ReaderProjections(sufficientColumns, outputColumnMapping.build()));
+        return Optional.of(new ReaderColumns(sufficientColumns, outputColumnMapping.build()));
     }
 
     private static class DereferenceChain

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderColumns.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderColumns.java
@@ -13,33 +13,29 @@
  */
 package io.prestosql.plugin.hive;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Stores a mapping of the projected columns required by {@link HivePageSource} to the columns supplied by format-specific
- * page sources or record cursors.
+ * Stores a mapping between
+ *  - the projected columns required by a connector level pagesource and
+ *  -  the columns supplied by format-specific page source
+ *
+ * Currently used in {@link HivePageSource}.
  */
 public class ReaderColumns
 {
     // columns to be read by the reader (ordered)
-    private final List<HiveColumnHandle> readerColumns;
+    private final List<ColumnHandle> readerColumns;
     // indices for mapping expected hive column handles to the reader's column handles
     private final List<Integer> readerBlockIndices;
 
-    private ReaderColumns(List<HiveColumnHandle> readerColumns, List<Integer> readerBlockIndices)
+    public ReaderColumns(List<? extends ColumnHandle> readerColumns, List<Integer> readerBlockIndices)
     {
         this.readerColumns = ImmutableList.copyOf(requireNonNull(readerColumns, "readerColumns is null"));
 
@@ -48,9 +44,9 @@ public class ReaderColumns
     }
 
     /**
-     * For a column required by the {@link HivePageSource}, returns the column read by the delegate page source or record cursor.
+     * For a column required by the wrapper page source, returns the column read by the delegate page source or record cursor.
      */
-    public HiveColumnHandle getForColumnAt(int index)
+    public ColumnHandle getForColumnAt(int index)
     {
         checkArgument(index >= 0 && index < readerBlockIndices.size(), "index is not valid");
         int readerIndex = readerBlockIndices.get(index);
@@ -58,7 +54,7 @@ public class ReaderColumns
     }
 
     /**
-     * For a channel expected by {@link HivePageSource}, returns the channel index in the underlying page source or record cursor.
+     * For a channel expected by wrapper page source, returns the channel index in the underlying page source or record cursor.
      */
     public int getPositionForColumnAt(int index)
     {
@@ -69,154 +65,8 @@ public class ReaderColumns
     /**
      * returns the actual list of columns being read by underlying page source or record cursor in order.
      */
-    public List<HiveColumnHandle> get()
+    public List<ColumnHandle> get()
     {
         return readerColumns;
-    }
-
-    /**
-     * Creates a mapping between the input {@param columns} and base columns if required.
-     */
-    public static Optional<ReaderColumns> projectBaseColumns(List<HiveColumnHandle> columns)
-    {
-        requireNonNull(columns, "columns is null");
-
-        // No projection is required if all columns are base columns
-        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
-            return Optional.empty();
-        }
-
-        ImmutableList.Builder<HiveColumnHandle> projectedColumns = ImmutableList.builder();
-        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
-        Map<Integer, Integer> mappedHiveColumnIndices = new HashMap<>();
-        int projectedColumnCount = 0;
-
-        for (HiveColumnHandle column : columns) {
-            int hiveColumnIndex = column.getBaseHiveColumnIndex();
-            Integer mapped = mappedHiveColumnIndices.get(hiveColumnIndex);
-
-            if (mapped == null) {
-                projectedColumns.add(column.getBaseColumn());
-                mappedHiveColumnIndices.put(hiveColumnIndex, projectedColumnCount);
-                outputColumnMapping.add(projectedColumnCount);
-                projectedColumnCount++;
-            }
-            else {
-                outputColumnMapping.add(mapped);
-            }
-        }
-
-        return Optional.of(new ReaderColumns(projectedColumns.build(), outputColumnMapping.build()));
-    }
-
-    /**
-     * Creates a set of sufficient columns for the input projected columns and prepares a mapping between the two. For example,
-     * if input {@param columns} include columns "a.b" and "a.b.c", then they will be projected from a single column "a.b".
-     */
-    public static Optional<ReaderColumns> projectSufficientColumns(List<HiveColumnHandle> columns)
-    {
-        requireNonNull(columns, "columns is null");
-
-        if (columns.stream().allMatch(HiveColumnHandle::isBaseColumn)) {
-            return Optional.empty();
-        }
-
-        ImmutableBiMap.Builder<DereferenceChain, HiveColumnHandle> dereferenceChainsBuilder = ImmutableBiMap.builder();
-
-        for (HiveColumnHandle column : columns) {
-            List<Integer> indices = column.getHiveColumnProjectionInfo()
-                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
-                    .orElse(ImmutableList.of());
-
-            DereferenceChain dereferenceChain = new DereferenceChain(column.getBaseColumnName(), indices);
-            dereferenceChainsBuilder.put(dereferenceChain, column);
-        }
-
-        BiMap<DereferenceChain, HiveColumnHandle> dereferenceChains = dereferenceChainsBuilder.build();
-
-        List<HiveColumnHandle> sufficientColumns = new ArrayList<>();
-        ImmutableList.Builder<Integer> outputColumnMapping = ImmutableList.builder();
-
-        Map<DereferenceChain, Integer> pickedColumns = new HashMap<>();
-
-        // Pick a covering column for every column
-        for (HiveColumnHandle columnHandle : columns) {
-            DereferenceChain column = dereferenceChains.inverse().get(columnHandle);
-            List<DereferenceChain> orderedPrefixes = column.getOrderedPrefixes();
-            DereferenceChain chosenColumn = null;
-
-            // Shortest existing prefix is chosen as the input.
-            for (DereferenceChain prefix : orderedPrefixes) {
-                if (dereferenceChains.containsKey(prefix)) {
-                    chosenColumn = prefix;
-                    break;
-                }
-            }
-
-            checkState(chosenColumn != null, "chosenColumn is null");
-            int inputBlockIndex;
-
-            if (pickedColumns.containsKey(chosenColumn)) {
-                // Use already picked column
-                inputBlockIndex = pickedColumns.get(chosenColumn);
-            }
-            else {
-                // Add a new column for the reader
-                sufficientColumns.add(dereferenceChains.get(chosenColumn));
-                pickedColumns.put(chosenColumn, sufficientColumns.size() - 1);
-                inputBlockIndex = sufficientColumns.size() - 1;
-            }
-
-            outputColumnMapping.add(inputBlockIndex);
-        }
-
-        return Optional.of(new ReaderColumns(sufficientColumns, outputColumnMapping.build()));
-    }
-
-    private static class DereferenceChain
-    {
-        private final String name;
-        private final List<Integer> indices;
-
-        public DereferenceChain(String name, List<Integer> indices)
-        {
-            this.name = requireNonNull(name, "name is null");
-            this.indices = ImmutableList.copyOf(requireNonNull(indices, "indices is null"));
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            DereferenceChain that = (DereferenceChain) o;
-            return Objects.equals(name, that.name) &&
-                    Objects.equals(indices, that.indices);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(name, indices);
-        }
-
-        /**
-         * Get Prefixes of this Dereference chain in increasing order of lengths
-         */
-        public List<DereferenceChain> getOrderedPrefixes()
-        {
-            ImmutableList.Builder<DereferenceChain> prefixes = ImmutableList.builder();
-
-            for (int prefixLen = 0; prefixLen <= indices.size(); prefixLen++) {
-                prefixes.add(new DereferenceChain(name, indices.subList(0, prefixLen)));
-            }
-
-            return prefixes.build();
-        }
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderPageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderPageSource.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import io.prestosql.spi.connector.ConnectorPageSource;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A wrapper class for
+ * - delegate reader page source and
+ * - columns to be read by the delegate (present only if different from the columns desired by the connector pagesource)
+ * <p>
+ */
+public class ReaderPageSource
+{
+    private final ConnectorPageSource connectorPageSource;
+    private final Optional<ReaderProjections> columns;
+
+    public ReaderPageSource(ConnectorPageSource connectorPageSource, Optional<ReaderProjections> columns)
+    {
+        this.connectorPageSource = requireNonNull(connectorPageSource, "connectorPageSource is null");
+        this.columns = requireNonNull(columns, "columns is null");
+    }
+
+    public ConnectorPageSource get()
+    {
+        return connectorPageSource;
+    }
+
+    public Optional<ReaderProjections> getReaderColumns()
+    {
+        return columns;
+    }
+
+    public static ReaderPageSource noProjectionAdaptation(ConnectorPageSource connectorPageSource)
+    {
+        return new ReaderPageSource(connectorPageSource, Optional.empty());
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderPageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderPageSource.java
@@ -28,9 +28,9 @@ import static java.util.Objects.requireNonNull;
 public class ReaderPageSource
 {
     private final ConnectorPageSource connectorPageSource;
-    private final Optional<ReaderProjections> columns;
+    private final Optional<ReaderColumns> columns;
 
-    public ReaderPageSource(ConnectorPageSource connectorPageSource, Optional<ReaderProjections> columns)
+    public ReaderPageSource(ConnectorPageSource connectorPageSource, Optional<ReaderColumns> columns)
     {
         this.connectorPageSource = requireNonNull(connectorPageSource, "connectorPageSource is null");
         this.columns = requireNonNull(columns, "columns is null");
@@ -41,7 +41,7 @@ public class ReaderPageSource
         return connectorPageSource;
     }
 
-    public Optional<ReaderProjections> getReaderColumns()
+    public Optional<ReaderColumns> getReaderColumns()
     {
         return columns;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
@@ -38,16 +38,16 @@ public class ReaderProjectionsAdapter
     private final List<Type> outputTypes;
     private final List<Type> inputTypes;
 
-    public ReaderProjectionsAdapter(List<HiveColumnHandle> expectedHiveColumns, ReaderProjections readerProjections)
+    public ReaderProjectionsAdapter(List<HiveColumnHandle> expectedHiveColumns, ReaderColumns readerColumns)
     {
         requireNonNull(expectedHiveColumns, "expectedHiveColumns is null");
-        requireNonNull(readerProjections, "readerProjections is null");
+        requireNonNull(readerColumns, "readerProjections is null");
 
         ImmutableList.Builder<ChannelMapping> mappingBuilder = ImmutableList.builder();
 
         for (int i = 0; i < expectedHiveColumns.size(); i++) {
-            HiveColumnHandle projectedColumnHandle = readerProjections.readerColumnForHiveColumnAt(i);
-            int inputChannel = readerProjections.readerColumnPositionForHiveColumnAt(i);
+            HiveColumnHandle projectedColumnHandle = readerColumns.getForColumnAt(i);
+            int inputChannel = readerColumns.getPositionForColumnAt(i);
             ChannelMapping mapping = createChannelMapping(expectedHiveColumns.get(i), projectedColumnHandle, inputChannel);
             mappingBuilder.add(mapping);
         }
@@ -58,7 +58,7 @@ public class ReaderProjectionsAdapter
                 .map(HiveColumnHandle::getType)
                 .collect(toImmutableList());
 
-        inputTypes = readerProjections.getReaderColumns().stream()
+        inputTypes = readerColumns.get().stream()
                 .map(HiveColumnHandle::getType)
                 .collect(toImmutableList());
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/ReaderProjectionsAdapter.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.block.ColumnarRow;
 import io.prestosql.spi.block.LazyBlock;
 import io.prestosql.spi.block.LazyBlockLoader;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.type.Type;
 
 import java.util.List;
@@ -28,7 +29,6 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.plugin.hive.ReaderProjectionsAdapter.ChannelMapping.createChannelMapping;
 import static io.prestosql.spi.block.ColumnarRow.toColumnarRow;
 import static java.util.Objects.requireNonNull;
 
@@ -38,28 +38,33 @@ public class ReaderProjectionsAdapter
     private final List<Type> outputTypes;
     private final List<Type> inputTypes;
 
-    public ReaderProjectionsAdapter(List<HiveColumnHandle> expectedHiveColumns, ReaderColumns readerColumns)
+    public ReaderProjectionsAdapter(
+            List<ColumnHandle> expectedColumns,
+            ReaderColumns readColumns,
+            ColumnTypeGetter typeGetter,
+            ProjectionGetter projectionGetter)
     {
-        requireNonNull(expectedHiveColumns, "expectedHiveColumns is null");
-        requireNonNull(readerColumns, "readerProjections is null");
+        requireNonNull(expectedColumns, "expectedColumns is null");
+        requireNonNull(readColumns, "readColumns is null");
 
         ImmutableList.Builder<ChannelMapping> mappingBuilder = ImmutableList.builder();
 
-        for (int i = 0; i < expectedHiveColumns.size(); i++) {
-            HiveColumnHandle projectedColumnHandle = readerColumns.getForColumnAt(i);
-            int inputChannel = readerColumns.getPositionForColumnAt(i);
-            ChannelMapping mapping = createChannelMapping(expectedHiveColumns.get(i), projectedColumnHandle, inputChannel);
-            mappingBuilder.add(mapping);
+        for (int i = 0; i < expectedColumns.size(); i++) {
+            ColumnHandle projectedColumnHandle = readColumns.getForColumnAt(i);
+            int inputChannel = readColumns.getPositionForColumnAt(i);
+            List<Integer> dereferences = projectionGetter.get(expectedColumns.get(i), projectedColumnHandle);
+
+            mappingBuilder.add(new ChannelMapping(inputChannel, dereferences));
         }
 
         outputToInputMapping = mappingBuilder.build();
 
-        outputTypes = expectedHiveColumns.stream()
-                .map(HiveColumnHandle::getType)
+        outputTypes = expectedColumns.stream()
+                .map(typeGetter::get)
                 .collect(toImmutableList());
 
-        inputTypes = readerColumns.get().stream()
-                .map(HiveColumnHandle::getType)
+        inputTypes = readColumns.get().stream()
+                .map(typeGetter::get)
                 .collect(toImmutableList());
     }
 
@@ -205,7 +210,7 @@ public class ReaderProjectionsAdapter
         private final int inputChannelIndex;
         private final List<Integer> dereferenceSequence;
 
-        private ChannelMapping(int inputBlockIndex, List<Integer> dereferenceSequence)
+        public ChannelMapping(int inputBlockIndex, List<Integer> dereferenceSequence)
         {
             checkArgument(inputBlockIndex >= 0, "inputBlockIndex cannot be negative");
             this.inputChannelIndex = inputBlockIndex;
@@ -221,29 +226,15 @@ public class ReaderProjectionsAdapter
         {
             return dereferenceSequence;
         }
+    }
 
-        static ChannelMapping createChannelMapping(HiveColumnHandle expected, HiveColumnHandle delegate, int inputBlockIndex)
-        {
-            List<Integer> dereferences = validateProjectionAndExtractDereferences(expected, delegate);
-            return new ChannelMapping(inputBlockIndex, dereferences);
-        }
+    public interface ColumnTypeGetter
+    {
+        Type get(ColumnHandle column);
+    }
 
-        private static List<Integer> validateProjectionAndExtractDereferences(HiveColumnHandle expectedColumn, HiveColumnHandle readerColumn)
-        {
-            checkArgument(expectedColumn.getBaseColumn().equals(readerColumn.getBaseColumn()), "reader column is not valid for expected column");
-
-            List<Integer> expectedDereferences = expectedColumn.getHiveColumnProjectionInfo()
-                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
-                    .orElse(ImmutableList.of());
-
-            List<Integer> readerDereferences = readerColumn.getHiveColumnProjectionInfo()
-                    .map(HiveColumnProjectionInfo::getDereferenceIndices)
-                    .orElse(ImmutableList.of());
-
-            checkArgument(readerDereferences.size() <= expectedDereferences.size(), "Field returned by the reader should include expected field");
-            checkArgument(expectedDereferences.subList(0, readerDereferences.size()).equals(readerDereferences), "Field returned by the reader should be a prefix of expected field");
-
-            return expectedDereferences.subList(readerDereferences.size(), expectedDereferences.size());
-        }
+    public interface ProjectionGetter
+    {
+        List<Integer> get(ColumnHandle required, ColumnHandle read);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
@@ -33,8 +33,8 @@ import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveColumnProjectionInfo;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.ReaderColumns;
 import io.prestosql.plugin.hive.ReaderPageSource;
-import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidSchema;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.plugin.hive.orc.OrcPageSource.ColumnAdaptation;
@@ -92,8 +92,8 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcTinyStripeThr
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOrcNestedLazy;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isUseOrcColumnNames;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
 import static io.prestosql.plugin.hive.ReaderPageSource.noProjectionAdaptation;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
 import static io.prestosql.plugin.hive.orc.OrcPageSource.handleException;
 import static io.prestosql.plugin.hive.util.HiveUtil.isDeserializerClass;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -158,7 +158,7 @@ public class OrcPageSourceFactory
             return Optional.of(context);
         }
 
-        Optional<ReaderProjections> projectedReaderColumns = projectBaseColumns(columns);
+        Optional<ReaderColumns> projectedReaderColumns = projectBaseColumns(columns);
 
         ConnectorPageSource orcPageSource = createOrcPageSource(
                 hdfsEnvironment,
@@ -169,7 +169,7 @@ public class OrcPageSourceFactory
                 length,
                 estimatedFileSize,
                 projectedReaderColumns
-                        .map(ReaderProjections::getReaderColumns)
+                        .map(ReaderColumns::get)
                         .orElse(columns),
                 columns,
                 isUseOrcColumnNames(session),

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/orc/OrcPageSourceFactory.java
@@ -33,6 +33,7 @@ import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveColumnProjectionInfo;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidSchema;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
@@ -82,7 +83,6 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILE_MISSING_COLUMN_NAMES;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
-import static io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections.noProjectionAdaptation;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcLazyReadSmallRanges;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcMaxBufferSize;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcMaxMergeDistance;
@@ -92,6 +92,7 @@ import static io.prestosql.plugin.hive.HiveSessionProperties.getOrcTinyStripeThr
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isOrcNestedLazy;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isUseOrcColumnNames;
+import static io.prestosql.plugin.hive.ReaderPageSource.noProjectionAdaptation;
 import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
 import static io.prestosql.plugin.hive.orc.OrcPageSource.handleException;
 import static io.prestosql.plugin.hive.util.HiveUtil.isDeserializerClass;
@@ -132,7 +133,7 @@ public class OrcPageSourceFactory
     }
 
     @Override
-    public Optional<ReaderPageSourceWithProjections> createPageSource(
+    public Optional<ReaderPageSource> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -153,7 +154,7 @@ public class OrcPageSourceFactory
 
         // per HIVE-13040 and ORC-162, empty files are allowed
         if (estimatedFileSize == 0) {
-            ReaderPageSourceWithProjections context = noProjectionAdaptation(new EmptyPageSource());
+            ReaderPageSource context = noProjectionAdaptation(new EmptyPageSource());
             return Optional.of(context);
         }
 
@@ -190,7 +191,7 @@ public class OrcPageSourceFactory
                 transaction,
                 stats);
 
-        return Optional.of(new ReaderPageSourceWithProjections(orcPageSource, projectedReaderColumns));
+        return Optional.of(new ReaderPageSource(orcPageSource, projectedReaderColumns));
     }
 
     private static ConnectorPageSource createOrcPageSource(

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -31,8 +31,8 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.ReaderColumns;
 import io.prestosql.plugin.hive.ReaderPageSource;
-import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorPageSource;
@@ -83,8 +83,8 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockSize;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isParquetIgnoreStatistics;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isUseParquetColumnNames;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
-import static io.prestosql.plugin.hive.ReaderProjections.projectSufficientColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectSufficientColumns;
 import static io.prestosql.plugin.hive.parquet.ParquetColumnIOConverter.constructField;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.lang.String.format;
@@ -190,7 +190,7 @@ public class ParquetPageSourceFactory
             fileSchema = fileMetaData.getSchema();
 
             Optional<MessageType> message = projectSufficientColumns(columns)
-                    .map(ReaderProjections::getReaderColumns)
+                    .map(ReaderColumns::get)
                     .orElse(columns).stream()
                     .filter(column -> column.getColumnType() == REGULAR)
                     .map(column -> getColumnType(column, fileSchema, useColumnNames))
@@ -256,8 +256,8 @@ public class ParquetPageSourceFactory
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
         }
 
-        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
-        List<HiveColumnHandle> baseColumns = readerProjections.map(ReaderProjections::getReaderColumns).orElse(columns);
+        Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
+        List<HiveColumnHandle> baseColumns = readerProjections.map(ReaderColumns::get).orElse(columns);
         for (HiveColumnHandle column : baseColumns) {
             checkArgument(column.getColumnType() == REGULAR, "column type must be REGULAR: %s", column);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -31,6 +31,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.spi.PrestoException;
@@ -115,7 +116,7 @@ public class ParquetPageSourceFactory
     }
 
     @Override
-    public Optional<ReaderPageSourceWithProjections> createPageSource(
+    public Optional<ReaderPageSource> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -156,7 +157,7 @@ public class ParquetPageSourceFactory
     /**
      * This method is available for other callers to use directly.
      */
-    public static ReaderPageSourceWithProjections createPageSource(
+    public static ReaderPageSource createPageSource(
             Path path,
             long start,
             long length,
@@ -280,7 +281,7 @@ public class ParquetPageSourceFactory
         }
 
         ConnectorPageSource parquetPageSource = new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build());
-        return new ReaderPageSourceWithProjections(parquetPageSource, readerProjections);
+        return new ReaderPageSource(parquetPageSource, readerProjections);
     }
 
     public static Optional<org.apache.parquet.schema.Type> getParquetType(GroupType groupType, boolean useParquetColumnNames, HiveColumnHandle column)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -25,6 +25,7 @@ import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
 import io.prestosql.plugin.hive.HiveTimestampPrecision;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.plugin.hive.util.FSDataInputStreamTail;
@@ -69,8 +70,8 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
-import static io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections.noProjectionAdaptation;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.prestosql.plugin.hive.ReaderPageSource.noProjectionAdaptation;
 import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.prestosql.rcfile.text.TextRcFileEncoding.DEFAULT_NULL_SEQUENCE;
@@ -111,7 +112,7 @@ public class RcFilePageSourceFactory
     }
 
     @Override
-    public Optional<ReaderPageSourceWithProjections> createPageSource(
+    public Optional<ReaderPageSource> createPageSource(
             Configuration configuration,
             ConnectorSession session,
             Path path,
@@ -200,7 +201,7 @@ public class RcFilePageSourceFactory
                     BUFFER_SIZE);
 
             ConnectorPageSource pageSource = new RcFilePageSource(rcFileReader, projectedReaderColumns);
-            return Optional.of(new ReaderPageSourceWithProjections(pageSource, readerProjections));
+            return Optional.of(new ReaderPageSource(pageSource, readerProjections));
         }
         catch (Throwable e) {
             try {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -25,8 +25,8 @@ import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
 import io.prestosql.plugin.hive.HiveTimestampPrecision;
+import io.prestosql.plugin.hive.ReaderColumns;
 import io.prestosql.plugin.hive.ReaderPageSource;
-import io.prestosql.plugin.hive.ReaderProjections;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.plugin.hive.util.FSDataInputStreamTail;
 import io.prestosql.rcfile.AircompressorCodecFactory;
@@ -71,8 +71,8 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
 import static io.prestosql.plugin.hive.ReaderPageSource.noProjectionAdaptation;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.prestosql.rcfile.text.TextRcFileEncoding.DEFAULT_NULL_SEQUENCE;
 import static io.prestosql.rcfile.text.TextRcFileEncoding.DEFAULT_SEPARATORS;
@@ -145,10 +145,10 @@ public class RcFilePageSourceFactory
             throw new PrestoException(HIVE_BAD_DATA, "RCFile is empty: " + path);
         }
 
-        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+        Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
 
         List<HiveColumnHandle> projectedReaderColumns = readerProjections
-                .map(ReaderProjections::getReaderColumns)
+                .map(ReaderColumns::get)
                 .orElse(columns);
 
         RcFileDataSource dataSource;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -18,7 +18,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider;
 import io.prestosql.plugin.hive.IonSqlQueryBuilder;
-import io.prestosql.plugin.hive.ReaderProjections;
+import io.prestosql.plugin.hive.ReaderColumns;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.RecordCursor;
@@ -37,7 +37,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
 
@@ -80,14 +80,14 @@ public class S3SelectRecordCursorProvider
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + path, e);
         }
 
-        Optional<ReaderProjections> projectedReaderColumns = projectBaseColumns(columns);
+        Optional<ReaderColumns> projectedReaderColumns = projectBaseColumns(columns);
         // Ignore predicates on partial columns for now.
         effectivePredicate = effectivePredicate.filter((column, domain) -> column.isBaseColumn());
 
         String serdeName = getDeserializerClassName(schema);
         if (CSV_SERDES.contains(serdeName)) {
             List<HiveColumnHandle> readerColumns = projectedReaderColumns
-                    .map(ReaderProjections::getReaderColumns)
+                    .map(ReaderColumns::get)
                     .orElse(columns);
 
             IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -37,9 +37,10 @@ import java.util.Properties;
 import java.util.Set;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
+import static io.prestosql.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class S3SelectRecordCursorProvider
         implements HiveRecordCursorProvider
@@ -88,6 +89,7 @@ public class S3SelectRecordCursorProvider
         if (CSV_SERDES.contains(serdeName)) {
             List<HiveColumnHandle> readerColumns = projectedReaderColumns
                     .map(ReaderColumns::get)
+                    .map(readColumns -> readColumns.stream().map(HiveColumnHandle.class::cast).collect(toUnmodifiableList()))
                     .orElse(columns);
 
             IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderColumns.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderColumns.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
-import static io.prestosql.plugin.hive.ReaderProjections.projectSufficientColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectSufficientColumns;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
@@ -33,7 +33,7 @@ import static io.prestosql.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class TestReaderProjections
+public class TestReaderColumns
 {
     private static final List<String> TEST_COLUMN_NAMES = ImmutableList.of(
             "col_bigint",
@@ -56,7 +56,7 @@ public class TestReaderProjections
     public void testNoProjections()
     {
         List<HiveColumnHandle> columns = new ArrayList<>(TEST_FULL_COLUMNS.values());
-        Optional<ReaderProjections> mapping;
+        Optional<ReaderColumns> mapping;
 
         mapping = projectBaseColumns(columns);
         assertTrue(mapping.isEmpty(), "Full columns should not require any adaptation");
@@ -75,15 +75,15 @@ public class TestReaderProjections
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0, 1)),
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0)));
 
-        Optional<ReaderProjections> mapping = projectBaseColumns(columns);
+        Optional<ReaderColumns> mapping = projectBaseColumns(columns);
         assertTrue(mapping.isPresent(), "Full columns should be created for corresponding projected columns");
 
-        List<HiveColumnHandle> readerColumns = mapping.get().getReaderColumns();
+        List<HiveColumnHandle> readerColumns = mapping.get().get();
 
         for (int i = 0; i < columns.size(); i++) {
             HiveColumnHandle column = columns.get(i);
-            int readerIndex = mapping.get().readerColumnPositionForHiveColumnAt(i);
-            HiveColumnHandle readerColumn = mapping.get().readerColumnForHiveColumnAt(i);
+            int readerIndex = mapping.get().getPositionForColumnAt(i);
+            HiveColumnHandle readerColumn = mapping.get().getForColumnAt(i);
             assertEquals(column.getBaseColumn(), readerColumn);
             assertEquals(readerColumns.get(readerIndex), readerColumn);
         }
@@ -99,22 +99,22 @@ public class TestReaderProjections
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0, 1)),
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col_struct_of_non_primitives"), ImmutableList.of(0)));
 
-        Optional<ReaderProjections> readerProjections = projectSufficientColumns(columns);
+        Optional<ReaderColumns> readerProjections = projectSufficientColumns(columns);
         assertTrue(readerProjections.isPresent(), "expected readerProjections to be present");
 
-        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(0), columns.get(0));
-        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(1), columns.get(1));
-        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(2), columns.get(2));
-        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(3), columns.get(4));
-        assertEquals(readerProjections.get().readerColumnForHiveColumnAt(4), columns.get(4));
+        assertEquals(readerProjections.get().getForColumnAt(0), columns.get(0));
+        assertEquals(readerProjections.get().getForColumnAt(1), columns.get(1));
+        assertEquals(readerProjections.get().getForColumnAt(2), columns.get(2));
+        assertEquals(readerProjections.get().getForColumnAt(3), columns.get(4));
+        assertEquals(readerProjections.get().getForColumnAt(4), columns.get(4));
 
-        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(0), 0);
-        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(1), 1);
-        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(2), 2);
-        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(3), 3);
-        assertEquals(readerProjections.get().readerColumnPositionForHiveColumnAt(4), 3);
+        assertEquals(readerProjections.get().getPositionForColumnAt(0), 0);
+        assertEquals(readerProjections.get().getPositionForColumnAt(1), 1);
+        assertEquals(readerProjections.get().getPositionForColumnAt(2), 2);
+        assertEquals(readerProjections.get().getPositionForColumnAt(3), 3);
+        assertEquals(readerProjections.get().getPositionForColumnAt(4), 3);
 
-        List<HiveColumnHandle> readerColumns = readerProjections.get().getReaderColumns();
+        List<HiveColumnHandle> readerColumns = readerProjections.get().get();
         assertEquals(readerColumns.get(0), columns.get(0));
         assertEquals(readerColumns.get(1), columns.get(1));
         assertEquals(readerColumns.get(2), columns.get(2));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderColumns.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderColumns.java
@@ -23,8 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
-import static io.prestosql.plugin.hive.ReaderColumns.projectSufficientColumns;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.hive.HivePageSourceProvider.projectBaseColumns;
+import static io.prestosql.plugin.hive.HivePageSourceProvider.projectSufficientColumns;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
@@ -78,12 +79,14 @@ public class TestReaderColumns
         Optional<ReaderColumns> mapping = projectBaseColumns(columns);
         assertTrue(mapping.isPresent(), "Full columns should be created for corresponding projected columns");
 
-        List<HiveColumnHandle> readerColumns = mapping.get().get();
+        List<HiveColumnHandle> readerColumns = mapping.get().get().stream()
+                .map(HiveColumnHandle.class::cast)
+                .collect(toImmutableList());
 
         for (int i = 0; i < columns.size(); i++) {
             HiveColumnHandle column = columns.get(i);
             int readerIndex = mapping.get().getPositionForColumnAt(i);
-            HiveColumnHandle readerColumn = mapping.get().getForColumnAt(i);
+            HiveColumnHandle readerColumn = (HiveColumnHandle) mapping.get().getForColumnAt(i);
             assertEquals(column.getBaseColumn(), readerColumn);
             assertEquals(readerColumns.get(readerIndex), readerColumn);
         }
@@ -114,7 +117,9 @@ public class TestReaderColumns
         assertEquals(readerProjections.get().getPositionForColumnAt(3), 3);
         assertEquals(readerProjections.get().getPositionForColumnAt(4), 3);
 
-        List<HiveColumnHandle> readerColumns = readerProjections.get().get();
+        List<HiveColumnHandle> readerColumns = readerProjections.get().get().stream()
+                .map(HiveColumnHandle.class::cast)
+                .collect(toImmutableList());
         assertEquals(readerColumns.get(0), columns.get(0));
         assertEquals(readerColumns.get(1), columns.get(1));
         assertEquals(readerColumns.get(2), columns.get(2));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestReaderProjectionsAdapter.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.block.BlockAssertions.assertBlockEquals;
-import static io.prestosql.plugin.hive.ReaderProjections.projectBaseColumns;
+import static io.prestosql.plugin.hive.ReaderColumns.projectBaseColumns;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.ROWTYPE_OF_ROW_AND_PRIMITIVES;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createProjectedColumnHandle;
 import static io.prestosql.plugin.hive.TestHiveReaderProjectionsUtil.createTestFullColumns;
@@ -61,7 +61,7 @@ public class TestReaderProjectionsAdapter
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col"), ImmutableList.of(0, 0)),
                 createProjectedColumnHandle(TEST_FULL_COLUMNS.get("col"), ImmutableList.of(0)));
 
-        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+        Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
 
         List<Object> inputBlockData = new ArrayList<>();
         inputBlockData.add(rowData(rowData(11L, 12L, 13L), 1L));
@@ -85,7 +85,7 @@ public class TestReaderProjectionsAdapter
         inputBlockData.add(rowData(rowData(31L, 32L, 33L), 3L));
 
         // Produce an output page by applying adaptation
-        Optional<ReaderProjections> readerProjections = projectBaseColumns(columns);
+        Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
         ReaderProjectionsAdapter adapter = new ReaderProjectionsAdapter(columns, readerProjections.get());
         Page inputPage = createPage(ImmutableList.of(inputBlockData), adapter.getInputTypes());
         adapter.adaptPage(inputPage).getLoadedPage();

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/benchmark/FileFormat.java
@@ -33,7 +33,6 @@ import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveCompressionCodec;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
-import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
 import io.prestosql.plugin.hive.HivePageSourceProvider;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider;
 import io.prestosql.plugin.hive.HiveRecordCursorProvider.ReaderRecordCursorWithProjections;
@@ -42,6 +41,7 @@ import io.prestosql.plugin.hive.HiveStorageFormat;
 import io.prestosql.plugin.hive.HiveTableHandle;
 import io.prestosql.plugin.hive.HiveType;
 import io.prestosql.plugin.hive.HiveTypeName;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.plugin.hive.RecordFileWriter;
 import io.prestosql.plugin.hive.TableToPartitionMapping;
 import io.prestosql.plugin.hive.orc.OrcPageSourceFactory;
@@ -462,7 +462,7 @@ public enum FileFormat
         List<HiveColumnHandle> readColumns = getBaseColumns(columnNames, columnTypes);
 
         Properties schema = createSchema(format, columnNames, columnTypes);
-        Optional<ReaderPageSourceWithProjections> readerPageSourceWithProjections = pageSourceFactory
+        Optional<ReaderPageSource> readerPageSourceWithProjections = pageSourceFactory
                 .createPageSource(
                         conf,
                         session,
@@ -479,8 +479,8 @@ public enum FileFormat
                         NO_ACID_TRANSACTION);
 
         checkState(readerPageSourceWithProjections.isPresent(), "readerPageSourceWithProjections is not present");
-        checkState(!readerPageSourceWithProjections.get().getProjectedReaderColumns().isPresent(), "projection should not be required");
-        return readerPageSourceWithProjections.get().getConnectorPageSource();
+        checkState(!readerPageSourceWithProjections.get().getReaderColumns().isPresent(), "projection should not be required");
+        return readerPageSourceWithProjections.get().get();
     }
 
     private static List<HiveColumnHandle> getBaseColumns(List<String> columnNames, List<Type> columnTypes)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -21,7 +21,7 @@ import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
-import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.connector.ConnectorPageSource;
 import io.prestosql.spi.predicate.Domain;
@@ -188,7 +188,7 @@ public class TestOrcPageSourceFactory
                 .map(HiveColumnHandle::getName)
                 .collect(toImmutableList());
 
-        Optional<ReaderPageSourceWithProjections> pageSourceWithProjections = PAGE_SOURCE_FACTORY.createPageSource(
+        Optional<ReaderPageSource> pageSourceWithProjections = PAGE_SOURCE_FACTORY.createPageSource(
                 new JobConf(new Configuration(false)),
                 SESSION,
                 new Path(filePath),
@@ -204,10 +204,10 @@ public class TestOrcPageSourceFactory
                 NO_ACID_TRANSACTION);
 
         checkArgument(pageSourceWithProjections.isPresent());
-        checkArgument(pageSourceWithProjections.get().getProjectedReaderColumns().isEmpty(),
+        checkArgument(pageSourceWithProjections.get().getReaderColumns().isEmpty(),
                 "projected columns not expected here");
 
-        ConnectorPageSource pageSource = pageSourceWithProjections.get().getConnectorPageSource();
+        ConnectorPageSource pageSource = pageSourceWithProjections.get().get();
 
         int nationKeyColumn = columnNames.indexOf("n_nationkey");
         int nameColumn = columnNames.indexOf("n_name");

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestTimestampMicros.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestTimestampMicros.java
@@ -16,10 +16,10 @@ package io.prestosql.plugin.hive.parquet;
 import com.google.common.io.Resources;
 import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HivePageSourceFactory;
-import io.prestosql.plugin.hive.HivePageSourceFactory.ReaderPageSourceWithProjections;
 import io.prestosql.plugin.hive.HiveStorageFormat;
 import io.prestosql.plugin.hive.HiveTimestampPrecision;
 import io.prestosql.plugin.hive.HiveType;
+import io.prestosql.plugin.hive.ReaderPageSource;
 import io.prestosql.plugin.hive.acid.AcidTransaction;
 import io.prestosql.plugin.hive.benchmark.FileFormat;
 import io.prestosql.spi.connector.ConnectorPageSource;
@@ -108,7 +108,7 @@ public class TestTimestampMicros
         Properties schema = new Properties();
         schema.setProperty(SERIALIZATION_LIB, HiveStorageFormat.PARQUET.getSerDe());
 
-        ReaderPageSourceWithProjections pageSourceWithProjections = pageSourceFactory.createPageSource(
+        ReaderPageSource pageSourceWithProjections = pageSourceFactory.createPageSource(
                 new Configuration(false),
                 session,
                 new Path(parquetFile.toURI()),
@@ -124,9 +124,9 @@ public class TestTimestampMicros
                 AcidTransaction.NO_ACID_TRANSACTION)
                 .orElseThrow();
 
-        pageSourceWithProjections.getProjectedReaderColumns()
+        pageSourceWithProjections.getReaderColumns()
                 .ifPresent(projections -> { throw new IllegalStateException("Unexpected projections: " + projections); });
 
-        return pageSourceWithProjections.getConnectorPageSource();
+        return pageSourceWithProjections.get();
     }
 }


### PR DESCRIPTION
Preparatory refactoring for #5179 

This contains

* a couple of commits to rename old classes and methods. (readability and separation from Hive*** classes)
* One commit refactoring the adaptation logic to be independent of HiveColumnHandle. This would make it easy to reuse the code for dereference pushdown in iceberg connector. (The modelling of projection is still kept as a series of dereferences. In future, we can change it to a more sophisticated representation if projection pushdown of the two connectors evolves separately.) 
