### PR TITLE
Unblock DF only when all child stages are blocked

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -119,6 +119,7 @@ public class FixedSourcePartitionedScheduler
                     Math.max(splitBatchSize / concurrentLifespans, 1),
                     groupedExecutionForScanNode,
                     dynamicFilterService,
+                    () -> true,
                     () -> true);
 
             if (stageExecutionDescriptor.isStageGroupedExecution() && !groupedExecutionForScanNode) {

--- a/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/io/prestosql/execution/scheduler/SqlQueryScheduler.java
@@ -363,7 +363,11 @@ public class SqlQueryScheduler
                     placementPolicy,
                     splitBatchSize,
                     dynamicFilterService,
-                    () -> childStages.stream().anyMatch(SqlStageExecution::isAnyTaskBlocked)));
+                    () -> childStages.stream().anyMatch(SqlStageExecution::isAnyTaskBlocked),
+                    () -> childStages.stream()
+                            // returns true if all stages that produce pages are blocked
+                            .filter(childStage -> childStage.getState() != FLUSHING && childStage.getState() != FINISHED)
+                            .allMatch(SqlStageExecution::isAnyTaskBlocked)));
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
             childStages = createChildStages.apply(Optional.of(new int[1]));

--- a/presto-main/src/test/java/io/prestosql/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/io/prestosql/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -332,6 +332,7 @@ public class TestSourcePartitionedScheduler
                     new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                     2,
                     new DynamicFilterService(new DynamicFilterConfig()),
+                    () -> false,
                     () -> false);
             scheduler.schedule();
         }).hasErrorCode(NO_NODES_AVAILABLE);
@@ -406,6 +407,7 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 500,
                 new DynamicFilterService(new DynamicFilterConfig()),
+                () -> false,
                 () -> false);
 
         // the queues of 3 running nodes should be full
@@ -445,7 +447,8 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 400,
                 new DynamicFilterService(new DynamicFilterConfig()),
-                () -> true);
+                () -> true,
+                () -> false);
 
         // the queues of 3 running nodes should be full
         ScheduleResult scheduleResult = scheduler.schedule();
@@ -481,6 +484,7 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 2,
                 dynamicFilterService,
+                () -> false,
                 () -> true);
 
         SymbolReference symbolReference = new SymbolReference("DF_SYMBOL1");
@@ -544,6 +548,7 @@ public class TestSourcePartitionedScheduler
                 placementPolicy,
                 splitBatchSize,
                 new DynamicFilterService(new DynamicFilterConfig()),
+                () -> false,
                 () -> false);
     }
 


### PR DESCRIPTION
This allows for connectors to wait longer for
potentially non-selective DFs.