### PR TITLE
Efficiently list data files for SymlinkTextInputFormat

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -140,6 +140,8 @@ public class HiveConfig
 
     private HiveTimestampPrecision timestampPrecision = HiveTimestampPrecision.MILLISECONDS;
 
+    private boolean optimizeSymlinkListing = true;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -993,6 +995,19 @@ public class HiveConfig
     public HiveConfig setTimestampPrecision(HiveTimestampPrecision timestampPrecision)
     {
         this.timestampPrecision = timestampPrecision;
+        return this;
+    }
+
+    public boolean isOptimizeSymlinkListing()
+    {
+        return this.optimizeSymlinkListing;
+    }
+
+    @Config("hive.optimize-symlink-listing")
+    @ConfigDescription("Optimize listing for SymlinkTextFormat tables with files in a single folder.")
+    public HiveConfig setOptimizeSymlinkListing(boolean optimizeSymlinkListing)
+    {
+        this.optimizeSymlinkListing = optimizeSymlinkListing;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -93,6 +93,7 @@ public final class HiveSessionProperties
     private static final String TIMESTAMP_PRECISION = "timestamp_precision";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "experimental_parquet_optimized_writer_enabled";
     private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
+    private static final String OPTIMIZE_SYMLINK_LISTING = "optimize_symlink_listing";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -384,6 +385,10 @@ public final class HiveSessionProperties
                         DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT,
                         "Duration to wait for completion of dynamic filters during split generation for probe side table",
                         hiveConfig.getDynamicFilteringProbeBlockingTimeout(),
+                        false),
+                booleanProperty(OPTIMIZE_SYMLINK_LISTING,
+                        "Optimize listing for SymlinkTextFormat tables with files in a single folder.",
+                        hiveConfig.isOptimizeSymlinkListing(),
                         false));
     }
 
@@ -654,5 +659,10 @@ public final class HiveSessionProperties
     public static Duration getDynamicFilteringProbeBlockingTimeout(ConnectorSession session)
     {
         return session.getProperty(DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT, Duration.class);
+    }
+
+    public static boolean isOptimizeSymlinkListing(ConnectorSession session)
+    {
+        return session.getProperty(OPTIMIZE_SYMLINK_LISTING, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -67,6 +67,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMA
 import static io.prestosql.plugin.hive.HivePartition.UNPARTITIONED_ID;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getDynamicFilteringProbeBlockingTimeout;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isIgnoreAbsentPartitions;
+import static io.prestosql.plugin.hive.HiveSessionProperties.isOptimizeSymlinkListing;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isPartitionUseColumnNames;
 import static io.prestosql.plugin.hive.TableToPartitionMapping.mapColumnsByIndex;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getProtectMode;
@@ -235,6 +236,7 @@ public class HiveSplitManager
                 executor,
                 concurrency,
                 recursiveDfsWalkerEnabled,
+                isOptimizeSymlinkListing(session),
                 !hiveTable.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session),
                 metastore.getValidWriteIds(session, hiveTable)
                         .map(validTxnWriteIdList -> validTxnWriteIdList.getTableValidWriteIdList(table.getDatabaseName() + "." + table.getTableName())));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -535,6 +535,7 @@ public class TestBackgroundHiveSplitLoader
                 threads,
                 false,
                 false,
+                true,
                 Optional.empty());
 
         HiveSplitSource hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader);
@@ -886,6 +887,7 @@ public class TestBackgroundHiveSplitLoader
                 2,
                 false,
                 false,
+                true,
                 validWriteIds);
     }
 
@@ -917,6 +919,7 @@ public class TestBackgroundHiveSplitLoader
                 2,
                 false,
                 false,
+                true,
                 Optional.empty());
     }
 
@@ -942,6 +945,7 @@ public class TestBackgroundHiveSplitLoader
                 2,
                 false,
                 false,
