### PR TITLE
Fix potential deadlock when HttpPageBufferClient exceeds memory limit

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/io/prestosql/operator/HttpPageBufferClient.java
@@ -387,24 +387,24 @@ public final class HttpPageBufferClient
                             }
                         });
                     }
+
+                    // add pages:
+                    // addPages must be called regardless of whether pages is an empty list because
+                    // clientCallback can keep stats of requests and responses. For example, it may
+                    // keep track of how often a client returns empty response and adjust request
+                    // frequency or buffer size.
+                    if (clientCallback.addPages(HttpPageBufferClient.this, pages)) {
+                        pagesReceived.addAndGet(pages.size());
+                        rowsReceived.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
+                    }
+                    else {
+                        pagesRejected.addAndGet(pages.size());
+                        rowsRejected.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
+                    }
                 }
                 catch (PrestoException e) {
                     handleFailure(e, resultFuture);
                     return;
-                }
-
-                // add pages:
-                // addPages must be called regardless of whether pages is an empty list because
-                // clientCallback can keep stats of requests and responses. For example, it may
-                // keep track of how often a client returns empty response and adjust request
-                // frequency or buffer size.
-                if (clientCallback.addPages(HttpPageBufferClient.this, pages)) {
-                    pagesReceived.addAndGet(pages.size());
-                    rowsReceived.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
-                }
-                else {
-                    pagesRejected.addAndGet(pages.size());
-                    rowsRejected.addAndGet(pages.stream().mapToLong(SerializedPage::getPositionCount).sum());
                 }
 
                 synchronized (HttpPageBufferClient.this) {


### PR DESCRIPTION
Comparable changes to https://github.com/prestodb/presto/pull/15220

Prior to this change, if the HttpPageBufferClient caused a task to exceed its memory limit inside of addPages, the exception would bubble to the root of the exchange client callback executor without ever marking the task as failed. If no other operator also saw the memory limit exceeded condition, then the task would become stuck in a deadlocked
state.