### PR TITLE
Implement getCatalogSessionProperties

### DIFF
--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -60,7 +60,7 @@ Consider the following set of requirements:
   limit of 1 hour (tighter than the constraint on ``global``).
 
 * All ETL queries (tagged with 'etl') are routed to subgroups under the ``global.pipeline`` group, and must be
-  configured with certain properties to control writer behavior.
+  configured with certain properties to control writer behavior and a hive catalog property.
 
 These requirements can be expressed with the following rules:
 
@@ -84,13 +84,8 @@ These requirements can be expressed with the following rules:
         "clientTags": ["etl"],
         "session_properties": {
           "scale_writers": "true",
-          "writer_min_size": "1GB"
+          "writer_min_size": "1GB",
+          "hive.insert_existing_partitions_behavior": "overwrite"
         }
       }
     ]
-
-Limitations
------------
-
-The session property manager only supports system session properties and does
-not support catalog session properties.

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/AbstractSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/AbstractSessionPropertyManager.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.session;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.session.SessionConfigurationContext;
+import io.prestosql.spi.session.SessionPropertyConfigurationManager;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractSessionPropertyManager
+        implements SessionPropertyConfigurationManager
+{
+    @Override
+    public final Map<String, String> getSystemSessionProperties(SessionConfigurationContext context)
+    {
+        // later properties override earlier properties
+        Map<String, String> combinedProperties = new HashMap<>();
+        for (SessionMatchSpec sessionMatchSpec : getSessionMatchSpecs()) {
+            combinedProperties.putAll(sessionMatchSpec.match(context));
+        }
+        return ImmutableMap.copyOf(combinedProperties);
+    }
+
+    @Override
+    public final Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context)
+    {
+        // NOT IMPLEMENTED YET
+        return ImmutableMap.of();
+    }
+
+    protected abstract List<SessionMatchSpec> getSessionMatchSpecs();
+}

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/db/DbSessionPropertyManager.java
@@ -13,16 +13,15 @@
  */
 package io.prestosql.plugin.session.db;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.session.AbstractSessionPropertyManager;
 import io.prestosql.plugin.session.SessionMatchSpec;
 import io.prestosql.spi.session.SessionConfigurationContext;
 import io.prestosql.spi.session.SessionPropertyConfigurationManager;
 
 import javax.inject.Inject;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * about session property overrides given {@link SessionConfigurationContext}.
  */
 public class DbSessionPropertyManager
-        implements SessionPropertyConfigurationManager
+        extends AbstractSessionPropertyManager
 {
     private final DbSpecsProvider specsProvider;
 
@@ -42,23 +41,8 @@ public class DbSessionPropertyManager
     }
 
     @Override
-    public Map<String, String> getSystemSessionProperties(SessionConfigurationContext context)
+    protected List<SessionMatchSpec> getSessionMatchSpecs()
     {
-        List<SessionMatchSpec> sessionMatchSpecs = specsProvider.get();
-
-        // later properties override earlier properties
-        Map<String, String> combinedProperties = new HashMap<>();
-        for (SessionMatchSpec sessionMatchSpec : sessionMatchSpecs) {
-            combinedProperties.putAll(sessionMatchSpec.match(context));
-        }
-
-        return ImmutableMap.copyOf(combinedProperties);
-    }
-
-    @Override
-    public Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context)
-    {
-        // NOT IMPLEMENTED YET
-        return ImmutableMap.of();
+        return ImmutableList.copyOf(specsProvider.get());
     }
 }

--- a/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/io/prestosql/plugin/session/file/FileSessionPropertyManager.java
@@ -15,13 +15,12 @@ package io.prestosql.plugin.session.file;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
+import io.prestosql.plugin.session.AbstractSessionPropertyManager;
 import io.prestosql.plugin.session.SessionMatchSpec;
-import io.prestosql.spi.session.SessionConfigurationContext;
-import io.prestosql.spi.session.SessionPropertyConfigurationManager;
 
 import javax.inject.Inject;
 