+                true,
                 Optional.empty());
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -98,7 +98,8 @@ public class TestHiveConfig
                 .setPartitionUseColumnNames(false)
                 .setProjectionPushdownEnabled(true)
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(0, TimeUnit.MINUTES))
-                .setTimestampPrecision(HiveTimestampPrecision.MILLISECONDS));
+                .setTimestampPrecision(HiveTimestampPrecision.MILLISECONDS)
+                .setOptimizeSymlinkListing(true));
     }
 
     @Test
@@ -168,6 +169,7 @@ public class TestHiveConfig
                 .put("hive.projection-pushdown-enabled", "false")
                 .put("hive.dynamic-filtering-probe-blocking-timeout", "10s")
                 .put("hive.timestamp-precision", "NANOSECONDS")
+                .put("hive.optimize-symlink-listing", "false")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -233,7 +235,8 @@ public class TestHiveConfig
                 .setPartitionUseColumnNames(true)
                 .setProjectionPushdownEnabled(false)
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(10, TimeUnit.SECONDS))
-                .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS);
+                .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS)
+                .setOptimizeSymlinkListing(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSymlinkInputFormat.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestAvroSymlinkInputFormat.java
@@ -14,8 +14,6 @@
 package io.prestosql.tests.hive;
 
 import com.google.inject.name.Named;
-import io.prestosql.tempto.AfterTestWithContext;
-import io.prestosql.tempto.BeforeTestWithContext;
 import io.prestosql.tempto.ProductTest;
 import io.prestosql.tempto.hadoop.hdfs.HdfsClient;
 import org.testng.annotations.Test;
@@ -45,20 +43,6 @@ public class TestAvroSymlinkInputFormat
     @Named("databases.hive.warehouse_directory_path")
     private String warehouseDirectory;
 
-    @BeforeTestWithContext
-    public void setup()
-            throws Exception
-    {
-        hdfsClient.createDirectory(warehouseDirectory + "/TestAvroSymlinkInputFormat/data");
-        saveResourceOnHdfs("avro/original_data.avro", warehouseDirectory + "/TestAvroSymlinkInputFormat/data/original_data.avro");
-    }
-
-    @AfterTestWithContext
-    public void cleanup()
-    {
-        hdfsClient.delete(warehouseDirectory + "/TestAvroSymlinkInputFormat");
-    }
-
     private void saveResourceOnHdfs(String resource, String location)
             throws IOException
     {
@@ -70,12 +54,14 @@ public class TestAvroSymlinkInputFormat
 
     @Test(groups = {AVRO, STORAGE_FORMATS})
     public void testSymlinkTable()
+            throws IOException
     {
-        onHive().executeQuery("DROP TABLE IF EXISTS test_avro_symlink");
+        String table = "test_avro_symlink";
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
 
         onHive().executeQuery("" +
-                "CREATE TABLE test_avro_symlink " +
-                "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
+                "CREATE TABLE " + table +
+                " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
                 "WITH SERDEPROPERTIES ('avro.schema.literal'='{" +
                 "\"namespace\": \"io.prestosql.tests.hive\"," +
                 "\"name\": \"test_avro_symlink\"," +
@@ -88,11 +74,86 @@ public class TestAvroSymlinkInputFormat
                 "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
                 "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'");
 
-        hdfsClient.delete(warehouseDirectory + "/test_avro_schema_symlink/symlink.txt");
-        hdfsClient.saveFile(warehouseDirectory + "/test_avro_symlink/symlink.txt", format("hdfs://%s/TestAvroSymlinkInputFormat/data/original_data.avro", warehouseDirectory));
+        String tableRoot = warehouseDirectory + '/' + table;
+        String dataDir = warehouseDirectory + "/data";
 
-        assertThat(onPresto().executeQuery("SELECT * FROM test_avro_symlink"))
-                .containsExactly(row("someValue", 1));
-        onHive().executeQuery("DROP TABLE IF EXISTS test_avro_symlink");
+        hdfsClient.createDirectory(tableRoot);
+        saveResourceOnHdfs("avro/original_data.avro", dataDir + "/original_data.avro");
+        hdfsClient.saveFile(dataDir + "/dontread.txt", format("This file will cause an error if read as avro."));
+        hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/original_data.avro", dataDir));
+        assertThat(onPresto().executeQuery("SELECT * FROM test_avro_symlink")).containsExactly(row("someValue", 1));
+        onHive().executeQuery("DROP TABLE " + table);
+        hdfsClient.delete(tableRoot);
+        hdfsClient.delete(dataDir);
+    }
+
+    @Test(groups = {AVRO, STORAGE_FORMATS})
+    public void testSymlinkTableWithMultipleParentDirectories()
+            throws IOException
+    {
+        String table = "test_avro_symlink_with_multiple_parents";
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        onHive().executeQuery("" +
+                "CREATE TABLE " + table +
+                " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
+                "WITH SERDEPROPERTIES ('avro.schema.literal'='{" +
+                "\"namespace\": \"io.prestosql.tests.hive\"," +
+                "\"name\": \"test_avro_symlink\"," +
+                "\"type\": \"record\"," +
+                "\"fields\": [" +
+                "{ \"name\":\"string_col\", \"type\":\"string\"}," +
+                "{ \"name\":\"int_col\", \"type\":\"int\" }" +
+                "]}') " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'");
+
+        String tableRoot = warehouseDirectory + '/' + table;
+        String dataDir = warehouseDirectory + "/data";
+        String anotherDataDir = warehouseDirectory + "/data2";
+
+        hdfsClient.createDirectory(tableRoot);
+        saveResourceOnHdfs("avro/original_data.avro", dataDir + "/original_data.avro");
+        saveResourceOnHdfs("avro/original_data.avro", anotherDataDir + "/more_data.avro");
+        hdfsClient.saveFile(dataDir + "/dontread.txt", format("This file will cause an error if read as avro."));
+        hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/original_data.avro\nhdfs:%s/more_data.avro", dataDir, anotherDataDir));
+        assertThat(onPresto().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactly(row(2));
+        onHive().executeQuery("DROP TABLE " + table);
+        hdfsClient.delete(tableRoot);
+        hdfsClient.delete(dataDir);
+    }
+
+    @Test(groups = {AVRO, STORAGE_FORMATS})
+    public void testSymlinkTableWithNestedDirectory()
+            throws IOException
+    {
+        String table = "test_avro_symlink_with_directory";
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        onHive().executeQuery("" +
+                "CREATE TABLE " + table +
+                " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
+                "WITH SERDEPROPERTIES ('avro.schema.literal'='{" +
+                "\"namespace\": \"io.prestosql.tests.hive\"," +
+                "\"name\": \"test_avro_symlink\"," +
+                "\"type\": \"record\"," +
+                "\"fields\": [" +
+                "{ \"name\":\"string_col\", \"type\":\"string\"}," +
+                "{ \"name\":\"int_col\", \"type\":\"int\" }" +
+                "]}') " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'");
+
+        String tableRoot = warehouseDirectory + '/' + table;
+        String dataDir = warehouseDirectory + "/data/subdir";
+        hdfsClient.createDirectory(dataDir);
+        saveResourceOnHdfs("avro/original_data.avro", dataDir + "/original_data.avro");
+        hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs://%s/", dataDir));
+        assertThat(onPresto().executeQuery("SELECT * FROM " + table)).containsExactly(row("someValue", 1));
+        onHive().executeQuery("DROP TABLE " + table);
+        hdfsClient.delete(tableRoot);
+        hdfsClient.delete(dataDir);
     }
 }


### PR DESCRIPTION
Presto currently uses hadoop code to list the entries in a SymlinkTextInputFormat manifest. This change should reduce the number of listings performed.