### PR TITLE
Add 'hive' connector name

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-alluxio.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-alluxio.rst
@@ -79,7 +79,7 @@ the following:
 
 .. code-block:: none
 
-    connector.name=hive-hadoop2
+    connector.name=hive
     hive.metastore=alluxio
     hive.metastore.alluxio.master.address=HOSTNAME:PORT
 

--- a/presto-docs/src/main/sphinx/connector/hive-caching.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-caching.rst
@@ -78,7 +78,7 @@ can be activated in the catalog properties file:
 
 .. code-block:: none
 
-    connector.name=hive-hadoop2
+    connector.name=hive
     hive.cache.enabled=true
     hive.cache.location=/opt/hive-cache
 

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -109,7 +109,7 @@ for your Hive metastore Thrift service:
 
 .. code-block:: none
 
-    connector.name=hive-hadoop2
+    connector.name=hive
     hive.metastore.uri=thrift://example.net:9083
 
 Multiple Hive Clusters

--- a/presto-hive-hadoop2/src/main/java/io/prestosql/plugin/hive/HiveHadoop2Plugin.java
+++ b/presto-hive-hadoop2/src/main/java/io/prestosql/plugin/hive/HiveHadoop2Plugin.java
@@ -23,6 +23,9 @@ public class HiveHadoop2Plugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new HiveConnectorFactory("hive-hadoop2"));
+        return ImmutableList.of(
+                new HiveConnectorFactory("hive"),
+                // hive-hadoop2 is a legacy name
+                new HiveConnectorFactory("hive-hadoop2"));
     }
 }

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-add-column=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-add-column=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-cached/hive-coordinator.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-cached/hive-coordinator.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-cached/hive-worker.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-cached/hive-worker.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
@@ -5,7 +5,7 @@
 # in production. For example configuration, see the Presto documentation.
 #
 
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.allow-drop-table=true
 hive.allow-rename-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml,/docker/presto-product-tests/conf/presto/etc/hive-data-protection-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.allow-drop-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.allow-drop-table=true
 hive.allow-rename-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.allow-drop-table=true
 hive.allow-rename-table=true

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive1.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive1.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master-2:9083
 hive.config.resources=/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2-default-fs-site.xml,\
   /docker/presto-product-tests/conf/environment/two-kerberos-hives/auth-to-local.xml

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive1.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive1.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore-cache-ttl=0s

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hadoop-master-2:9083
 hive.config.resources=/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2-default-fs-site.xml
 hive.allow-add-column=true

--- a/presto-server-main/etc/catalog/hive.properties
+++ b/presto-server-main/etc/catalog/hive.properties
@@ -5,7 +5,7 @@
 # in production. For example configuration, see the Presto documentation.
 #
 
-connector.name=hive-hadoop2
+connector.name=hive
 
 # Configuration appropriate for Hive as started by product test environment, e.g.
 #   presto-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-presto

--- a/presto-server-rpm/src/test/java/io/prestosql/server/rpm/ServerIT.java
+++ b/presto-server-rpm/src/test/java/io/prestosql/server/rpm/ServerIT.java
@@ -58,7 +58,7 @@ public class ServerIT
                 // create Hive catalog file
                 "mkdir /etc/presto/catalog\n" +
                 "cat > /etc/presto/catalog/hive.properties <<\"EOT\"\n" +
-                "connector.name=hive-hadoop2\n" +
+                "connector.name=hive\n" +
                 "hive.metastore.uri=thrift://localhost:9083\n" +
                 "EOT\n" +
                 // create JMX catalog file


### PR DESCRIPTION
The name `hive-hadoop2` is misleading, making people think Hadoop 3 is
not supported.  The `-hadoop2` suffix is historically sound and comes
from the times where we had multiple hive connector flavours. It is no
longer needed, nor accurate.