@@ -29,22 +28,20 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class FileSessionPropertyManager
-        implements SessionPropertyConfigurationManager
+        extends AbstractSessionPropertyManager
 {
     public static final JsonCodec<List<SessionMatchSpec>> CODEC = new JsonCodecFactory(
             () -> new ObjectMapperProvider().get().enable(FAIL_ON_UNKNOWN_PROPERTIES))
             .listJsonCodec(SessionMatchSpec.class);
 
-    private final List<SessionMatchSpec> sessionMatchSpecs;
+    private final ImmutableList<SessionMatchSpec> sessionMatchSpecs;
 
     @Inject
     public FileSessionPropertyManager(FileSessionPropertyManagerConfig config)
@@ -53,7 +50,7 @@ public class FileSessionPropertyManager
 
         Path configurationFile = config.getConfigFile().toPath();
         try {
-            sessionMatchSpecs = CODEC.fromJson(Files.readAllBytes(configurationFile));
+            sessionMatchSpecs = ImmutableList.copyOf(CODEC.fromJson(Files.readAllBytes(configurationFile)));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -80,20 +77,8 @@ public class FileSessionPropertyManager
     }
 
     @Override
-    public Map<String, String> getSystemSessionProperties(SessionConfigurationContext context)
+    protected List<SessionMatchSpec> getSessionMatchSpecs()
     {
-        // later properties override earlier properties
-        Map<String, String> combinedProperties = new HashMap<>();
-        for (SessionMatchSpec sessionMatchSpec : sessionMatchSpecs) {
-            combinedProperties.putAll(sessionMatchSpec.match(context));
-        }
-
-        return ImmutableMap.copyOf(combinedProperties);
-    }
-
-    @Override
-    public Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context)
-    {
-        return ImmutableMap.of();
+        return sessionMatchSpecs;
     }
 }

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
@@ -85,7 +85,7 @@ public abstract class AbstractTestSessionPropertyManager
                         "PROPERTY3", "VALUE3",
                         "CATALOG1.PROPERTY1", "VALUE_C1_P1",
                         "CATALOG1.PROPERTY3", "VALUE_C1_P3",
-                        "CATALOG2.PROPERTY1", "VALUE_C2_P1"));
+                        "CATALOG2.PROPERTY", "VALUE_C2"));
         SessionMatchSpec spec2 = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
@@ -93,21 +93,75 @@ public abstract class AbstractTestSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 ImmutableMap.of(
-                        "PROPERTY1", "VALUE1_BIS",
                         "PROPERTY2", "VALUE2",
-                        "CATALOG1.PROPERTY1", "VALUE_C1_P1_BIS",
-                        "CATALOG1.PROPERTY2", "VALUE_C1_P2"));
+                        "CATALOG1.PROPERTY2", "VALUE_C1_P2",
+                        "CATALOG3.PROPERTY", "VALUE_C3"));
 
         assertProperties(
-                ImmutableMap.of("PROPERTY1", "VALUE1_BIS",
+                ImmutableMap.of(
+                        "PROPERTY1", "VALUE1",
                         "PROPERTY2", "VALUE2",
                         "PROPERTY3", "VALUE3"),
-                ImmutableMap.of("CATALOG1", ImmutableMap.of(
-                        "PROPERTY1", "VALUE_C1_P1_BIS",
-                        "PROPERTY2", "VALUE_C1_P2",
-                        "PROPERTY3", "VALUE_C1_P3"),
-                        "CATALOG2", ImmutableMap.of("PROPERTY1", "VALUE_C2_P1")),
+                ImmutableMap.of(
+                        "CATALOG1", ImmutableMap.of(
+                                "PROPERTY1", "VALUE_C1_P1",
+                                "PROPERTY2", "VALUE_C1_P2",
+                                "PROPERTY3", "VALUE_C1_P3"),
+                        "CATALOG2", ImmutableMap.of("PROPERTY", "VALUE_C2"),
+                        "CATALOG3", ImmutableMap.of("PROPERTY", "VALUE_C3")),
                 spec1, spec2);
+    }
+
+    @Test
+    public void testSystemPropertyOverrides()
+            throws Exception
+    {
+        SessionMatchSpec spec1 = matchAllSpec(ImmutableMap.of(
+                "PROPERTY0", "VALUE0",
+                "PROPERTY1", "VALUE1",
+                "PROPERTY2", "VALUE2",
+                "PROPERTY3", "VALUE3"));
+        SessionMatchSpec spec2 = matchAllSpec(ImmutableMap.of(
+                "PROPERTY2", "VALUE2_BIS",
+                "PROPERTY3", "VALUE3_BIS"));
+        SessionMatchSpec spec3 = matchAllSpec(ImmutableMap.of(
+                "PROPERTY0", "VALUE0_TER",
+                "PROPERTY3", "VALUE3_TER"));
+
+        assertProperties(
+                ImmutableMap.of(
+                        "PROPERTY0", "VALUE0_TER",
+                        "PROPERTY1", "VALUE1",
+                        "PROPERTY2", "VALUE2_BIS",
+                        "PROPERTY3", "VALUE3_TER"),
+                ImmutableMap.of(),
+                spec1, spec2, spec3);
+    }
+
+    @Test
+    public void testCatalogPropertyOverrides()
+            throws Exception
+    {
+        SessionMatchSpec spec1 = matchAllSpec(ImmutableMap.of(
+                "CATALOG.PROPERTY0", "VALUE0",
+                "CATALOG.PROPERTY1", "VALUE1",
+                "CATALOG.PROPERTY2", "VALUE2",
+                "CATALOG.PROPERTY3", "VALUE3"));
+        SessionMatchSpec spec2 = matchAllSpec(ImmutableMap.of(
+                "CATALOG.PROPERTY2", "VALUE2_BIS",
+                "CATALOG.PROPERTY3", "VALUE3_BIS"));
+        SessionMatchSpec spec3 = matchAllSpec(ImmutableMap.of(
+                "CATALOG.PROPERTY0", "VALUE0_TER",
+                "CATALOG.PROPERTY3", "VALUE3_TER"));
+
+        assertProperties(
+                ImmutableMap.of(),
+                ImmutableMap.of("CATALOG", ImmutableMap.of(
+                        "PROPERTY0", "VALUE0_TER",
+                        "PROPERTY1", "VALUE1",
+                        "PROPERTY2", "VALUE2_BIS",
+                        "PROPERTY3", "VALUE3_TER")),
+                spec1, spec2, spec3);
     }
 
     @Test
