### PR TITLE
Produce a better message when test fails

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -534,7 +534,7 @@ public class HiveConfig
 
     public DateTimeZone getRcfileDateTimeZone()
     {
-        return DateTimeZone.forTimeZone(TimeZone.getTimeZone(rcfileTimeZone));
+        return DateTimeZone.forID(rcfileTimeZone);
     }
 
     @NotNull
@@ -582,7 +582,7 @@ public class HiveConfig
 
     public DateTimeZone getOrcLegacyDateTimeZone()
     {
-        return DateTimeZone.forTimeZone(TimeZone.getTimeZone(orcLegacyTimeZone));
+        return DateTimeZone.forID(orcLegacyTimeZone);
     }
 
     @NotNull
@@ -601,7 +601,7 @@ public class HiveConfig
 
     public DateTimeZone getParquetDateTimeZone()
     {
-        return DateTimeZone.forTimeZone(TimeZone.getTimeZone(parquetTimeZone));
+        return DateTimeZone.forID(parquetTimeZone);
     }
 
     @NotNull

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/AbstractPrestoResultSet.java
@@ -274,7 +274,7 @@ abstract class AbstractPrestoResultSet
             // are not compatible with java.sql.Date.
             LocalDate localDate = DATE_FORMATTER.parseLocalDate(String.valueOf(value));
             Calendar calendar = new GregorianCalendar(localDate.getYear(), localDate.getMonthOfYear() - 1, localDate.getDayOfMonth());
-            calendar.setTimeZone(TimeZone.getTimeZone(localTimeZone.getID()));
+            calendar.setTimeZone(TimeZone.getTimeZone(ZoneId.of(localTimeZone.getID())));
 
             return new Date(calendar.getTimeInMillis());
         }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcPreparedStatement.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcPreparedStatement.java
@@ -617,7 +617,7 @@ public class TestJdbcPreparedStatement
         assertParameter(sqlTimestamp, Types.TIMESTAMP, (ps, i) -> ps.setTimestamp(i, sqlTimestamp));
         assertParameter(sqlTimestamp, Types.TIMESTAMP, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, null));
         assertParameter(sqlTimestamp, Types.TIMESTAMP, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance()));
-        assertParameter(sameInstantInWarsawZone, Types.TIMESTAMP, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone("Europe/Warsaw"))));
+        assertParameter(sameInstantInWarsawZone, Types.TIMESTAMP, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("Europe/Warsaw")))));
         assertParameter(sqlTimestamp, Types.TIMESTAMP, (ps, i) -> ps.setObject(i, sqlTimestamp));
         assertParameter(new Timestamp(sqlDate.getTime()), Types.TIMESTAMP, (ps, i) -> ps.setObject(i, sqlDate, Types.TIMESTAMP));
         assertParameter(new Timestamp(sqlTime.getTime()), Types.TIMESTAMP, (ps, i) -> ps.setObject(i, sqlTime, Types.TIMESTAMP));

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSetTimezone.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestJdbcResultSetTimezone.java
@@ -215,7 +215,7 @@ public class TestJdbcResultSetTimezone
         assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp));
         assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, null));
         assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance()));
-        assertParameter(sameInstantInWarsawZone, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone("Europe/Warsaw"))));
+        assertParameter(sameInstantInWarsawZone, sessionTimezoneId, (ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("Europe/Warsaw")))));
         assertParameter(sqlTimestamp, sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTimestamp));
         assertParameter(new Timestamp(sqlDate.getTime()), sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlDate, Types.TIMESTAMP));
         assertParameter(new Timestamp(sqlTime.getTime()), sessionTimezoneId, (ps, i) -> ps.setObject(i, sqlTime, Types.TIMESTAMP));
