### PR TITLE
Rename configuration property for JDBC aggregation pushdown

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -62,7 +62,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.prestosql.plugin.jdbc.JdbcMetadataSessionProperties.isAllowAggregationPushdown;
+import static io.prestosql.plugin.jdbc.JdbcMetadataSessionProperties.isAggregationPushdownEnabled;
 import static io.prestosql.spi.StandardErrorCode.PERMISSION_DENIED;
 import static java.util.Objects.requireNonNull;
 
@@ -207,7 +207,7 @@ public class JdbcMetadata
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets)
     {
-        if (!isAllowAggregationPushdown(session)) {
+        if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();
         }
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataConfig.java
@@ -15,11 +15,12 @@ package io.prestosql.plugin.jdbc;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 
 public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
-    private boolean allowAggregationPushdown = true;
+    private boolean aggregationPushdownEnabled = true;
 
     public boolean isAllowDropTable()
     {
@@ -34,16 +35,17 @@ public class JdbcMetadataConfig
         return this;
     }
 
-    public boolean isAllowAggregationPushdown()
+    public boolean isAggregationPushdownEnabled()
     {
-        return allowAggregationPushdown;
+        return aggregationPushdownEnabled;
     }
 
-    @Config("allow-aggregation-pushdown")
-    @ConfigDescription("Allow aggregation pushdown")
-    public JdbcMetadataConfig setAllowAggregationPushdown(boolean allowAggregationPushdown)
+    @Config("aggregation-pushdown.enabled")
+    @LegacyConfig("allow-aggregation-pushdown")
+    @ConfigDescription("Enable aggregation pushdown")
+    public JdbcMetadataConfig setAggregationPushdownEnabled(boolean aggregationPushdownEnabled)
     {
-        this.allowAggregationPushdown = allowAggregationPushdown;
+        this.aggregationPushdownEnabled = aggregationPushdownEnabled;
         return this;
     }
 }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -26,7 +26,7 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 public class JdbcMetadataSessionProperties
         implements SessionPropertiesProvider
 {
-    public static final String ALLOW_AGGREGATION_PUSHDOWN = "allow_aggregation_pushdown";
+    public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> properties;
 
@@ -35,9 +35,9 @@ public class JdbcMetadataSessionProperties
     {
         properties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(booleanProperty(
-                        ALLOW_AGGREGATION_PUSHDOWN,
-                        "Allow aggregation pushdown",
-                        jdbcMetadataConfig.isAllowAggregationPushdown(),
+                        AGGREGATION_PUSHDOWN_ENABLED,
+                        "Enable aggregation pushdown",
+                        jdbcMetadataConfig.isAggregationPushdownEnabled(),
                         false))
                 .build();
     }
@@ -48,8 +48,8 @@ public class JdbcMetadataSessionProperties
         return properties;
     }
 
-    public static boolean isAllowAggregationPushdown(ConnectorSession session)
+    public static boolean isAggregationPushdownEnabled(ConnectorSession session)
     {
-        return session.getProperty(ALLOW_AGGREGATION_PUSHDOWN, Boolean.class);
+        return session.getProperty(AGGREGATION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -29,7 +29,7 @@ public class TestJdbcMetadataConfig
     {
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
                 .setAllowDropTable(false)
-                .setAllowAggregationPushdown(true));
+                .setAggregationPushdownEnabled(true));
     }
 
     @Test
@@ -37,12 +37,12 @@ public class TestJdbcMetadataConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("allow-drop-table", "true")
-                .put("allow-aggregation-pushdown", "false")
+                .put("aggregation-pushdown.enabled", "false")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
                 .setAllowDropTable(true)
-                .setAllowAggregationPushdown(false);
+                .setAggregationPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
The previous name did not match naming convention for feature toggles
like that.