### PR TITLE
Validate that same dynamic filter domain is set

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/io/prestosql/server/DynamicFilterService.java
@@ -659,7 +659,8 @@ public class DynamicFilterService
                 // Narrowing down of task dynamic filter is not supported.
                 // Currently, task dynamic filters are derived from join and semi-join,
                 // which produce just a single version of dynamic filter.
-                checkState(taskDomains.put(taskId, domain) == null, "Task dynamic filter is set twice");
+                Domain previousDomain = taskDomains.put(taskId, domain);
+                checkState(previousDomain == null || domain.equals(previousDomain), "Different task domains were set");
             });
         }
 


### PR DESCRIPTION
DynamicFilterFetcher can make two subsequent requests
with same local DF version (triggered by TaskStatus
updates). In such case same DF might be received twice.

Fixes: https://github.com/prestosql/presto/issues/5424