### PR TITLE
Display schema in the presto-benchmark-driver result

### DIFF
--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkResultsPrinter.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkResultsPrinter.java
@@ -63,6 +63,7 @@ public class BenchmarkResultsPrinter
         // print header row
         printRow(ImmutableList.builder()
                 .add("suite")
+                .add("schema")
                 .add("query")
                 .addAll(tagNames)
                 .add("wallTimeP50")
@@ -91,6 +92,7 @@ public class BenchmarkResultsPrinter
 
         printRow(ImmutableList.builder()
                 .add(result.getSuite().getName())
+                .add(benchmarkSchema.getName())
                 .add(result.getBenchmarkQuery().getName())
                 .addAll(tagNames.stream().map(forMap(tags, "")).iterator())
                 .add(NANOSECONDS.toMillis((long) result.getWallTimeNanos().getMedian()))


### PR DESCRIPTION
Since the presto-benchmark-driver does not show the schema name in the result, it's difficult to compare the performance between varied schemas when we specify multiple schemas in `suites.json`. 

```
$ cat suites.json
{
  "mysuite": {
    "schema": [ "schema1", "schema2" ],
    "session": {
    },
    "query": []
  }
}
```

This PR modifies the driver to display the schema information too so that the comparison between multiple schemas can be easier. 

## Before

```
$ /path/to/presto-benchmark-driver/target/presto-benchmark-driver-342-SNAPSHOT-executable.jar --suite-config /path/to/suites.json --suite mysuite
suite	query	wallTimeP50	wallTimeMean	wallTimeStd	processCpuTimeP50	processCpuTimeMean	processCpuTimeStd	queryCpuTimeP50	queryCpuTimeMean	queryCpuTimeStd	status	error
mysuite	query1	10440	10397	115	63920	71353	16479	5664	5848	338	pass
mysuite	query1	12071	12037	96	13460	13436	535	1874	1876	9	pass
mysuite	query2	227170	236654	18988	600270	-201583	1401557	31388	29966	2930	pass
mysuite	query2	248531	201950	91342	122830	116373	33761	4788	5039	444	pass
```

## After

```
$ /path/to/presto-benchmark-driver/target/presto-benchmark-driver-342-SNAPSHOT-executable.jar --suite-config /path/to/suites.json --suite mysuite
suite	schema	query	wallTimeP50	wallTimeMean	wallTimeStd	processCpuTimeP50	processCpuTimeMean	processCpuTimeStd	queryCpuTimeP50	queryCpuTimeMean	queryCpuTimeStd	status	error
mysuite	schema1	query1	10440	10397	115	63920	71353	16479	5664	5848	338	pass
mysuite	schema2	query1	12071	12037	96	13460	13436	535	1874	1876	9	pass
mysuite	schema1	query2	227170	236654	18988	600270	-201583	1401557	31388	29966	2930	pass
mysuite	schema2	query2	248531	201950	91342	122830	116373	33761	4788	5039	444	pass
```