### PR TITLE
Mark TestRaptorIntegrationSmokeTest.testCreateBucketedTable as flaky

### DIFF
--- a/presto-raptor-legacy/pom.xml
+++ b/presto-raptor-legacy/pom.xml
@@ -225,6 +225,12 @@
 
         <dependency>
             <groupId>io.prestosql</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
             <artifactId>presto-tpch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorIntegrationSmokeTest.java
@@ -22,6 +22,7 @@ import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.MaterializedRow;
 import io.prestosql.testing.QueryRunner;
+import io.prestosql.testng.services.Flaky;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
@@ -421,6 +422,8 @@ public class TestRaptorIntegrationSmokeTest
     }
 
     @Test
+    @Flaky(issue = "https://github.com/prestosql/presto/issues/1977",
+            match = "(?s)AssertionError.*query.*SELECT count(DISTINCT \"\\$shard_uuid\") FROM orders_bucketed.*Actual rows.*\\[\\d\\d\\].*Expected rows.*\\[100\\]")
     public void testCreateBucketedTable()
     {
         assertUpdate("" +


### PR DESCRIPTION
Relates to https://github.com/prestosql/presto/issues/1977