### PR TITLE
Push down aggregation with LIMIT into JDBC connectors

### DIFF
--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTest.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTest.java
@@ -17,6 +17,7 @@ import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
@@ -283,5 +284,14 @@ public class TestDruidIntegrationSmokeTest
 
         // with filter over varchar column
         assertThat(query("SELECT name FROM nation WHERE name < 'EEE' LIMIT 5")).isCorrectlyPushedDown();
+
+        // with aggregation
+        assertThat(query("SELECT max(regionkey) FROM nation LIMIT 5")).isNotFullyPushedDown(AggregationNode.class); // global aggregation, LIMIT removed TODO https://github.com/prestosql/presto/pull/4313
+        assertThat(query("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
+        // TODO (https://github.com/prestosql/presto/issues/5522) assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isCorrectlyPushedDown();
+
+        // with filter and aggregation
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
     }
 }

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
@@ -252,6 +252,15 @@ abstract class BaseMySqlIntegrationSmokeTest
 
         // with filter over varchar column
         assertThat(query("SELECT name FROM nation WHERE name < 'EEE' LIMIT 5")).isNotFullyPushedDown(FilterNode.class);
+
+        // with aggregation
+        assertThat(query("SELECT max(regionkey) FROM nation LIMIT 5")).isCorrectlyPushedDown(); // global aggregation, LIMIT removed
+        assertThat(query("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5")).isCorrectlyPushedDown();
+        // TODO (https://github.com/prestosql/presto/issues/5522) assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isCorrectlyPushedDown();
+
+        // with filter and aggregation
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isCorrectlyPushedDown();
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isNotFullyPushedDown(FilterNode.class);
     }
 
     @Test

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -385,6 +385,15 @@ public class TestPostgreSqlIntegrationSmokeTest
 
         // with filter over varchar column
         assertThat(query("SELECT name FROM nation WHERE name < 'EEE' LIMIT 5")).isCorrectlyPushedDown();
+
+        // with aggregation
+        assertThat(query("SELECT max(regionkey) FROM nation LIMIT 5")).isCorrectlyPushedDown(); // global aggregation, LIMIT removed
+        assertThat(query("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5")).isCorrectlyPushedDown();
+        // TODO (https://github.com/prestosql/presto/issues/5522) assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isCorrectlyPushedDown();
+
+        // with filter and aggregation
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isCorrectlyPushedDown();
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isCorrectlyPushedDown();
     }
 
     /**

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
@@ -275,6 +275,15 @@ public class TestSqlServerIntegrationSmokeTest
 
         // with filter over varchar column
         assertThat(query("SELECT name FROM nation WHERE name < 'EEE' LIMIT 5")).isCorrectlyPushedDown();
+
+        // with aggregation
+        assertThat(query("SELECT max(regionkey) FROM nation LIMIT 5")).isCorrectlyPushedDown(); // global aggregation, LIMIT removed
+        assertThat(query("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5")).isCorrectlyPushedDown();
+        // TODO (https://github.com/prestosql/presto/issues/5522) assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isCorrectlyPushedDown();
+
+        // with filter and aggregation
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isCorrectlyPushedDown();
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isCorrectlyPushedDown();
     }
 
     /**

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -866,6 +866,22 @@ public abstract class AbstractTestQueries
 
         assertEquals(actual.getMaterializedRows().size(), 10);
         assertContains(all, actual);
+
+        // with ORDER BY
+        assertQuery("SELECT name FROM nation ORDER BY nationkey LIMIT 3");
+        assertQuery("SELECT name FROM nation ORDER BY regionkey LIMIT 5"); // query is deterministic because first peer group in regionkey order has 5 rows
+
+        // global aggregation, LIMIT should be removed (and connector should not prevent this from happening)
+        assertQuery("SELECT max(regionkey) FROM nation LIMIT 5");
+
+        // with aggregation
+        assertQuery("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5");
+
+        // with DISTINCT (can be expressed as DistinctLimitNode and handled differently)
+        assertQuery("SELECT DISTINCT regionkey FROM nation LIMIT 5");
+
+        // with filter and aggregation
+        assertQuery("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3");
     }
 
     @Test


### PR DESCRIPTION
For a query like

    SELECT k, max(v) FROM table LIMIT 5

the plan after aggregation pushdown looks like this:

    - LIMIT 5
      - Project k=k, max=generated_column
        - TableScan producing k, generated_column

The Project prevents Limit from being pushed into the connector.
The `PushProjectionIntoTableScan` cannot remove the projection, because
it can only narrow down selection of columns, it cannot do renaming
(also, requiring connector to support _renaming_ would feel abundant).
The projection is not an identity projection either. It can currently be
removed by `UnaliasSymbolReferences` (which turns it into an identity
projection) + `RemoveRedundantIdentityProjections` (which removes it).

This commit adds another attempt of "push into table scan" optimizations
(which already include `RemoveRedundantIdentityProjections`), preceded
with `UnaliasSymbolReferences`, so that the unaliasing can take place
between aggregation and limit pushdown.

It is considered temporarily adequate for `UnaliasSymbolReferences` to
be run once. In the future we may require more invocations of
`UnaliasSymbolReferences` + "push into table scan" optimization pairs.
Better yet, the unaliasing is either turned into optimizer rules, or
made redundant by other means.

Fixes https://github.com/prestosql/presto/issues/5261