### PR TITLE
Updating IN clause and standardizing query formatting

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -394,7 +394,8 @@ is equivalent to::
         (origin_state, destination_state),
         (origin_state),
         (destination_state),
-        ());
+        ()
+    );
 
 .. code-block:: none
 
@@ -470,7 +471,8 @@ is logically equivalent to::
     FROM shipping
     GROUP BY GROUPING SETS (
         (origin_state, destination_state, origin_zip),
-        (origin_state, destination_state));
+        (origin_state, destination_state)
+    );
 
 .. code-block:: none
 
@@ -515,7 +517,8 @@ is equivalent to::
         (origin_state, destination_state),
         (origin_state),
         (destination_state),
-        ());
+        ()
+    );
 
 However, if the query uses the ``DISTINCT`` quantifier for the ``GROUP BY``::
 
@@ -535,7 +538,8 @@ only unique grouping sets are generated::
         (origin_state, destination_state),
         (origin_state),
         (destination_state),
-        ());
+        ()
+    );
 
 The default set quantifier is ``ALL``.
 
@@ -558,9 +562,10 @@ below::
            grouping(origin_state, origin_zip, destination_state)
     FROM shipping
     GROUP BY GROUPING SETS (
-            (origin_state),
-            (origin_state, origin_zip),
-            (destination_state));
+        (origin_state),
+        (origin_state, origin_zip),
+        (destination_state)
+    );
 
 .. code-block:: none
 
@@ -766,7 +771,7 @@ In the following example, the clause only applies to the select statement.
 
     INSERT INTO some_table
     SELECT * FROM another_table
-    ORDER BY field
+    ORDER BY field;
 
 Since tables in SQL are inherently unordered, and the ``ORDER BY`` clause in
 this case does not result in any difference, but negatively impacts performance
@@ -780,7 +785,7 @@ the outcome of the overall statement, is a nested query:
     SELECT *
     FROM some_table
         JOIN (SELECT * FROM another_table ORDER BY field) u
-        ON some_table.key = u.key
+        ON some_table.key = u.key;
 
 More background information and details can be found in
 `a blog post about this optimization <https://prestosql.io/blog/2019/06/03/redundant-order-by.html>`_.
@@ -888,7 +893,9 @@ clause be present. The result set consists of the same set of leading rows
 and all of the rows in the same peer group as the last of them ('ties')
 as established by the ordering in the ``ORDER BY`` clause. The result set is sorted::
 
-    SELECT name, regionkey FROM nation ORDER BY regionkey FETCH FIRST ROW WITH TIES;
+    SELECT name, regionkey 
+    FROM nation 
+    ORDER BY regionkey FETCH FIRST ROW WITH TIES;
 
 .. code-block:: none
 
@@ -1076,7 +1083,7 @@ computing the rows to be joined::
     SELECT name, x, y
     FROM nation
     CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
-    CROSS JOIN LATERAL (SELECT x || ')' AS y)
+    CROSS JOIN LATERAL (SELECT x || ')' AS y);
 
 Qualifying Column Names
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -1121,7 +1128,11 @@ The ``EXISTS`` predicate determines if a subquery returns any rows::
 
     SELECT name
     FROM nation
-    WHERE EXISTS (SELECT * FROM region WHERE region.regionkey = nation.regionkey)
+    WHERE EXISTS (
+         SELECT * 
+         FROM region 
+         WHERE region.regionkey = nation.regionkey
+    );
 
 IN
 ^^
@@ -1132,7 +1143,11 @@ standard rules for nulls. The subquery must produce exactly one column::
 
     SELECT name
     FROM nation
-    WHERE regionkey IN (SELECT regionkey FROM region)
+    WHERE regionkey IN (
+         SELECT regionkey 
+         FROM region
+         WHERE name = 'AMERICA' OR name = 'AFRICA'
+    );
 
 Scalar Subquery
 ^^^^^^^^^^^^^^^
@@ -1143,6 +1158,6 @@ row. The returned value is ``NULL`` if the subquery produces no rows::
 
     SELECT name
     FROM nation
-    WHERE regionkey = (SELECT max(regionkey) FROM region)
+    WHERE regionkey = (SELECT max(regionkey) FROM region);
 
 .. note:: Currently only single column can be returned from the scalar subquery.


### PR DESCRIPTION
This replaces https://github.com/prestosql/presto/pull/4528, which will be closed.

- IN query WHERE clause was updated
- Semi colons added as suggested
- Doc reviewed and updates for semicolon usage 
- Formatting applied to IN example as suggested, and all queries cleaned up for line length and indentation as per example