### PR TITLE
Catch all runtime errors from UI password authenticator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/ui/PasswordManagerFormAuthenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/PasswordManagerFormAuthenticator.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.server.ui;
 
+import io.airlift.log.Logger;
 import io.prestosql.server.security.PasswordAuthenticatorManager;
 import io.prestosql.server.security.SecurityConfig;
 import io.prestosql.spi.security.AccessDeniedException;
@@ -24,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 public class PasswordManagerFormAuthenticator
         implements FormAuthenticator
 {
+    private static final Logger log = Logger.get(PasswordManagerFormAuthenticator.class);
     private final PasswordAuthenticatorManager passwordAuthenticatorManager;
     private final boolean insecureAuthenticationOverHttpAllowed;
 
@@ -68,6 +70,10 @@ public class PasswordManagerFormAuthenticator
             return true;
         }
         catch (AccessDeniedException e) {
+            return false;
+        }
+        catch (RuntimeException e) {
+            log.debug(e, "Error authenticating user for Web UI");
             return false;
         }
     }


### PR DESCRIPTION
Some password authenticators throw runtime exceptions to signal login did not work. Instead of showing 500 to the end user, the failure is logged and the login is denied.

Note there is no facility in the Web UI to propagate errors back to the user, nor is it clear that the error message would be appropriate for an end user, so the best that can be done is to log.