### PR TITLE
Do not stop attached environment

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -289,6 +289,8 @@ public final class TestRun
                                 .withStartupTimeout(ofMinutes(15)));
             });
 
+            builder.setAttached(attach);
+
             return builder.build(getStandardListeners(logsDirBase));
         }
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
@@ -217,7 +217,7 @@ public final class Environment
             while (testContainer.isRunning()) {
                 Thread.sleep(10000); // check every 10 seconds
 
-                if (!allContainersHealthy(containers)) {
+                if (!attached && !allContainersHealthy(containers)) {
                     log.warn("Environment %s is not healthy, interrupting tests", name);
                     return ENVIRONMENT_FAILED_EXIT_CODE;
                 }
@@ -277,7 +277,7 @@ public final class Environment
         }
     }
 
-    public static boolean allContainersHealthy(Iterable<DockerContainer> containers)
+    private static boolean allContainersHealthy(Iterable<DockerContainer> containers)
     {
         return Streams.stream(containers)
                 .allMatch(Environment::containerIsHealthy);

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/Environment.java
@@ -383,10 +383,10 @@ public final class Environment
         private static List<Ulimit> standardUlimits()
         {
             return ImmutableList.of(
-                // Number of open file descriptors
-                new Ulimit("nofile", 65535L, 65535L),
-                // Number of processes
-                new Ulimit("nproc", 8096L, 8096L));
+                    // Number of open file descriptors
+                    new Ulimit("nofile", 65535L, 65535L),
+                    // Number of processes
+                    new Ulimit("nproc", 8096L, 8096L));
         }
 
         public Builder configureContainer(String logicalName, Consumer<DockerContainer> configurer)


### PR DESCRIPTION
Do not stop attached environment

Environment to which `test run` is attaching is controlled by separate
process and so it should be stopped by that process.
Thanks to this environment can be reused multiple times.
