### PR TITLE
Simplify extra large domains in JDBC connectors by default

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -68,7 +68,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
+import static io.prestosql.plugin.jdbc.ColumnMapping.disablePushdown;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
@@ -384,7 +384,7 @@ public abstract class BaseJdbcClient
                             NOT_SUPPORTED,
                             "Underlying type that is mapped to VARCHAR is not supported for INSERT: " + typeHandle.getJdbcTypeName().get());
                 },
-                DISABLE_PUSHDOWN));
+                disablePushdown()));
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -141,7 +141,7 @@ public class JdbcMetadata
             for (int i = 0; i < columnHandles.size(); i++) {
                 JdbcColumnHandle column = columnHandles.get(i);
                 ColumnMapping mapping = columnMappings.get(i);
-                DomainPushdownResult pushdownResult = mapping.getPredicatePushdownController().apply(domains.get(column));
+                DomainPushdownResult pushdownResult = mapping.getPredicatePushdownController().apply(session, domains.get(column));
                 supported.put(column, pushdownResult.getPushedDown());
                 unsupported.put(column, pushdownResult.getRemainingFilter());
             }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataConfig.java
@@ -16,10 +16,13 @@ package io.prestosql.plugin.jdbc;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 
+import javax.validation.constraints.Min;
+
 public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
     private boolean allowAggregationPushdown = true;
+    private int domainSizeThreshold = 10_000;
 
     public boolean isAllowDropTable()
     {
@@ -44,6 +47,20 @@ public class JdbcMetadataConfig
     public JdbcMetadataConfig setAllowAggregationPushdown(boolean allowAggregationPushdown)
     {
         this.allowAggregationPushdown = allowAggregationPushdown;
+        return this;
+    }
+
+    @Min(0)
+    public int getDomainSizeThreshold()
+    {
+        return domainSizeThreshold;
+    }
+
+    @Config("domain-size-threshold")
+    @ConfigDescription("Maximum ranges to allow in a tuple domain without compacting it")
+    public JdbcMetadataConfig setDomainSizeThreshold(int domainSizeThreshold)
+    {
+        this.domainSizeThreshold = domainSizeThreshold;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -22,11 +22,13 @@ import javax.inject.Inject;
 import java.util.List;
 
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 
 public class JdbcMetadataSessionProperties
         implements SessionPropertiesProvider
 {
     public static final String ALLOW_AGGREGATION_PUSHDOWN = "allow_aggregation_pushdown";
+    public static final String DOMAIN_SIZE_THRESHOLD = "domain_size_threshold";
 
     private final List<PropertyMetadata<?>> properties;
 
@@ -38,6 +40,11 @@ public class JdbcMetadataSessionProperties
                         ALLOW_AGGREGATION_PUSHDOWN,
                         "Allow aggregation pushdown",
                         jdbcMetadataConfig.isAllowAggregationPushdown(),
+                        false))
+                .add(integerProperty(
+                        DOMAIN_SIZE_THRESHOLD,
+                        "Maximum ranges to allow in a tuple domain without simplifying it",
+                        jdbcMetadataConfig.getDomainSizeThreshold(),
                         false))
                 .build();
     }
@@ -51,5 +58,10 @@ public class JdbcMetadataSessionProperties
     public static boolean isAllowAggregationPushdown(ConnectorSession session)
     {
         return session.getProperty(ALLOW_AGGREGATION_PUSHDOWN, Boolean.class);
+    }
+
+    public static int getDomainSizeThreshold(ConnectorSession session)
+    {
+        return session.getProperty(DOMAIN_SIZE_THRESHOLD, Integer.class);
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/PredicatePushdownController.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/PredicatePushdownController.java
@@ -13,13 +13,14 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.predicate.Domain;
 
 import static java.util.Objects.requireNonNull;
 
 public interface PredicatePushdownController
 {
-    DomainPushdownResult apply(Domain domain);
+    DomainPushdownResult apply(ConnectorSession session, Domain domain);
 
     final class DomainPushdownResult
     {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/QueryBuilder.java
@@ -167,7 +167,7 @@ public class QueryBuilder
     {
         return client.toPrestoType(session, connection, column.getJdbcTypeHandle())
                 .orElseThrow(() -> new IllegalStateException(format("Unsupported type %s with handle %s", column.getColumnType(), column.getJdbcTypeHandle())))
-                .getPredicatePushdownController().apply(domain).getPushedDown();
+                .getPredicatePushdownController().apply(session, domain).getPushedDown();
     }
 
     private List<String> toConjuncts(

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -46,7 +46,7 @@ import static com.google.common.io.BaseEncoding.base16;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
+import static io.prestosql.plugin.jdbc.ColumnMapping.disablePushdown;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.CharType.createCharType;
@@ -269,7 +269,7 @@ public final class StandardColumnMappings
                 VARBINARY,
                 (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)),
                 varbinaryWriteFunction(),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     public static SliceWriteFunction varbinaryWriteFunction()
@@ -374,7 +374,7 @@ public final class StandardColumnMappings
                     return ((time.toNanoOfDay() / NANOSECONDS_PER_MILLISECOND) * PICOSECONDS_PER_MILLISECOND) % PICOSECONDS_PER_DAY;
                 },
                 timeWriteFunction(),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     public static LongWriteFunction timeWriteFunction()

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -29,7 +29,8 @@ public class TestJdbcMetadataConfig
     {
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
                 .setAllowDropTable(false)
-                .setAllowAggregationPushdown(true));
+                .setAllowAggregationPushdown(true)
+                .setDomainSizeThreshold(10_000));
     }
 
     @Test
