### PR TITLE
Allow Decimal values in String format to be extracted as numbers from…

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -613,7 +613,8 @@ abstract class AbstractPrestoResultSet
             return null;
         }
 
-        return toBigDecimal(String.valueOf(value));
+        return toBigDecimal(String.valueOf(value))
+                .orElseThrow(() -> new SQLException("Value is not a number: " + value));
     }
 
     @Override
@@ -1751,18 +1752,21 @@ abstract class AbstractPrestoResultSet
             return ((Boolean) value) ? 1 : 0;
         }
         if (value instanceof String) {
-            return toBigDecimal((String) value);
+            Optional<BigDecimal> bigDecimal = toBigDecimal((String) value);
+            if (bigDecimal.isPresent()) {
+                return bigDecimal.get();
+            }
         }
         throw new SQLException("Value is not a number: " + value.getClass().getCanonicalName());
     }
 
-    private static BigDecimal toBigDecimal(String value) throws SQLException
+    private static Optional<BigDecimal> toBigDecimal(String value)
     {
         try {
-            return new BigDecimal(value);
+            return Optional.of(new BigDecimal(value));
         }
         catch (NumberFormatException ne) {
-            throw new SQLException("Value is not a number: " + value);
+            return Optional.empty();
         }
     }
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -613,7 +613,7 @@ abstract class AbstractPrestoResultSet
             return null;
         }
 
-        return convertStrToBigDecimal(String.valueOf(value));
+        return toBigDecimal(String.valueOf(value));
     }
 
     @Override
@@ -1751,19 +1751,17 @@ abstract class AbstractPrestoResultSet
             return ((Boolean) value) ? 1 : 0;
         }
         if (value instanceof String) {
-            return convertStrToBigDecimal((String) value);
+            return toBigDecimal((String) value);
         }
         throw new SQLException("Value is not a number: " + value.getClass().getCanonicalName());
     }
 
-    private static BigDecimal convertStrToBigDecimal(String value) throws SQLException
+    private static BigDecimal toBigDecimal(String value) throws SQLException
     {
-        try
-        {
+        try {
             return new BigDecimal(value);
         }
-        catch (NumberFormatException ne)
-        {
+        catch (NumberFormatException ne) {
             throw new SQLException("Value is not a number: " + value);
         }
     }

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -1757,7 +1757,7 @@ abstract class AbstractPrestoResultSet
                 return bigDecimal.get();
             }
         }
-        throw new SQLException("Value is not a number: " + value.getClass().getCanonicalName());
+        throw new SQLException("Value is not a number: " + value);
     }
 
     private static Optional<BigDecimal> toBigDecimal(String value)

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -613,7 +613,7 @@ abstract class AbstractPrestoResultSet
             return null;
         }
 
-        return new BigDecimal(String.valueOf(value));
+        return convertStrToBigDecimal(String.valueOf(value));
     }
 
     @Override
@@ -1750,7 +1750,22 @@ abstract class AbstractPrestoResultSet
         if (value instanceof Boolean) {
             return ((Boolean) value) ? 1 : 0;
         }
+        if (value instanceof String) {
+            return convertStrToBigDecimal((String) value);
+        }
         throw new SQLException("Value is not a number: " + value.getClass().getCanonicalName());
+    }
+
+    private static BigDecimal convertStrToBigDecimal(String value) throws SQLException
+    {
+        try
+        {
+            return new BigDecimal(value);
+        }
+        catch (NumberFormatException ne)
+        {
+            throw new SQLException("Value is not a number: " + value);
+        }
     }
 
     static SQLException resultsException(QueryStatusInfo results)

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -95,9 +95,9 @@ public abstract class BaseTestJdbcResultSet
             });
 
             checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123e-1'", Types.VARCHAR, (rs, column) -> {
-                        assertEquals(rs.getDouble(column), 12.3);
-                        assertEquals(rs.getLong(column), 12);
-                        assertEquals(rs.getFloat(column), 12.3f);
+                assertEquals(rs.getDouble(column), 12.3);
+                assertEquals(rs.getLong(column), 12);
+                assertEquals(rs.getFloat(column), 12.3f);
             });
 
             checkRepresentation(connectedStatement.getStatement(), "DOUBLE '123.456'", Types.DOUBLE, (rs, column) -> {

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -87,26 +87,29 @@ public abstract class BaseTestJdbcResultSet
             checkRepresentation(connectedStatement.getStatement(), "VARCHAR ''", Types.VARCHAR, (rs, column) -> {
                 assertThatThrownBy(() -> rs.getLong(column))
                         .isInstanceOf(SQLException.class)
-                        .hasMessage("Value is not a number: java.lang.String");
+                        .hasMessage("Value is not a number: ");
 
                 assertThatThrownBy(() -> rs.getDouble(column))
                         .isInstanceOf(SQLException.class)
-                        .hasMessage("Value is not a number: java.lang.String");
+                        .hasMessage("Value is not a number: ");
             });
 
             checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123e-1'", Types.VARCHAR, (rs, column) -> {
-                        assertEquals(rs.getDouble(column), 12.3D);
+                        assertEquals(rs.getDouble(column), 12.3);
                         assertEquals(rs.getLong(column), 12);
+                        assertEquals(rs.getFloat(column), 12.3f);
             });
 
             checkRepresentation(connectedStatement.getStatement(), "DOUBLE '123.456'", Types.DOUBLE, (rs, column) -> {
-                assertEquals(rs.getDouble(column), 123.456D);
+                assertEquals(rs.getDouble(column), 123.456);
                 assertEquals(rs.getLong(column), 123);
+                assertEquals(rs.getFloat(column), 123.456f);
             });
 
             checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123'", Types.VARCHAR, (rs, column) -> {
