### PR TITLE
Bump Airlift Resolver to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -790,7 +790,7 @@
             <dependency>
                 <groupId>io.airlift.resolver</groupId>
                 <artifactId>resolver</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
             </dependency>
 
             <!-- 3rd party -->


### PR DESCRIPTION
The fix for using `https` URL instead of `http` in `ArtifactResolver` was released in 1.6. (issue https://support.sonatype.com/hc/en-us/articles/360041287334, PR https://github.com/airlift/resolver/pull/18)

Without this bump, dependencies are not downloaded for plugins being loaded from a pom file, and silently catches exceptions of the following form, later appearing as cryptic ClassNotFound errors.

 ```
Could not transfer artifact com.sap.cloud.db.jdbc:ngdbc:pom:2.6.28 from/to central (http://repo.maven.apache.org/maven2): Failed to transfer http://repo.maven.apache.org/maven2/com/sap/cloud/db/jdbc/ngdbc/2.6.28/ngdbc-2.6.28.pom. Error code 501, HTTPS Required
```

cc @martint 