@@ -38,11 +39,13 @@ public class TestJdbcMetadataConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("allow-drop-table", "true")
                 .put("allow-aggregation-pushdown", "false")
+                .put("domain-size-threshold", "100")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
                 .setAllowDropTable(true)
-                .setAllowAggregationPushdown(false);
+                .setAllowAggregationPushdown(false)
+                .setDomainSizeThreshold(100);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -24,7 +24,6 @@ import io.prestosql.plugin.jdbc.JdbcExpression;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
-import io.prestosql.plugin.jdbc.PredicatePushdownController;
 import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.plugin.jdbc.expression.AggregateFunctionRewriter;
 import io.prestosql.plugin.jdbc.expression.AggregateFunctionRule;
@@ -68,8 +67,8 @@ import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
 import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.plugin.base.util.JsonTypeUtil.jsonParse;
-import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
-import static io.prestosql.plugin.jdbc.ColumnMapping.PUSHDOWN_AND_KEEP;
+import static io.prestosql.plugin.jdbc.ColumnMapping.disablePushdown;
+import static io.prestosql.plugin.jdbc.ColumnMapping.pushDownAndKeep;
 import static io.prestosql.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.prestosql.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.prestosql.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -235,8 +234,7 @@ public class MySqlClient
             case Types.LONGNVARCHAR:
                 VarcharType varcharType = (columnSize <= VarcharType.MAX_LENGTH) ? createVarcharType(columnSize) : createUnboundedVarcharType();
                 // Remote database can be case insensitive.
-                PredicatePushdownController predicatePushdownController = PUSHDOWN_AND_KEEP;
-                return Optional.of(ColumnMapping.sliceMapping(varcharType, varcharReadFunction(varcharType), varcharWriteFunction(), predicatePushdownController));
+                return Optional.of(ColumnMapping.sliceMapping(varcharType, varcharReadFunction(varcharType), varcharWriteFunction(), pushDownAndKeep()));
 
             case Types.DECIMAL:
                 int precision = columnSize;
@@ -371,7 +369,7 @@ public class MySqlClient
                 jsonType,
                 (resultSet, columnIndex) -> jsonParse(utf8Slice(resultSet.getString(columnIndex))),
                 varcharWriteFunction(),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private static boolean isGtidMode(Connection connection)

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClientModule.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.ForBaseJdbc;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.JdbcMetadataConfig;
 import io.prestosql.plugin.jdbc.RetryingConnectionFactory;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import oracle.jdbc.OracleConnection;
@@ -33,6 +34,7 @@ import java.util.Properties;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.prestosql.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
+import static io.prestosql.plugin.oracle.OracleClient.ORACLE_MAX_LIST_EXPRESSIONS;
 
 public class OracleClientModule
         implements Module
@@ -43,6 +45,7 @@ public class OracleClientModule
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(OracleClient.class).in(Scopes.SINGLETON);
         bindSessionPropertiesProvider(binder, OracleSessionProperties.class);
         configBinder(binder).bindConfig(OracleConfig.class);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setDomainSizeThreshold(ORACLE_MAX_LIST_EXPRESSIONS));
     }
 
     @Provides

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseOracleIntegrationSmokeTest.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseOracleIntegrationSmokeTest.java
@@ -161,6 +161,14 @@ public abstract class BaseOracleIntegrationSmokeTest
         }
     }
 
