### PR TITLE
Make generating the embedded plan JSON representation configurable

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -126,6 +126,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
     public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
+    public static final String EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED = "embedded_json_plan_representations_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -561,6 +562,11 @@ public final class SystemSessionProperties
                         OMIT_DATETIME_TYPE_PRECISION,
                         "Omit precision when rendering datetime type names with default precision",
                         featuresConfig.isOmitDateTimeTypePrecision(),
+                        false),
+                booleanProperty(
+                        EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED,
+                        "Enable creating embedded JSON plan representations for the consumption by the Web UI",
+                        featuresConfig.isEmbeddedJsonPlanRepresentationEnabled(),
                         false));
     }
 
@@ -1007,5 +1013,10 @@ public final class SystemSessionProperties
     public static boolean isOmitDateTimeTypePrecision(Session session)
     {
         return session.getSystemProperty(OMIT_DATETIME_TYPE_PRECISION, Boolean.class);
+    }
+
+    public static boolean isEmbeddedJsonPlanRepresentationEnabled(Session session)
+    {
+        return session.getSystemProperty(EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -129,6 +129,7 @@ public class FeaturesConfig
     private boolean predicatePushdownUseTableProperties = true;
     private boolean ignoreDownstreamPreferences;
     private boolean iterativeRuleBasedColumnPruning = true;
+    private boolean embeddedJsonPlanRepresentationEnabled = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -999,6 +1000,18 @@ public class FeaturesConfig
     public FeaturesConfig setIterativeRuleBasedColumnPruning(boolean iterativeRuleBasedColumnPruning)
     {
         this.iterativeRuleBasedColumnPruning = iterativeRuleBasedColumnPruning;
+        return this;
+    }
+
+    public boolean isEmbeddedJsonPlanRepresentationEnabled()
+    {
+        return embeddedJsonPlanRepresentationEnabled;
+    }
+
+    @Config("embedded-json-plan-representations-enabled")
+    public FeaturesConfig setEmbeddedJsonPlanRepresentationEnabled(boolean embeddedJsonPlanRepresentationEnabled)
+    {
+        this.embeddedJsonPlanRepresentationEnabled = embeddedJsonPlanRepresentationEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanFragmenter.java
@@ -67,6 +67,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.prestosql.SystemSessionProperties.getQueryMaxStageCount;
 import static io.prestosql.SystemSessionProperties.isDynamicScheduleForGroupedExecution;
+import static io.prestosql.SystemSessionProperties.isEmbeddedJsonPlanRepresentationEnabled;
 import static io.prestosql.SystemSessionProperties.isForceSingleNodeOutput;
 import static io.prestosql.operator.StageExecutionDescriptor.ungroupedExecution;
 import static io.prestosql.spi.StandardErrorCode.QUERY_HAS_TOO_MANY_STAGES;
@@ -250,6 +251,11 @@ public class PlanFragmenter
 
             Map<Symbol, Type> symbols = Maps.filterKeys(types.allTypes(), in(dependencies));
 
+            Optional<String> embeddedPlanJson = Optional.empty();
+            if (isEmbeddedJsonPlanRepresentationEnabled(session)) {
+                embeddedPlanJson = Optional.of(jsonFragmentPlan(root, symbols, metadata, session));
+            }
+
             PlanFragment fragment = new PlanFragment(
                     fragmentId,
                     root,
@@ -259,7 +265,7 @@ public class PlanFragmenter
                     properties.getPartitioningScheme(),
                     ungroupedExecution(),
                     statsAndCosts.getForSubplan(root),
-                    Optional.of(jsonFragmentPlan(root, symbols, metadata, session)));
+                    embeddedPlanJson);
 
             return new SubPlan(fragment, properties.getChildren());
         }

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -110,7 +110,8 @@ public class TestFeaturesConfig
                 .setPredicatePushdownUseTableProperties(true)
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
-                .setIterativeRuleBasedColumnPruning(true));
+                .setIterativeRuleBasedColumnPruning(true)
+                .setEmbeddedJsonPlanRepresentationEnabled(true));
     }
 
     @Test
@@ -183,6 +184,7 @@ public class TestFeaturesConfig
                 .put("optimizer.ignore-downstream-preferences", "true")
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
+                .put("embedded-json-plan-representations-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -251,7 +253,8 @@ public class TestFeaturesConfig
                 .setPredicatePushdownUseTableProperties(false)
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
-                .setIterativeRuleBasedColumnPruning(false);
+                .setIterativeRuleBasedColumnPruning(false)
+                .setEmbeddedJsonPlanRepresentationEnabled(false);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Follows on further from changes in https://github.com/prestosql/presto/pull/5192 with comparable changes to https://github.com/prestodb/presto/pull/15235

For particularly complex queries, the embedded JSON plan representation can be quite large and is only present to help display the query plan within the Web UI. Clients like the JDBC driver may want to avoid the extra overhead placed on the coordinator if they don't use this payload and some deployments may want to default to not generating them at all.