### PR TITLE
Add ExternalAuthorizer to JDBC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <dep.tempto.version>181</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
         <dep.errorprone.version>2.4.0</dep.errorprone.version>
+        <!-- TODO remove after changing the airbase version to >= 103 -->
         <dep.joda.version>2.10.6</dep.joda.version>
         <dep.coral.version>1.0.8</dep.coral.version>
 
@@ -942,6 +943,12 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.scribejava</groupId>
+                <artifactId>scribejava-core</artifactId>
+                <version>6.9.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
         <dep.airlift.version>201</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.11.749</dep.aws-sdk.version>
-        <dep.okhttp.version>3.11.0</dep.okhttp.version>
+        <dep.okhttp.version>3.9.1</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>
-        <dep.selenium.version>3.141.59</dep.selenium.version>
+        <dep.selenium.version>3.12.0</dep.selenium.version>
         <dep.tempto.version>181</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
         <dep.errorprone.version>2.4.0</dep.errorprone.version>
@@ -916,6 +916,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.auth0</groupId>
+                <artifactId>jwks-rsa</artifactId>
+                <version>0.13.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.clearspring.analytics</groupId>
                 <artifactId>stream</artifactId>
                 <version>2.9.5</version>
@@ -1067,6 +1073,12 @@
                 <groupId>com.teradata</groupId>
                 <artifactId>re2j-td</artifactId>
                 <version>1.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.13</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,11 @@
         <dep.airlift.version>201</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.11.749</dep.aws-sdk.version>
-        <dep.okhttp.version>3.9.0</dep.okhttp.version>
+        <dep.okhttp.version>3.11.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>
+        <dep.selenium.version>3.141.59</dep.selenium.version>
         <dep.tempto.version>181</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
         <dep.errorprone.version>2.4.0</dep.errorprone.version>
