### PR TITLE
Hide Delta Lake tables

### DIFF
--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHive.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHive.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Parameters;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHive
         extends AbstractTestHive
@@ -64,5 +65,19 @@ public class TestHive
         }
 
         super.testGetPartitionSplitsTableOfflinePartition();
+    }
+
+    @Override
+    public void testHideDeltaLakeTables()
+    {
+        assertThatThrownBy(super::testHideDeltaLakeTables)
+                .hasMessageMatching("(?s)\n" +
+                        "Expecting\n" +
+                        " <\\[.*\\b(\\w+.tmp_presto_test_presto_delta_lake_table_\\w+)\\b.*]>\n" +
+                        "not to contain\n" +
+                        " <\\[\\1]>\n" +
+                        "but found.*");
+
+        throw new SkipException("not supported");
     }
 }

--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.hive;
 import alluxio.client.table.TableMasterClient;
 import alluxio.conf.PropertyKey;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.alluxio.AlluxioHiveMetastore;
 import io.prestosql.plugin.hive.metastore.alluxio.AlluxioHiveMetastoreConfig;
 import io.prestosql.plugin.hive.metastore.alluxio.AlluxioMetastoreModule;
@@ -60,7 +61,7 @@ public class TestHiveAlluxioMetastore
         alluxioConfig.setMasterAddress(this.alluxioAddress);
         TableMasterClient client = AlluxioMetastoreModule.createCatalogMasterClient(alluxioConfig);
         hdfsEnvironment = new HdfsEnvironment(createTestHdfsConfiguration(), new HdfsConfig(), new NoHdfsAuthentication());
-        setup(SCHEMA, hiveConfig, new AlluxioHiveMetastore(client), hdfsEnvironment);
+        setup(SCHEMA, hiveConfig, new AlluxioHiveMetastore(client, new MetastoreConfig()), hdfsEnvironment);
     }
 
     private int getHiveVersionMajor()
@@ -149,6 +150,13 @@ public class TestHiveAlluxioMetastore
     public void testHiveViewsAreNotSupported()
     {
         // Alluxio metastore does not support insert/update operations
+    }
+
+    @Override
+    public void testHideDeltaLakeTables()
+    {
+        // Alluxio metastore does not support create operations
+        throw new SkipException("not supported");
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -298,6 +298,7 @@ public class HiveMetadata
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final boolean translateHiveViews;
+    private final boolean hideDeltaLakeTables;
     private final String prestoVersion;
     private final HiveStatisticsProvider hiveStatisticsProvider;
     private final AccessControlMetadata accessControlMetadata;
@@ -310,6 +311,7 @@ public class HiveMetadata
             boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
             boolean translateHiveViews,
+            boolean hideDeltaLakeTables,
             TypeManager typeManager,
             LocationService locationService,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
@@ -327,6 +329,7 @@ public class HiveMetadata
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.translateHiveViews = translateHiveViews;
+        this.hideDeltaLakeTables = hideDeltaLakeTables;
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.hiveStatisticsProvider = requireNonNull(hiveStatisticsProvider, "hiveStatisticsProvider is null");
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
@@ -748,15 +751,19 @@ public class HiveMetadata
         if (!filterSchema(tableName.getSchemaName())) {
             return ImmutableList.of();
         }
+
+        Optional<Table> optionalTable;
         try {
-            if (metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), tableName.getTableName()).isEmpty()) {
-                return ImmutableList.of();
-            }
+            optionalTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), tableName.getTableName());
         }
         catch (HiveViewNotSupportedException e) {
             // exists, would be returned by listTables from schema
+            return ImmutableList.of(tableName);
         }
