### PR TITLE
Add contains_sequence function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -171,6 +171,10 @@ Array Functions
 
     Returns true if the array ``x`` contains the ``element``.
 
+.. function:: contains_sequence(x, seq) -> boolean
+
+    Return true if array ``x`` contains all of array ``seq`` as a subsequence (all values in the same consecutive order).
+
 .. function:: element_at(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``.

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -79,6 +79,7 @@ import io.prestosql.operator.scalar.ArrayAnyMatchFunction;
 import io.prestosql.operator.scalar.ArrayCardinalityFunction;
 import io.prestosql.operator.scalar.ArrayCombinationsFunction;
 import io.prestosql.operator.scalar.ArrayContains;
+import io.prestosql.operator.scalar.ArrayContainsSequence;
 import io.prestosql.operator.scalar.ArrayDistinctFunction;
 import io.prestosql.operator.scalar.ArrayElementAtFunction;
 import io.prestosql.operator.scalar.ArrayExceptFunction;
@@ -501,6 +502,7 @@ public class FunctionRegistry
                 .scalars(DataSizeFunctions.class)
                 .scalar(ArrayCardinalityFunction.class)
                 .scalar(ArrayContains.class)
+                .scalar(ArrayContainsSequence.class)
                 .scalar(ArrayFilterFunction.class)
                 .scalar(ArrayPositionFunction.class)
                 .scalars(CombineHashFunction.class)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayContainsSequence.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayContainsSequence.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.function.Convention;
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.OperatorDependency;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlNullable;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.function.TypeParameter;
+import io.prestosql.spi.type.StandardTypes;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.prestosql.spi.function.OperatorType.IS_DISTINCT_FROM;
+
+@Description("Determines whether an array contains a sequence, with the values in the exact order")
+@ScalarFunction("contains_sequence")
+public final class ArrayContainsSequence
+{
+    private ArrayContainsSequence() {}
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean containsSequence(
+            @OperatorDependency(
+                    operator = IS_DISTINCT_FROM,
+                    argumentTypes = {"T", "T"},
+                    convention = @Convention(arguments = {BLOCK_POSITION, BLOCK_POSITION}, result = FAIL_ON_NULL))
+                    MethodHandle distinctFrom,
+            @SqlType("array(T)") Block arrayBlock,
+            @SqlType("array(T)") Block value)
+            throws Throwable
+    {
+        int arrayLimit = arrayBlock.getPositionCount() - value.getPositionCount();
+        for (int arrayPosition = 0; arrayPosition <= arrayLimit; arrayPosition++) {
+            if (containsSequenceAt(distinctFrom, arrayBlock, arrayPosition, value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsSequenceAt(MethodHandle distinctFrom, Block arrayBlock, int arrayPosition, Block value)
+            throws Throwable
+    {
+        for (int valuePosition = 0; valuePosition < value.getPositionCount(); valuePosition++) {
+            if ((boolean) distinctFrom.invokeExact(arrayBlock, arrayPosition + valuePosition, value, valuePosition)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestArrayContainsSequence.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestArrayContainsSequence.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+
+public class TestArrayContainsSequence
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[1,2])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[3,4])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[5,6])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[1,2,4])", BOOLEAN, false);
+        assertFunction("contains_sequence(ARRAY [1,2,3,NULL,4,5,6], ARRAY[3,NULL,4])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[1,2,3,4,5,6])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY ['1','2','3'], ARRAY['1','2'])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [1.1,2.2,3.3], ARRAY[1.1,2.2])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [ARRAY[1,2],ARRAY[3],ARRAY[4,5]], ARRAY[ARRAY[1,2],ARRAY[3]])", BOOLEAN, true);
+        assertFunction("contains_sequence(ARRAY [ARRAY[1,2],ARRAY[3],ARRAY[4,5]], ARRAY[ARRAY[1,2],ARRAY[4]])", BOOLEAN, false);
+
+        for (int i = 1; i <= 6; i++) {
+            assertFunction("contains_sequence(ARRAY [1,2,3,4,5,6], ARRAY[" + i + "])", BOOLEAN, true);
+        }
+    }
+}


### PR DESCRIPTION
Add a function determines whether an array contains another, with the values in the exact order.

```
select contains_subarray(array['1','2','3','4'], array['2',3'])  -> true
select contains_subarray(array['1','2','3','4'], array['1',5'])  -> false
select contains_subarray(array['1','2','3','4'], array['1',3'])  -> false
```