### PR TITLE
Add PagesSerdeContext abstraction to enable temporary buffer reuse

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -503,7 +503,7 @@ class Query
                 .withExceptionConsumer(this::handleSerializationException)
                 .withColumnsAndTypes(columns, types);
 
-        try {
+        try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
             long bytes = 0;
             while (bytes < targetResultBytes) {
                 SerializedPage serializedPage = exchangeClient.pollPage();
@@ -511,7 +511,7 @@ class Query
                     break;
                 }
 
-                Page page = serde.deserialize(serializedPage);
+                Page page = serde.deserialize(context, serializedPage);
                 bytes += page.getLogicalSizeInBytes();
                 resultBuilder.addPage(page);
             }

--- a/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.spiller;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.prestosql.spi.PrestoException;
 
 import javax.crypto.Cipher;
@@ -27,7 +28,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
-final class AesSpillCipher
+@VisibleForTesting
+public final class AesSpillCipher
         implements SpillCipher
 {
     //  256-bit AES CBC mode
@@ -39,7 +41,8 @@ final class AesSpillCipher
     private Cipher encryptSizer;
     private final int ivBytes;
 
-    AesSpillCipher()
+    @VisibleForTesting
+    public AesSpillCipher()
     {
         this.key = generateNewSecretKey();
         this.encryptSizer = createEncryptCipher(key);

--- a/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/FileSingleStreamSpiller.java
@@ -143,11 +143,12 @@ public class FileSingleStreamSpiller
     private void writePages(Iterator<Page> pageIterator)
     {
         checkState(writable, "Spilling no longer allowed. The spiller has been made non-writable on first read for subsequent reads to be consistent");
-        try (SliceOutput output = new OutputStreamSliceOutput(targetFile.newOutputStream(APPEND), BUFFER_SIZE)) {
+        try (SliceOutput output = new OutputStreamSliceOutput(targetFile.newOutputStream(APPEND), BUFFER_SIZE);
+             PagesSerde.PagesSerdeContext context = serde.newContext()) {
             while (pageIterator.hasNext()) {
                 Page page = pageIterator.next();
                 spilledPagesInMemorySize += page.getSizeInBytes();
-                SerializedPage serializedPage = serde.serialize(page);
+                SerializedPage serializedPage = serde.serialize(context, page);
                 long pageSize = serializedPage.getSizeInBytes();
                 localSpillContext.updateBytes(pageSize);
                 spillerStats.addToTotalSpilledBytes(pageSize);

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkPagesSerde.java
@@ -64,8 +64,10 @@ public class BenchmarkPagesSerde
     {
         Page[] pages = data.dataPages;
         PagesSerde serde = data.serde;
-        for (int i = 0; i < pages.length; i++) {
-            blackhole.consume(serde.serialize(pages[i]));
+        try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
+            for (int i = 0; i < pages.length; i++) {
+                blackhole.consume(serde.serialize(context, pages[i]));
+            }
         }
     }
 
@@ -74,8 +76,10 @@ public class BenchmarkPagesSerde
     {
         SerializedPage[] serializedPages = data.serializedPages;
         PagesSerde serde = data.serde;
-        for (int i = 0; i < serializedPages.length; i++) {
-            blackhole.consume(serde.deserialize(serializedPages[i]));
+        try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
+            for (int i = 0; i < serializedPages.length; i++) {
+                blackhole.consume(serde.deserialize(context, serializedPages[i]));
+            }
         }
     }
 
@@ -87,9 +91,11 @@ public class BenchmarkPagesSerde
         data.initialize();
         SerializedPage[] serializedPages = data.serializedPages;
         PagesSerde serde = data.serde;
-        // Sanity test by deserializing and checking against the original pages
-        for (int i = 0; i < serializedPages.length; i++) {
-            assertPageEquals(BenchmarkData.TYPES, serde.deserialize(serializedPages[i]), data.dataPages[i]);
+        try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
+            // Sanity test by deserializing and checking against the original pages
+            for (int i = 0; i < serializedPages.length; i++) {
+                assertPageEquals(BenchmarkData.TYPES, serde.deserialize(context, serializedPages[i]), data.dataPages[i]);
+            }
         }
     }
 
@@ -131,8 +137,10 @@ public class BenchmarkPagesSerde
         private SerializedPage[] createSerializedPages()
         {
             SerializedPage[] result = new SerializedPage[dataPages.length];
-            for (int i = 0; i < result.length; i++) {
-                result[i] = serde.serialize(dataPages[i]);
+            try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
+                for (int i = 0; i < result.length; i++) {
+                    result[i] = serde.serialize(context, dataPages[i]);
+                }
             }
             return result;
         }

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkPagesSerde.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution.buffer;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spiller.AesSpillCipher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
+import static io.prestosql.operator.PageAssertions.assertPageEquals;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(SECONDS)
+@Fork(1)
+@Warmup(iterations = 12, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = SECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class BenchmarkPagesSerde
+{
+    @Benchmark
+    public void serialize(BenchmarkData data, Blackhole blackhole)
+    {
+        Page[] pages = data.dataPages;
+        PagesSerde serde = data.serde;
+        for (int i = 0; i < pages.length; i++) {
+            blackhole.consume(serde.serialize(pages[i]));
+        }
+    }
+
+    @Benchmark
+    public void deserialize(BenchmarkData data, Blackhole blackhole)
+    {
+        SerializedPage[] serializedPages = data.serializedPages;
+        PagesSerde serde = data.serde;
+        for (int i = 0; i < serializedPages.length; i++) {
+            blackhole.consume(serde.deserialize(serializedPages[i]));
+        }
+    }
+
+    @Test
+    public void testBenchmarkData()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.compressed = true;
+        data.initialize();
+        SerializedPage[] serializedPages = data.serializedPages;
+        PagesSerde serde = data.serde;
+        // Sanity test by deserializing and checking against the original pages
+        for (int i = 0; i < serializedPages.length; i++) {
+            assertPageEquals(BenchmarkData.TYPES, serde.deserialize(serializedPages[i]), data.dataPages[i]);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final int ROW_COUNT = 15000;
+        private static final List<Type> TYPES = ImmutableList.of(VARCHAR);
+        @Param({"true", "false"})
+        private boolean encrypted;
+        @Param({"true", "false"})
+        private boolean compressed;
+        @Param("1000")
+        private int randomSeed = 1000;
+
+        private PagesSerde serde;
+        private Page[] dataPages;
+        private SerializedPage[] serializedPages;
+
+        @Setup
+        public void initialize()
+        {
+            serde = createPagesSerde();
+            dataPages = createPages();
+            serializedPages = createSerializedPages();
+        }
+
+        public Page[] getDataPages()
+        {
+            return dataPages;
+        }
+
+        private PagesSerde createPagesSerde()
+        {
+            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(createTestMetadataManager().getBlockEncodingSerde(), compressed);
+            return encrypted ? serdeFactory.createPagesSerdeForSpill(Optional.of(new AesSpillCipher())) : serdeFactory.createPagesSerde();
+        }
+
+        private SerializedPage[] createSerializedPages()
+        {
+            SerializedPage[] result = new SerializedPage[dataPages.length];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = serde.serialize(dataPages[i]);
+            }
+            return result;
+        }
+
+        private Page[] createPages()
+        {
+            Random random = new Random(randomSeed);
+            List<Page> pages = new ArrayList<>();
+            int remainingRows = ROW_COUNT;
+            PageBuilder pageBuilder = new PageBuilder(TYPES);
+            while (remainingRows > 0) {
+                int rows = 100 + random.nextInt(900); // 100 - 1000 rows per pass
+                List<Object>[] testRows = generateTestRows(random, TYPES, rows);
+                remainingRows -= rows;
+                for (int i = 0; i < testRows.length; i++) {
+                    writeRow(testRows[i], pageBuilder.getBlockBuilder(0));
+                }
+                pageBuilder.declarePositions(rows);
+                pages.add(pageBuilder.build());
+                pageBuilder.reset();
+            }
+            return pages.toArray(Page[]::new);
+        }
+
+        private void writeRow(List<Object> testRow, BlockBuilder blockBuilder)
+        {
+            for (Object fieldValue : testRow) {
+                if (fieldValue == null) {
+                    blockBuilder.appendNull();
+                }
+                else if (fieldValue instanceof String) {
+                    VARCHAR.writeSlice(blockBuilder, utf8Slice((String) fieldValue));
+                }
+                else {
+                    throw new UnsupportedOperationException();
+                }
+            }
+        }
+
+        // copied & modifed from TestRowBlock
+        private List<Object>[] generateTestRows(Random random, List<Type> fieldTypes, int numRows)
+        {
+            @SuppressWarnings("unchecked")
+            List<Object>[] testRows = new List[numRows];
+            for (int i = 0; i < numRows; i++) {
+                List<Object> testRow = new ArrayList<>(fieldTypes.size());
+                for (int j = 0; j < fieldTypes.size(); j++) {
+                    if (fieldTypes.get(j) == VARCHAR) {
+                        int mode = random.nextInt(4); // 25% null, 25% repeat previous value
+                        if (mode == 0) {
+                            testRow.add(null);
+                        }
+                        else if (i > 0 && mode == 1) {
+                            // Repeat values to make compression more interesting
+                            testRow.add(testRows[i - 1].get(j));
+                        }
+                        else {
+                            byte[] data = new byte[random.nextInt(256)];
+                            random.nextBytes(data);
+                            testRow.add(new String(data, ISO_8859_1));
+                        }
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+                testRows[i] = testRow;
+            }
+            return testRows;
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.compressed = true; // Get usable stats on compressibility
+        data.initialize();
+        System.out.println("Page Size Avg: " + Arrays.stream(data.dataPages).mapToLong(Page::getSizeInBytes).average().getAsDouble());
+        System.out.println("Page Size Min: " + Arrays.stream(data.dataPages).mapToLong(Page::getSizeInBytes).min().getAsLong());
+        System.out.println("Page Size Max: " + Arrays.stream(data.dataPages).mapToLong(Page::getSizeInBytes).max().getAsLong());
+        System.out.println("Page Size Sum: " + Arrays.stream(data.dataPages).mapToLong(Page::getSizeInBytes).sum());
+        System.out.println("Page count: " + data.dataPages.length);
+        System.out.println("Compressed: " + Arrays.stream(data.serializedPages).filter(SerializedPage::isCompressed).count());
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .jvmArgs("-Xms4g", "-Xmx4g")
+                .include(".*" + BenchmarkPagesSerde.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestArbitraryOutputBuffer.java
@@ -39,7 +39,6 @@ import static io.prestosql.execution.buffer.BufferState.OPEN;
 import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
-import static io.prestosql.execution.buffer.BufferTestUtils.PAGES_SERDE;
 import static io.prestosql.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.assertBufferResultEquals;
 import static io.prestosql.execution.buffer.BufferTestUtils.assertFinished;
@@ -47,6 +46,7 @@ import static io.prestosql.execution.buffer.BufferTestUtils.assertFutureIsDone;
 import static io.prestosql.execution.buffer.BufferTestUtils.createBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.createPage;
 import static io.prestosql.execution.buffer.BufferTestUtils.getFuture;
+import static io.prestosql.execution.buffer.BufferTestUtils.serializePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.sizeOfPages;
 import static io.prestosql.execution.buffer.OutputBuffers.BROADCAST_PARTITION_ID;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.ARBITRARY;
@@ -1000,7 +1000,7 @@ public class TestArbitraryOutputBuffer
 
     private static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(ImmutableList.of(serializePage(page)));
         ListenableFuture<?> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
@@ -1008,7 +1008,7 @@ public class TestArbitraryOutputBuffer
 
     private static void addPage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(ImmutableList.of(serializePage(page)));
         assertTrue(buffer.isFull().isDone(), "Expected add page to not block");
     }
 

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestBroadcastOutputBuffer.java
@@ -53,6 +53,7 @@ import static io.prestosql.execution.buffer.BufferTestUtils.createPage;
 import static io.prestosql.execution.buffer.BufferTestUtils.enqueuePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.getBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.getFuture;
+import static io.prestosql.execution.buffer.BufferTestUtils.serializePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.sizeOfPages;
 import static io.prestosql.execution.buffer.OutputBuffers.BROADCAST_PARTITION_ID;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.BROADCAST;
@@ -1016,7 +1017,7 @@ public class TestBroadcastOutputBuffer
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
 
         Page page = createPage(1);
-        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+        long pageSize = serializePage(page).getRetainedSizeInBytes();
 
         // create a buffer that can only hold two pages
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), DataSize.ofBytes(pageSize * 2), memoryContext, directExecutor());
@@ -1047,7 +1048,7 @@ public class TestBroadcastOutputBuffer
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
 
         Page page = createPage(1);
-        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+        long pageSize = serializePage(page).getRetainedSizeInBytes();
 
         // create a buffer that can only hold two pages
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), DataSize.ofBytes(pageSize * 2), memoryContext, directExecutor());
@@ -1093,7 +1094,7 @@ public class TestBroadcastOutputBuffer
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
 
         Page page = createPage(1);
-        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+        long pageSize = serializePage(page).getRetainedSizeInBytes();
 
         // create a buffer that can only hold two pages
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), DataSize.ofBytes(pageSize * 2), memoryContext, directExecutor());

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestClientBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestClientBuffer.java
@@ -36,11 +36,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.execution.buffer.BufferResult.emptyResults;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
-import static io.prestosql.execution.buffer.BufferTestUtils.PAGES_SERDE;
 import static io.prestosql.execution.buffer.BufferTestUtils.assertBufferResultEquals;
 import static io.prestosql.execution.buffer.BufferTestUtils.createBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.createPage;
 import static io.prestosql.execution.buffer.BufferTestUtils.getFuture;
+import static io.prestosql.execution.buffer.BufferTestUtils.serializePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.sizeOfPages;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
@@ -383,7 +383,7 @@ public class TestClientBuffer
     private static AtomicBoolean addPage(ClientBuffer buffer, Page page)
     {
         AtomicBoolean dereferenced = new AtomicBoolean(true);
-        SerializedPageReference serializedPageReference = new SerializedPageReference(PAGES_SERDE.serialize(page), 1, () -> dereferenced.set(false));
+        SerializedPageReference serializedPageReference = new SerializedPageReference(serializePage(page), 1, () -> dereferenced.set(false));
         buffer.enqueuePages(ImmutableList.of(serializedPageReference));
         serializedPageReference.dereferencePage();
         return dereferenced;
@@ -456,7 +456,7 @@ public class TestClientBuffer
         {
             requireNonNull(page, "page is null");
             checkState(!noMorePages);
-            buffer.add(new SerializedPageReference(PAGES_SERDE.serialize(page), 1, () -> {}));
+            buffer.add(new SerializedPageReference(serializePage(page), 1, () -> {}));
         }
 
         @Override

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestPartitionedOutputBuffer.java
@@ -35,7 +35,6 @@ import static io.prestosql.execution.buffer.BufferState.OPEN;
 import static io.prestosql.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static io.prestosql.execution.buffer.BufferTestUtils.MAX_WAIT;
 import static io.prestosql.execution.buffer.BufferTestUtils.NO_WAIT;
-import static io.prestosql.execution.buffer.BufferTestUtils.PAGES_SERDE;
 import static io.prestosql.execution.buffer.BufferTestUtils.acknowledgeBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.addPage;
 import static io.prestosql.execution.buffer.BufferTestUtils.assertBufferResultEquals;
@@ -48,6 +47,7 @@ import static io.prestosql.execution.buffer.BufferTestUtils.createPage;
 import static io.prestosql.execution.buffer.BufferTestUtils.enqueuePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.getBufferResult;
 import static io.prestosql.execution.buffer.BufferTestUtils.getFuture;
+import static io.prestosql.execution.buffer.BufferTestUtils.serializePage;
 import static io.prestosql.execution.buffer.BufferTestUtils.sizeOfPages;
 import static io.prestosql.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static io.prestosql.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
@@ -808,7 +808,7 @@ public class TestPartitionedOutputBuffer
                         .withNoMoreBufferIds(),
                 sizeOfPages(5));
         Page page = createPage(1);
-        long serializePageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+        long serializePageSize = serializePage(page).getRetainedSizeInBytes();
         for (int i = 0; i < 5; i++) {
             addPage(buffer, page, 0);
             assertEquals(buffer.getPeakMemoryUsage(), (i + 1) * serializePageSize);

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestingPagesSerdeFactory.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestingPagesSerdeFactory.java
@@ -52,15 +52,21 @@ public class TestingPagesSerdeFactory
         }
 
         @Override
-        public synchronized SerializedPage serialize(Page page)
+        public synchronized SerializedPage serialize(PagesSerdeContext context, Page page)
         {
-            return super.serialize(page);
+            return super.serialize(context, page);
         }
 
         @Override
         public synchronized Page deserialize(SerializedPage serializedPage)
         {
             return super.deserialize(serializedPage);
+        }
+
+        @Override
+        public synchronized Page deserialize(PagesSerdeContext context, SerializedPage page)
+        {
+            return super.deserialize(context, page);
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/MockExchangeRequestProcessor.java
+++ b/presto-main/src/test/java/io/prestosql/operator/MockExchangeRequestProcessor.java
@@ -165,7 +165,9 @@ public class MockExchangeRequestProcessor
         public synchronized void addPage(Page page)
         {
             checkState(completed.get() != Boolean.TRUE, "Location %s is complete", location);
-            serializedPages.add(PAGES_SERDE.serialize(page));
+            try (PagesSerde.PagesSerdeContext context = PAGES_SERDE.newContext()) {
+                serializedPages.add(PAGES_SERDE.serialize(context, page));
+            }
         }
 
         public BufferResult getPages(long sequenceId, DataSize maxSize)

--- a/presto-main/src/test/java/io/prestosql/operator/TestingExchangeHttpClientHandler.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestingExchangeHttpClientHandler.java
@@ -75,7 +75,10 @@ public class TestingExchangeHttpClientHandler
         if (page != null) {
             headers.put(PRESTO_PAGE_NEXT_TOKEN, String.valueOf(pageToken + 1));
             headers.put(PRESTO_BUFFER_COMPLETE, String.valueOf(false));
-            SerializedPage serializedPage = PAGES_SERDE.serialize(page);
+            SerializedPage serializedPage;
+            try (PagesSerde.PagesSerdeContext context = PAGES_SERDE.newContext()) {
+                serializedPage = PAGES_SERDE.serialize(context, page);
+            }
             DynamicSliceOutput output = new DynamicSliceOutput(256);
             output.writeInt(SERIALIZED_PAGES_MAGIC);
             output.writeLong(calculateChecksum(ImmutableList.of(serializedPage)));

--- a/presto-main/src/test/java/io/prestosql/spiller/TestBinaryFileSpiller.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestBinaryFileSpiller.java
@@ -137,11 +137,13 @@ public class TestBinaryFileSpiller
         long spilledBytes = 0;
 
         assertEquals(memoryContext.getBytes(), 0);
-        for (List<Page> spill : spills) {
-            spilledBytes += spill.stream()
-                    .mapToLong(page -> pagesSerde.serialize(page).getSizeInBytes())
-                    .sum();
-            spiller.spill(spill.iterator()).get();
+        try (PagesSerde.PagesSerdeContext context = pagesSerde.newContext()) {
+            for (List<Page> spill : spills) {
+                spilledBytes += spill.stream()
+                        .mapToLong(page -> pagesSerde.serialize(context, page).getSizeInBytes())
+                        .sum();
+                spiller.spill(spill.iterator()).get();
+            }
         }
         assertEquals(spillerStats.getTotalSpilledBytes() - spilledBytesBefore, spilledBytes);
         // At this point, the buffers should still be accounted for in the memory context, because

--- a/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/spiller/TestSpillCipherPagesSerde.java
@@ -43,21 +43,23 @@ public class TestSpillCipherPagesSerde
         PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerdeForSpill(Optional.of(cipher));
         List<Type> types = ImmutableList.of(VARCHAR);
         Page emptyPage = new Page(VARCHAR.createBlockBuilder(null, 0).build());
-        assertPageEquals(types, serde.deserialize(serde.serialize(emptyPage)), emptyPage);
+        try (PagesSerde.PagesSerdeContext context = serde.newContext()) {
+            assertPageEquals(types, serde.deserialize(serde.serialize(context, emptyPage)), emptyPage);
 
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
-        VARCHAR.writeString(blockBuilder, "hello");
-        VARCHAR.writeString(blockBuilder, "world");
-        Page helloWorldPage = new Page(blockBuilder.build());
+            BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
+            VARCHAR.writeString(blockBuilder, "hello");
+            VARCHAR.writeString(blockBuilder, "world");
+            Page helloWorldPage = new Page(blockBuilder.build());
 
-        SerializedPage serialized = serde.serialize(helloWorldPage);
-        assertPageEquals(types, serde.deserialize(serialized), helloWorldPage);
-        assertTrue(serialized.isEncrypted(), "page should be encrypted");
+            SerializedPage serialized = serde.serialize(context, helloWorldPage);
+            assertPageEquals(types, serde.deserialize(serialized), helloWorldPage);
+            assertTrue(serialized.isEncrypted(), "page should be encrypted");
 
-        cipher.close();
+            cipher.close();
 
-        assertFailure(() -> serde.serialize(helloWorldPage), "Spill cipher already closed");
-        assertFailure(() -> serde.deserialize(serialized), "Spill cipher already closed");
+            assertFailure(() -> serde.serialize(context, helloWorldPage), "Spill cipher already closed");
+            assertFailure(() -> serde.deserialize(context, serialized), "Spill cipher already closed");
+        }
     }
 
     private static void assertFailure(ThrowingRunnable runnable, String expectedErrorMessage)


### PR DESCRIPTION
Reduces the allocation rate of `PagesSerde` when multiple pages are serialized or deserialized in a batch by reusing byte array buffers and `DynamicSliceOutput` instances through the new `PagesSerdeContext`.

~~[Benchmark Run with GC Profiling Results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/b15a49b768f92d91df664faeeef3b19cfeac8dfe/baseline-single-varchar.json,https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/b15a49b768f92d91df664faeeef3b19cfeac8dfe/pages-serde-context-single-varchar.json)~~

The above benchmarks for deserialization are no longer valid after identifying an issue of unsafe slice sharing, updated reference:
[Benchmarks with commit 51cff0b7](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/ee8b264bf2b1a9e2afae4b2e2d613b3157d93c66/baseline-pages-serde-51cff0b7.json,https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/ee8b264bf2b1a9e2afae4b2e2d613b3157d93c66/pages-serde-context-51cff0b7.json)