### PR TITLE
Use proper connector session in ConnectorNodePartitioningProvider

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/NodePartitioningManager.java
@@ -207,7 +207,7 @@ public class NodePartitioningManager
 
         ConnectorBucketNodeMap connectorBucketNodeMap = partitioningProvider.getBucketNodeMap(
                 partitioningHandle.getTransactionHandle().orElse(null),
-                session.toConnectorSession(),
+                session.toConnectorSession(partitioningHandle.getConnectorId().get()),
                 partitioningHandle.getConnectorHandle());
 
         checkArgument(connectorBucketNodeMap != null, "No partition map %s", partitioningHandle);
@@ -221,7 +221,7 @@ public class NodePartitioningManager
 
         ToIntFunction<ConnectorSplit> splitBucketFunction = partitioningProvider.getSplitBucketFunction(
                 partitioningHandle.getTransactionHandle().orElse(null),
-                session.toConnectorSession(),
+                session.toConnectorSession(partitioningHandle.getConnectorId().get()),
                 partitioningHandle.getConnectorHandle());
         checkArgument(splitBucketFunction != null, "No partitioning %s", partitioningHandle);
 


### PR DESCRIPTION
Fix cannot fetch session properties in method `ConnectorNodePartitioningProvider#getSplitBucketFunction`