### PR TITLE
Remove redundant code

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -400,18 +400,12 @@ public class JdbcMetadata
     {
         JdbcOutputTableHandle handle = (JdbcOutputTableHandle) tableHandle;
         jdbcClient.commitCreateTable(JdbcIdentity.from(session), handle);
-        clearRollback();
         return Optional.empty();
     }
 
     private void setRollback(Runnable action)
     {
         checkState(rollbackAction.compareAndSet(null, action), "rollback action is already set");
-    }
-
-    private void clearRollback()
-    {
-        rollbackAction.set(null);
     }
 
     public void rollback()


### PR DESCRIPTION
JDBC connectors do not support transactions, as indicated by
`io.prestosql.plugin.jdbc.JdbcConnector#isSingleStatementWritesOnly`.