### PR TITLE
Return date/time in UTC in JMX connector

### DIFF
--- a/presto-jmx/src/main/java/io/prestosql/plugin/jmx/JmxRecordSetProvider.java
+++ b/presto-jmx/src/main/java/io/prestosql/plugin/jmx/JmxRecordSetProvider.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.connector.InMemoryRecordSet;
 import io.prestosql.spi.connector.RecordSet;
-import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
@@ -34,7 +33,6 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -45,13 +43,12 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Objects.requireNonNull;
 
 public class JmxRecordSetProvider
         implements ConnectorRecordSetProvider
 {
-    private static final TimeZoneKey JVM_TIME_ZONE = TimeZoneKey.getTimeZoneKey(ZoneId.systemDefault().getId());
-
     private final MBeanServer mbeanServer;
     private final String nodeId;
     private final JmxHistoricalData jmxHistoricalData;
@@ -79,7 +76,7 @@ public class JmxRecordSetProvider
                 row.add(objectName);
             }
             else if (jmxColumn.getColumnName().equals(JmxMetadata.TIMESTAMP_COLUMN_NAME)) {
-                row.add(packDateTimeWithZone(entryTimestamp, JVM_TIME_ZONE));
+                row.add(packDateTimeWithZone(entryTimestamp, UTC_KEY));
             }
             else {
                 Optional<Object> optionalValue = attributes.get(jmxColumn.getColumnName());


### PR DESCRIPTION
Using server zone introduces ambiguity problem during DST change.
Presto engine has no problem representing and distinguishing
`(point-in-time, zone)` pairs regardless of DST.  However, due to
how they are formatted for the client, client can no longer distinguish
values within summer→winter DST change.

In the example below, rows with `increment` 1 and 2 represent different
point in time, but are rendered the same for the client.

```
presto> SELECT
     ->     increment,
     ->     from_unixtime(base + increment * 3600, 'America/Los_Angeles')
     -> FROM (VALUES(1572766200)) t(base)
     -> CROSS JOIN UNNEST(sequence(0, 3)) u(increment);
     ->
 increment |                    _col1
-----------+---------------------------------------------
         0 | 2019-11-03 00:30:00.000 America/Los_Angeles
         1 | 2019-11-03 01:30:00.000 America/Los_Angeles
         2 | 2019-11-03 01:30:00.000 America/Los_Angeles
         3 | 2019-11-03 02:30:00.000 America/Los_Angeles
(4 rows)
```