### PR TITLE
Fix AccummulatorCompiler to work with type-specific stack representation

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/AccumulatorCompiler.java
@@ -461,7 +461,11 @@ public final class AccumulatorCompiler
                         expressions.add(index.invoke("getSlice", Slice.class, getChannel, position));
                     }
                     else {
-                        expressions.add(index.invoke("getObject", Object.class, getChannel, position));
+                        BytecodeExpression expression = index.invoke("getObject", Object.class, getChannel, position);
+                        if (parameterType != Object.class) {
+                            expression = expression.cast(parameterType);
+                        }
+                        expressions.add(expression);
                     }
 
                     inputChannel++;
@@ -658,6 +662,9 @@ public final class AccumulatorCompiler
                     .append(getBlockBytecode)
                     .append(position)
                     .invokeInterface(Type.class, "getObject", Object.class, Block.class, int.class);
+            if (sqlType.getJavaType() != Object.class) {
+                block.checkCast(sqlType.getJavaType());
+            }
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationMetadata.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/AggregationMetadata.java
@@ -147,7 +147,7 @@ public class AggregationMetadata
     {
         Class<?>[] parameters = method.type().parameterArray();
         checkArgument(parameters.length > 0, "Aggregation input function must have at least one parameter");
-        checkArgument(parameters.length == dataChannelMetadata.size() + lambdaInterfaces.size(), "Wenlei TODO...");
+        checkArgument(parameters.length == dataChannelMetadata.size() + lambdaInterfaces.size(), "Aggregation input function parameters count match parameter metadata");
         checkArgument(dataChannelMetadata.stream().filter(m -> m.getParameterType() == STATE).count() == stateDescriptors.size(), "Number of state parameter in input function must be the same as size of stateDescriptors");
         checkArgument(dataChannelMetadata.get(0).getParameterType() == STATE, "First parameter must be state");
 

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/TestAccumulatorCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/TestAccumulatorCompiler.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.prestosql.operator.aggregation.state.StateCompiler;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateFactory;
+import io.prestosql.spi.function.AccumulatorStateSerializer;
+import io.prestosql.spi.type.LongTimestamp;
+import io.prestosql.spi.type.RealType;
+import io.prestosql.spi.type.TimestampType;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static io.prestosql.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static io.prestosql.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static io.prestosql.util.Reflection.methodHandle;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAccumulatorCompiler
+{
+    @Test
+    public void testAccumulatorCompilerForTypeSpecificObjectParameter()
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(TestAccumulatorCompiler.class.getClassLoader());
+
+        TimestampType parameterType = TimestampType.TIMESTAMP_NANOS;
+        assertThat(parameterType.getJavaType()).isEqualTo(LongTimestamp.class);
+
+        Class<? extends AccumulatorState> stateInterface = LongTimestampAggregation.State.class;
+        AccumulatorStateSerializer<?> stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateInterface, classLoader);
+
+        MethodHandle inputFunction = methodHandle(LongTimestampAggregation.class, "input", LongTimestampAggregation.State.class, LongTimestamp.class);
+        MethodHandle combineFunction = methodHandle(LongTimestampAggregation.class, "combine", LongTimestampAggregation.State.class, LongTimestampAggregation.State.class);
+        MethodHandle outputFunction = methodHandle(LongTimestampAggregation.class, "output", LongTimestampAggregation.State.class, BlockBuilder.class);
+        AggregationMetadata metadata = new AggregationMetadata(
+                "longTimestampAggregation",
+                ImmutableList.of(
+                        new AggregationMetadata.ParameterMetadata(STATE),
+                        new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, parameterType)),
+                inputFunction,
+                Optional.empty(),
+                combineFunction,
+                outputFunction,
+                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
+                        stateInterface,
+                        stateSerializer,
+                        stateFactory)),
+                RealType.REAL);
+
+        // test if we can compile aggregation
+        assertThat(AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader)).isNotNull();
+
+        // TODO test if aggregation actually works...
+    }
+
+    public static class LongTimestampAggregation
+    {
+        public interface State
+                extends AccumulatorState {}
+
+        public static void input(State state, LongTimestamp value) {}
+
+        public static void combine(State stateA, State stateB) {}
+
+        public static void output(State state, BlockBuilder blockBuilder) {}
+    }
+}


### PR DESCRIPTION
Fix aggregation compiler to work fine if input function is defined for
Type which uses non standard stack representation. E.g. TIMESTAMP(p>6)
uses LongTimestamp on stack.