### PR TITLE
More flexible match in isNotFullyPushedDown()

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanAssert.java
@@ -45,8 +45,7 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, StatsProvider statsProvider, Plan actual, Lookup lookup, PlanMatchPattern pattern)
     {
-        MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, statsProvider, lookup), pattern);
-        if (!matches.isMatch()) {
+        if (!matches(session, metadata, statsProvider, actual, lookup, pattern)) {
             String formattedPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata, StatsAndCosts.empty(), session, 0, false);
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
             String resolvedFormattedPlan = textLogicalPlan(resolvedPlan, actual.getTypes(), metadata, StatsAndCosts.empty(), session, 0, false);
@@ -56,5 +55,11 @@ public final class PlanAssert
                     formattedPlan,
                     resolvedFormattedPlan));
         }
+    }
+
+    public static boolean matches(Session session, Metadata metadata, StatsProvider statsProvider, Plan actual, Lookup lookup, PlanMatchPattern pattern)
+    {
+        MatchResult matchResult = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, statsProvider, lookup), pattern);
+        return matchResult.isMatch();
     }
 }

--- a/presto-tests/src/test/java/io/prestosql/tests/AbstractQueryAssertionsTest.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/AbstractQueryAssertionsTest.java
@@ -157,17 +157,17 @@ public abstract class AbstractQueryAssertionsTest
                         "Plan does not match, expected [\n" +
                                 "\n" +
                                 "- anyTree\n" +
-                                "    - node(FilterNode)\n")
-                .hasMessageContaining(
-                        "\n" +
+                                "    - node(FilterNode)\n" +
+                                "        - node(TableScanNode)\n" +
+                                "\n" +
+                                "] or [\n" +
+                                "\n" +
+                                "- anyTree\n" +
+                                "    - node(FilterNode)\n" +
+                                "        - anyTree\n" +
+                                "            - node(TableScanNode)\n" +
                                 "\n" +
                                 "] but found [\n" +
-                                "\n" +
-                                "Output[name]\n")
-                .hasMessageContaining(
-                        "\n" +
-                                "\n" +
-                                "] which resolves to [\n" +
                                 "\n" +
                                 "Output[name]\n");
     }


### PR DESCRIPTION
Allow the retained node not to be directly above TableScan.

Fixes https://github.com/prestosql/presto/issues/5541