### PR TITLE
Remove a redundant check

### DIFF
--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -110,6 +110,13 @@
 
         <dependency>
             <groupId>io.prestosql</groupId>
+            <artifactId>presto-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
             <artifactId>presto-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestKdbTreeType.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestKdbTreeType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.geospatial;
+
+import io.prestosql.geospatial.KdbTree;
+import io.prestosql.geospatial.KdbTree.Node;
+import io.prestosql.geospatial.Rectangle;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.type.AbstractTestType;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.prestosql.plugin.geospatial.KdbTreeType.KDB_TREE;
+
+public class TestKdbTreeType
+        extends AbstractTestType
+{
+    protected TestKdbTreeType()
+    {
+        super(KDB_TREE, KdbTree.class, createTestBlock());
+    }
+
+    private static Block createTestBlock()
+    {
+        BlockBuilder blockBuilder = KDB_TREE.createBlockBuilder(null, 1);
+        KdbTree kdbTree = new KdbTree(
+                new Node(
+                        new Rectangle(10, 20, 30, 40),
+                        OptionalInt.of(42),
+                        Optional.empty(),
+                        Optional.empty()));
+        KDB_TREE.writeObject(blockBuilder, kdbTree);
+        return blockBuilder.build();
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        return null;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/metadata/LiteralFunction.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/LiteralFunction.java
@@ -14,7 +14,6 @@
 package io.prestosql.metadata;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
 import io.prestosql.operator.scalar.ChoicesScalarFunctionImplementation;
@@ -27,7 +26,6 @@ import io.prestosql.spi.type.VarcharType;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -46,7 +44,6 @@ public class LiteralFunction
         extends SqlScalarFunction
 {
     public static final String LITERAL_FUNCTION_NAME = "$literal$";
-    private static final Set<Class<?>> SUPPORTED_LITERAL_TYPES = ImmutableSet.of(long.class, double.class, Slice.class, boolean.class);
 
     private final Supplier<BlockEncodingSerde> blockEncodingSerdeSupplier;
 
@@ -100,11 +97,6 @@ public class LiteralFunction
                 FAIL_ON_NULL,
                 ImmutableList.of(NEVER_NULL),
                 methodHandle);
-    }
-
-    public static boolean isSupportedLiteralType(Type type)
-    {
-        return SUPPORTED_LITERAL_TYPES.contains(type.getJavaType());
     }
 
     public static Type typeForMagicLiteral(Type type)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
@@ -118,7 +118,6 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.metadata.LiteralFunction.isSupportedLiteralType;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
@@ -1173,12 +1172,6 @@ public class ExpressionInterpreter
 
             if (node.isTypeOnly()) {
                 return value;
-            }
-
-            // hack!!! don't optimize CASTs for types that cannot be represented in the SQL AST
-            // TODO: this will not be an issue when we migrate to RowExpression tree for this, which allows arbitrary literals.
-            if (optimize && !isSupportedLiteralType(type(node))) {
-                return new Cast(toExpression(value, sourceType), node.getType(), node.isSafe(), node.isTypeOnly());
             }
 
             if (value == null) {


### PR DESCRIPTION
`LiterlEncoder` handles representation of the optimized value back in
the plan, so `ExpressionInterpreter` does not need to care about this.