### PR TITLE
Add support for COMMENT ON COLUMN in Oracle connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -20,6 +20,13 @@ properties in the file:
     connection-user=root
     connection-password=secret
 
+.. note::
+    Oracle does not expose metadata comment via ``REMARKS`` column by default
+    in JDBC driver. This can be enabled by appending ``remarksReporting=true``
+    to ``connection-url`` in properties. See `Additional Oracle Performance Extensions
+    <https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/performance-extensions.html#GUID-96A38C6D-A288-4E0B-9F03-E711C146632B>`_
+    for more details.
+
 By default, the Oracle connector uses connection pooling for performance
 improvement. The below configuration shows the typical default values. To update
 them, change the properties in the catalog configuration file:

--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -49,7 +49,7 @@ sales.
 Querying Oracle
 ---------------
 
-The Oracle connector provides a schema for every Oracle database. 
+The Oracle connector provides a schema for every Oracle database.
 
 Run ``SHOW SCHEMAS`` to see the available Oracle databases::
 
@@ -159,9 +159,9 @@ For example:
 
 - If ``unsupported-type.handling`` is set to ``FAIL``, then the
   querying of an unsupported table fails.
-- If ``unsupported-type.handling`` is set to ``IGNORE``, 
+- If ``unsupported-type.handling`` is set to ``IGNORE``,
   then you can't see the unsupported types in Presto.
-- If ``unsupported-type.handling`` is set to ``CONVERT_TO_VARCHAR``, 
+- If ``unsupported-type.handling`` is set to ``CONVERT_TO_VARCHAR``,
   then the column is exposed as unbounded ``VARCHAR``.
 
 Presto to Oracle type mapping
@@ -234,13 +234,13 @@ An Oracle ``NUMBER(p, s)`` maps to Presto's ``DECIMAL(p, s)`` except in these
 conditions:
 
 - No precision is specified for the column (example: ``NUMBER`` or
-  ``NUMBER(*)``), unless ``oracle.number.default-scale`` is set. 
-- Scale (``s`` ) is greater than precision. 
-- Precision (``p`` ) is greater than 38. 
+  ``NUMBER(*)``), unless ``oracle.number.default-scale`` is set.
+- Scale (``s`` ) is greater than precision.
+- Precision (``p`` ) is greater than 38.
 - Scale is negative and the difference between ``p`` and ``s`` is greater than
   38, unless ``oracle.number.rounding-mode`` is set to a different value than
-  ``UNNECESSARY``. 
-   
+  ``UNNECESSARY``.
+
 If ``s`` is negative, ``NUMBER(p, s)`` maps to ``DECIMAL(p + s, 0)``.
 
 For Oracle ``NUMBER`` (without precision and scale), you can change
@@ -308,19 +308,19 @@ Type mapping configuration properties
 
     - ``IGNORE``
   * - ``oracle.number.default-scale``
-    - ``number_default_scale``               
-    - Default Presto ``DECIMAL`` scale for Oracle ``NUMBER`` (without precision 
-      and scale) date type. When not set then such column is treated as not 
+    - ``number_default_scale``
+    - Default Presto ``DECIMAL`` scale for Oracle ``NUMBER`` (without precision
+      and scale) date type. When not set then such column is treated as not
       supported.
     - not set
   * - ``oracle.number.rounding-mode``
     - ``number_rounding_mode``
-    - Rounding mode for the Oracle ``NUMBER`` data type. This is useful when 
-      Oracle ``NUMBER`` data type specifies higher scale than is supported in 
+    - Rounding mode for the Oracle ``NUMBER`` data type. This is useful when
+      Oracle ``NUMBER`` data type specifies higher scale than is supported in
       Presto. Possible values are:
 
-      - ``UNNECESSARY`` - Rounding mode to assert that the 
-        requested operation has an exact result, 
+      - ``UNNECESSARY`` - Rounding mode to assert that the
+        requested operation has an exact result,
         hence no rounding is necessary.
       - ``CEILING`` - Rounding mode to round towards
         positive infinity.
@@ -345,7 +345,7 @@ Synonyms
 --------
 
 Based on performance reasons, Presto disables support for Oracle ``SYNONYM``. To
-include ``SYNONYM``, add the following configuration property: 
+include ``SYNONYM``, add the following configuration property:
 
 .. code-block:: none
 

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -20,7 +20,9 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DoubleWriteFunction;
+import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.LongWriteFunction;
 import io.prestosql.plugin.jdbc.PredicatePushdownController;
@@ -478,5 +480,16 @@ public class OracleClient
             return writeMapping;
         }
         throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    @Override
+    public void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    {
+        String sql = format(
+                "COMMENT ON COLUMN %s.%s IS '%s'",
+                quoted(handle.getRemoteTableName()),
+                quoted(column.getColumnName()),
+                comment.orElse(""));
+        execute(identity, sql);
     }
 }

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleDistributedQueries.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestOracleDistributedQueries.java
@@ -83,12 +83,6 @@ public class TestOracleDistributedQueries
     }
 
     @Override
-    protected boolean supportsCommentOnColumn()
-    {
-        return false;
-    }
-
-    @Override
     public void testCreateSchema()
     {
         // schema creation is not supported

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestingOracleServer.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestingOracleServer.java
@@ -87,7 +87,7 @@ public class TestingOracleServer
     @Override
     public String getJdbcUrl()
     {
-        return "jdbc:oracle:thin:@" + getHost() + ":" + getOraclePort() + ":" + getSid();
+        return "jdbc:oracle:thin:@" + getHost() + ":" + getOraclePort() + ":" + getSid() + "?remarksReporting=true";
     }
 
     public void execute(String sql)


### PR DESCRIPTION
Related to #5333

Oracle doesn't support `IS NULL` syntax to remove existing comment.

We may want to enable `remarksReporting` in  OraclePoolConnectionFactory, but Oracle official documentation mentions:
> remarksReporting: If the value of this property is "true", OracleDatabaseMetaData will include remarks in the meta data. This can result in a substantial reduction in performance.
https://docs.oracle.com/cd/E16338_01/appdev.112/e13995/oracle/jdbc/pool/OracleDataSource.html