### PR TITLE
Move DefaultSystemAccessControl to presto-plugin-toolkit

### DIFF
--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -23,6 +23,7 @@ import io.prestosql.connector.CatalogName;
 import io.prestosql.eventlistener.EventListenerManager;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.plugin.base.security.AllowAllSystemAccessControl;
+import io.prestosql.plugin.base.security.DefaultSystemAccessControl;
 import io.prestosql.plugin.base.security.FileBasedSystemAccessControl;
 import io.prestosql.plugin.base.security.ForwardingSystemAccessControl;
 import io.prestosql.plugin.base.security.ReadOnlySystemAccessControl;

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/DefaultSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/DefaultSystemAccessControl.java
@@ -11,9 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.prestosql.security;
+package io.prestosql.plugin.base.security;
 
-import io.prestosql.plugin.base.security.AllowAllSystemAccessControl;
 import io.prestosql.spi.security.SystemAccessControl;
 import io.prestosql.spi.security.SystemAccessControlFactory;
 import io.prestosql.spi.security.SystemSecurityContext;


### PR DESCRIPTION
Move DefaultSystemAccessControl to presto-plugin-toolkit

That way it could be accessible by plugins so they can leverage default
behaviour.