-        return ImmutableList.of(tableName);
+        return optionalTable
+                .filter(table -> !hideDeltaLakeTables || !isDeltaLakeTable(table))
+                .map(table -> ImmutableList.of(tableName))
+                .orElseGet(ImmutableList::of);
     }
 
     /**

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -18,6 +18,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
 import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.security.AccessControlMetadataFactory;
 import io.prestosql.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
@@ -41,6 +42,7 @@ public class HiveMetadataFactory
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final boolean translateHiveViews;
+    private final boolean hideDeltaLakeTables;
     private final long perTransactionCacheMaximumSize;
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
@@ -60,6 +62,7 @@ public class HiveMetadataFactory
     public HiveMetadataFactory(
             CatalogName catalogName,
             HiveConfig hiveConfig,
+            MetastoreConfig metastoreConfig,
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             HivePartitionManager partitionManager,
@@ -85,6 +88,7 @@ public class HiveMetadataFactory
                 hiveConfig.isTranslateHiveViews(),
                 hiveConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 hiveConfig.getHiveTransactionHeartbeatInterval(),
+                metastoreConfig.isHideDeltaLakeTables(),
                 typeManager,
                 locationService,
                 partitionUpdateCodec,
@@ -108,6 +112,7 @@ public class HiveMetadataFactory
             boolean translateHiveViews,
             long perTransactionCacheMaximumSize,
             Optional<Duration> hiveTransactionHeartbeatInterval,
+            boolean hideDeltaLakeTables,
             TypeManager typeManager,
             LocationService locationService,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
@@ -122,6 +127,7 @@ public class HiveMetadataFactory
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.translateHiveViews = translateHiveViews;
+        this.hideDeltaLakeTables = hideDeltaLakeTables;
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
 
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -160,6 +166,7 @@ public class HiveMetadataFactory
                 writesToNonManagedTablesEnabled,
                 createsOfNonManagedTablesEnabled,
                 translateHiveViews,
+                hideDeltaLakeTables,
                 typeManager,
                 locationService,
                 partitionUpdateCodec,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
@@ -22,6 +22,7 @@ import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
 import io.prestosql.plugin.base.CatalogName;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.orc.OrcFileWriterFactory;
 import io.prestosql.plugin.hive.orc.OrcPageSourceFactory;
@@ -70,6 +71,7 @@ public class HiveModule
 
         binder.bind(DirectoryLister.class).to(CachingDirectoryLister.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(HiveConfig.class);
+        configBinder(binder).bindConfig(MetastoreConfig.class);
 
         binder.bind(HiveSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(HiveTableProperties.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class MetastoreConfig
+{
+    private boolean hideDeltaLakeTables;
+
+    public boolean isHideDeltaLakeTables()
+    {
+        return hideDeltaLakeTables;
+    }
+
+    @Config("hive.hide-delta-lake-tables")
+    @ConfigDescription("Hide Delta Lake tables in table listings")
+    public MetastoreConfig setHideDeltaLakeTables(boolean hideDeltaLakeTables)
+    {
+        this.hideDeltaLakeTables = hideDeltaLakeTables;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -32,6 +32,7 @@ import io.prestosql.plugin.hive.metastore.HiveColumnStatistics;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
 import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
@@ -53,6 +54,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
@@ -70,9 +72,11 @@ public class AlluxioHiveMetastore
     private final TableMasterClient client;
 
     @Inject
-    public AlluxioHiveMetastore(TableMasterClient client)
+    public AlluxioHiveMetastore(TableMasterClient client, MetastoreConfig metastoreConfig)
     {
         this.client = requireNonNull(client);
+        requireNonNull(metastoreConfig, "metastoreConfig is null");
+        checkArgument(!metastoreConfig.isHideDeltaLakeTables(), "Hiding Delta Lake tables is not supported"); // TODO
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -39,6 +39,7 @@ import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
 import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
@@ -244,6 +245,7 @@ import static io.prestosql.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKE
 import static io.prestosql.plugin.hive.util.HiveUtil.columnExtraInfo;
 import static io.prestosql.plugin.hive.util.HiveUtil.toPartitionValues;
 import static io.prestosql.plugin.hive.util.HiveWriteUtils.createDirectory;
+import static io.prestosql.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.prestosql.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -281,7 +283,9 @@ import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -732,7 +736,13 @@ public abstract class AbstractTestHive
 
         hdfsEnvironment = new HdfsEnvironment(createTestHdfsConfiguration(), new HdfsConfig(), new NoHdfsAuthentication());
         HiveMetastore metastore = cachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, hiveConfig, new ThriftMetastoreConfig(), hdfsEnvironment, false)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(
+                        metastoreLocator,
+                        hiveConfig,
+                        new MetastoreConfig(),
+                        new ThriftMetastoreConfig(),
+                        hdfsEnvironment,
+                        false)),
                 executor,
                 Duration.valueOf("1m"),
                 Optional.of(Duration.valueOf("15s")),
@@ -764,6 +774,7 @@ public abstract class AbstractTestHive
                 false,
                 1000,
                 Optional.empty(),
+                true,
                 TYPE_MANAGER,
                 locationService,
                 partitionUpdateCodec,
@@ -2574,6 +2585,74 @@ public abstract class AbstractTestHive
             catch (PrestoException e) {
                 assertEquals(e.getErrorCode(), NOT_SUPPORTED.toErrorCode());
             }
+        }
+    }
+
+    @Test
+    public void testHideDeltaLakeTables()
+    {
+        ConnectorSession session = newSession();
+        HiveIdentity identity = new HiveIdentity(session);
+        SchemaTableName tableName = temporaryTable("presto_delta_lake_table");
+
+        Table.Builder table = Table.builder()
+                .setDatabaseName(tableName.getSchemaName())
+                .setTableName(tableName.getTableName())
+                .setOwner(session.getUser())
+                .setTableType(MANAGED_TABLE.name())
+                .setDataColumns(List.of(new Column("a_column", HIVE_STRING, Optional.empty())))
+                .setParameter(HiveMetadata.SPARK_TABLE_PROVIDER_KEY, HiveMetadata.DELTA_LAKE_PROVIDER);
+        table.getStorageBuilder()
+                .setStorageFormat(fromHiveStorageFormat(PARQUET))
+                .setLocation(getTableDefaultLocation(
+                        metastoreClient.getDatabase(tableName.getSchemaName()).orElseThrow(),
+                        new HdfsContext(session.getIdentity()),
+                        hdfsEnvironment,
+                        tableName.getSchemaName(),
+                        tableName.getTableName()).toString());
+        PrincipalPrivileges principalPrivileges = new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of());
+        metastoreClient.createTable(identity, table.build(), principalPrivileges);
+
+        try {
+            // Verify the table was created as a Delta Lake table
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                metadata.beginQuery(session);
+                assertThatThrownBy(() -> getTableHandle(metadata, tableName))
+                        .hasMessage("Cannot query Delta Lake table");
+            }
+
+            // Assert that table is hidden
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+
+                // TODO (https://github.com/prestosql/presto/issues/5426) these assertions should use information_schema instead of metadata directly,
+                //  as information_schema or MetadataManager may apply additional logic
+
+                // list all tables
+                assertThat(metadata.listTables(session, Optional.empty()))
+                        .doesNotContain(tableName);
+
+                // list all tables in a schema
+                assertThat(metadata.listTables(session, Optional.of(tableName.getSchemaName())))
+                        .doesNotContain(tableName);
+
+                // list all columns
+                assertThat(metadata.listTableColumns(session, new SchemaTablePrefix()).keySet())
+                        .doesNotContain(tableName);
+
+                // list all columns in a schema
+                assertThat(metadata.listTableColumns(session, new SchemaTablePrefix(tableName.getSchemaName())).keySet())
+                        .doesNotContain(tableName);
+
+                // list all columns in a table
+                assertThat(metadata.listTableColumns(session, new SchemaTablePrefix(tableName.getSchemaName(), tableName.getTableName())).keySet())
+                        .doesNotContain(tableName);
+            }
+        }
+        finally {
+            // Clean up
+            metastoreClient.dropTable(identity, tableName.getSchemaName(), tableName.getTableName(), true);
         }
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -30,6 +30,7 @@ import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.PrincipalPrivileges;
 import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.plugin.hive.metastore.cache.CachingHiveMetastore;
@@ -182,8 +183,15 @@ public abstract class AbstractTestHiveFileSystem
         HivePartitionManager hivePartitionManager = new HivePartitionManager(config);
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, new HdfsConfig(), new NoHdfsAuthentication());
+        MetastoreConfig metastoreConfig = new MetastoreConfig();
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), hdfsEnvironment, false)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(
+                        metastoreLocator,
+                        new HiveConfig(),
+                        metastoreConfig,
+                        new ThriftMetastoreConfig(),
+                        hdfsEnvironment,
+                        false)),
                 executor,
                 getBasePath(),
                 hdfsEnvironment);
@@ -192,6 +200,7 @@ public abstract class AbstractTestHiveFileSystem
         metadataFactory = new HiveMetadataFactory(
                 new CatalogName("hive"),
                 config,
+                metastoreConfig,
                 metastoreClient,
                 hdfsEnvironment,
                 hivePartitionManager,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
@@ -23,6 +23,7 @@ import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.plugin.hive.testing.TestingHivePlugin;
@@ -93,6 +94,7 @@ public final class HiveQueryRunner
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
             return new FileHiveMetastore(
                     HDFS_ENVIRONMENT,
+                    new MetastoreConfig(),
                     new FileHiveMetastoreConfig()
                             .setCatalogDirectory(baseDir.toURI().toString())
                             .setMetastoreUser("test")

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.hive;
 
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import org.testng.SkipException;
@@ -31,6 +32,8 @@ public class TestHiveFileMetastore
         File baseDir = new File(tempDir, "metastore");
         return new FileHiveMetastore(
                 HDFS_ENVIRONMENT,
+                new MetastoreConfig()
+                        .setHideDeltaLakeTables(true),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveInMemoryMetastore.java
@@ -17,6 +17,7 @@ import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.InMemoryThriftMetastore;
 import io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
+import org.testng.SkipException;
 
 import java.io.File;
 
@@ -42,5 +43,11 @@ public class TestHiveInMemoryMetastore
     public void testTransactionDeleteInsert()
     {
         // InMemoryHiveMetastore does not check whether partition exist in createPartition and dropPartition
+    }
+
+    @Override
+    public void testHideDeltaLakeTables()
+    {
+        throw new SkipException("not supported");
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/TestMetastoreConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive.metastore;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(MetastoreConfig.class)
+                .setHideDeltaLakeTables(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.hide-delta-lake-tables", "true")
+                .build();
+
+        MetastoreConfig expected = new MetastoreConfig()
+                .setHideDeltaLakeTables(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.hive.HiveConfig;
 import io.prestosql.plugin.hive.HiveMetastoreClosure;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.Partition;
 import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.plugin.hive.metastore.thrift.BridgingHiveMetastore;
@@ -106,7 +107,7 @@ public class TestCachingHiveMetastore
     private ThriftHiveMetastore createThriftHiveMetastore()
     {
         MetastoreLocator metastoreLocator = new MockMetastoreLocator(mockClient);
-        return new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new ThriftMetastoreConfig(), HDFS_ENVIRONMENT, false);
+        return new ThriftHiveMetastore(metastoreLocator, new HiveConfig(), new MetastoreConfig(), new ThriftMetastoreConfig(), HDFS_ENVIRONMENT, false);
     }
 
     @Test

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.hive.HiveTestUtils;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.PartitionWithStatistics;
 import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.spi.connector.ColumnMetadata;
@@ -132,7 +133,14 @@ public class TestHiveGlueMetastore
         glueConfig.setAssumeCanonicalPartitionKeys(true);
 
         Executor executor = new BoundedExecutor(this.executor, 10);
-        return new GlueHiveMetastore(HDFS_ENVIRONMENT, glueConfig, new DisabledGlueColumnStatisticsProvider(), executor, Optional.empty());
+        return new GlueHiveMetastore(
+                HDFS_ENVIRONMENT,
+                new MetastoreConfig()
+                        .setHideDeltaLakeTables(true),
+                glueConfig,
+                new DisabledGlueColumnStatisticsProvider(),
+                executor,
+                Optional.empty());
     }
 
     @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -33,6 +33,7 @@ import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.plugin.hive.testing.TestingHiveConnectorFactory;
@@ -103,6 +104,7 @@ public class TestConnectorPushdownRulesWithHive
 
         metastore = new FileHiveMetastore(
                 environment,
+                new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -31,6 +31,7 @@ import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.plugin.hive.testing.TestingHiveConnectorFactory;
@@ -88,6 +89,7 @@ public class TestHiveProjectionPushdownIntoTableScan
 
         HiveMetastore metastore = new FileHiveMetastore(
                 environment,
+                new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergModule.java
@@ -20,6 +20,7 @@ import com.google.inject.multibindings.Multibinder;
 import io.prestosql.plugin.hive.FileFormatDataSourceStats;
 import io.prestosql.plugin.hive.HiveHdfsModule;
 import io.prestosql.plugin.hive.HiveNodePartitioningProvider;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.orc.OrcReaderConfig;
 import io.prestosql.plugin.hive.orc.OrcWriterConfig;
 import io.prestosql.plugin.hive.parquet.ParquetReaderConfig;
@@ -46,6 +47,7 @@ public class IcebergModule
         binder.bind(IcebergTransactionManager.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(IcebergConfig.class);
+        configBinder(binder).bindConfig(MetastoreConfig.class);
 
         binder.bind(IcebergSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableProperties.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.plugin.hive.testing.TestingHivePlugin;
@@ -65,6 +66,7 @@ public class TestIcebergMetadataListing
 
         metastore = new FileHiveMetastore(
                 hdfsEnvironment,
+                new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -23,6 +23,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.plugin.tpch.TpchPlugin;
@@ -71,6 +72,7 @@ public class TestIcebergOrcMetricsCollection
 
         HiveMetastore metastore = new FileHiveMetastore(
                 hdfsEnvironment,
+                new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -22,6 +22,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
 import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
 import io.prestosql.testing.AbstractTestQueryFramework;
@@ -62,6 +63,7 @@ public class TestIcebergSystemTables
 
         HiveMetastore metastore = new FileHiveMetastore(
                 hdfsEnvironment,
+                new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));


### PR DESCRIPTION
Hive connector cannot read from Delta Lake tables and some users prefer
not to see such tables at all.