### PR TITLE
Add TIMESTAMP WITH TIME ZONE support to LiteralEncoder

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
@@ -118,7 +118,6 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.metadata.LiteralFunction.isSupportedLiteralType;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
@@ -1173,12 +1172,6 @@ public class ExpressionInterpreter
 
             if (node.isTypeOnly()) {
                 return value;
-            }
-
-            // hack!!! don't optimize CASTs for types that cannot be represented in the SQL AST
-            // TODO: this will not be an issue when we migrate to RowExpression tree for this, which allows arbitrary literals.
-            if (optimize && !isSupportedLiteralType(type(node))) {
-                return new Cast(toExpression(value, sourceType), node.getType(), node.isSafe(), node.isTypeOnly());
             }
 
             if (value == null) {

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLiteralEncoder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLiteralEncoder.java
@@ -25,6 +25,9 @@ import io.prestosql.metadata.ResolvedFunction;
 import io.prestosql.metadata.Signature;
 import io.prestosql.operator.scalar.Re2JCastToRegexpFunction;
 import io.prestosql.security.AllowAllAccessControl;
+import io.prestosql.spi.type.LongTimestampWithTimeZone;
+import io.prestosql.spi.type.TimeZoneKey;
+import io.prestosql.spi.type.TimestampWithTimeZoneType;
 import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
 import io.prestosql.spi.type.VarcharType;
@@ -105,6 +108,10 @@ public class TestLiteralEncoder
         assertEncode(utf8Slice("hello"), createVarcharType(5), "'hello'");
         assertEncode(utf8Slice("hello"), createVarcharType(13), "CAST('hello' AS varchar(13))");
         assertEncode(utf8Slice("hello"), VARCHAR, "CAST('hello' AS varchar)");
+
+        LongTimestampWithTimeZone timestamp = LongTimestampWithTimeZone.fromEpochSecondsAndFraction(0, 0, TimeZoneKey.UTC_KEY);
+        assertEncode(timestamp, TimestampWithTimeZoneType.createTimestampWithTimeZoneType(6), "TIMESTAMP(6) WITH TIME ZONE '1970-01-01 00:00:00.000000 UTC'");
+        assertRoundTrip(timestamp, TimestampWithTimeZoneType.createTimestampWithTimeZoneType(6), LongTimestampWithTimeZone::equals);
 
         assertEncodeCaseInsensitively(utf8Slice("hello"), VARBINARY, literalVarbinary("hello".getBytes(UTF_8)));
 


### PR DESCRIPTION
Fixes #5543 