### PR TITLE
Improve AesSpillCipher performance and reduce internal allocations

### DIFF
--- a/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
+++ b/presto-main/src/main/java/io/prestosql/spiller/AesSpillCipher.java
@@ -69,7 +69,9 @@ final class AesSpillCipher
         Cipher cipher = createEncryptCipher(key);
         System.arraycopy(cipher.getIV(), 0, destination, destinationOffset, ivBytes);
         try {
-            return ivBytes + cipher.doFinal(data, inputOffset, length, destination, destinationOffset + ivBytes);
+            // Do not refactor into single doFinal call, performance and allocation rate are significantly worse. See prestosql#5557
+            int n = cipher.update(data, inputOffset, length, destination, destinationOffset + ivBytes);
+            return ivBytes + n + cipher.doFinal(destination, destinationOffset + ivBytes + n);
         }
         catch (GeneralSecurityException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to encrypt data: " + e.getMessage(), e);
@@ -83,7 +85,9 @@ final class AesSpillCipher
         checkArgument(destination.length - destinationOffset >= decryptedMaxLength(length), "destination buffer too small for decrypted output");
         Cipher cipher = createDecryptCipher(key, new IvParameterSpec(encryptedData, inputOffset, ivBytes));
         try {
-            return cipher.doFinal(encryptedData, inputOffset + ivBytes, length - ivBytes, destination, destinationOffset);
+            // Do not refactor into single doFinal call, performance and allocation rate are significantly worse. See prestosql#5557
+            int n = cipher.update(encryptedData, inputOffset + ivBytes, length - ivBytes, destination, destinationOffset);
+            return n + cipher.doFinal(destination, destinationOffset + n);
         }
         catch (GeneralSecurityException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Cannot decrypt previously encrypted data: " + e.getMessage(), e);


### PR DESCRIPTION
The JDK Cipher implementation for AES leveraged by the `AesSpillCipher` behaves differently when doFinal is called than it does inside of the update method. Notably, a single doFinal compared to an update + doFinal will:
- Take much longer for the AES hardware accelerated intrinsics to be used since the 10,000 invocation threshold for C2 compilation will require 10,000 SpillCipher calls
- Allocate a buffer larger than the output length in a attempt to strip out the padding, ultimately doubling the memory usage

Performance benchmarks run with the `BenchmarkPagesSerde` from https://github.com/prestosql/presto/pull/5545 shows a massive allocation rate decrease (even compared to that PR which reduces the rate significantly itself) and a ~40% improvement in deserialization throughput.

[Benchmark Comparison to prestosql#5545](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/0e5e36006c1d8d1371d302db250432823d616c2c/pages-serde-context-benchmark.json,https://gist.githubusercontent.com/pettyjamesm/5177ed85f452df7708e28e15e1f55bfc/raw/44a230493dd2f3787b24715cf932fdead097b51a/pages-serde-cipher-fix-benchmark.json)