### PR TITLE
Push down varbinary predicates to mysql driver

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/StandardColumnMappings.java
@@ -268,9 +268,14 @@ public final class StandardColumnMappings
     {
         return ColumnMapping.sliceMapping(
                 VARBINARY,
-                (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)),
+                varbinaryReadFunction(),
                 varbinaryWriteFunction(),
                 DISABLE_PUSHDOWN);
+    }
+
+    public static SliceReadFunction varbinaryReadFunction()
+    {
+        return (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex));
     }
 
     public static SliceWriteFunction varbinaryWriteFunction()

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -67,7 +67,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
 import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.prestosql.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.prestosql.plugin.jdbc.ColumnMapping.DISABLE_PUSHDOWN;
 import static io.prestosql.plugin.jdbc.ColumnMapping.FULL_PUSHDOWN;
@@ -83,6 +82,7 @@ import static io.prestosql.plugin.jdbc.StandardColumnMappings.integerColumnMappi
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.timestampWriteFunctionUsingSqlTimestamp;
+import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryReadFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
@@ -251,7 +251,7 @@ public class MySqlClient
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
-                return Optional.of(ColumnMapping.sliceMapping(VARBINARY, (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)), varbinaryWriteFunction(), FULL_PUSHDOWN));
+                return Optional.of(ColumnMapping.sliceMapping(VARBINARY, varbinaryReadFunction(), varbinaryWriteFunction(), FULL_PUSHDOWN));
         }
 
         // TODO add explicit mappings

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
@@ -309,6 +309,16 @@ abstract class BaseMySqlIntegrationSmokeTest
         assertThat(query("SELECT orderkey FROM orders WHERE orderdate = DATE '1992-09-29'"))
                 .matches("VALUES BIGINT '1250', 34406, 38436, 57570")
                 .isFullyPushedDown();
+
+        execute("CREATE TABLE tpch.binary_test (x int, y varbinary(100))");
+        execute("INSERT INTO tpch.binary_test VALUES (3, from_base64('AFCBhLrkidtNTZcA9Ru3hw=='))");
+
+        // varbinary equality
+        assertThat(query("SELECT x, y FROM tpch.binary_test WHERE y = from_base64('AFCBhLrkidtNTZcA9Ru3hw==')"))
+                .matches("VALUES (3, from_base64('AFCBhLrkidtNTZcA9Ru3hw=='))")
+                .isFullyPushedDown();
+
+        execute("DROP TABLE tpch.binary_test");
     }
 
     private AutoCloseable withTable(String tableName, String tableDefinition)

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlTypeMapping.java
@@ -42,6 +42,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -379,7 +380,22 @@ public class TestMySqlTypeMapping
     @Test
     public void testVarbinary()
     {
-        varbinaryTestCases(binaryDataType())
+        varbinaryTestCases(mysqlBinaryDataType("varbinary(50)"))
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
+
+        binaryTestCases(mysqlBinaryDataType("binary(50)"))
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
+
+        varbinaryTestCases(mysqlBinaryDataType("tinyblob"))
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
+
+        varbinaryTestCases(mysqlBinaryDataType("blob"))
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
+
+        varbinaryTestCases(mysqlBinaryDataType("mediumblob"))
+                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
+
+        varbinaryTestCases(mysqlBinaryDataType("longblob"))
                 .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.test_varbinary"));
 
         varbinaryTestCases(varbinaryDataType())
@@ -388,13 +404,24 @@ public class TestMySqlTypeMapping
 
     private DataTypeTest varbinaryTestCases(DataType<byte[]> varbinaryDataType)
     {
-        return DataTypeTest.create()
+        return DataTypeTest.create(true)
                 .addRoundTrip(varbinaryDataType, "hello".getBytes(UTF_8))
                 .addRoundTrip(varbinaryDataType, "Piękna łąka w 東京都".getBytes(UTF_8))
                 .addRoundTrip(varbinaryDataType, "Bag full of 💰".getBytes(UTF_16LE))
                 .addRoundTrip(varbinaryDataType, null)
                 .addRoundTrip(varbinaryDataType, new byte[] {})
                 .addRoundTrip(varbinaryDataType, new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 13, -7, 54, 122, -89, 0, 0, 0});
+    }
+
+    private DataTypeTest binaryTestCases(DataType<byte[]> varbinaryDataType)
+    {
+        return DataTypeTest.create(true)
+                .addRoundTrip(varbinaryDataType, Arrays.copyOf("hello".getBytes(UTF_8), 50))
+                .addRoundTrip(varbinaryDataType, Arrays.copyOf("Piękna łąka w 東京都".getBytes(UTF_8), 50))
+                .addRoundTrip(varbinaryDataType, Arrays.copyOf("Bag full of 💰".getBytes(UTF_16LE), 50))
+                .addRoundTrip(varbinaryDataType, null)
+                .addRoundTrip(varbinaryDataType, new byte[50])
+                .addRoundTrip(varbinaryDataType, Arrays.copyOf(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 13, -7, 54, 122, -89, 0, 0, 0}, 50));
     }
 
     @DataProvider
@@ -604,10 +631,10 @@ public class TestMySqlTypeMapping
         return dataType("double precision", DoubleType.DOUBLE, Object::toString);
     }
 
-    private static DataType<byte[]> binaryDataType()
+    private static DataType<byte[]> mysqlBinaryDataType(String insertType)
     {
         return dataType(
-                "varbinary(50)",
+                insertType,
                 VARBINARY,
                 bytes -> "X'" + base16().encode(bytes) + "'",
                 DataType::binaryLiteral,


### PR DESCRIPTION
This PR would allow Presto to pushdown filter predicates to the MySQL driver to allow the following types of query to make use of the database's filtering instead of requirering to load all the data in Presto. The use-case for me is when using binary UUID keys with `binary(16)` data type instead of `char(36)` for performance reasons.

```sql 
select * from mysql.test.user where id = from_base64('SOME BASE64 decoded string')
```

I realize that other drivers might benefit from this as well, however, the string is transferred using hex encoded so each database will have it own unique way of representing that (in MySQL/MariaDB its either `X'78797A`, `x'78797a'` or `0x78797a`) and thus will be implemented different per driver