### PR TITLE
Be consistent about optimized Parquet writer being experimental

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -91,7 +91,7 @@ public final class HiveSessionProperties
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     private static final String TIMESTAMP_PRECISION = "timestamp_precision";
-    private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
+    private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "experimental_parquet_optimized_writer_enabled";
     private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
 
     private final List<PropertyMetadata<?>> sessionProperties;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetWriterConfig.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive.parquet;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.prestosql.parquet.writer.ParquetWriterOptions;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -55,8 +56,9 @@ public class ParquetWriterConfig
         return parquetOptimizedWriterEnabled;
     }
 
-    @Config("hive.parquet.optimized-writer.enabled")
-    @ConfigDescription("Enable optimized Parquet writer")
+    @Config("hive.parquet.experimental-optimized-writer.enabled")
+    @LegacyConfig("hive.parquet.optimized-writer.enabled")
+    @ConfigDescription("Experimental: Enable optimized Parquet writer")
     public ParquetWriterConfig setParquetOptimizedWriterEnabled(boolean parquetOptimizedWriterEnabled)
     {
         this.parquetOptimizedWriterEnabled = parquetOptimizedWriterEnabled;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -40,7 +40,7 @@ public class TestParquetWriterConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("hive.parquet.optimized-writer.enabled", "true")
+                .put("hive.parquet.experimental-optimized-writer.enabled", "true")
                 .put("hive.parquet.writer.block-size", "234MB")
                 .put("hive.parquet.writer.page-size", "11MB")
                 .build();


### PR DESCRIPTION
The optimized Parquet writer is still experimental and was described as
in session property's description. This makes the naming and
descriptions consistent.

Relates to: https://github.com/prestosql/presto/issues/5518