@@ -128,6 +182,25 @@ public abstract class AbstractTestSessionPropertyManager
     }
 
     @Test
+    public void testEmptyPropertyAndCatalogNames()
+            throws Exception
+    {
+        SessionMatchSpec spec1 = matchAllSpec(ImmutableMap.of(
+                "", "VALUE1",
+                "CATALOG1.", "VALUE2",
+                ".PROPERTY", "VALUE3",
+                ".", "VALUE4"));
+        assertProperties(
+                ImmutableMap.of("", "VALUE1"),
+                ImmutableMap.of(
+                        "CATALOG1", ImmutableMap.of("", "VALUE2"),
+                        "", ImmutableMap.of(
+                                "PROPERTY", "VALUE3",
+                                "", "VALUE4")),
+                spec1);
+    }
+
+    @Test
     public void testNoMatch()
             throws Exception
     {
@@ -140,5 +213,16 @@ public abstract class AbstractTestSessionPropertyManager
                 ImmutableMap.of("PROPERTY", "VALUE"));
 
         assertProperties(ImmutableMap.of(), ImmutableMap.of(), spec);
+    }
+
+    private SessionMatchSpec matchAllSpec(Map<String, String> sessionProperties)
+    {
+        return new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                sessionProperties);
     }
 }

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/AbstractTestSessionPropertyManager.java
@@ -35,39 +35,39 @@ public abstract class AbstractTestSessionPropertyManager
             Optional.of(QueryType.DATA_DEFINITION.toString()),
             new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar")));
 
-    protected abstract void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+    protected abstract void assertProperties(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties, SessionMatchSpec... spec)
             throws Exception;
 
     @Test
     public void testResourceGroupMatch()
             throws Exception
     {
-        Map<String, String> properties = ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2");
+        Map<String, String> systemProperties = ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2");
         SessionMatchSpec spec = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("global.pipeline.user_.*")),
-                properties);
+                systemProperties);
 
-        assertProperties(properties, spec);
+        assertProperties(systemProperties, ImmutableMap.of(), spec);
     }
 
     @Test
     public void testClientTagMatch()
             throws Exception
     {
-        ImmutableMap<String, String> properties = ImmutableMap.of("PROPERTY", "VALUE");
+        ImmutableMap<String, String> systemProperties = ImmutableMap.of("PROPERTY", "VALUE");
         SessionMatchSpec spec = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag2")),
                 Optional.empty(),
                 Optional.empty(),
-                properties);
+                systemProperties);
 
