### PR TITLE
Fix testcontainers/Docker incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1246,7 +1246,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.14.3</version>
+                <version>1.15.0-rc2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -156,6 +156,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-memsql/pom.xml
+++ b/presto-memsql/pom.xml
@@ -134,6 +134,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/StatisticsFetcher.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/StatisticsFetcher.java
@@ -17,11 +17,11 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.MemoryStatsConfig;
 import com.github.dockerjava.api.model.StatisticNetworksConfig;
 import com.github.dockerjava.api.model.Statistics;
-import com.github.dockerjava.core.InvocationBuilder;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import net.jodah.failsafe.FailsafeExecutor;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.shaded.com.github.dockerjava.core.InvocationBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;


### PR DESCRIPTION
Docker for Mac issued a new release that is incompatible
with the org.testcontainers version 1.14.3 library.  This
commit updates to testcontainers version 1.15.0-rc2, released
today, and fixes the consequences of that upgrade.

Here is the backtrace you'll see before these changes when you run a product test:

```
2020-10-01T14:16:30.173-0700	INFO	main	org.testcontainers.utility.RegistryAuthLocator	Credential helper/store (docker-credential-desktop) does not have credentials for index.docker.io
2020-10-01T14:16:30.629-0700	WARN	testcontainers-ryuk	org.testcontainers.utility.ResourceReaper	Can not connect to Ryuk at localhost:32768
java.net.SocketException: Broken pipe (Write failed)
	at java.base/java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.base/java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:110)
	at java.base/java.net.SocketOutputStream.write(SocketOutputStream.java:138)
	at org.testcontainers.utility.ResourceReaper$FilterRegistry.register(ResourceReaper.java:424)
	at org.testcontainers.utility.ResourceReaper.lambda$null$1(ResourceReaper.java:152)
	at org.rnorth.ducttape.ratelimits.RateLimiter.doWhenReady(RateLimiter.java:27)
	at org.testcontainers.utility.ResourceReaper.lambda$start$2(ResourceReaper.java:136)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