@@ -272,7 +272,7 @@ public class TestJdbcResultSetTimezone
 
     private Calendar getCalendar()
     {
-        return Calendar.getInstance(TimeZone.getTimeZone(OTHER_TIMEZONE));
+        return Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of(OTHER_TIMEZONE)));
     }
 
     private ZoneId getZoneId()

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriver.java
@@ -42,6 +42,7 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -79,7 +80,7 @@ import static org.testng.Assert.fail;
 public class TestPrestoDriver
 {
     private static final DateTimeZone ASIA_ORAL_ZONE = DateTimeZone.forID("Asia/Oral");
-    private static final GregorianCalendar ASIA_ORAL_CALENDAR = new GregorianCalendar(ASIA_ORAL_ZONE.toTimeZone());
+    private static final GregorianCalendar ASIA_ORAL_CALENDAR = new GregorianCalendar(TimeZone.getTimeZone(ZoneId.of(ASIA_ORAL_ZONE.getID())));
     private static final String TEST_CATALOG = "test_catalog";
 
     private TestingPrestoServer server;

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/format/CustomDateTimeFormatter.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/format/CustomDateTimeFormatter.java
@@ -28,7 +28,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 import java.util.Locale;
 import java.util.Optional;
-import java.util.TimeZone;
 
 import static io.prestosql.plugin.kafka.encoder.json.format.util.TimeConversions.PICOSECONDS_PER_SECOND;
 import static io.prestosql.plugin.kafka.encoder.json.format.util.TimeConversions.getMillisOfDay;
@@ -98,7 +97,7 @@ public class CustomDateTimeFormatter
     @Override
     public String formatTimestampWithZone(SqlTimestampWithTimeZone value)
     {
-        DateTimeZone dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(value.getTimeZoneKey().getZoneId()));
+        DateTimeZone dateTimeZone = DateTimeZone.forID(value.getTimeZoneKey().getId());
         return formatter.withZone(dateTimeZone).print(new DateTime(value.getEpochMillis(), dateTimeZone));
     }
 }

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/format/RFC2822DateTimeFormatter.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/encoder/json/format/RFC2822DateTimeFormatter.java
@@ -23,7 +23,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -51,7 +50,7 @@ public class RFC2822DateTimeFormatter
     @Override
     public String formatTimestampWithZone(SqlTimestampWithTimeZone value)
     {
-        DateTimeZone dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(value.getTimeZoneKey().getZoneId()));
+        DateTimeZone dateTimeZone = DateTimeZone.forID(value.getTimeZoneKey().getId());
         return RFC_FORMATTER.withZone(dateTimeZone).print(new DateTime(value.getEpochMillis(), dateTimeZone));
     }
 }