@@ -1285,6 +1286,36 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>42.2.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-api</artifactId>
+                <version>${dep.selenium.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-chrome-driver</artifactId>
+                <version>${dep.selenium.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-java</artifactId>
+                <version>${dep.selenium.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-remote-driver</artifactId>
+                <version>${dep.selenium.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-support</artifactId>
+                <version>${dep.selenium.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -221,6 +221,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -183,6 +183,12 @@
             <artifactId>avro</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -68,10 +68,27 @@
             <artifactId>okhttp-urlconnection</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/AuthenticationAssembler.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/AuthenticationAssembler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+class AuthenticationAssembler
+{
+    private static final String REDIRECT_URL_FIELD = "redirectUrl=";
+    private static final String TOKEN_PATH_FIELD = "tokenUrl=";
+
+    private final String baseUri;
+
+    AuthenticationAssembler(URI baseUri)
+    {
+        this.baseUri = requireNonNull(baseUri.toString(), "baseUri is null");
+    }
+
+    ExternalAuthentication toAuthentication(String header)
+    {
+        int space = header.indexOf(' ');
+        String ssoData = header.substring(space + 1);
+        String[] fields = ssoData.split(", ");
+        String tokenPath = null;
+        String redirectUrl = null;
+        for (String field : fields) {
+            if (field.startsWith(REDIRECT_URL_FIELD)) {
+                redirectUrl = relativeOrAbsolute(extractFieldValue(field, REDIRECT_URL_FIELD));
+            }
+            else if (field.startsWith(TOKEN_PATH_FIELD)) {
+                tokenPath = relativeOrAbsolute(extractFieldValue(field, TOKEN_PATH_FIELD));
+            }
+        }
+        return new ExternalAuthentication(redirectUrl, tokenPath);
+    }
+
+    private String relativeOrAbsolute(String url)
+    {
+        if (url.startsWith("/")) {
+            return baseUri + url;
+        }
+        return url;
+    }
+
+    private static String extractFieldValue(String field, String fieldKey)
+    {
+        return field.substring(fieldKey.length() + 1, field.length() - 1);
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/AuthenticationToken.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/AuthenticationToken.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import static java.util.Objects.requireNonNull;
+
+class AuthenticationToken
+{
+    private final String token;
+
+    AuthenticationToken(String token)
+    {
+        this.token = requireNonNull(token, "token is null");
+    }
+
+    public String asString()
+    {
+        return token;
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/DesktopBrowserRedirectHandler.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/DesktopBrowserRedirectHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static java.awt.Desktop.Action.BROWSE;
+import static java.awt.Desktop.getDesktop;
+import static java.awt.Desktop.isDesktopSupported;
+
+public final class DesktopBrowserRedirectHandler
+        implements RedirectHandler
+{
+    public DesktopBrowserRedirectHandler() {}
+
+    @Override
+    public void redirectTo(String uri)
+            throws RedirectException
+    {
+        if (isDesktopSupported() && getDesktop().isSupported(BROWSE)) {
+            try {
+                getDesktop().browse(new URI(uri));
+            }
+            catch (IOException | URISyntaxException e) {
+                throw new RedirectException("Failed to redirect", e);
+            }
+        }
+        else {
+            throw new RedirectException("Desktop Browser is not available. Make sure your java process is not in headless mode (-Djava.awt.headless=false)");
+        }
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/ExternalAuthentication.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/ExternalAuthentication.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class ExternalAuthentication
+{
+    private final String redirectUrl;
+    private final String tokenPath;
+
+    ExternalAuthentication(String redirectUrl, String tokenPath)
+    {
+        this.redirectUrl = requireNonNull(redirectUrl, "redirectUrl is null");
+        this.tokenPath = requireNonNull(tokenPath, "tokenUrl is null");
+    }
+
+    Optional<AuthenticationToken> obtainToken(RetryPolicy<TokenPoll> retryPolicy, RedirectHandler handler, Tokens tokens)
+    {
+        requireNonNull(retryPolicy, "retryPolicy is null");
+        requireNonNull(handler, "handler is null");
+        requireNonNull(tokens, "prestoAuthentications is null");
+
+        handler.redirectTo(redirectUrl);
+
+        TokenPoll tokenPoll = Failsafe.with(retryPolicy
+                .abortIf(TokenPoll::hasFailed)
+                .handleIf(ex -> ex instanceof TokenPollException)
+                .handleResultIf(TokenPoll::isNotAvailableYet))
+                .get(() -> tokens.pollForToken(tokenPath));
+
+        return tokenPoll.getToken();
+    }
+
+    String getRedirectUrl()
+    {
+        return redirectUrl;
+    }
+
+    String getTokenPath()
+    {
+        return tokenPath;
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/ExternalAuthenticator.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/ExternalAuthenticator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import net.jodah.failsafe.RetryPolicy;
+import okhttp3.Authenticator;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+import javax.annotation.Nullable;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
+import static io.prestosql.client.auth.external.RetryPolicies.retryWithBackoffUntil;
+import static java.util.Objects.requireNonNull;
+
+public class ExternalAuthenticator
+        implements Authenticator
+{
+    private final Tokens tokens;
+    private final RedirectHandler redirect;
+    private final RetryPolicy<TokenPoll> retryPolicy;
+    private final AuthenticationAssembler assember;
+
+    ExternalAuthenticator(RedirectHandler redirect, Tokens tokens, AuthenticationAssembler assember, RetryPolicy<TokenPoll> retryPolicy)
+    {
+        this.tokens = requireNonNull(tokens, "tokens is null");
+        this.redirect = requireNonNull(redirect, "redirect is null");
+        this.retryPolicy = requireNonNull(retryPolicy, "retryPolicy is null");
+        this.assember = assember;
+    }
+
+    public static void setupExternalAuthenticator(OkHttpClient.Builder builder, URI httpUri, Duration timeout, RedirectHandler redirectHandler)
+    {
+        builder.authenticator(new ExternalAuthenticator(
+                redirectHandler,
+                new Tokens(builder.build(), timeout),
+                new AuthenticationAssembler(httpUri),
+                retryWithBackoffUntil(timeout)));
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(Route route, Response response)
+    {
+        List<String> authorizationHeaders = response.request().headers(AUTHORIZATION);
+        if (authorizationHeaders.stream()
+                .anyMatch(header -> header.startsWith("Bearer"))) {
+            return null;
+        }
+        return response.headers(WWW_AUTHENTICATE).stream()
+                .filter(header -> header.startsWith("External-Bearer"))
+                .findFirst()
+                .map(assember::toAuthentication)
+                .flatMap(authentication -> authentication.obtainToken(
+                        retryPolicy.copy(),
+                        redirect,
+                        tokens))
+                .map(token -> addBearerToken(response.request().newBuilder(), token))
+                .orElse(null);
+    }
+
+    private Request addBearerToken(Request.Builder requestBuilder, AuthenticationToken token)
+    {
+        return requestBuilder
+                .addHeader(AUTHORIZATION, "Bearer " + token.asString())
+                .build();
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/RedirectException.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/RedirectException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+public class RedirectException
+        extends RuntimeException
+{
+    public RedirectException(String message, Throwable throwable)
+    {
+        super(message, throwable);
+    }
+
+    public RedirectException(String message)
+    {
+        super(message);
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/RedirectHandler.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/RedirectHandler.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+public interface RedirectHandler
+{
+    void redirectTo(String uri)
+            throws RedirectException;
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/RetryPolicies.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/RetryPolicies.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import net.jodah.failsafe.RetryPolicy;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Objects.requireNonNull;
+
+class RetryPolicies
+{
+    private RetryPolicies()
+    {
+    }
+
+    static <T> RetryPolicy<T> retryWithBackoffUntil(Duration timeout)
+    {
+        return RetryPolicies.<T>retryUntil(timeout)
+                .withBackoff(100, 500, MILLIS, 1.1d);
+    }
+
+    static <T> RetryPolicy<T> retryUntil(Duration timeout)
+    {
+        requireNonNull(timeout, "timeout is nul");
+
+        return new RetryPolicy<T>()
+                .withMaxAttempts(-1)
+                .withMaxDuration(timeout);
+    }
+
+    static <T> RetryPolicy<T> noRetries()
+    {
+        return new RetryPolicy<T>()
+                .withMaxAttempts(1);
+    }
+
+    static <T> RetryPolicy<T> retries(int noOfRetries)
+    {
+        return new RetryPolicy<T>()
+                .withMaxAttempts(1 + noOfRetries);
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/TokenPoll.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/TokenPoll.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import java.util.Optional;
+
+import static io.prestosql.client.auth.external.TokenPoll.Status.FAILED;
+import static io.prestosql.client.auth.external.TokenPoll.Status.PENDING;
+import static io.prestosql.client.auth.external.TokenPoll.Status.SUCCESSFUL;
+import static java.util.Objects.requireNonNull;
+
+class TokenPoll
+{
+    private final Status status;
+    private final Optional<AuthenticationToken> token;
+
+    static TokenPoll failed()
+    {
+        return new TokenPoll(FAILED, Optional.empty());
+    }
+
+    static TokenPoll pending()
+    {
+        return new TokenPoll(PENDING, Optional.empty());
+    }
+
+    static TokenPoll successful(AuthenticationToken token)
+    {
+        return new TokenPoll(SUCCESSFUL, Optional.of(token));
+    }
+
+    private TokenPoll(Status status, Optional<AuthenticationToken> token)
+    {
+        this.status = requireNonNull(status, "status is null");
+        this.token = requireNonNull(token, "token is null");
+    }
+
+    public boolean hasFailed()
+    {
+        return status == FAILED;
+    }
+
+    public boolean isNotAvailableYet()
+    {
+        return status == PENDING;
+    }
+
+    public Optional<AuthenticationToken> getToken()
+    {
+        return token;
+    }
+
+    enum Status
+    {
+        PENDING,
+        SUCCESSFUL,
+        FAILED;
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/TokenPollException.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/TokenPollException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+public class TokenPollException
+        extends RuntimeException
+{
+    public TokenPollException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/presto-client/src/main/java/io/prestosql/client/auth/external/Tokens.java
+++ b/presto-client/src/main/java/io/prestosql/client/auth/external/Tokens.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.FailsafeException;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.time.Duration;
+
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_ACCEPTED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Objects.requireNonNull;
+
+class Tokens
+{
+    public static final int HTTP_FAILED_DEPENDENCY = 424;
+    private final OkHttpClient client;
+    private Duration timeout;
+
+    Tokens(OkHttpClient client, Duration timeout)
+    {
+        this.client = requireNonNull(client, "client is null");
+        this.timeout = requireNonNull(timeout, "timeout is null");
+    }
+
+    public TokenPoll pollForToken(String tokenUrl)
+            throws TokenPollException
+    {
+        Call call = client.newCall(new Request.Builder()
+                .url(tokenUrl)
+                .get()
+                .build());
+        try {
+            return Failsafe.with(RetryPolicies.<TokenPoll>retryUntil(timeout)
+                    .handleResultIf(TokenPoll::isNotAvailableYet)
+                    .handleIf(tx -> false))
+                    .get(() -> handleResponse(call.clone()));
+        }
+        catch (FailsafeException e) {
+            // OkHttp throws this after clearing the interrupt status
+            // TODO: remove after updating to Okio 1.15.0+
+            Throwable cause = e.getCause();
+            if (InterruptedIOException.class.equals(cause.getClass()) && "thread interrupted".equals(cause.getMessage())) {
+                Thread.currentThread().interrupt();
+            }
+            throw new TokenPollException(cause);
+        }
+    }
+
+    private TokenPoll handleResponse(Call call)
+            throws IOException
+    {
+        try (Response response = call.execute()) {
+            switch (response.code()) {
+                case HTTP_OK:
+                    return TokenPoll.successful(
+                            new AuthenticationToken(response.body().string()));
+                case HTTP_ACCEPTED:
+                    return TokenPoll.pending();
+                case HTTP_FAILED_DEPENDENCY:
+                    return TokenPoll.failed();
+                default:
+                    if (response.code() > 399) {
+                        String body = response.body().string();
+                        throw new IOException("Token poll failed with message: " + body);
+                    }
+                    throw new IllegalArgumentException(format("Unknown response code \"%s\", retrieved from token poll", response.code()));
+            }
+        }
+    }
+}

--- a/presto-client/src/test/java/io/prestosql/client/auth/external/TestAuthenticationAssembler.java
+++ b/presto-client/src/test/java/io/prestosql/client/auth/external/TestAuthenticationAssembler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestAuthenticationAssembler
+{
+    private final AuthenticationAssembler assembler = new AuthenticationAssembler(uri("http://base.url"));
+
+    @Test
+    public void testAssemblyForEmptyHeader()
+    {
+        assertThatThrownBy(() -> assembler.toAuthentication(""))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("is null");
+    }
+
+    @Test
+    public void testAssemblyWithAbsoluteUrls()
+    {
+        ExternalAuthentication authentication = assembler.toAuthentication("External-Bearer redirectUrl=\"http://redirect.url\", tokenUrl=\"http://token.url\"");
+
+        assertThat(authentication.getRedirectUrl()).isEqualTo("http://redirect.url");
+        assertThat(authentication.getTokenPath()).isEqualTo("http://token.url");
+    }
+
+    @Test
+    public void testAssemblyWithRelativeUrls()
+    {
+        ExternalAuthentication authentication = new AuthenticationAssembler(uri("http://base.url"))
+                .toAuthentication("External-Bearer redirectUrl=\"/redirect/url\", tokenUrl=\"/path/to/token\"");
+
+        assertThat(authentication.getRedirectUrl()).isEqualTo("http://base.url/redirect/url");
+        assertThat(authentication.getTokenPath()).isEqualTo("http://base.url/path/to/token");
+    }
+
+    private static URI uri(String uri)
+    {
+        try {
+            return new URI(uri);
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-client/src/test/java/io/prestosql/client/auth/external/TestExternalAuthentication.java
+++ b/presto-client/src/test/java/io/prestosql/client/auth/external/TestExternalAuthentication.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import com.google.common.collect.ImmutableList;
+import okhttp3.OkHttpClient;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static io.prestosql.client.auth.external.RetryPolicies.noRetries;
+import static io.prestosql.client.auth.external.RetryPolicies.retries;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExternalAuthentication
+{
+    private static final String AUTH_TOKEN = "authToken";
+
+    @Test
+    public void testObtainTokenWhenTokenAlreadyExists()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+        StubTokens tokens = new StubTokens("tokenUrl", TokenPoll.successful(authToken()));
+
+        Optional<AuthenticationToken> token = new ExternalAuthentication("redirectUrl", "tokenUrl")
+                .obtainToken(noRetries(), redirectHandler, tokens);
+
+        assertThat(redirectHandler.redirectToUrl).isEqualTo("redirectUrl");
+        assertThat(token.map(AuthenticationToken::asString)).isEqualTo(Optional.of(AUTH_TOKEN));
+    }
+
+    @Test
+    public void testObtainTokenWhenTokenIsReadyAt2ndAttempt()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+        StubTokens tokens = new StubTokens("tokenUrl", ImmutableList.of(TokenPoll.pending(), TokenPoll.successful(authToken())));
+
+        Optional<AuthenticationToken> token = new ExternalAuthentication("redirectUrl", "tokenUrl")
+                .obtainToken(retries(1), redirectHandler, tokens);
+
+        assertThat(token)
+                .map(AuthenticationToken::asString)
+                .isEqualTo(Optional.of(AUTH_TOKEN));
+    }
+
+    private AuthenticationToken authToken()
+    {
+        return new AuthenticationToken(AUTH_TOKEN);
+    }
+
+    @Test
+    public void testObtainTokenWhenPollingFails()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+        StubTokens tokens = new StubTokens("tokenUrl", ImmutableList.of(TokenPoll.pending(), TokenPoll.failed()));
+
+        Optional<AuthenticationToken> token = new ExternalAuthentication("redirectUrl", "tokenUrl")
+                .obtainToken(retries(1), redirectHandler, tokens);
+
+        assertThat(token).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testObtainTokenWhenPollingFailsWithException()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+        StubTokens tokens = new StubTokens(() -> new RuntimeException("polling failed"));
+
+        assertThatThrownBy(() -> new ExternalAuthentication("redirectUrl", "tokenUrl")
+                .obtainToken(retries(1), redirectHandler, tokens))
+                .hasMessage("polling failed");
+    }
+
+    @Test
+    public void testObtainTokenWhenPollingFailsWithTokenPollException()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+        StubTokens tokens = new StubTokens(() -> new TokenPollException(new RuntimeException("polling failed")))
+                .withTokenPolls("tokenUrl", ImmutableList.of(TokenPoll.successful(authToken())));
+
+        Optional<AuthenticationToken> token = new ExternalAuthentication("redirectUrl", "tokenUrl")
+                .obtainToken(retries(2), redirectHandler, tokens);
+
+        assertThat(token)
+                .map(AuthenticationToken::asString)
+                .isEqualTo(Optional.of(AUTH_TOKEN));
+    }
+
+    private static class MockRedirectHandler
+            implements RedirectHandler
+    {
+        private String redirectToUrl;
+
+        @Override
+        public void redirectTo(String uri)
+                throws RedirectException
+        {
+            this.redirectToUrl = uri;
+        }
+    }
+
+    private static class StubTokens
+            extends Tokens
+    {
+        private final Map<String, List<TokenPoll>> tokenPolls = new HashMap<>();
+        private Runnable throwingRunnable = () -> {};
+
+        StubTokens(String tokenUrl, TokenPoll expectedTokenPoll)
+        {
+            super(new OkHttpClient.Builder().build(), Duration.ZERO);
+
+            tokenPolls.put(tokenUrl, ImmutableList.of(expectedTokenPoll));
+        }
+
+        StubTokens(String tokenPath, List<TokenPoll> expectedTokenPoll)
+        {
+            super(new OkHttpClient.Builder().build(), Duration.ZERO);
+
+            tokenPolls.put(tokenPath, expectedTokenPoll);
+        }
+
+        StubTokens(Supplier<RuntimeException> throwable)
+        {
+            super(new OkHttpClient.Builder().build(), Duration.ZERO);
+
+            throwingRunnable = () -> {
+                throw throwable.get();
+            };
+        }
+
+        StubTokens withTokenPolls(String tokenPath, List<TokenPoll> expectedTokenPoll)
+        {
+            tokenPolls.put(tokenPath, expectedTokenPoll);
+            return this;
+        }
+
+        @Override
+        public TokenPoll pollForToken(String tokenUrl)
+        {
+            try {
+                throwingRunnable.run();
+            }
+            finally {
+                throwingRunnable = () -> {};
+            }
+
+            if (tokenPolls.containsKey(tokenUrl)) {
+                List<TokenPoll> tokens = this.tokenPolls.get(tokenUrl);
+                if (tokens.size() > 1) {
+                    this.tokenPolls.put(tokenUrl, ImmutableList.copyOf(tokens.subList(1, tokens.size())));
+                }
+                else {
+                    this.tokenPolls.put(tokenUrl, ImmutableList.of());
+                }
+                return tokens.get(0);
+            }
+            throw new IllegalArgumentException("Unknown tokenPath: " + tokenUrl);
+        }
+    }
+}

--- a/presto-client/src/test/java/io/prestosql/client/auth/external/TestTokens.java
+++ b/presto-client/src/test/java/io/prestosql/client/auth/external/TestTokens.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.client.auth.external;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.QueueDispatcher;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.ANY_TEXT_TYPE;
+import static io.prestosql.client.auth.external.Tokens.HTTP_FAILED_DEPENDENCY;
+import static java.net.HttpURLConnection.HTTP_ACCEPTED;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestTokens
+{
+    private static final String TOKEN_PATH = "/v1/authentications/sso/test/token";
+    private Tokens tokens;
+    private MockWebServer server;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup()
+            throws Exception
+    {
+        server = new MockWebServer();
+        server.start();
+
+        tokens = new Tokens(
+                new OkHttpClient.Builder().build(),
+                Duration.ofSeconds(1));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown()
+            throws IOException
+    {
+        server.close();
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenTokenIsReady()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, "token"));
+
+        TokenPoll tokenPoll = tokens.pollForToken(tokenUrl());
+
+        assertThat(tokenPoll.getToken()).map(AuthenticationToken::asString)
+                .isEqualTo(Optional.of("token"));
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenItsNotReadyAtFirst()
+    {
+        Stream.concat(
+                Stream.generate(() -> status(HTTP_ACCEPTED)).limit(999),
+                Stream.of(statusAndBody(HTTP_OK, "token")))
+                .forEach(server::enqueue);
+
+        TokenPoll tokenPoll = tokens.pollForToken(tokenUrl());
+
+        assertThat(tokenPoll.getToken()).map(AuthenticationToken::asString)
+                .isEqualTo(Optional.of("token"));
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenItsNotReadyOverATimeout()
+    {
+        server.setDispatcher(delayedDispatcher(Duration.ofMillis(10)));
+        Stream.generate(() -> status(HTTP_ACCEPTED)).limit(200)
+                .forEach(server::enqueue);
+
+        TokenPoll tokenPoll = tokens.pollForToken(tokenUrl());
+
+        assertThat(tokenPoll.getToken()).isEqualTo(Optional.empty());
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenItHasFailedDependency()
+    {
+        server.enqueue(status(HTTP_FAILED_DEPENDENCY));
+
+        TokenPoll tokenPoll = tokens.pollForToken(tokenUrl());
+
+        assertThat(tokenPoll.hasFailed()).isTrue();
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenServerReturns201()
+    {
+        server.enqueue(status(HTTP_CREATED));
+
+        assertThatThrownBy(() -> tokens.pollForToken(tokenUrl()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageEndingWith("Unknown response code \"201\", retrieved from token poll");
+    }
+
+    private String tokenUrl()
+    {
+        return "http://" + server.getHostName() + ":" + server.getPort() + TOKEN_PATH;
+    }
+
+    @Test(singleThreaded = true)
+    public void testTokenPollWhenServerReturns500()
+    {
+        server.enqueue(statusAndBody(500, "Server failed unexpectedly"));
+
+        assertThatThrownBy(() -> tokens.pollForToken(tokenUrl()))
+                .isInstanceOf(TokenPollException.class)
+                .hasMessageEndingWith("Server failed unexpectedly")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    private MockResponse statusAndBody(int status, String body)
+    {
+        return new MockResponse()
+                .setResponseCode(status)
+                .addHeader(CONTENT_TYPE, ANY_TEXT_TYPE)
+                .setBody(body);
+    }
+
+    private MockResponse status(int code)
+    {
+        return new MockResponse()
+                .setResponseCode(code);
+    }
+
+    private Dispatcher delayedDispatcher(Duration timeOfDelay)
+    {
+        return new QueueDispatcher()
+        {
+            @Override
+            public MockResponse dispatch(RecordedRequest request)
+                    throws InterruptedException
+            {
+                MILLISECONDS.sleep(timeOfDelay.toMillis());
+                return super.dispatch(request);
+            }
+        };
+    }
+}

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -61,6 +61,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -261,6 +261,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${dep.log4j.version}</version>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -109,6 +109,12 @@
             <artifactId>validation-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -242,6 +242,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <scope>runtime</scope>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -138,6 +138,18 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
@@ -170,6 +182,12 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/RedirectHandlerFactory.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/RedirectHandlerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.jdbc;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.prestosql.client.auth.external.DesktopBrowserRedirectHandler;
+import io.prestosql.client.auth.external.RedirectHandler;
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+class RedirectHandlerFactory
+{
+    private static final AtomicReference<Supplier<RedirectHandler>> handlerFactory = new AtomicReference<>(DesktopBrowserRedirectHandler::new);
+
+    private RedirectHandlerFactory()
+    {
+    }
+
+    static RedirectHandler create()
+    {
+        return handlerFactory.get()
+                .get();
+    }
+
+    @VisibleForTesting
+    static void setHandlerFactory(Supplier<RedirectHandler> next)
+    {
+        Supplier<RedirectHandler> current = handlerFactory.get();
+        if (!handlerFactory.compareAndSet(current, next)) {
+            throw new ConcurrentModificationException("Concurrent modification of RedirectHandlerFactory detected. Use @Test(singleThreaded = true)");
+        }
+    }
+}

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverExternalAuth.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverExternalAuth.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.prestosql.client.auth.external.DesktopBrowserRedirectHandler;
+import io.prestosql.client.auth.external.RedirectException;
+import io.prestosql.client.auth.external.RedirectHandler;
+import io.prestosql.plugin.tpch.TpchPlugin;
+import io.prestosql.server.security.AuthenticationException;
+import io.prestosql.server.security.Authenticator;
+import io.prestosql.server.security.ResourceSecurity;
+import io.prestosql.server.testing.TestingPrestoServer;
+import io.prestosql.spi.security.Identity;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Predicates.not;
+import static com.google.common.io.Resources.getResource;
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.prestosql.jdbc.RedirectHandlerFactory.setHandlerFactory;
+import static io.prestosql.jdbc.TestPrestoDriver.waitForNodeRefresh;
+import static io.prestosql.jdbc.TestPrestoDriverExternalAuth.Authentications.VALID_TOKEN;
+import static io.prestosql.jdbc.TestPrestoDriverExternalAuth.RedirectHandlerFixture.withHandler;
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.ServerSecurityModule.authenticatorModule;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestPrestoDriverExternalAuth
+{
+    private static final String TEST_CATALOG = "test_catalog";
+    private TestingPrestoServer server;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+
+        server = TestingPrestoServer.builder()
+                .setAdditionalModule(new DummyExternalAuthModule(() -> server.getAddress().getPort()))
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "dummy-external")
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", getResource("localhost.keystore").getPath())
+                        .put("http-server.https.keystore.key", "changeit")
+                        .put("web-ui.enabled", "false")
+                        .build())
+                .build();
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog(TEST_CATALOG, "tpch");
+        waitForNodeRefresh(server);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+            throws Exception
+    {
+        server.close();
+    }
+
+    @Test(singleThreaded = true)
+    public void testSuccessfulAuthenticationWithHTTPGetOnlyRedirectHandler()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(HTTPGetOnlyRedirectHandler::new);
+                Connection connection = createConnection(ImmutableMap.of(
+                        "externalAuthentication", "true"));
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 123")).isTrue();
+        }
+    }
+
+    /**
+     * Ignored due to lack of ui environment with web-browser on CI servers.
+     * Still this test is useful for local environments.
+     */
+    @Test(singleThreaded = true, enabled = false)
+    public void testSuccessfulAuthenticationWithDefaultBrowserRedirect()
+            throws Exception
+    {
+        try (Connection connection = createConnection(ImmutableMap.of("externalAuthentication", "true"));
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 123")).isTrue();
+        }
+    }
+
+    @Test(singleThreaded = true)
+    public void testAuthenticationFailsAfterUnfinishedRedirect()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(NoOpRedirectHandler::new);
+                Connection connection = createConnection(ImmutableMap.of(
+                        "externalAuthentication", "true",
+                        "externalAuthenticationTimeout", "2"));
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class);
+        }
+    }
+
+    @Test(singleThreaded = true)
+    public void testAuthenticationFailsAfterRedirectException()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(FailingRedirectHandler::new);
+                Connection connection = createConnection(ImmutableMap.of(
+                        "externalAuthentication", "true",
+                        "externalAuthenticationTimeout", "2"));
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class)
+                    .hasCauseExactlyInstanceOf(RedirectException.class);
+        }
+    }
+
+    private Connection createConnection(Map<String, String> additionalProperties)
+            throws SQLException
+    {
+        String url = format("jdbc:presto://localhost:%s", server.getHttpsAddress().getPort());
+        Properties properties = new Properties();
+        properties.setProperty("user", "test");
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", getResource("localhost.truststore").getPath());
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        additionalProperties.forEach(properties::setProperty);
+        return DriverManager.getConnection(url, properties);
+    }
+
+    static class DummyExternalAuthModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final IntSupplier port;
+
+        DummyExternalAuthModule(IntSupplier port)
+        {
+            this.port = port;
+        }
+
+        @Override
+        protected void setup(Binder binder)
+        {
+            install(authenticatorModule("dummy-external", DummyAuthenticator.class, subBinder -> {
+                subBinder.bind(Authentications.class).in(SINGLETON);
+                subBinder.bind(IntSupplier.class).toInstance(port);
+                jaxrsBinder(subBinder).bind(DummyExternalAuthResources.class);
+            }));
+        }
+    }
+
+    static class Authentications
+    {
+        public static final String VALID_TOKEN = "VALID_TOKEN";
+        private final ConcurrentHashMap<String, String> logginSessions = new ConcurrentHashMap<>();
+
+        String startAuthentication()
+        {
+            String sessionId = UUID.randomUUID().toString();
+            logginSessions.put(sessionId, "");
+            return sessionId;
+        }
+
+        public void logIn(String sessionId)
+        {
+            logginSessions.put(sessionId, VALID_TOKEN);
+        }
+
+        public Optional<String> getToken(String sessionId)
+                throws IllegalArgumentException
+        {
+            if (logginSessions.containsKey(sessionId)) {
+                return Optional.of(logginSessions.get(sessionId))
+                        .filter(not(String::isEmpty));
+            }
+            throw new IllegalArgumentException("No login session exists for " + sessionId);
+        }
+    }
+
+    static class DummyAuthenticator
+            implements Authenticator
+    {
+        private IntSupplier port;
+        private Authentications authentications;
+
+        @Inject
+        DummyAuthenticator(IntSupplier port, Authentications authentications)
+        {
+            this.port = requireNonNull(port, "port is null");
+            this.authentications = requireNonNull(authentications, "authentications is null");
+        }
+
+        @Override
+        public Identity authenticate(ContainerRequestContext request)
+                throws AuthenticationException
+        {
+            List<String> bearerHeaders = request.getHeaders().get(AUTHORIZATION);
+            if (bearerHeaders != null
+                    && !bearerHeaders.isEmpty()
+                    && bearerHeaders.get(0).startsWith("Bearer ")
+                    && bearerHeaders.get(0).contains(VALID_TOKEN)) {
+                return Identity.ofUser("user");
+            }
+            String sessionId = authentications.startAuthentication();
+            throw new AuthenticationException(
+                    "Authentication required",
+                    /**
+                     * - redirectUrl should take relative path as well.
+                     * - presto server can communicate with IdP directly (to exchange tokens)
+                     * - User's browser can talk to IdP and presto server
+                     */
+                    format("External-Bearer redirectUrl=\"http://localhost:%s/v1/authentications/dummy/logins/%s\", " +
+                                    "tokenPath=\"/v1/authentications/dummy/%s\"",
+                            port.getAsInt(), sessionId, sessionId));
+        }
+    }
+
+    @Path("/v1/authentications/dummy")
+    public static class DummyExternalAuthResources
+    {
+        private final Authentications authentications;
+
+        @Inject
+        public DummyExternalAuthResources(Authentications authentications)
+        {
+            this.authentications = authentications;
+        }
+
+        @GET
+        @Produces(TEXT_PLAIN)
+        @ResourceSecurity(PUBLIC)
+        @Path("logins/{sessionId}")
+        public String logInUser(@PathParam("sessionId") String sessionId)
+        {
+            authentications.logIn(sessionId);
+            return "User has been successfully logged in during " + sessionId + " session";
+        }
+
+        @GET
+        @ResourceSecurity(PUBLIC)
+        @Path("{sessionId}")
+        public Response getToken(@PathParam("sessionId") String sessionId)
+        {
+            try {
+                return authentications.getToken(sessionId)
+                        .map(token -> Response.ok(token, TEXT_PLAIN_TYPE))
+                        .orElseGet(Response::accepted)
+                        .build();
+            }
+            catch (IllegalArgumentException ex) {
+                return Response.status(NOT_FOUND).build();
+            }
+        }
+    }
+
+    public static class HTTPGetOnlyRedirectHandler
+            implements RedirectHandler
+    {
+        private final Logger log = Logger.get(HTTPGetOnlyRedirectHandler.class);
+
+        @Override
+        public void redirectTo(String uri)
+                throws RedirectException
+        {
+            try {
+                InputStream content = (InputStream) new URI(uri).toURL()
+                        .openConnection()
+                        .getContent();
+
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(content))) {
+                    log.info("redirected to %s and obtained response %s",
+                            uri,
+                            reader.lines()
+                                    .collect(joining("/n")));
+                }
+            }
+            catch (IOException | URISyntaxException e) {
+                throw new RedirectException("Redirection failed", e);
+            }
+        }
+    }
+
+    public static class NoOpRedirectHandler
+            implements RedirectHandler
+    {
+        @Override
+        public void redirectTo(String uri)
+                throws RedirectException
+        {
+        }
+    }
+
+    public static class FailingRedirectHandler
+            implements RedirectHandler
+    {
+        @Override
+        public void redirectTo(String uri)
+                throws RedirectException
+        {
+            throw new RedirectException("Redirect to uri has failed " + uri);
+        }
+    }
+
+    static class RedirectHandlerFixture
+            implements AutoCloseable
+    {
+        private static final RedirectHandlerFixture INSTANCE = new RedirectHandlerFixture();
+
+        public static RedirectHandlerFixture withHandler(Supplier<RedirectHandler> handler)
+        {
+            setHandlerFactory(handler);
+            return INSTANCE;
+        }
+
+        @Override
+        public void close()
+        {
+            setHandlerFactory(DesktopBrowserRedirectHandler::new);
+        }
+    }
+}

--- a/presto-kinesis/pom.xml
+++ b/presto-kinesis/pom.xml
@@ -127,6 +127,12 @@
             <artifactId>validation-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -482,6 +482,12 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.13.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -177,6 +177,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.clearspring.analytics</groupId>
             <artifactId>stream</artifactId>
         </dependency>
@@ -416,24 +421,48 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-support</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -407,8 +407,44 @@
         </dependency>
 
         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>selenium</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -202,6 +202,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
@@ -398,6 +403,18 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-main/src/main/java/io/prestosql/server/ServletSecurityUtils.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServletSecurityUtils.java
@@ -27,7 +27,9 @@ import java.util.Collection;
 
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static io.prestosql.server.HttpRequestSessionContext.AUTHENTICATED_IDENTITY;
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
+import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public final class ServletSecurityUtils
@@ -42,6 +44,11 @@ public final class ServletSecurityUtils
     public static void sendWwwAuthenticate(ContainerRequestContext request, String errorMessage, Collection<String> authenticateHeaders)
     {
         request.abortWith(authenticateResponse(errorMessage, authenticateHeaders).build());
+    }
+
+    public static void sendRedirect(ContainerRequestContext request, String location)
+    {
+        request.abortWith(Response.status(FOUND).header(LOCATION, location).build());
     }
 
     private static ResponseBuilder authenticateResponse(String errorMessage, Collection<String> authenticateHeaders)

--- a/presto-main/src/main/java/io/prestosql/server/security/RedirectAuthenticationException.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/RedirectAuthenticationException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security;
+
+import static java.util.Objects.requireNonNull;
+
+public class RedirectAuthenticationException
+        extends AuthenticationException
+{
+    private final String location;
+
+    public RedirectAuthenticationException(String message, String authenticateHeader, String location)
+    {
+        super(message, authenticateHeader);
+        this.location = requireNonNull(location, "location");
+    }
+
+    public String getLocation()
+    {
+        return location;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -26,6 +26,8 @@ import io.airlift.discovery.store.StoreResource;
 import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.jmx.MBeanResource;
+import io.prestosql.server.security.oauth2.OAuth2Authenticator;
+import io.prestosql.server.security.oauth2.OAuth2Config;
 
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,7 @@ public class ServerSecurityModule
         installAuthenticator("kerberos", KerberosAuthenticator.class, KerberosConfig.class);
         installAuthenticator("password", PasswordAuthenticator.class, PasswordAuthenticatorConfig.class);
         installAuthenticator("jwt", JsonWebTokenAuthenticator.class, JsonWebTokenConfig.class);
+        installAuthenticator("oauth2", OAuth2Authenticator.class, OAuth2Config.class);
 
         configBinder(binder).bindConfig(InsecureAuthenticatorConfig.class);
         binder.bind(InsecureAuthenticator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -28,7 +28,7 @@ import io.airlift.http.server.HttpServerConfig;
 import io.airlift.jmx.MBeanResource;
 import io.prestosql.server.security.oauth2.OAuth2Authenticator;
 import io.prestosql.server.security.oauth2.OAuth2Config;
-import io.prestosql.server.security.oauth2.OAuth2Error;
+import io.prestosql.server.security.oauth2.OAuth2ErrorResponse;
 import io.prestosql.server.security.oauth2.OAuth2Resource;
 import io.prestosql.server.security.oauth2.OAuth2Service;
 
@@ -81,7 +81,7 @@ public class ServerSecurityModule
             configBinder(oauth2Binder).bindConfig(OAuth2Config.class);
             binder.bind(OAuth2Service.class).in(Scopes.SINGLETON);
             jaxrsBinder(binder).bind(OAuth2Resource.class);
-            jsonCodecBinder(binder).bindJsonCodec(OAuth2Error.class);
+            jsonCodecBinder(binder).bindJsonCodec(OAuth2ErrorResponse.class);
         }));
 
         configBinder(binder).bindConfig(InsecureAuthenticatorConfig.class);

--- a/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/ServerSecurityModule.java
@@ -31,6 +31,7 @@ import io.prestosql.server.security.oauth2.OAuth2Config;
 import io.prestosql.server.security.oauth2.OAuth2ErrorResponse;
 import io.prestosql.server.security.oauth2.OAuth2Resource;
 import io.prestosql.server.security.oauth2.OAuth2Service;
+import io.prestosql.server.security.oauth2.TokenPollingExecutors;
 
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,7 @@ public class ServerSecurityModule
         install(authenticatorModule("oauth2", OAuth2Authenticator.class, oauth2Binder -> {
             configBinder(oauth2Binder).bindConfig(OAuth2Config.class);
             binder.bind(OAuth2Service.class).in(Scopes.SINGLETON);
+            binder.bind(TokenPollingExecutors.class).in(Scopes.SINGLETON);
             jaxrsBinder(binder).bind(OAuth2Resource.class);
             jsonCodecBinder(binder).bindJsonCodec(OAuth2ErrorResponse.class);
         }));

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
@@ -17,9 +17,11 @@ import com.github.scribejava.core.model.OAuth2AccessToken;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
-class Challenge
+abstract class Challenge
 {
     private final State state;
     private final Status status;
@@ -38,6 +40,17 @@ class Challenge
     Status getStatus()
     {
         return status;
+    }
+
+    boolean isPending()
+    {
+        return !status.isFinal();
+    }
+
+    <T extends Challenge> Optional<T> isInStatus(Status<T> status)
+    {
+        return status
+                .toStatus(this);
     }
 
     static class Started

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import static java.util.Objects.requireNonNull;
+
+class Challenge
+{
+    private final State state;
+    private final Status status;
+
+    Challenge(State state, Status status)
+    {
+        this.state = requireNonNull(state, "state is null");
+        this.status = requireNonNull(status, "status is null");
+    }
+
+    State getState()
+    {
+        return state;
+    }
+
+    Status getStatus()
+    {
+        return status;
+    }
+
+    static class Started
+            extends Challenge
+    {
+        private final String authorizationUrl;
+
+        Started(State state, String authorizationUrl)
+        {
+            super(state, Status.STARTED);
+            this.authorizationUrl = requireNonNull(authorizationUrl, "authorizationUrl is null");
+        }
+
+        String getAuthorizationUrl()
+        {
+            return authorizationUrl;
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/Challenge.java
@@ -13,6 +13,10 @@
  */
 package io.prestosql.server.security.oauth2;
 
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
 import static java.util.Objects.requireNonNull;
 
 class Challenge
@@ -50,6 +54,57 @@ class Challenge
         String getAuthorizationUrl()
         {
             return authorizationUrl;
+        }
+
+        Succeeded succeed(OAuth2AccessToken token, Jws<Claims> jwtToken)
+        {
+            return new Succeeded(getState(), token, jwtToken);
+        }
+
+        Failed fail(OAuth2ErrorResponse error)
+        {
+            return new Failed(getState(), error);
+        }
+    }
+
+    static class Succeeded
+            extends Challenge
+    {
+        private final OAuth2AccessToken token;
+        private final Jws<Claims> jwtToken;
+
+        Succeeded(State state, OAuth2AccessToken token, Jws<Claims> jwtToken)
+        {
+            super(state, Status.SUCCEEDED);
+            this.token = requireNonNull(token, "token is null");
+            this.jwtToken = requireNonNull(jwtToken, "jwtToken is null");
+        }
+
+        OAuth2AccessToken getToken()
+        {
+            return token;
+        }
+
+        Jws<Claims> getJwtToken()
+        {
+            return jwtToken;
+        }
+    }
+
+    static class Failed
+            extends Challenge
+    {
+        private final OAuth2ErrorResponse error;
+
+        Failed(State state, OAuth2ErrorResponse error)
+        {
+            super(state, Status.FAILED);
+            this.error = requireNonNull(error, "error is null");
+        }
+
+        OAuth2ErrorResponse getError()
+        {
+            return error;
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/ChallengeNotFoundException.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/ChallengeNotFoundException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import static java.util.Objects.requireNonNull;
+
+class ChallengeNotFoundException
+        extends RuntimeException
+{
+    private final State state;
+
+    ChallengeNotFoundException(State state)
+    {
+        this.state = requireNonNull(state, "state is null");
+    }
+
+    State getState()
+    {
+        return state;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/DynamicCallbackOAuth2Service.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/DynamicCallbackOAuth2Service.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.oauth.AccessTokenRequestParams;
+import com.github.scribejava.core.oauth.OAuth20Service;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class DynamicCallbackOAuth2Service
+        extends OAuth20Service
+{
+    public DynamicCallbackOAuth2Service(
+            DefaultApi20 api,
+            String apiKey,
+            String apiSecret,
+            String defaultScope)
+    {
+        super(api, apiKey, apiSecret, null, defaultScope, "code", null, null, null, null);
+    }
+
+    public OAuth2AccessToken getAccessToken(String code, String callbackUrl)
+            throws IOException, InterruptedException, ExecutionException
+    {
+        OAuthRequest request = createAccessTokenRequest(AccessTokenRequestParams.create(code));
+        request.addParameter(OAuthConstants.REDIRECT_URI, callbackUrl);
+        return sendAccessTokenRequestSync(request);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/JWKSSigningKeyResolver.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/JWKSSigningKeyResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.UrlJwkProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SigningKeyResolver;
+
+import java.security.Key;
+import java.security.PublicKey;
+
+import static java.util.Objects.requireNonNull;
+
+class JWKSSigningKeyResolver
+        implements SigningKeyResolver
+{
+    private final String idpUrl;
+
+    JWKSSigningKeyResolver(String idpUrl)
+    {
+        this.idpUrl = requireNonNull(idpUrl, "idpUrl is null");
+    }
+
+    @Override
+    public Key resolveSigningKey(JwsHeader header, Claims claims)
+    {
+        return getPublicKey(header.getKeyId());
+    }
+
+    @Override
+    public Key resolveSigningKey(JwsHeader header, String plaintext)
+    {
+        return getPublicKey(header.getKeyId());
+    }
+
+    private PublicKey getPublicKey(String keyId)
+    {
+        JwkProvider provider = new UrlJwkProvider(idpUrl);
+        try {
+            Jwk jwk = provider.get(keyId);
+            return jwk.getPublicKey();
+        }
+        catch (JwkException e) {
+            throw new UncheckedJwkException(e);
+        }
+    }
+
+    static class UncheckedJwkException
+            extends RuntimeException
+    {
+        public UncheckedJwkException(JwkException cause)
+        {
+            super(cause);
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Api.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Api.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+
+import static java.util.Objects.requireNonNull;
+
+class OAuth2Api
+        extends DefaultApi20
+{
+    private final String accessTokenEndpoint;
+    private final String authorizationBaseUrl;
+
+    OAuth2Api(String accessTokenEndpoint, String authorizationBaseUrl)
+    {
+        this.accessTokenEndpoint = requireNonNull(accessTokenEndpoint, "accessTokenEndpoint is null");
+        this.authorizationBaseUrl = requireNonNull(authorizationBaseUrl, "authorizationBaseUrl is null");
+    }
+
+    @Override
+    public String getAccessTokenEndpoint()
+    {
+        return accessTokenEndpoint;
+    }
+
+    @Override
+    protected String getAuthorizationBaseUrl()
+    {
+        return authorizationBaseUrl;
+    }
+
+    static OAuth2Api create(OAuth2Config config)
+    {
+        return new OAuth2Api(config.getTokenUrl(), config.getAuthUrl());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
@@ -13,37 +13,116 @@
  */
 package io.prestosql.server.security.oauth2;
 
+import io.airlift.log.Logger;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.prestosql.server.security.AuthenticationException;
 import io.prestosql.server.security.Authenticator;
 import io.prestosql.server.security.RedirectAuthenticationException;
+import io.prestosql.server.security.UserMapping;
+import io.prestosql.server.security.UserMappingException;
+import io.prestosql.server.security.oauth2.JWKSSigningKeyResolver.UncheckedJwkException;
+import io.prestosql.spi.security.BasicPrincipal;
 import io.prestosql.spi.security.Identity;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.prestosql.server.security.oauth2.OAuth2Resource.OAUTH2_COOKIE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 
 public class OAuth2Authenticator
         implements Authenticator
 {
+    private static final Logger LOG = Logger.get(OAuth2Authenticator.class);
+
     private final OAuth2Service service;
+    private final UserMapping userMapping;
 
     @Inject
-    public OAuth2Authenticator(OAuth2Service service)
+    public OAuth2Authenticator(OAuth2Service service, OAuth2Config oauth2Config)
     {
         this.service = requireNonNull(service, "service is null");
+        requireNonNull(oauth2Config, "oauth2Config is null");
+        this.userMapping = UserMapping.createUserMapping(oauth2Config.getUserMappingPattern(), oauth2Config.getUserMappingFile());
     }
 
     @Override
     public Identity authenticate(ContainerRequestContext request)
-            throws RedirectAuthenticationException
+            throws AuthenticationException
     {
-        Challenge.Started challenge = service.startChallenge();
-        throw new RedirectAuthenticationException(
-                "Unauthorized",
-                format("Bearer realm=\"Presto\", authorizationUrl=\"%s\", status=\"%s\"",
-                        challenge.getAuthorizationUrl(),
-                        challenge.getStatus()),
-                challenge.getAuthorizationUrl());
+        String principal = getAccessToken(request)
+                .map(token -> token.getBody().getSubject())
+                .orElseThrow(() -> {
+                    Challenge.Started challenge = service.startChallenge(request.getUriInfo().getBaseUri());
+                    return new RedirectAuthenticationException(
+                            "Unauthorized",
+                            format("Bearer realm=\"Presto\", authorizationUrl=\"%s\", status=\"%s\"",
+                                    challenge.getAuthorizationUrl(),
+                                    challenge.getStatus()),
+                            challenge.getAuthorizationUrl());
+                });
+        try {
+            return Identity.forUser(userMapping.mapUser(principal))
+                    .withPrincipal(new BasicPrincipal(principal))
+                    .build();
+        }
+        catch (UserMappingException e) {
+            throw new AuthenticationException(e.getMessage());
+        }
+    }
+
+    private Optional<Jws<Claims>> getAccessToken(ContainerRequestContext request)
+    {
+        Stream<String> accessTokenSources = Stream.concat(Stream.concat(
+                getTokenFromCookie(request),
+                getTokenFromHeader(request)),
+                getTokenFromQueryParam(request));
+        return accessTokenSources
+                .filter(not(String::isBlank))
+                .map(token -> {
+                    try {
+                        return Optional.ofNullable(service.parseClaimsJws(token));
+                    }
+                    catch (JwtException | IllegalArgumentException | UncheckedJwkException e) {
+                        LOG.debug("Unable to parse JWT token: " + e.getMessage(), e);
+                        return Optional.<Jws<Claims>>empty();
+                    }
+                })
+                .findFirst()
+                .flatMap(Function.identity());
+    }
+
+    private Stream<String> getTokenFromCookie(ContainerRequestContext request)
+    {
+        return Stream.ofNullable(request.getCookies().get(OAUTH2_COOKIE))
+                .map(Cookie::getValue);
+    }
+
+    private Stream<String> getTokenFromHeader(ContainerRequestContext request)
+    {
+        return Stream.ofNullable(request.getHeaders().get(AUTHORIZATION))
+                .flatMap(Collection::stream)
+                .filter(Objects::nonNull)
+                .filter(header -> header.startsWith("Bearer "))
+                .map(header -> header.substring("Bearer ".length()));
+    }
+
+    private Stream<String> getTokenFromQueryParam(ContainerRequestContext request)
+    {
+        return Stream.ofNullable(request.getUriInfo().getQueryParameters().get("access_token"))
+                .flatMap(Collection::stream)
+                .filter(Objects::nonNull);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
@@ -36,7 +36,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static io.prestosql.server.security.oauth2.OAuth2Resource.OAUTH2_API_PREFIX;
 import static io.prestosql.server.security.oauth2.OAuth2Resource.OAUTH2_COOKIE;
+import static io.prestosql.server.security.oauth2.OAuth2Resource.TOKENS_ENDPOINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
@@ -68,9 +70,10 @@ public class OAuth2Authenticator
                     Challenge.Started challenge = service.startChallenge(request.getUriInfo().getBaseUri());
                     return new RedirectAuthenticationException(
                             "Unauthorized",
-                            format("Bearer realm=\"Presto\", authorizationUrl=\"%s\", status=\"%s\"",
+                            format("External-Bearer redirectUrl=\"%s\", tokenUrl=\"%s?state=%s\"",
                                     challenge.getAuthorizationUrl(),
-                                    challenge.getStatus()),
+                                    OAUTH2_API_PREFIX + TOKENS_ENDPOINT,
+                                    challenge.getState()),
                             challenge.getAuthorizationUrl());
                 });
         try {

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Authenticator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import io.airlift.http.server.HttpServerConfig;
+import io.prestosql.server.security.Authenticator;
+import io.prestosql.server.security.RedirectAuthenticationException;
+import io.prestosql.spi.security.Identity;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2Authenticator
+        implements Authenticator
+{
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final OAuth20Service service;
+
+    @Inject
+    public OAuth2Authenticator(OAuth2Config oauth2Config, HttpServerConfig httpServerConfig)
+    {
+        requireNonNull(oauth2Config, "oauth2Config is null");
+        requireNonNull(httpServerConfig, "httpServerConfig is null");
+        this.service = new ServiceBuilder(oauth2Config.getClientId())
+                .apiSecret(oauth2Config.getClientSecret())
+                .defaultScope("openid")
+                .callback(format("https://127.0.0.1:%s/callback", httpServerConfig.getHttpsPort()))
+                .build(new DefaultApi20()
+                {
+                    @Override
+                    public String getAccessTokenEndpoint()
+                    {
+                        return oauth2Config.getTokenUrl();
+                    }
+
+                    @Override
+                    protected String getAuthorizationBaseUrl()
+                    {
+                        return oauth2Config.getAuthUrl();
+                    }
+                });
+    }
+
+    @Override
+    public Identity authenticate(ContainerRequestContext request)
+            throws RedirectAuthenticationException
+    {
+        String authorizationUrl = service.getAuthorizationUrl(randomState());
+        throw new RedirectAuthenticationException(
+                "Unauthorized",
+                format("Bearer realm=\"Presto\", redirectUrl=\"%s\", status=\"STARTED\"", authorizationUrl),
+                authorizationUrl);
+    }
+
+    private static String randomState()
+    {
+        byte[] randomBytes = new byte[16];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return Base64.getEncoder().encodeToString(randomBytes);
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
@@ -25,6 +25,9 @@ import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public class OAuth2Config
 {
     private String serverUrl;
@@ -35,6 +38,7 @@ public class OAuth2Config
     private Duration challengeTimeout = new Duration(15, TimeUnit.MINUTES);
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
+    private Duration maxSinglePollDuration = Duration.succinctDuration(3, SECONDS);
 
     @NotNull
     public String getServerUrl()
@@ -138,6 +142,26 @@ public class OAuth2Config
     public OAuth2Config setUserMappingFile(File userMappingFile)
     {
         this.userMappingFile = Optional.ofNullable(userMappingFile);
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("3s")
+    public Duration getMaxSinglePollDuration()
+    {
+        return maxSinglePollDuration;
+    }
+
+    public long getMaxSinglePollMs()
+    {
+        return maxSinglePollDuration.roundTo(MILLISECONDS);
+    }
+
+    @Config("http-server.authentication.oauth2.token.polling.max-single-duration")
+    @ConfigDescription("Maximum duration of a single poll token request - when token is not ready yet")
+    public OAuth2Config setMaxSinglePollDuration(Duration duration)
+    {
+        this.maxSinglePollDuration = duration;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
@@ -15,15 +15,40 @@ package io.prestosql.server.security.oauth2;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.validation.FileExists;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
 
+import java.io.File;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
 public class OAuth2Config
 {
+    private String serverUrl;
     private String authUrl;
     private String tokenUrl;
     private String clientId;
     private String clientSecret;
+    private Duration challengeTimeout = new Duration(15, TimeUnit.MINUTES);
+    private Optional<String> userMappingPattern = Optional.empty();
+    private Optional<File> userMappingFile = Optional.empty();
+
+    @NotNull
+    public String getServerUrl()
+    {
+        return serverUrl;
+    }
+
+    @Config("http-server.authentication.oauth2.server-url")
+    @ConfigDescription("URL of the authorization server")
+    public OAuth2Config setServerUrl(String serverUrl)
+    {
+        this.serverUrl = serverUrl;
+        return this;
+    }
 
     @NotNull
     public String getAuthUrl()
@@ -76,6 +101,43 @@ public class OAuth2Config
     public OAuth2Config setClientSecret(String clientSecret)
     {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getChallengeTimeout()
+    {
+        return challengeTimeout;
+    }
+
+    @Config("http-server.authentication.oauth2.challenge-timeout")
+    public OAuth2Config setChallengeTimeout(Duration challengeTimeout)
+    {
+        this.challengeTimeout = challengeTimeout;
+        return this;
+    }
+
+    public Optional<String> getUserMappingPattern()
+    {
+        return userMappingPattern;
+    }
+
+    @Config("http-server.authentication.oauth2.user-mapping.pattern")
+    public OAuth2Config setUserMappingPattern(String userMappingPattern)
+    {
+        this.userMappingPattern = Optional.ofNullable(userMappingPattern);
+        return this;
+    }
+
+    public Optional<@FileExists File> getUserMappingFile()
+    {
+        return userMappingFile;
+    }
+
+    @Config("http-server.authentication.oauth2.user-mapping.file")
+    public OAuth2Config setUserMappingFile(File userMappingFile)
+    {
+        this.userMappingFile = Optional.ofNullable(userMappingFile);
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Config.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotNull;
+
+public class OAuth2Config
+{
+    private String authUrl;
+    private String tokenUrl;
+    private String clientId;
+    private String clientSecret;
+
+    @NotNull
+    public String getAuthUrl()
+    {
+        return authUrl;
+    }
+
+    @Config("http-server.authentication.oauth2.auth-url")
+    @ConfigDescription("URL of the authorization server's authorization endpoint")
+    public OAuth2Config setAuthUrl(String authUrl)
+    {
+        this.authUrl = authUrl;
+        return this;
+    }
+
+    @NotNull
+    public String getTokenUrl()
+    {
+        return tokenUrl;
+    }
+
+    @Config("http-server.authentication.oauth2.token-url")
+    @ConfigDescription("URL of the authorization server's token endpoint")
+    public OAuth2Config setTokenUrl(String tokenUrl)
+    {
+        this.tokenUrl = tokenUrl;
+        return this;
+    }
+
+    @NotNull
+    public String getClientId()
+    {
+        return clientId;
+    }
+
+    @Config("http-server.authentication.oauth2.client-id")
+    public OAuth2Config setClientId(String clientId)
+    {
+        this.clientId = clientId;
+        return this;
+    }
+
+    @NotNull
+    public String getClientSecret()
+    {
+        return clientSecret;
+    }
+
+    @Config("http-server.authentication.oauth2.client-secret")
+    public OAuth2Config setClientSecret(String clientSecret)
+    {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Error.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Error.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2Error
+{
+    private final String error;
+    private final Optional<String> errorDescription;
+    private final Optional<String> errorUri;
+
+    @JsonCreator
+    public OAuth2Error(
+            @JsonProperty("error") String error,
+            @JsonProperty("error_description") Optional<String> errorDescription,
+            @JsonProperty("error_uri") Optional<String> errorUri)
+    {
+        this.error = requireNonNull(error, "error is null");
+        this.errorDescription = requireNonNull(errorDescription, "errorDescription is null");
+        this.errorUri = requireNonNull(errorUri, "errorUri is null");
+    }
+
+    @JsonProperty
+    public String getError()
+    {
+        return error;
+    }
+
+    @JsonProperty("error_description")
+    public Optional<String> getErrorDescription()
+    {
+        return errorDescription;
+    }
+
+    @JsonProperty("error_uri")
+    @Nullable
+    public Optional<String> getErrorUri()
+    {
+        return errorUri;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2ErrorResponse.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2ErrorResponse.java
@@ -15,24 +15,29 @@ package io.prestosql.server.security.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.scribejava.core.oauth2.OAuth2Error;
 
 import javax.annotation.Nullable;
 
+import java.net.URI;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public class OAuth2Error
+/**
+ * Error response according to: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+ */
+public class OAuth2ErrorResponse
 {
-    private final String error;
+    private final OAuth2Error error;
     private final Optional<String> errorDescription;
-    private final Optional<String> errorUri;
+    private final Optional<URI> errorUri;
 
     @JsonCreator
-    public OAuth2Error(
-            @JsonProperty("error") String error,
+    public OAuth2ErrorResponse(
+            @JsonProperty("error") OAuth2Error error,
             @JsonProperty("error_description") Optional<String> errorDescription,
-            @JsonProperty("error_uri") Optional<String> errorUri)
+            @JsonProperty("error_uri") Optional<URI> errorUri)
     {
         this.error = requireNonNull(error, "error is null");
         this.errorDescription = requireNonNull(errorDescription, "errorDescription is null");
@@ -42,7 +47,7 @@ public class OAuth2Error
     @JsonProperty
     public String getError()
     {
-        return error;
+        return error.getErrorString();
     }
 
     @JsonProperty("error_description")
@@ -55,6 +60,6 @@ public class OAuth2Error
     @Nullable
     public Optional<String> getErrorUri()
     {
-        return errorUri;
+        return errorUri.map(URI::toString);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Resource.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Resource.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import io.prestosql.server.security.ResourceSecurity;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import java.util.Optional;
+
+import static io.prestosql.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.prestosql.server.security.oauth2.OAuth2Resource.OAUTH2_API_PREFIX;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.PRESTO_UI_COOKIE;
+import static io.prestosql.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.FOUND;
+
+@Path(OAUTH2_API_PREFIX)
+public class OAuth2Resource
+{
+    static final String OAUTH2_API_PREFIX = "/oauth2";
+    static final String CALLBACK_ENDPOINT = "/callback";
+
+    private final OAuth2Service service;
+
+    @Inject
+    public OAuth2Resource(OAuth2Service service)
+    {
+        this.service = requireNonNull(service, "service is null");
+    }
+
+    @ResourceSecurity(PUBLIC)
+    @GET
+    @Path(CALLBACK_ENDPOINT)
+    public Response callback(
+            @QueryParam("state") String state,
+            @QueryParam("code") String code,
+            @QueryParam("error") String error,
+            @QueryParam("error_description") String errorDescription,
+            @QueryParam("error_uri") String errorUri,
+            @Context SecurityContext securityContext)
+    {
+        if (error != null && !error.isBlank()) {
+            return Response
+                    .status(BAD_REQUEST)
+                    .entity(new OAuth2Error(error, Optional.ofNullable(errorDescription), Optional.ofNullable(errorUri)))
+                    .build();
+        }
+        if (state == null || state.isBlank()) {
+            return Response
+                    .status(BAD_REQUEST)
+                    .entity(new OAuth2Error("State is null or empty", Optional.empty(), Optional.empty()))
+                    .build();
+        }
+        if (code == null || code.isBlank()) {
+            return Response
+                    .status(BAD_REQUEST)
+                    .entity(new OAuth2Error("Code is null or empty", Optional.empty(), Optional.empty()))
+                    .build();
+        }
+        String accessToken = service.finishChallenge(new State(state), code);
+        return Response
+                .status(FOUND)
+                .header(LOCATION, UI_LOCATION)
+                .cookie(new NewCookie(
+                        PRESTO_UI_COOKIE,
+                        accessToken,
+                        UI_LOCATION,
+                        null,
+                        Cookie.DEFAULT_VERSION,
+                        null,
+                        NewCookie.DEFAULT_MAX_AGE,
+                        null, // TODO: get from token
+                        securityContext.isSecure(),
+                        true))
+                .build();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Service.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/OAuth2Service.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import io.airlift.http.server.HttpServerConfig;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static io.prestosql.server.security.oauth2.OAuth2Resource.CALLBACK_ENDPOINT;
+import static io.prestosql.server.security.oauth2.OAuth2Resource.OAUTH2_API_PREFIX;
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2Service
+{
+    private final HttpServerConfig httpServerConfig;
+    private final OAuth20Service service;
+
+    @Inject
+    public OAuth2Service(OAuth2Config oauth2Config, HttpServerConfig httpServerConfig)
+    {
+        requireNonNull(oauth2Config, "oauth2Config is null");
+        this.httpServerConfig = requireNonNull(httpServerConfig, "httpServerConfig is null");
+        this.service = new ServiceBuilder(oauth2Config.getClientId())
+                .apiSecret(oauth2Config.getClientSecret())
+                .defaultScope("openid")
+                .callback(serverUrl() + OAUTH2_API_PREFIX + CALLBACK_ENDPOINT)
+                .build(new DefaultApi20()
+                {
+                    @Override
+                    public String getAccessTokenEndpoint()
+                    {
+                        return oauth2Config.getTokenUrl();
+                    }
+
+                    @Override
+                    protected String getAuthorizationBaseUrl()
+                    {
+                        return oauth2Config.getAuthUrl();
+                    }
+                });
+    }
+
+    Challenge.Started startChallenge()
+    {
+        State state = State.randomState();
+        String authorizationUrl = service.getAuthorizationUrl(state.get());
+        return new Challenge.Started(state, authorizationUrl);
+    }
+
+    String finishChallenge(State state, String code)
+    {
+        requireNonNull(state, "state is null");
+        requireNonNull(code, "code is null");
+        try {
+            return service.getAccessToken(code).getAccessToken();
+        }
+        catch (IOException | InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String serverUrl()
+    {
+        // TODO: use server external address
+        String host = "host.testcontainers.internal";
+        if (httpServerConfig.isHttpsEnabled()) {
+            return "https://" + host + ":" + httpServerConfig.getHttpsPort();
+        }
+        else {
+            return "http://" + host + ":" + httpServerConfig.getHttpPort();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/State.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/State.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import java.util.Base64;
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+class State
+{
+    private final String value;
+
+    State(String value)
+    {
+        this.value = requireNonNull(value, "values is null");
+    }
+
+    String get()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        State state = (State) o;
+        return value.equals(state.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value);
+    }
+
+    static State randomState()
+    {
+        return new State(
+                new String(
+                        Base64.getEncoder()
+                                .encode(UUID.randomUUID().toString().getBytes(UTF_8)), UTF_8));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/State.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/State.java
@@ -13,25 +13,23 @@
  */
 package io.prestosql.server.security.oauth2;
 
+import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Objects;
-import java.util.UUID;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 class State
 {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final String value;
 
-    State(String value)
+    private State(String value)
     {
-        this.value = requireNonNull(value, "values is null");
-    }
-
-    String get()
-    {
-        return value;
+        checkArgument(!isNullOrEmpty(value), "State is null or empty");
+        this.value = value;
     }
 
     @Override
@@ -53,11 +51,21 @@ class State
         return Objects.hash(value);
     }
 
+    @Override
+    public String toString()
+    {
+        return value;
+    }
+
+    static State valueOf(String value)
+    {
+        return new State(value);
+    }
+
     static State randomState()
     {
-        return new State(
-                new String(
-                        Base64.getEncoder()
-                                .encode(UUID.randomUUID().toString().getBytes(UTF_8)), UTF_8));
+        byte[] randomBytes = new byte[16];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return valueOf(Base64.getEncoder().encodeToString(randomBytes));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/Status.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/Status.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+enum Status
+{
+    STARTED, SUCCEEDED, FAILED
+}

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/Status.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/Status.java
@@ -13,7 +13,54 @@
  */
 package io.prestosql.server.security.oauth2;
 
-enum Status
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class Status<T extends Challenge>
 {
-    STARTED, SUCCEEDED, FAILED
+    static final Status<Challenge.Started> STARTED = new Status(Challenge.Started.class, false);
+    static final Status<Challenge.Succeeded> SUCCEEDED = new Status(Challenge.Succeeded.class, true);
+    static final Status<Challenge.Failed> FAILED = new Status(Challenge.Failed.class, true);
+
+    private final Class<T> correspondingChallengeClass;
+    private final boolean isFinal;
+
+    private Status(Class<T> correspondingChallengeClass, boolean isFinal)
+    {
+        this.correspondingChallengeClass = requireNonNull(correspondingChallengeClass, "correspondingChallengeClass is null");
+        this.isFinal = isFinal;
+    }
+
+    public Optional<T> toStatus(Challenge challenge)
+    {
+        return Optional.of(challenge)
+                .filter(correspondingChallengeClass::isInstance)
+                .map(correspondingChallengeClass::cast);
+    }
+
+    boolean isFinal()
+    {
+        return isFinal;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Status)) {
+            return false;
+        }
+        Status<?> status = (Status<?>) o;
+        return Objects.equals(correspondingChallengeClass, status.correspondingChallengeClass);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(correspondingChallengeClass);
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/server/security/oauth2/TokenPollingExecutors.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/oauth2/TokenPollingExecutors.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import javax.annotation.PreDestroy;
+
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.Executors.newCachedThreadPool;
+
+public class TokenPollingExecutors
+{
+    private final ExecutorService pollingExecutor = newCachedThreadPool(
+            new ThreadFactoryBuilder()
+                    .setNameFormat("oauth2-token-poll-%d")
+                    .build());
+    private final ExecutorService pollingHttpRequestExecutor = newCachedThreadPool(
+            new ThreadFactoryBuilder()
+                    .setNameFormat("oauth2-token-poll-http-%d")
+                    .build());
+
+    @PreDestroy
+    public void shutdown()
+    {
+        pollingExecutor.shutdownNow();
+        pollingHttpRequestExecutor.shutdownNow();
+    }
+
+    ExecutorService getPollingExecutor()
+    {
+        return pollingExecutor;
+    }
+
+    ExecutorService getPollingHttpRequestExecutor()
+    {
+        return pollingHttpRequestExecutor;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/io/prestosql/server/testing/TestingPrestoServer.java
@@ -387,6 +387,11 @@ public class TestingPrestoServer
         return server.getBaseUrl();
     }
 
+    public URI getHttpsBaseUrl()
+    {
+        return server.getHttpServerInfo().getHttpsUri();
+    }
+
     public URI resolve(String path)
     {
         return server.getBaseUrl().resolve(path);

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
@@ -58,7 +58,7 @@ public class FormWebUiAuthenticationFilter
     private static final Logger LOG = Logger.get(FormWebUiAuthenticationFilter.class);
 
     private static final String PRESTO_UI_AUDIENCE = "presto-ui";
-    public static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
+    private static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
     static final String LOGIN_FORM = "/ui/login.html";
     static final URI LOGIN_FORM_URI = URI.create(LOGIN_FORM);
     static final String DISABLED_LOCATION = "/ui/disabled.html";

--- a/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/FormWebUiAuthenticationFilter.java
@@ -58,12 +58,12 @@ public class FormWebUiAuthenticationFilter
     private static final Logger LOG = Logger.get(FormWebUiAuthenticationFilter.class);
 
     private static final String PRESTO_UI_AUDIENCE = "presto-ui";
-    private static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
+    public static final String PRESTO_UI_COOKIE = "Presto-UI-Token";
     static final String LOGIN_FORM = "/ui/login.html";
     static final URI LOGIN_FORM_URI = URI.create(LOGIN_FORM);
     static final String DISABLED_LOCATION = "/ui/disabled.html";
     static final URI DISABLED_LOCATION_URI = URI.create(DISABLED_LOCATION);
-    private static final String UI_LOCATION = "/ui/";
+    public static final String UI_LOCATION = "/ui/";
     private static final URI UI_LOCATION_URI = URI.create(UI_LOCATION);
     static final String UI_LOGIN = "/ui/login";
     static final String UI_LOGOUT = "/ui/logout";

--- a/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ui/WebUiAuthenticationModule.java
@@ -26,6 +26,8 @@ import io.prestosql.server.security.JsonWebTokenConfig;
 import io.prestosql.server.security.KerberosAuthenticator;
 import io.prestosql.server.security.KerberosConfig;
 import io.prestosql.server.security.SecurityConfig;
+import io.prestosql.server.security.oauth2.OAuth2Authenticator;
+import io.prestosql.server.security.oauth2.OAuth2Config;
 
 import java.util.List;
 
@@ -57,6 +59,7 @@ public class WebUiAuthenticationModule
         }));
         installWebUiAuthenticator("kerberos", KerberosAuthenticator.class, KerberosConfig.class);
         installWebUiAuthenticator("jwt", JsonWebTokenAuthenticator.class, JsonWebTokenConfig.class);
+        installWebUiAuthenticator("oauth2", OAuth2Authenticator.class, OAuth2Config.class);
     }
 
     private void installWebUiAuthenticator(String type, Module module)

--- a/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Authenticator.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Authenticator.java
@@ -18,6 +18,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.airlift.log.Logging;
 import io.airlift.testing.Closeables;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultClaims;
 import io.prestosql.server.testing.TestingPrestoServer;
 import io.prestosql.server.ui.WebUiModule;
 import okhttp3.HttpUrl;
@@ -25,6 +30,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -37,24 +43,32 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.airlift.testing.Assertions.assertLessThan;
 import static io.prestosql.client.OkHttpUtil.setupInsecureSsl;
+import static io.prestosql.server.security.oauth2.TestingHydraService.TTL_ACCESS_TOKEN_IN_SECONDS;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
 import static javax.ws.rs.core.Response.Status.FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
@@ -101,10 +115,12 @@ public class TestOAuth2Authenticator
                                 .put("http-server.https.keystore.path", Resources.getResource("cert/localhost.pem").getPath())
                                 .put("http-server.https.keystore.key", "")
                                 .put("http-server.authentication.type", "oauth2")
+                                .put("http-server.authentication.oauth2.server-url", "http://localhost:" + testingHydraService.getHydraPort())
                                 .put("http-server.authentication.oauth2.auth-url", "http://hydra:4444/oauth2/auth")
                                 .put("http-server.authentication.oauth2.token-url", format("http://localhost:%s/oauth2/token", testingHydraService.getHydraPort()))
                                 .put("http-server.authentication.oauth2.client-id", "another-consumer")
                                 .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
+                                .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)@.*")
                                 .build())
                 .build();
         waitForNodeRefresh(server);
@@ -142,17 +158,88 @@ public class TestOAuth2Authenticator
     }
 
     @Test
-    public void testSuccessfulAuthorizationFlow()
+    public void testInvalidToken()
+            throws NoSuchAlgorithmException, IOException
     {
-        try (BrowserWebDriverContainer<?> browser = createChromeContainer()) {
-            WebDriver driver = browser.getWebDriver();
-            driver.get(format("https://host.testcontainers.internal:%d/ui/", HTTPS_PORT));
-            WebDriverWait wait = new WebDriverWait(driver, 5);
-            submitCredentials(driver, "foo@bar.com", "foobar", wait);
-            giveConsent(driver, wait);
-            // TODO: check cookie, after removing permanent redirect
-            wait.until(ExpectedConditions.urlContains("http://consent:3000/login"));
+        KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+        keyGenerator.initialize(4096);
+        String token = Jwts.builder()
+                .setHeaderParam("alg", "RS256")
+                .setHeaderParam("kid", "public:f467aa08-1c1b-4cde-ba45-84b0ef5d2ba8")
+                .setHeaderParam("typ", "JWT")
+                .setClaims(
+                        new DefaultClaims(
+                                ImmutableMap.<String, Object>builder()
+                                        .put("aud", ImmutableList.of())
+                                        .put("client_id", "another-consumer")
+                                        .put("exp", System.currentTimeMillis() / 1000L + 60L)
+                                        .put("iat", System.currentTimeMillis())
+                                        .put("iss", "http://hydra:4444/")
+                                        .put("jti", UUID.randomUUID())
+                                        .put("nbf", System.currentTimeMillis() - 60L)
+                                        .put("scp", ImmutableList.of("openid"))
+                                        .put("sub", "foo@bar.com")
+                                        .build()))
+                .signWith(signatureAlgorithm, keyGenerator.generateKeyPair().getPrivate())
+                .compact();
+
+        try (Response response = httpClient.newCall(
+                apiCall()
+                        .header(AUTHORIZATION, "Bearer " + token)
+                        .build())
+                .execute()) {
+            assertUnauthorizedApiResponse(response);
         }
+    }
+
+    @Test
+    public void testSuccessfulFlow()
+            throws Exception
+    {
+        withSuccessfulAuthentication((driver, wait) -> {
+            assertPrestoCookie(driver.manage().getCookieNamed("Presto-OAuth2-Token"));
+            String accessToken = driver.manage().getCookieNamed("Presto-OAuth2-Token").getValue();
+
+            // pass access token in header
+            assertThat(httpClient.newCall(
+                    apiCall()
+                            .header(AUTHORIZATION, "Bearer " + accessToken)
+                            .build())
+                    .execute()
+                    .code())
+                    .isEqualTo(OK.getStatusCode());
+
+            // pass access token in query
+            assertThat(httpClient.newCall(
+                    apiCall()
+                            .url(UriBuilder
+                                    .fromUri(serverUri.resolve("/v1/query"))
+                                    .queryParam("access_token", accessToken)
+                                    .build()
+                                    .toURL())
+                            .build())
+                    .execute()
+                    .code())
+                    .isEqualTo(OK.getStatusCode());
+        });
+    }
+
+    @Test
+    public void testExpiredAccessToken()
+            throws Exception
+    {
+        withSuccessfulAuthentication(((driver, wait) -> {
+            String accessToken = driver.manage().getCookieNamed("Presto-OAuth2-Token").getValue();
+            Thread.sleep((TTL_ACCESS_TOKEN_IN_SECONDS + 1) * 1000L); // wait for the token expiration
+            try (Response response = httpClient.newCall(
+                    apiCall()
+                            .header(AUTHORIZATION, "Bearer " + accessToken)
+                            .build())
+                    .execute()) {
+                assertUnauthorizedApiResponse(response);
+            }
+        }));
     }
 
     private void createConsumer()
@@ -182,6 +269,21 @@ public class TestOAuth2Authenticator
         return new Request.Builder()
                 .url(serverUri.resolve("/v1/query/").toString())
                 .get();
+    }
+
+    private void withSuccessfulAuthentication(AuthenticationAssertion assertion)
+            throws Exception
+    {
+        try (BrowserWebDriverContainer<?> browser = createChromeContainer()) {
+            WebDriver driver = browser.getWebDriver();
+            driver.get(format("https://host.testcontainers.internal:%d/ui/", HTTPS_PORT));
+            WebDriverWait wait = new WebDriverWait(driver, 5);
+            submitCredentials(driver, "foo@bar.com", "foobar", wait);
+            giveConsent(driver, wait);
+            wait.until(ExpectedConditions.urlMatches(format("https://host.testcontainers.internal:%d/ui/", HTTPS_PORT)));
+
+            assertion.assertWith(driver, wait);
+        }
     }
 
     private BrowserWebDriverContainer<?> createChromeContainer()
@@ -217,6 +319,29 @@ public class TestOAuth2Authenticator
         wait.until(elementToBeClickable(acceptButtonLocator));
         WebElement acceptButton = driver.findElement(acceptButtonLocator);
         acceptButton.click();
+    }
+
+    private void assertPrestoCookie(Cookie cookie)
+    {
+        assertThat(cookie.getName()).isEqualTo("Presto-OAuth2-Token");
+        assertThat(cookie.getDomain()).isEqualTo("host.testcontainers.internal");
+        assertThat(cookie.getPath()).isEqualTo("/ui/");
+        assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getValue()).isNotBlank();
+        Jws<Claims> jwt = Jwts.parser()
+                .setSigningKeyResolver(new JWKSSigningKeyResolver("http://localhost:" + testingHydraService.getHydraPort()))
+                .parseClaimsJws(cookie.getValue());
+        // TODO: check source of the difference
+        //        assertThat(cookie.getExpiry()).isEqualTo(jwt.getBody().getExpiration());
+        assertAccessToken(jwt);
+    }
+
+    private void assertAccessToken(Jws<Claims> jwt)
+    {
+        assertThat(jwt.getBody().getSubject()).isEqualTo("foo@bar.com");
+        assertThat(jwt.getBody().get("client_id")).isEqualTo("another-consumer");
+        assertThat(jwt.getBody().getIssuer()).isEqualTo("http://hydra:4444/");
     }
 
     private static int findAvailablePort()
@@ -264,8 +389,14 @@ public class TestOAuth2Authenticator
         assertThat(location.getPath()).isEqualTo("/oauth2/auth");
         assertThat(url.queryParameterValues("response_type")).isEqualTo(ImmutableList.of("code"));
         assertThat(url.queryParameterValues("scope")).isEqualTo(ImmutableList.of("openid"));
-        assertThat(url.queryParameterValues("redirect_uri")).isEqualTo(ImmutableList.of(format("https://host.testcontainers.internal:%s/oauth2/callback", HTTPS_PORT)));
+        assertThat(url.queryParameterValues("redirect_uri")).isEqualTo(ImmutableList.of(format("https://127.0.0.1:%s/oauth2/callback", HTTPS_PORT)));
         assertThat(url.queryParameterValues("client_id")).isEqualTo(ImmutableList.of("another-consumer"));
         assertThat(url.queryParameterValues("state")).isNotNull();
+    }
+
+    private interface AuthenticationAssertion
+    {
+        void assertWith(WebDriver driver, WebDriverWait wait)
+                throws Exception;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Authenticator.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Authenticator.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import io.airlift.log.Logging;
+import io.airlift.testing.Closeables;
+import io.prestosql.server.testing.TestingPrestoServer;
+import io.prestosql.server.ui.WebUiModule;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.airlift.testing.Assertions.assertLessThan;
+import static io.prestosql.client.OkHttpUtil.setupInsecureSsl;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
+import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
+import static javax.ws.rs.core.Response.Status.FOUND;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestOAuth2Authenticator
+{
+    private static final int HTTPS_PORT = findAvailablePort();
+
+    private final TestingHydraService testingHydraService = new TestingHydraService();
+    private final OkHttpClient httpClient;
+
+    private TestingPrestoServer server;
+    private URI serverUri;
+
+    public TestOAuth2Authenticator()
+    {
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
+        setupInsecureSsl(httpClientBuilder);
+        httpClientBuilder.followRedirects(false);
+        this.httpClient = httpClientBuilder.build();
+    }
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+
+        Testcontainers.exposeHostPorts(HTTPS_PORT);
+        testingHydraService.start();
+
+        createConsumer();
+
+        server = TestingPrestoServer.builder()
+                .setCoordinator(true)
+                .setAdditionalModule(new WebUiModule())
+                .setProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("web-ui.enabled", "true")
+                                .put("web-ui.authentication.type", "oauth2")
+                                .put("http-server.https.port", Integer.toString(HTTPS_PORT))
+                                .put("http-server.https.enabled", "true")
+                                .put("http-server.https.keystore.path", Resources.getResource("cert/localhost.pem").getPath())
+                                .put("http-server.https.keystore.key", "")
+                                .put("http-server.authentication.type", "oauth2")
+                                .put("http-server.authentication.oauth2.auth-url", "http://127.0.0.1:9000/oauth2/auth")
+                                .put("http-server.authentication.oauth2.token-url", "http://127.0.0.1:9000/oauth2/token")
+                                .put("http-server.authentication.oauth2.client-id", "another-consumer")
+                                .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
+                                .build())
+                .build();
+        waitForNodeRefresh(server);
+        serverUri = server.getHttpsBaseUrl();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        Closeables.closeAll(server, testingHydraService);
+    }
+
+    @Test
+    public void testUnauthorizedApiCall()
+            throws IOException
+    {
+        try (Response response = httpClient
+                .newCall(apiCall().build())
+                .execute()) {
+            assertUnauthorizedApiResponse(response);
+        }
+    }
+
+    @Test
+    public void testUnauthorizedUICall()
+            throws IOException
+    {
+        try (Response response = httpClient
+                .newCall(uiCall().build())
+                .execute()) {
+            assertThat(response.code()).isEqualTo(FOUND.getStatusCode());
+            assertRedirectUrl(response.header(LOCATION));
+        }
+    }
+
+    private void createConsumer()
+    {
+        testingHydraService.createHydraContainer()
+                .withCommand(format("clients create " +
+                        "--endpoint http://hydra:4445 " +
+                        "--id another-consumer " +
+                        "--secret consumer-secret " +
+                        "-g authorization_code,refresh_token " +
+                        "-r token,code,id_token " +
+                        "--scope openid,offline " +
+                        "--callbacks https://127.0.0.1:%s/callback", HTTPS_PORT))
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)))
+                .start();
+    }
+
+    private Request.Builder uiCall()
+    {
+        return new Request.Builder()
+                .url(serverUri.resolve("/ui/").toString())
+                .get();
+    }
+
+    private Request.Builder apiCall()
+    {
+        return new Request.Builder()
+                .url(serverUri.resolve("/v1/query/").toString())
+                .get();
+    }
+
+    private static int findAvailablePort()
+    {
+        try (ServerSocket tempSocket = new ServerSocket(0)) {
+            return tempSocket.getLocalPort();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void waitForNodeRefresh(TestingPrestoServer server)
+            throws InterruptedException
+    {
+        Instant start = Instant.now();
+        while (server.refreshNodes().getActiveNodes().size() < 1) {
+            assertLessThan(Duration.between(start, Instant.now()), Duration.ofSeconds(10));
+            MILLISECONDS.sleep(10);
+        }
+    }
+
+    private static void assertUnauthorizedApiResponse(Response response)
+            throws MalformedURLException
+    {
+        assertThat(response.code()).isEqualTo(UNAUTHORIZED.getStatusCode());
+        String authenticateHeader = response.header(WWW_AUTHENTICATE);
+        assertThat(authenticateHeader).isNotNull();
+        Matcher authenticateHeaderMatcher = Pattern.compile("^Bearer realm=\"Presto\", redirectUrl=\"(.*)\", status=\"STARTED\"$")
+                .matcher(authenticateHeader);
+        assertThat(authenticateHeaderMatcher.matches()).isTrue();
+        assertRedirectUrl(authenticateHeaderMatcher.group(1));
+    }
+
+    private static void assertRedirectUrl(String redirectUrl)
+            throws MalformedURLException
+    {
+        assertThat(redirectUrl).isNotNull();
+        URL location = new URL(redirectUrl);
+        HttpUrl url = HttpUrl.parse(redirectUrl);
+        assertThat(url).isNotNull();
+        assertThat(location.getProtocol()).isEqualTo("http");
+        assertThat(location.getHost()).isEqualTo("127.0.0.1");
+        assertThat(location.getPort()).isEqualTo(9000);
+        assertThat(location.getPath()).isEqualTo("/oauth2/auth");
+        assertThat(url.queryParameterValues("response_type")).isEqualTo(ImmutableList.of("code"));
+        assertThat(url.queryParameterValues("scope")).isEqualTo(ImmutableList.of("openid"));
+        assertThat(url.queryParameterValues("redirect_uri")).isEqualTo(ImmutableList.of(format("https://127.0.0.1:%s/callback", HTTPS_PORT)));
+        assertThat(url.queryParameterValues("client_id")).isEqualTo(ImmutableList.of("another-consumer"));
+        assertThat(url.queryParameterValues("state")).isNotNull();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Config.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestOAuth2Config.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestOAuth2Config
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(OAuth2Config.class)
+                .setAuthUrl(null)
+                .setTokenUrl(null)
+                .setClientId(null)
+                .setClientSecret(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("http-server.authentication.oauth2.auth-url", "http://127.0.0.1:9000/oauth2/auth")
+                .put("http-server.authentication.oauth2.token-url", "http://127.0.0.1:9000/oauth2/token")
+                .put("http-server.authentication.oauth2.client-id", "another-consumer")
+                .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
+                .build();
+
+        OAuth2Config expected = new OAuth2Config()
+                .setAuthUrl("http://127.0.0.1:9000/oauth2/auth")
+                .setTokenUrl("http://127.0.0.1:9000/oauth2/token")
+                .setClientId("another-consumer")
+                .setClientSecret("consumer-secret");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestingHydraService.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestingHydraService.java
@@ -30,6 +30,7 @@ import static java.time.Duration.ofMinutes;
 public class TestingHydraService
         implements Closeable
 {
+    static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
     private static final String HYDRA_IMAGE = "oryd/hydra:v1.4.2";
     private static final String DSN = "postgres://hydra:mysecretpassword@database:5432/hydra?sslmode=disable";
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
@@ -64,6 +65,7 @@ public class TestingHydraService
             .withEnv("URLS_CONSENT", "http://consent:3000/consent")
             .withEnv("URLS_LOGIN", "http://consent:3000/login")
             .withEnv("OAUTH2_ACCESS_TOKEN_STRATEGY", "jwt")
+            .withEnv("TTL_ACCESS_TOKEN", TTL_ACCESS_TOKEN_IN_SECONDS + "s")
             .withCommand("serve all --dangerous-force-http")
             .waitingFor(Wait.forHttp("/health/ready").forPort(4444).forStatusCode(200));
 
@@ -91,12 +93,12 @@ public class TestingHydraService
         return new GenericContainer<>(HYDRA_IMAGE).withNetwork(network);
     }
 
-    Network getNetwork()
+    public Network getNetwork()
     {
         return network;
     }
 
-    int getHydraPort()
+    public int getHydraPort()
     {
         return hydraContainer.getMappedPort(4444);
     }

--- a/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestingHydraService.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/oauth2/TestingHydraService.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.server.security.oauth2;
+
+import io.prestosql.util.AutoCloseableCloser;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static java.time.Duration.ofMinutes;
+
+public class TestingHydraService
+        implements Closeable
+{
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.4.2";
+    private static final String DSN = "postgres://hydra:mysecretpassword@database:5432/hydra?sslmode=disable";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final Network network = Network.newNetwork();
+
+    private final PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>()
+            .withNetwork(network)
+            .withNetworkAliases("database")
+            .withUsername("hydra")
+            .withPassword("mysecretpassword")
+            .withDatabaseName("hydra");
+
+    private final GenericContainer<?> migrationContainer = createHydraContainer()
+            .withCommand("migrate sql --yes " + DSN)
+            .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(ofMinutes(5)));
+
+    private final GenericContainer<?> consentContainer = new GenericContainer<>("oryd/hydra-login-consent-node:v1.4.2")
+            .withNetwork(network)
+            .withNetworkAliases("consent")
+            .withEnv("HYDRA_ADMIN_URL", "http://hydra:4445")
+            .withEnv("NODE_TLS_REJECT_UNAUTHORIZED", "0")
+            .waitingFor(Wait.forHttp("/").forStatusCode(200));
+
+    private final GenericContainer<?> hydraContainer = createHydraContainer()
+            .withNetworkAliases("hydra")
+            .withExposedPorts(4444, 4445)
+            .withEnv("SECRETS_SYSTEM", generateSecret())
+            .withEnv("DSN", DSN)
+            .withEnv("URLS_SELF_ISSUER", "http://127.0.0.1:9000/")
+            .withEnv("URLS_CONSENT", "http://127.0.0.1:9020/consent")
+            .withEnv("URLS_LOGIN", "http://127.0.0.1:9020/login")
+            .withCommand("serve all --dangerous-force-http")
+            .waitingFor(Wait.forHttp("/health/ready").forPort(4444).forStatusCode(200));
+
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+
+    public TestingHydraService()
+    {
+        closer.register(network);
+        closer.register(databaseContainer);
+        closer.register(migrationContainer);
+        closer.register(consentContainer);
+        closer.register(hydraContainer);
+    }
+
+    public void start()
+    {
+        databaseContainer.start();
+        migrationContainer.start();
+        consentContainer.start();
+        hydraContainer.start();
+    }
+
+    public GenericContainer<?> createHydraContainer()
+    {
+        return new GenericContainer<>(HYDRA_IMAGE).withNetwork(network);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        try {
+            closer.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String generateSecret()
+    {
+        byte[] randomBytes = new byte[32];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return Base64.getEncoder().encodeToString(randomBytes);
+    }
+}

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
+            <version>1.13</version>
         </dependency>
 
         <dependency>

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -121,6 +121,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>io.prestosql</groupId>


### PR DESCRIPTION
This change adds possibility to utilize web-browser in authentication to Presto from jdbc and in feature from cli level. 

## Authentication Protocol

The modifications to the Presto client protocol (as defined here https://github.com/prestosql/presto/wiki/HTTP-Protocol) are fairly simple.  

The query submission `POST` to `/v1/statement` may fail with status `401 Unauthorized`:
```
WWW-Authenticate: Bearer [x_redirect_server="...",] x_token_server="..."
```
When a client gets this, the client should:
1. Open a web browser `x_redirect_server` URI if the field is present.
2. Polling the `x_token_server` URI until a bearer token is available or an error occurs.
3. Resubmit the query to `/v1/statement`, with the token in the header: 
```
Authorization: Bearer the-bearer-token-from-polling
```
Note: both of these URIs are absolute, so they should not be resolved.

## Token Polling

When polling the token address, the client should execute a request and when a the response is the following HTTP status code:
- `200 OK`: see below
- `3xx redirection`: Follow the redirects for the current request
- `503`: retry (same as client protocol)
- Other: Any other code should be treated as an error, and fail with an  “Unauthorized” message” (same as client protocol)

OK response body is one of the three following JSON documents:

**Success:** The authentication is complete and the token should be attached to all future query submission requests as a bearer token. Example:
```json
{
    "token" : "the-bearer-token"
}
```

**Not-ready:** The authentication is not complete. The client should immediately fetch the nextURI.  Example:
```json
{
    "nextUri" : "https://example.com/oauth/token/123456789"
}
```

**Error:** The authentication failed. The error message in the json document should be shown to the end user. Example:
```json
{
    "error" : "Authentication was canceled by the user"
}
```

This PR contains only the jdbc part, but I will be adding the required polling url soon.