### PR TITLE
Make type checks for EXTRACT more precise 

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -717,6 +717,8 @@ public class FunctionRegistry
                 .scalar(io.prestosql.operator.scalar.timetz.ExtractMinute.class)
                 .scalar(io.prestosql.operator.scalar.timetz.ExtractSecond.class)
                 .scalar(io.prestosql.operator.scalar.timetz.ExtractMillisecond.class)
+                .scalar(io.prestosql.operator.scalar.timetz.TimeZoneHour.class)
+                .scalar(io.prestosql.operator.scalar.timetz.TimeZoneMinute.class)
                 .scalar(io.prestosql.operator.scalar.timetz.DateTrunc.class)
                 .scalar(io.prestosql.operator.scalar.timetz.AtTimeZone.class)
                 .scalar(io.prestosql.operator.scalar.timetz.AtTimeZoneWithOffset.class)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimeZoneHour.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimeZoneHour.java
@@ -24,7 +24,7 @@ import static io.prestosql.util.DateTimeZoneIndex.extractZoneOffsetMinutes;
 
 @Description("Time zone hour of the given timestamp")
 @ScalarFunction("timezone_hour")
-public class TimeZoneHour
+public final class TimeZoneHour
 {
     private TimeZoneHour() {}
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimeZoneMinute.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/TimeZoneMinute.java
@@ -24,7 +24,7 @@ import static io.prestosql.util.DateTimeZoneIndex.extractZoneOffsetMinutes;
 
 @Description("Time zone minute of the given timestamp")
 @ScalarFunction("timezone_minute")
-public class TimeZoneMinute
+public final class TimeZoneMinute
 {
     private TimeZoneMinute() {}
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeZoneHour.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeZoneHour.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar.timetz;
+
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.LiteralParameters;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.LongTimeWithTimeZone;
+import io.prestosql.spi.type.StandardTypes;
+
+import static io.prestosql.spi.type.DateTimeEncoding.unpackOffsetMinutes;
+import static io.prestosql.type.DateTimes.MINUTES_PER_HOUR;
+
+@Description("Time zone hour of the given time")
+@ScalarFunction("timezone_hour")
+public final class TimeZoneHour
+{
+    private TimeZoneHour() {}
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long extract(@SqlType("time(p) with time zone") long packedTime)
+    {
+        return unpackOffsetMinutes(packedTime) / MINUTES_PER_HOUR;
+    }
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
+    {
+        return time.getOffsetMinutes() / MINUTES_PER_HOUR;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeZoneMinute.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeZoneMinute.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar.timetz;
+
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.LiteralParameters;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.LongTimeWithTimeZone;
+import io.prestosql.spi.type.StandardTypes;
+
+import static io.prestosql.spi.type.DateTimeEncoding.unpackOffsetMinutes;
+import static io.prestosql.type.DateTimes.MINUTES_PER_HOUR;
+
+@Description("Time zone minute of the given time")
+@ScalarFunction("timezone_minute")
+public final class TimeZoneMinute
+{
+    private TimeZoneMinute() {}
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long extract(@SqlType("time(p) with time zone") long packedTime)
+    {
+        return unpackOffsetMinutes(packedTime) % MINUTES_PER_HOUR;
+    }
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
+    {
+        return time.getOffsetMinutes() % MINUTES_PER_HOUR;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -36,6 +36,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.type.CharType;
+import io.prestosql.spi.type.DateType;
 import io.prestosql.spi.type.DecimalParseResult;
 import io.prestosql.spi.type.DecimalType;
 import io.prestosql.spi.type.Decimals;
@@ -176,8 +177,6 @@ import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
 import static io.prestosql.sql.tree.ArrayConstructor.ARRAY_CONSTRUCTOR;
-import static io.prestosql.sql.tree.Extract.Field.TIMEZONE_HOUR;
-import static io.prestosql.sql.tree.Extract.Field.TIMEZONE_MINUTE;
 import static io.prestosql.sql.tree.FrameBound.Type.FOLLOWING;
 import static io.prestosql.sql.tree.FrameBound.Type.PRECEDING;
 import static io.prestosql.sql.tree.SortItem.Ordering.ASCENDING;
@@ -1292,12 +1291,60 @@ public class ExpressionAnalyzer
         protected Type visitExtract(Extract node, StackableAstVisitorContext<Context> context)
         {
             Type type = process(node.getExpression(), context);
-            if (!isDateTimeType(type)) {
-                throw semanticException(TYPE_MISMATCH, node.getExpression(), "Type of argument to extract must be DATE, TIME, TIMESTAMP, or INTERVAL (actual %s)", type);
-            }
             Extract.Field field = node.getField();
-            if ((field == TIMEZONE_HOUR || field == TIMEZONE_MINUTE) && !(type.equals(TIME_WITH_TIME_ZONE) || type instanceof TimestampWithTimeZoneType)) {
-                throw semanticException(TYPE_MISMATCH, node.getExpression(), "Type of argument to extract time zone field must have a time zone (actual %s)", type);
+
+            switch (field) {
+                case YEAR:
+                case MONTH:
+                    if (!(type instanceof DateType) &&
+                            !(type instanceof TimestampType) &&
+                            !(type instanceof TimestampWithTimeZoneType) &&
+                            !(type.equals(INTERVAL_YEAR_MONTH))) {
+                        throw semanticException(TYPE_MISMATCH, node.getExpression(), "Cannot extract %s from %s", field, type);
+                    }
+                    break;
+                case DAY:
+                    if (!(type instanceof DateType) &&
+                            !(type instanceof TimestampType) &&
+                            !(type instanceof TimestampWithTimeZoneType) &&
+                            !(type.equals(INTERVAL_DAY_TIME))) {
+                        throw semanticException(TYPE_MISMATCH, node.getExpression(), "Cannot extract %s from %s", field, type);
+                    }
+                    break;
+                case QUARTER:
+                case WEEK:
+                case DAY_OF_MONTH:
+                case DAY_OF_WEEK:
+                case DOW:
+                case DAY_OF_YEAR:
+                case DOY:
+                case YEAR_OF_WEEK:
+                case YOW:
+                    if (!(type instanceof DateType) &&
+                            !(type instanceof TimestampType) &&
+                            !(type instanceof TimestampWithTimeZoneType)) {
+                        throw semanticException(TYPE_MISMATCH, node.getExpression(), "Cannot extract %s from %s", field, type);
+                    }
+                    break;
+                case HOUR:
+                case MINUTE:
+                case SECOND:
+                    if (!(type instanceof TimestampType) &&
+                            !(type instanceof TimestampWithTimeZoneType) &&
+                            !(type instanceof TimeType) &&
+                            !(type instanceof TimeWithTimeZoneType) &&
+                            !(type.equals(INTERVAL_DAY_TIME))) {
+                        throw semanticException(TYPE_MISMATCH, node.getExpression(), "Cannot extract %s from %s", field, type);
+                    }
+                    break;
+                case TIMEZONE_MINUTE:
+                case TIMEZONE_HOUR:
+                    if (!(type instanceof TimestampWithTimeZoneType) && !(type instanceof TimeWithTimeZoneType)) {
+                        throw semanticException(TYPE_MISMATCH, node.getExpression(), "Cannot extract %s from %s", field, type);
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unknown field: " + field);
             }
 
             return setExpressionType(node, BIGINT);

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/date/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/date/TestExtract.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar.date;
+
+import io.prestosql.spi.PrestoException;
+import io.prestosql.sql.query.QueryAssertions;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExtract
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testYear()
+    {
+        assertThat(assertions.expression("EXTRACT(YEAR FROM DATE '2020-05-10')")).matches("BIGINT '2020'");
+        assertThat(assertions.expression("EXTRACT(YEAR FROM DATE '1960-05-10')")).matches("BIGINT '1960'");
+    }
+
+    @Test
+    public void testMonth()
+    {
+        assertThat(assertions.expression("EXTRACT(MONTH FROM DATE '2020-05-10')")).matches("BIGINT '5'");
+        assertThat(assertions.expression("EXTRACT(MONTH FROM DATE '1960-05-10')")).matches("BIGINT '5'");
+    }
+
+    @Test
+    public void testDay()
+    {
+        assertThat(assertions.expression("EXTRACT(DAY FROM DATE '2020-05-10')")).matches("BIGINT '10'");
+        assertThat(assertions.expression("EXTRACT(DAY FROM DATE '1960-05-10')")).matches("BIGINT '10'");
+    }
+
+    @Test
+    public void testHour()
+    {
+        assertThatThrownBy(() -> assertions.expression("EXTRACT(HOUR FROM DATE '2020-05-10')"))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("line 1:26: Cannot extract HOUR from date");
+    }
+
+    @Test
+    public void testMinute()
+    {
+        assertThatThrownBy(() -> assertions.expression("EXTRACT(MINUTE FROM DATE '2020-05-10')"))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("line 1:28: Cannot extract MINUTE from date");
+    }
+
+    @Test
+    public void testSecond()
+    {
+        assertThatThrownBy(() -> assertions.expression("EXTRACT(SECOND FROM DATE '2020-05-10')"))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("line 1:28: Cannot extract SECOND from date");
+    }
+
+    @Test
+    public void testTimeZoneHour()
+    {
+        assertThatThrownBy(() -> assertions.expression("EXTRACT(TIMEZONE_HOUR FROM DATE '2020-05-10')"))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("line 1:35: Cannot extract TIMEZONE_HOUR from date");
+    }
+
+    @Test
+    public void testTimeZoneMinute()
+    {
+        assertThatThrownBy(() -> assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM DATE '2020-05-10')"))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("line 1:37: Cannot extract TIMEZONE_MINUTE from date");
+    }
+
+    @Test
+    public void testDayOfWeek()
+    {
+        assertThat(assertions.expression("EXTRACT(DAY_OF_WEEK FROM DATE '2020-05-10')")).matches("BIGINT '7'");
+        assertThat(assertions.expression("EXTRACT(DAY_OF_WEEK FROM DATE '1960-05-10')")).matches("BIGINT '2'");
+    }
+
+    @Test
+    public void testDayOfYear()
+    {
+        assertThat(assertions.expression("EXTRACT(DAY_OF_YEAR FROM DATE '2020-05-10')")).matches("BIGINT '131'");
+        assertThat(assertions.expression("EXTRACT(DAY_OF_YEAR FROM DATE '1960-05-10')")).matches("BIGINT '131'");
+    }
+
+    @Test
+    public void testQuarter()
+    {
+        assertThat(assertions.expression("EXTRACT(QUARTER FROM DATE '2020-05-10')")).matches("BIGINT '2'");
+        assertThat(assertions.expression("EXTRACT(QUARTER FROM DATE '1960-05-10')")).matches("BIGINT '2'");
+    }
+
+    @Test
+    public void testYearOfWeek()
+    {
+        assertThat(assertions.expression("EXTRACT(YEAR_OF_WEEK FROM DATE '2020-05-10')")).matches("BIGINT '2020'");
+        assertThat(assertions.expression("EXTRACT(YEAR_OF_WEEK FROM DATE '1960-05-10')")).matches("BIGINT '1960'");
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/time/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/time/TestExtract.java
@@ -13,12 +13,14 @@
  */
 package io.prestosql.operator.scalar.time;
 
+import io.prestosql.spi.PrestoException;
 import io.prestosql.sql.parser.ParsingException;
 import io.prestosql.sql.query.QueryAssertions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,6 +39,39 @@ public class TestExtract
     {
         assertions.close();
         assertions = null;
+    }
+
+    @Test
+    public void testYear()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(YEAR FROM CAST(NULL AS TIME(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:26: Cannot extract YEAR from time(%s)", precision));
+        }
+    }
+
+    @Test
+    public void testMonth()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(MONTH FROM CAST(NULL AS TIME(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:27: Cannot extract MONTH from time(%s)", precision));
+        }
+    }
+
+    @Test
+    public void testDay()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(DAY FROM CAST(NULL AS TIME(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:25: Cannot extract DAY from time(%s)", precision));
+        }
     }
 
     @Test
@@ -155,5 +190,27 @@ public class TestExtract
         assertThat(assertions.expression("millisecond(TIME '12:34:56.1234567890')")).matches("BIGINT '123'");
         assertThat(assertions.expression("millisecond(TIME '12:34:56.12345678901')")).matches("BIGINT '123'");
         assertThat(assertions.expression("millisecond(TIME '12:34:56.123456789012')")).matches("BIGINT '123'");
+    }
+
+    @Test
+    public void testTimezoneHour()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(TIMEZONE_HOUR FROM CAST(NULL AS TIME(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:35: Cannot extract TIMEZONE_HOUR from time(%s)", precision));
+        }
+    }
+
+    @Test
+    public void testTimezoneMinute()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(TIMEZONE_MINUTE FROM CAST(NULL AS TIME(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:37: Cannot extract TIMEZONE_MINUTE from time(%s)", precision));
+        }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/TestExtract.java
@@ -13,12 +13,14 @@
  */
 package io.prestosql.operator.scalar.timestamp;
 
+import io.prestosql.spi.PrestoException;
 import io.prestosql.sql.parser.ParsingException;
 import io.prestosql.sql.query.QueryAssertions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -280,6 +282,28 @@ public class TestExtract
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56.1234567890')")).matches("BIGINT '123'");
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56.12345678901')")).matches("BIGINT '123'");
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56.123456789012')")).matches("BIGINT '123'");
+    }
+
+    @Test
+    public void testTimezoneHour()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(TIMEZONE_HOUR FROM CAST(NULL AS TIMESTAMP(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:35: Cannot extract TIMEZONE_HOUR from timestamp(%s)", precision));
+        }
+    }
+
+    @Test
+    public void testTimezoneMinute()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(TIMEZONE_MINUTE FROM CAST(NULL AS TIMESTAMP(%s)))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:37: Cannot extract TIMEZONE_MINUTE from timestamp(%s)", precision));
+        }
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timestamp/TestExtract.java
@@ -13,15 +13,12 @@
  */
 package io.prestosql.operator.scalar.timestamp;
 
-import io.prestosql.Session;
 import io.prestosql.sql.parser.ParsingException;
 import io.prestosql.sql.query.QueryAssertions;
-import io.prestosql.testing.TestingSession;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static io.prestosql.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,10 +29,7 @@ public class TestExtract
     @BeforeClass
     public void init()
     {
-        Session session = testSessionBuilder()
-                .setTimeZoneKey(TestingSession.DEFAULT_TIME_ZONE_KEY)
-                .build();
-        assertions = new QueryAssertions(session);
+        assertions = new QueryAssertions();
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timetz/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timetz/TestExtract.java
@@ -13,12 +13,14 @@
  */
 package io.prestosql.operator.scalar.timetz;
 
+import io.prestosql.spi.PrestoException;
 import io.prestosql.sql.parser.ParsingException;
 import io.prestosql.sql.query.QueryAssertions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,6 +39,39 @@ public class TestExtract
     {
         assertions.close();
         assertions = null;
+    }
+
+    @Test
+    public void testYear()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(YEAR FROM CAST(NULL AS TIME(%s) WITH TIME ZONE))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:26: Cannot extract YEAR from time(%s) with time zone", precision));
+        }
+    }
+
+    @Test
+    public void testMonth()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(MONTH FROM CAST(NULL AS TIME(%s) WITH TIME ZONE))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:27: Cannot extract MONTH from time(%s) with time zone", precision));
+        }
+    }
+
+    @Test
+    public void testDay()
+    {
+        for (int i = 0; i <= 12; i++) {
+            int precision = i;
+            assertThatThrownBy(() -> assertions.expression(format("EXTRACT(DAY FROM CAST(NULL AS TIME(%s) WITH TIME ZONE))", precision)))
+                    .isInstanceOf(PrestoException.class)
+                    .hasMessage(format("line 1:25: Cannot extract DAY from time(%s) with time zone", precision));
+        }
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/timetz/TestExtract.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/timetz/TestExtract.java
@@ -191,4 +191,184 @@ public class TestExtract
         assertThat(assertions.expression("millisecond(TIME '12:34:56.12345678901+08:35')")).matches("BIGINT '123'");
         assertThat(assertions.expression("millisecond(TIME '12:34:56.123456789012+08:35')")).matches("BIGINT '123'");
     }
+
+    @Test
+    public void testTimeZoneHour()
+    {
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567890+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678901+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789012+08:35')")).matches("BIGINT '8'");
+
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567890+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678901+08:35')")).matches("BIGINT '8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789012+08:35')")).matches("BIGINT '8'");
+
+        // negative offsets
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567890-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678901-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789012-08:35')")).matches("BIGINT '-8'");
+
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567890-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678901-08:35')")).matches("BIGINT '-8'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789012-08:35')")).matches("BIGINT '-8'");
+
+        // negative offset minutes
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.1234567890-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.12345678901-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_HOUR FROM TIME '12:34:56.123456789012-00:35')")).matches("BIGINT '0'");
+
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.1234567890-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.12345678901-00:35')")).matches("BIGINT '0'");
+        assertThat(assertions.expression("timezone_hour(TIME '12:34:56.123456789012-00:35')")).matches("BIGINT '0'");
+    }
+
+    @Test
+    public void testTimeZoneMinute()
+    {
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567890+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678901+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789012+08:35')")).matches("BIGINT '35'");
+
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567890+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678901+08:35')")).matches("BIGINT '35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789012+08:35')")).matches("BIGINT '35'");
+
+        // negative offsets
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567890-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678901-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789012-08:35')")).matches("BIGINT '-35'");
+
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567890-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678901-08:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789012-08:35')")).matches("BIGINT '-35'");
+
+        // negative offset minutes
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.1234567890-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.12345678901-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("EXTRACT(TIMEZONE_MINUTE FROM TIME '12:34:56.123456789012-00:35')")).matches("BIGINT '-35'");
+
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.1234567890-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.12345678901-00:35')")).matches("BIGINT '-35'");
+        assertThat(assertions.expression("timezone_minute(TIME '12:34:56.123456789012-00:35')")).matches("BIGINT '-35'");
+    }
 }


### PR DESCRIPTION
Per the SQL specification:

    If <extract field> is a <primary datetime field>, then it shall identify
    a <primary datetime field> of the <interval value expression> or
    <datetime value expression> immediately contained in <extract source>.

Depends on https://github.com/prestosql/presto/pull/5696