### PR TITLE
Fix validation of expressions in ORDER BY for DISTINCT queries

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/CanonicalizationAware.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/CanonicalizationAware.java
@@ -91,7 +91,7 @@ public class CanonicalizationAware<T extends Node>
         return OptionalInt.empty();
     }
 
-    private static String canonicalize(Identifier identifier)
+    public static String canonicalize(Identifier identifier)
     {
         if (identifier.isDelimited()) {
             return identifier.getValue();

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -3103,9 +3103,20 @@ class StatementAnalyzer
                     }
                 }
                 else if (item instanceof AllColumns) {
-                    ((AllColumns) item).getAliases().stream()
-                            .map(CanonicalizationAware::canonicalizationAwareKey)
-                            .forEach(aliases::add);
+                    AllColumns allColumns = (AllColumns) item;
+
+                    List<Field> fields = analysis.getSelectAllResultFields(allColumns);
+                    checkNotNull(fields, "output fields is null for select item %s", item);
+                    for (int i = 0; i < fields.size(); i++) {
+                        Field field = fields.get(i);
+
+                        if (!allColumns.getAliases().isEmpty()) {
+                            aliases.add(canonicalizationAwareKey(allColumns.getAliases().get(i)));
+                        }
+                        else if (field.getName().isPresent()) {
+                            aliases.add(canonicalizationAwareKey(new Identifier(field.getName().get())));
+                        }
+                    }
                 }
             }
 

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -318,6 +318,9 @@ public class TestAnalyzer
         // reference to outer scope relation with anonymous field
         assertFails("SELECT (SELECT outer_relation.* FROM (VALUES 1) inner_relation) FROM (values 2) outer_relation")
                 .hasErrorCode(NOT_SUPPORTED);
+
+        assertFails("SELECT t.a FROM (SELECT t.* FROM (VALUES 1) t(a))")
+                .hasErrorCode(COLUMN_NOT_FOUND);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -735,6 +735,10 @@ public class TestAnalyzer
     {
         // TODO: validate output
         analyze("SELECT t1.* FROM t1 ORDER BY a");
+
+        analyze("SELECT DISTINCT t1.* FROM t1 ORDER BY a");
+        analyze("SELECT DISTINCT t1.* FROM t1 ORDER BY t1.a");
+        analyze("SELECT DISTINCT t1.* AS (w, x, y, z) FROM t1 ORDER BY w");
     }
 
     @Test


### PR DESCRIPTION
Fixes two issues:

1) The derived schema was using fully qualified aliases from the underlying tables.
This resulted in the following query succeeding, when it should fail due to
table t not being visible in the outer query: (#5660)

        SELECT t.a FROM (SELECT t.* FROM (VALUES 1) t(a))

2) Validation of DISTINCT with ORDER BY was only considering syntactic aliases, but it
    should also consider implied aliases derived from the names of the underlying columns. (#5647)

Fixes #5660, #5647 