### PR TITLE
Document case-insensitive-name-matching in MongoDB

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -71,6 +71,13 @@ At startup, this connector tries guessing fields' types, but it might not be cor
 
 This property is optional; the default is ``_schema``.
 
+``mongodb.case-insensitive-name-matching``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Match database and collection names case insensitively.
+
+This property is optional; the default is ``false``.
+
 ``mongodb.credentials``
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Related to Slack question: https://prestosql.slack.com/archives/CFLB9AMBN/p1602186266204100