### PR TITLE
Increase dynamic filtering limits

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/DynamicFilterConfig.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DynamicFilterConfig.java
@@ -37,19 +37,19 @@ public class DynamicFilterConfig
     private boolean enableLargeDynamicFilters;
     private int serviceThreadCount = 2;
 
-    private int smallBroadcastMaxDistinctValuesPerDriver = 100;
-    private DataSize smallBroadcastMaxSizePerDriver = DataSize.of(10, KILOBYTE);
-    private int smallBroadcastRangeRowLimitPerDriver;
-    private int smallPartitionedMaxDistinctValuesPerDriver = 10;
+    private int smallBroadcastMaxDistinctValuesPerDriver = 200;
+    private DataSize smallBroadcastMaxSizePerDriver = DataSize.of(20, KILOBYTE);
+    private int smallBroadcastRangeRowLimitPerDriver = 400;
+    private int smallPartitionedMaxDistinctValuesPerDriver = 20;
     private DataSize smallPartitionedMaxSizePerDriver = DataSize.of(10, KILOBYTE);
-    private int smallPartitionedRangeRowLimitPerDriver;
+    private int smallPartitionedRangeRowLimitPerDriver = 100;
 
     private int largeBroadcastMaxDistinctValuesPerDriver = 5_000;
     private DataSize largeBroadcastMaxSizePerDriver = DataSize.of(500, KILOBYTE);
-    private int largeBroadcastRangeRowLimitPerDriver;
+    private int largeBroadcastRangeRowLimitPerDriver = 10_000;
     private int largePartitionedMaxDistinctValuesPerDriver = 500;
     private DataSize largePartitionedMaxSizePerDriver = DataSize.of(50, KILOBYTE);
-    private int largePartitionedRangeRowLimitPerDriver;
+    private int largePartitionedRangeRowLimitPerDriver = 1_000;
 
     public boolean isEnableDynamicFiltering()
     {

--- a/presto-main/src/test/java/io/prestosql/execution/TestDynamicFilterConfig.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestDynamicFilterConfig.java
@@ -33,18 +33,18 @@ public class TestDynamicFilterConfig
                 .setEnableDynamicFiltering(true)
                 .setEnableLargeDynamicFilters(false)
                 .setServiceThreadCount(2)
-                .setSmallBroadcastMaxDistinctValuesPerDriver(100)
-                .setSmallBroadcastMaxSizePerDriver(DataSize.of(10, KILOBYTE))
-                .setSmallBroadcastRangeRowLimitPerDriver(0)
-                .setSmallPartitionedMaxDistinctValuesPerDriver(10)
+                .setSmallBroadcastMaxDistinctValuesPerDriver(200)
+                .setSmallBroadcastMaxSizePerDriver(DataSize.of(20, KILOBYTE))
+                .setSmallBroadcastRangeRowLimitPerDriver(400)
+                .setSmallPartitionedMaxDistinctValuesPerDriver(20)
                 .setSmallPartitionedMaxSizePerDriver(DataSize.of(10, KILOBYTE))
-                .setSmallPartitionedRangeRowLimitPerDriver(0)
+                .setSmallPartitionedRangeRowLimitPerDriver(100)
                 .setLargeBroadcastMaxDistinctValuesPerDriver(5000)
                 .setLargeBroadcastMaxSizePerDriver(DataSize.of(500, KILOBYTE))
-                .setLargeBroadcastRangeRowLimitPerDriver(0)
+                .setLargeBroadcastRangeRowLimitPerDriver(10_000)
                 .setLargePartitionedMaxDistinctValuesPerDriver(500)
                 .setLargePartitionedMaxSizePerDriver(DataSize.of(50, KILOBYTE))
-                .setLargePartitionedRangeRowLimitPerDriver(0));
+                .setLargePartitionedRangeRowLimitPerDriver(1_000));
     }
 
     @Test

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
@@ -57,8 +57,10 @@ public class TestMemorySmoke
             throws Exception
     {
         return MemoryQueryRunner.createQueryRunner(
-                // Reduced broadcast join limit for large DF to make withLargeDynamicFilters use range DF collection
+                // Adjust DF limits to test edge cases
                 ImmutableMap.of(
+                        "dynamic-filtering.small-broadcast.max-distinct-values-per-driver", "100",
+                        "dynamic-filtering.small-broadcast.range-row-limit-per-driver", "100",
                         "dynamic-filtering.large-broadcast.max-distinct-values-per-driver", "100",
                         "dynamic-filtering.large-broadcast.range-row-limit-per-driver", "100000"));
     }


### PR DESCRIPTION
Benchmark results from: https://github.com/prestosql/presto/pull/5366#issuecomment-701640635
```
Benchmark                                                  (collectionLimits)  (positionsPerPage)  Mode  Cnt  Score   Error  Units
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect               100,0                1024  avgt   60  0.052 ± 0.002  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect            200,2000                1024  avgt   60  0.052 ± 0.002  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect            200,5000                1024  avgt   60  0.059 ± 0.001  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect            500,2000                1024  avgt   60  0.076 ± 0.003  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect            500,5000                1024  avgt   60  0.076 ± 0.002  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect           500,10000                1024  avgt   60  0.110 ± 0.001  ms/op
BenchmarkDynamicFilterSourceOperator.dynamicFilterCollect          1000,10000                1024  avgt   60  0.144 ± 0.005  ms/op
```