-                assertEquals(rs.getDouble(column), 123D);
+                assertEquals(rs.getDouble(column), 123.0);
                 assertEquals(rs.getLong(column), 123);
+                assertEquals(rs.getFloat(column), 123f);
             });
         }
     }
@@ -117,13 +120,12 @@ public abstract class BaseTestJdbcResultSet
     {
         try (ConnectedStatement connectedStatement = newStatement()) {
             checkRepresentation(connectedStatement.getStatement(), "0.1", Types.DECIMAL, new BigDecimal("0.1"));
-            checkRepresentation(connectedStatement.getStatement(), "DECIMAL '0.1'", Types.DECIMAL, new BigDecimal("0.1"));
-            checkRepresentation(connectedStatement.getStatement(), "0.12", Types.DECIMAL,
-                    (rs, column) -> assertEquals(rs.getDouble(column), 0.12D));
-            checkRepresentation(connectedStatement.getStatement(), "DECIMAL '0.1'", Types.DECIMAL,
-                    (rs, column) -> assertEquals(rs.getDouble(column), 0.1D));
-            checkRepresentation(connectedStatement.getStatement(), "DECIMAL '0.1'", Types.DECIMAL,
-                    (rs, column) -> assertEquals(rs.getLong(column), 0));
+            checkRepresentation(connectedStatement.getStatement(), "DECIMAL '0.12'", Types.DECIMAL, (rs, column) -> {
+                assertEquals(rs.getBigDecimal(column), new BigDecimal("0.12"));
+                assertEquals(rs.getDouble(column), 0.12);
+                assertEquals(rs.getLong(column), 0);
+                assertEquals(rs.getFloat(column), 0.12f);
+            });
 
             long outsideOfDoubleExactRange = 9223372036854775774L;
             //noinspection ConstantConditions

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -87,26 +87,27 @@ public abstract class BaseTestJdbcResultSet
             checkRepresentation(connectedStatement.getStatement(), "VARCHAR ''", Types.VARCHAR, (rs, column) -> {
                 assertThatThrownBy(() -> rs.getLong(column))
                         .isInstanceOf(SQLException.class)
-                        .hasMessage("Value is not a number: ");
-            });
+                        .hasMessage("Value is not a number: java.lang.String");
 
-            checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123e-1'", Types.VARCHAR,
-                    (rs, column) -> assertEquals(rs.getLong(column), 12));
-
-            checkRepresentation(connectedStatement.getStatement(), "DOUBLE '123.456'", Types.DOUBLE,
-                    (rs, column) -> assertEquals(rs.getDouble(column), 123.456D));
-
-            checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123'", Types.VARCHAR,
-                    (rs, column) -> assertEquals(rs.getDouble(column), 123D));
-
-            checkRepresentation(connectedStatement.getStatement(), "VARCHAR ''", Types.VARCHAR, (rs, column) -> {
                 assertThatThrownBy(() -> rs.getDouble(column))
                         .isInstanceOf(SQLException.class)
-                        .hasMessage("Value is not a number: ");
+                        .hasMessage("Value is not a number: java.lang.String");
             });
 
-            checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123e-1'", Types.VARCHAR,
-                    (rs, column) -> assertEquals(rs.getDouble(column), 12.3D));
+            checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123e-1'", Types.VARCHAR, (rs, column) -> {
+                        assertEquals(rs.getDouble(column), 12.3D);
+                        assertEquals(rs.getLong(column), 12);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "DOUBLE '123.456'", Types.DOUBLE, (rs, column) -> {
+                assertEquals(rs.getDouble(column), 123.456D);
+                assertEquals(rs.getLong(column), 123);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "VARCHAR '123'", Types.VARCHAR, (rs, column) -> {
+                assertEquals(rs.getDouble(column), 123D);
+                assertEquals(rs.getLong(column), 123);
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #5165 . The change will allow valid string values in the result set to be converted to a Number (Double) data type. 

```
=== RELEASE NOTES ===

General Change
* Allow Decimal values in String format to be extracted as double from ResultSet.

```