### PR TITLE
Direct upload to S3

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -1265,6 +1265,8 @@ public class PrestoS3FileSystem
                             .withRequesterPays(requesterPaysEnabled);
 
             this.uploadId = s3.initiateMultipartUpload(initRequest).getUploadId();
+
+            log.debug("OutputStream for S3 key '%s' using direct upload: %s", keyName, uploadId);
         }
 
         @Override


### PR DESCRIPTION
This change allows the direct upload of data to S3 using the streaming upload. This means that large tables don't first need to sit on worker nodes' local storage and means that the closing of the table is faster