+    @Test
+    public void testDomainSizeThreshold()
+    {
+        assertQuery(
+                "SHOW SESSION LIKE 'oracle.domain_size_threshold'",
+                "VALUES ('oracle.domain_size_threshold', '1000', '1000', 'integer', 'Maximum ranges to allow in a tuple domain without simplifying it')");
+    }
+
     private void predicatePushdownTest(String oracleType, String oracleLiteral, String operator, String filterLiteral)
     {
         String tableName = "test_pdown_" + oracleType.replaceAll("[^a-zA-Z0-9]", "");

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -103,7 +103,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.prestosql.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.prestosql.plugin.base.util.JsonTypeUtil.toJsonValue;
-import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
+import static io.prestosql.plugin.jdbc.ColumnMapping.disablePushdown;
 import static io.prestosql.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.prestosql.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.prestosql.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -590,7 +590,7 @@ public class PostgreSqlClient
                 varcharMapType,
                 varcharMapReadFunction(),
                 hstoreWriteFunction(session),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private ObjectReadFunction varcharMapReadFunction()
@@ -683,7 +683,7 @@ public class PostgreSqlClient
                 jsonType,
                 arrayAsJsonReadFunction(session, baseElementMapping),
                 (statement, index, block) -> { throw new UnsupportedOperationException(); },
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private static SliceReadFunction arrayAsJsonReadFunction(ConnectorSession session, ColumnMapping baseElementMapping)
@@ -744,7 +744,7 @@ public class PostgreSqlClient
                 jsonType,
                 (resultSet, columnIndex) -> jsonParse(utf8Slice(resultSet.getString(columnIndex))),
                 typedVarcharWriteFunction("json"),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private static ColumnMapping typedVarcharColumnMapping(String jdbcTypeName)
@@ -799,7 +799,7 @@ public class PostgreSqlClient
                     }
                 },
                 (statement, index, value) -> { throw new PrestoException(NOT_SUPPORTED, "Money type is not supported for INSERT"); },
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private static SliceWriteFunction uuidWriteFunction()

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -29,6 +29,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -25,7 +25,6 @@ import io.prestosql.plugin.jdbc.JdbcExpression;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
-import io.prestosql.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
 import io.prestosql.plugin.jdbc.SliceWriteFunction;
 import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.plugin.jdbc.expression.AggregateFunctionRewriter;
@@ -41,7 +40,6 @@ import io.prestosql.spi.connector.AggregateFunction;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
-import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.type.CharType;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Type;
@@ -61,7 +59,8 @@ import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
+import static io.prestosql.plugin.jdbc.ColumnMapping.disablePushdown;
+import static io.prestosql.plugin.jdbc.ColumnMapping.fullPushDown;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.charWriteFunction;
@@ -75,10 +74,10 @@ import static java.util.stream.Collectors.joining;
 public class SqlServerClient
         extends BaseJdbcClient
 {
-    private static final Joiner DOT_JOINER = Joiner.on(".");
-
     // SqlServer supports 2100 parameters in prepared statement, let's create a space for about 4 big IN predicates
-    private static final int SQL_SERVER_MAX_LIST_EXPRESSIONS = 500;
+    public static final int SQL_SERVER_MAX_LIST_EXPRESSIONS = 500;
+
+    private static final Joiner DOT_JOINER = Joiner.on(".");
 
     private final AggregateFunctionRewriter aggregateFunctionRewriter;
 
@@ -163,7 +162,7 @@ public class SqlServerClient
                         columnMapping.getType(),
                         columnMapping.getReadFunction(),
                         columnMapping.getWriteFunction(),
-                        this::fullPushDownIfPossilble));
+                        fullPushDown()));
     }
 
     @Override
@@ -249,12 +248,13 @@ public class SqlServerClient
                 VARBINARY,
                 (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)),
                 varbinaryWriteFunction(),
-                DISABLE_PUSHDOWN);
+                disablePushdown());
     }
 
     private static SliceWriteFunction varbinaryWriteFunction()
     {
-        return new SliceWriteFunction() {
+        return new SliceWriteFunction()
+        {
             @Override
             public void set(PreparedStatement statement, int index, Slice value)
                     throws SQLException
@@ -269,13 +269,5 @@ public class SqlServerClient
                 statement.setBytes(index, null);
             }
         };
-    }
-
-    private DomainPushdownResult fullPushDownIfPossilble(Domain domain)
-    {
-        if (domain.getValues().getRanges().getRangeCount() > SQL_SERVER_MAX_LIST_EXPRESSIONS) {
-            return new DomainPushdownResult(domain.simplify(), domain);
-        }
-        return new DomainPushdownResult(domain, Domain.all(domain.getType()));
     }
 }

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClientModule.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClientModule.java
@@ -24,7 +24,11 @@ import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.ForBaseJdbc;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.JdbcMetadataConfig;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.prestosql.plugin.sqlserver.SqlServerClient.SQL_SERVER_MAX_LIST_EXPRESSIONS;
 
 public class SqlServerClientModule
         implements Module
@@ -33,6 +37,7 @@ public class SqlServerClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setDomainSizeThreshold(SQL_SERVER_MAX_LIST_EXPRESSIONS));
     }
 
     @Provides

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
@@ -290,6 +290,14 @@ public class TestSqlServerIntegrationSmokeTest
         sqlServer.execute("SELECT count(*) FROM dbo.orders WHERE " + getLongInClause(0, 10_000));
     }
 
+    @Test
+    public void testDomainSizeThreshold()
+    {
+        assertQuery(
+                "SHOW SESSION LIKE 'sqlserver.domain_size_threshold'",
+                "VALUES ('sqlserver.domain_size_threshold', '500', '500', 'integer', 'Maximum ranges to allow in a tuple domain without simplifying it')");
+    }
+
     /**
      * This test helps to tune TupleDomain simplification threshold.
      */


### PR DESCRIPTION
Based on testing native IN capabilities of various connectors
it makes sense to cap maximum domain size to 10_000 by default.
Large domains can cause query overhead. Connector that
supports larger domains should enable them explicitly.