--- a/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisSessionProperties.java
+++ b/presto-kinesis/src/main/java/io/prestosql/plugin/kinesis/KinesisSessionProperties.java
@@ -147,7 +147,7 @@ public final class KinesisSessionProperties
         SimpleDateFormat format = new SimpleDateFormat(PRESTO_TIMESTAMP_FORMAT);
 
         if (!session.getTimeZoneKey().getId().equals(TimeZone.getDefault().getID())) {
-            TimeZone sessionTimeZone = TimeZone.getTimeZone(session.getTimeZoneKey().getId());
+            TimeZone sessionTimeZone = TimeZone.getTimeZone(session.getTimeZoneKey().getZoneId());
             format.setTimeZone(sessionTimeZone);
         }
 

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
@@ -1236,6 +1236,6 @@ public class TestDateTimeFunctions
 
     private static SqlTimestampWithTimeZone toTimestampWithTimeZone(DateTime dateTime)
     {
-        return SqlTimestampWithTimeZone.newInstance(3, dateTime.getMillis(), 0, getTimeZoneKey(dateTime.getZone().toTimeZone().getID()));
+        return SqlTimestampWithTimeZone.newInstance(3, dateTime.getMillis(), 0, getTimeZoneKey(dateTime.getZone().getID()));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestArrayOperators.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.TimeZone;
@@ -1868,7 +1869,7 @@ public class TestArrayOperators
             throws ParseException
     {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateFormat.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
         return new SqlDate(toIntExact(TimeUnit.MILLISECONDS.toDays(dateFormat.parse(dateString).getTime())));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
@@ -228,7 +228,7 @@ public class TestTimestamp
     {
         assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321' as timestamp with time zone)",
                 TIMESTAMP_TZ_MILLIS,
-                SqlTimestampWithTimeZone.newInstance(3, new DateTime(2001, 1, 22, 3, 4, 5, 321, DATE_TIME_ZONE).getMillis(), 0, TimeZoneKey.getTimeZoneKey(DATE_TIME_ZONE.toTimeZone().getID())));
+                SqlTimestampWithTimeZone.newInstance(3, new DateTime(2001, 1, 22, 3, 4, 5, 321, DATE_TIME_ZONE).getMillis(), 0, TimeZoneKey.getTimeZoneKey(DATE_TIME_ZONE.getID())));
         functionAssertions.assertFunctionString("cast(TIMESTAMP '2001-1-22 03:04:05.321' as timestamp with time zone)",
                 TIMESTAMP_TZ_MILLIS,
                 "2001-01-22 03:04:05.321 " + DATE_TIME_ZONE.getID());

--- a/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
@@ -65,7 +65,7 @@ public class TestTimeZoneUtils
     public static void assertTimeZone(String zoneId, DateTimeZone dateTimeZone)
     {
         long packWithDateTime = packDateTimeWithZone(new DateTime(42, dateTimeZone));
-        long packWithZoneId = packDateTimeWithZone(42L, dateTimeZone.toTimeZone().getID());
+        long packWithZoneId = packDateTimeWithZone(42L, ZoneId.of(dateTimeZone.getID()).getId());
         if (packWithDateTime != packWithZoneId) {
             fail(format(
                     "packWithDateTime and packWithZoneId differ for zone [%s] / [%s]: %s [%s %s] and %s [%s %s]",

--- a/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/io/prestosql/util/TestTimeZoneUtils.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertEquals;
 public class TestTimeZoneUtils
 {
     @Test
-    public void test()
+    public void testNamedZones()
     {
         TreeSet<String> jdkZones = new TreeSet<>(ZoneId.getAvailableZoneIds());
         for (String zoneId : jdkZones) {
@@ -45,7 +45,11 @@ public class TestTimeZoneUtils
             assertDateTimeZoneEquals(zoneId, indexedZone);
             assertTimeZone(zoneId, dateTimeZone);
         }
+    }
 
+    @Test
+    public void testOffsets()
+    {
         for (int offsetHours = -13; offsetHours < 14; offsetHours++) {
             for (int offsetMinutes = 0; offsetMinutes < 60; offsetMinutes++) {
                 DateTimeZone dateTimeZone = DateTimeZone.forOffsetHoursMinutes(offsetHours, offsetMinutes);

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -376,7 +376,7 @@ public class OracleClient
     public static LongWriteFunction oracleTimestampWriteFunction()
     {
         return (statement, index, utcMillis) -> {
-            statement.setObject(index, new oracle.sql.TIMESTAMP(new Timestamp(epochMicrosToMillisWithRounding(utcMillis)), Calendar.getInstance(TimeZone.getTimeZone("UTC"))));
+            statement.setObject(index, new oracle.sql.TIMESTAMP(new Timestamp(epochMicrosToMillisWithRounding(utcMillis)), Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))));
         };
     }
 

--- a/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/OrcRecordReader.java
@@ -229,7 +229,7 @@ public class OrcRecordReader
 
         stripeReader = new StripeReader(
                 orcDataSource,
-                legacyFileTimeZone.toTimeZone().toZoneId(),
+                ZoneId.of(legacyFileTimeZone.getID()),
                 decompressor,
                 orcTypes,
                 ImmutableSet.copyOf(readColumns),

--- a/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/metadata/OrcMetadataReader.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.TimeZone;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.emptyToNull;
@@ -172,7 +171,7 @@ public class OrcMetadataReader
                 toStream(stripeFooter.getStreamsList()),
                 toColumnEncoding(stripeFooter.getColumnsList()),
                 Optional.ofNullable(emptyToNull(stripeFooter.getWriterTimezone()))
-                        .map(zone -> TimeZone.getTimeZone(zone).toZoneId())
+                        .map(ZoneId::of)
                         .orElse(legacyFileTimeZone));
     }
 

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -68,6 +68,12 @@
     </violation>
 
     <violation>
+        <name>org/joda/time/DateTimeZone.toTimeZone:()Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid DateTimeZone.toTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(dtz.getId())) instead.</comment>
+    </violation>
+
+    <violation>
         <name>com/esri/core/geometry/ogc/OGCGeometry.equals:(Lcom/esri/core/geometry/ogc/OGCGeometry;)Z</name>
         <version>1.6</version>
         <comment>Prefer OGCGeometry.Equals(OGCGeometry)</comment>

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -68,6 +68,12 @@
     </violation>
 
     <violation>
+        <name>java/util/TimeZone.getTimeZone:(Ljava/lang/String;)Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid TimeZone.getTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(..)) instead, or TimeZone.getTimeZone(..., false).</comment>
+    </violation>
+
+    <violation>
         <name>org/joda/time/DateTimeZone.toTimeZone:()Ljava/util/TimeZone;</name>
         <version>1.8</version>
         <comment>Avoid DateTimeZone.toTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(dtz.getId())) instead.</comment>


### PR DESCRIPTION
Before the change the test fails a message that was hard to understand for me:

```
java.lang.AssertionError: expected [174262] but found [172032]
    Expected :174262
    Actual   :172032
```

the change introduces a better exception message but also cleans up the test code, which was unnecessarily involving `java.util.TimeZone`.
