### PR TITLE
Add default implementation for checkCanSetSystemSessionProperty

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
@@ -56,6 +56,7 @@ import static io.prestosql.spi.security.AccessDeniedException.denyRevokeTablePri
 import static io.prestosql.spi.security.AccessDeniedException.denySelectColumns;
 import static io.prestosql.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.prestosql.spi.security.AccessDeniedException.denySetSchemaAuthorization;
+import static io.prestosql.spi.security.AccessDeniedException.denySetSystemSessionProperty;
 import static io.prestosql.spi.security.AccessDeniedException.denySetUser;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowColumns;
 import static io.prestosql.spi.security.AccessDeniedException.denyShowCreateSchema;
@@ -160,7 +161,10 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName);
+    default void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    {
+        denySetSystemSessionProperty(propertyName);
+    }
 
     /**
      * Check if identity is allowed to access the specified catalog


### PR DESCRIPTION
Add default implementation for checkCanSetSystemSessionProperty

This was the only method that was missing this.
