### PR TITLE
Add support for yearly partitioned table in BigQuery

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>8.0.0</version>
+                <version>11.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,6 +79,12 @@
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-cloud-bigquerystorage-v1beta1</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/presto-bigquery/src/test/java/io/prestosql/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -73,6 +73,20 @@ public class TestBigQueryIntegrationSmokeTest
         assertEquals((long) actualValues.getOnlyValue(), 1L);
     }
 
+    @Test(enabled = false)
+    public void testSelectFromYearlyPartitionedTable()
+    {
+        BigQuery client = createBigQueryClient();
+
+        executeBigQuerySql(client, "DROP TABLE IF EXISTS test.yearly_partitioned");
+        executeBigQuerySql(client, "CREATE TABLE test.yearly_partitioned (value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, YEAR)");
+        executeBigQuerySql(client, "INSERT INTO test.yearly_partitioned (value, ts) VALUES (1000, '2018-01-01 10:00:00')");
+
+        MaterializedResult actualValues = computeActual("SELECT COUNT(1) FROM test.yearly_partitioned");
+
+        assertEquals((long) actualValues.getOnlyValue(), 1L);
+    }
+
     private static void executeBigQuerySql(BigQuery bigquery, String query)
     {
         QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)


### PR DESCRIPTION
Error message before upgrade: `Illegal Argument - Got unexpected time partitioning YEAR in project xxx in dataset test in table yearly_partitioned`