-        assertProperties(properties, spec);
+        assertProperties(systemProperties, ImmutableMap.of(), spec);
     }
 
     @Test
@@ -80,16 +80,51 @@ public abstract class AbstractTestSessionPropertyManager
                 Optional.of(ImmutableList.of("tag2")),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY3", "VALUE3"));
+                ImmutableMap.of(
+                        "PROPERTY1", "VALUE1",
+                        "PROPERTY3", "VALUE3",
+                        "CATALOG1.PROPERTY1", "VALUE_C1_P1",
+                        "CATALOG1.PROPERTY3", "VALUE_C1_P3",
+                        "CATALOG2.PROPERTY1", "VALUE_C2_P1"));
         SessionMatchSpec spec2 = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2"));
+                ImmutableMap.of(
+                        "PROPERTY1", "VALUE1_BIS",
+                        "PROPERTY2", "VALUE2",
+                        "CATALOG1.PROPERTY1", "VALUE_C1_P1_BIS",
+                        "CATALOG1.PROPERTY2", "VALUE_C1_P2"));
 
-        assertProperties(ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2", "PROPERTY3", "VALUE3"), spec1, spec2);
+        assertProperties(
+                ImmutableMap.of("PROPERTY1", "VALUE1_BIS",
+                        "PROPERTY2", "VALUE2",
+                        "PROPERTY3", "VALUE3"),
+                ImmutableMap.of("CATALOG1", ImmutableMap.of(
+                        "PROPERTY1", "VALUE_C1_P1_BIS",
+                        "PROPERTY2", "VALUE_C1_P2",
+                        "PROPERTY3", "VALUE_C1_P3"),
+                        "CATALOG2", ImmutableMap.of("PROPERTY1", "VALUE_C2_P1")),
+                spec1, spec2);
+    }
+
+    @Test
+    public void testCatalogPropertiesWithDots()
+            throws Exception
+    {
+        SessionMatchSpec spec1 = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(ImmutableList.of("tag2")),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of("CATALOG.P.R.O.P.E.R.T.Y", "VALUE"));
+        assertProperties(
+                ImmutableMap.of(),
+                ImmutableMap.of("CATALOG", ImmutableMap.of("P.R.O.P.E.R.T.Y", "VALUE")),
+                spec1);
     }
 
     @Test
@@ -104,6 +139,6 @@ public abstract class AbstractTestSessionPropertyManager
                 Optional.of(Pattern.compile("global.interactive.user_.*")),
                 ImmutableMap.of("PROPERTY", "VALUE"));
 
-        assertProperties(ImmutableMap.of(), spec);
+        assertProperties(ImmutableMap.of(), ImmutableMap.of(), spec);
     }
 }

--- a/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/io/prestosql/plugin/session/file/TestFileSessionPropertyManager.java
@@ -32,14 +32,15 @@ public class TestFileSessionPropertyManager
         extends AbstractTestSessionPropertyManager
 {
     @Override
-    protected void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+    protected void assertProperties(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties, SessionMatchSpec... specs)
             throws IOException
     {
         try (TempFile tempFile = new TempFile()) {
             Path configurationFile = tempFile.path();
-            Files.write(configurationFile, CODEC.toJsonBytes(Arrays.asList(spec)));
+            Files.write(configurationFile, CODEC.toJsonBytes(Arrays.asList(specs)));
             SessionPropertyConfigurationManager manager = new FileSessionPropertyManager(new FileSessionPropertyManagerConfig().setConfigFile(configurationFile.toFile()));
-            assertEquals(manager.getSystemSessionProperties(CONTEXT), properties);
+            assertEquals(manager.getSystemSessionProperties(CONTEXT), systemProperties);
+            assertEquals(manager.getCatalogSessionProperties(CONTEXT), catalogProperties);
         }
     }
 }


### PR DESCRIPTION
What: Add support for setting default catalog session properties in FileSessionPropertyManager & DbSessionPropertyManager
How: Use the convention that the first dot in a property name is a separator between a catalog name and a the catalog specific property name

This PR is a replacement for https://github.com/prestosql/presto/pull/5188