### PR TITLE
Fix documentation source syntax

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -99,7 +99,7 @@ This property controls how often the list of available Elasticsearch nodes is re
 This property is optional; the default is ``1m``.
 
 ``elasticsearch.ignore-publish-address``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Enable or disable using the address published by Elasticsearch to connect for
 queries.

--- a/presto-docs/src/main/sphinx/release/release-0.70.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.70.rst
@@ -29,8 +29,8 @@ write your queries without a ``FROM`` clause or use the ``VALUES`` syntax.
 Presto Verifier
 ---------------
 
-There is a new project, :doc:`/installation/verifier`, which can be used to
-verify a set of queries against two different clusters.
+There is a new project, Presto Verifier, which can be used to verify a set of
+queries against two different clusters.
 
 Connector Improvements
 ----------------------


### PR DESCRIPTION
Currently presto-doc build fails.. this fixes the two syntax problems