### PR TITLE
Add support for HDFS only iceberg tables

### DIFF
--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -26,7 +26,6 @@ public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
-    private String warehouse;
     private boolean hadoopMode;
 
     @NotNull
@@ -52,18 +51,6 @@ public class IcebergConfig
     public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         this.compressionCodec = compressionCodec;
-        return this;
-    }
-
-    public String getWarehouse()
-    {
-        return warehouse;
-    }
-
-    @Config("iceberg.warehouse")
-    public IcebergConfig setWarehouse(String warehouse)
-    {
-        this.warehouse = warehouse;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -26,6 +26,8 @@ public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
+    private String warehouse;
+    private boolean hadoopMode;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -50,6 +52,30 @@ public class IcebergConfig
     public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         this.compressionCodec = compressionCodec;
+        return this;
+    }
+
+    public String getWarehouse()
+    {
+        return warehouse;
+    }
+
+    @Config("iceberg.warehouse")
+    public IcebergConfig setWarehouse(String warehouse)
+    {
+        this.warehouse = warehouse;
+        return this;
+    }
+
+    public boolean isHadoopMode()
+    {
+        return hadoopMode;
+    }
+
+    @Config("iceberg.hadoopmode")
+    public IcebergConfig setHadoopMode(boolean hadoopMode)
+    {
+        this.hadoopMode = hadoopMode;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -43,7 +43,6 @@ import static java.lang.String.format;
 public final class IcebergSessionProperties
 {
     private static final String HADOOP_MODE = "hadoopmode";
-    private static final String WAREHOUSE_LOCATION = "warehouse";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -75,11 +74,6 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
-                .add(stringProperty(
-                        WAREHOUSE_LOCATION,
-                        "Location of warehouse in hadoop mode",
-                        icebergConfig.getWarehouse(),
-                        false))
                 .add(booleanProperty(
                         HADOOP_MODE,
                         "Use hadoop file system to store schema/table information.",
@@ -201,11 +195,6 @@ public final class IcebergSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
-    }
-
-    public static String getWarehouseLocation(ConnectorSession session)
-    {
-        return session.getProperty(WAREHOUSE_LOCATION, String.class);
     }
 
     public static boolean isHadoopMode(ConnectorSession session)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -37,7 +37,6 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
-import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static java.lang.String.format;
 
 public final class IcebergSessionProperties

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -37,10 +37,13 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
+import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
+    private static final String HADOOP_MODE = "hadoopmode";
+    private static final String WAREHOUSE_LOCATION = "warehouse";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -72,6 +75,16 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(stringProperty(
+                        WAREHOUSE_LOCATION,
+                        "Location of warehouse in hadoop mode",
+                        icebergConfig.getWarehouse(),
+                        false))
+                .add(booleanProperty(
+                        HADOOP_MODE,
+                        "Use hadoop file system to store schema/table information.",
+                        icebergConfig.isHadoopMode(),
+                        false))
                 .add(enumProperty(
                         COMPRESSION_CODEC,
                         "Compression codec to use when writing files",
@@ -188,6 +201,16 @@ public final class IcebergSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static String getWarehouseLocation(ConnectorSession session)
+    {
+        return session.getProperty(WAREHOUSE_LOCATION, String.class);
+    }
+
+    public static boolean isHadoopMode(ConnectorSession session)
+    {
+        return session.getProperty(HADOOP_MODE, Boolean.class);
     }
 
     public static boolean isOrcBloomFiltersEnabled(ConnectorSession session)

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.testing.QueryAssertions.copyTpchTables;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class IcebergQueryRunner
 {
@@ -81,7 +82,7 @@ public final class IcebergQueryRunner
                 "</property>\n" +
                 "</configuration>\n";
         FileOutputStream out = new FileOutputStream(hivesiteLocation);
-        out.write(hivesite.getBytes());
+        out.write(hivesite.getBytes(UTF_8));
         out.close();
 
         queryRunner.installPlugin(new IcebergPlugin());

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.prestosql.plugin.hive.testing.TestingHivePlugin;
+import io.prestosql.spi.security.Identity;
+import io.prestosql.spi.security.SelectedRole;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class TestIcebergMetadataListingHadoopMode
+        extends AbstractTestQueryFramework
+{
+    private HiveMetastore metastore;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setIdentity(Identity.forUser("hive")
+                        .withRole("hive", new SelectedRole(ROLE, Optional.of("admin")))
+                        .build())
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+        File baseHadoopDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_hadoop").toFile();
+
+        baseHadoopDir.mkdirs();
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+
+        metastore = new FileHiveMetastore(
+                hdfsEnvironment,
+                new MetastoreConfig(),
+                new FileHiveMetastoreConfig()
+                        .setCatalogDirectory(baseDir.toURI().toString())
+                        .setMetastoreUser("test"));
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.warehouse", baseHadoopDir.getAbsolutePath(), "iceberg.hadoopmode", "true"));
+        queryRunner.installPlugin(new TestingHivePlugin(metastore));
+        queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        assertQuerySucceeds("CREATE SCHEMA hive.test_schema");
+        assertQuerySucceeds("CREATE SCHEMA iceberg.test_schema");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
+        assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
+        //assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS hive.test_schema.hive_table");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table2");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table1");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS hive.test_schema");
+    }
+
+    @Test
+    public void testTableListing()
+    {
+        assertQuery("SHOW TABLES FROM iceberg.test_schema", "VALUES 'iceberg_table1', 'iceberg_table2'");
+    }
+
+    @Test
+    public void testTableColumnListing()
+    {
+        // Verify information_schema.columns does not include columns from non-Iceberg tables
+        assertQuery("SELECT table_name, column_name FROM iceberg.information_schema.columns WHERE table_schema = 'test_schema'",
+                "VALUES ('iceberg_table1', '_string'), ('iceberg_table1', '_integer'), ('iceberg_table2', '_double')");
+    }
+
+    @Test
+    public void testTableDescribing()
+    {
+        assertQuery("DESCRIBE iceberg.test_schema.iceberg_table1", "VALUES ('_string', 'varchar', '', ''), ('_integer', 'integer', '', '')");
+    }
+
+    @Test
+    public void testTableValidation()
+    {
+        assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
+        // jcc iceberg table not in hive catalog
+        // assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -36,6 +36,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.util.Optional;
 
 import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
@@ -58,9 +59,19 @@ public class TestIcebergMetadataListingHadoopMode
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
-        File baseHadoopDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_hadoop").toFile();
+        baseDir.mkdirs();
 
-        baseHadoopDir.mkdirs();
+        String hivesiteLocation = queryRunner.getCoordinator().getBaseDataDir() + "/hive-site.xml";
+        String hivesite = "<configuration>\n" +
+                "<property>\n" +
+                "  <name>hive.metastore.warehouse.dir</name>\n" +
+                "  <value>" + baseDir + "</value>\n" +
+                "  <description></description>\n" +
+                "</property>\n" +
+                "</configuration>\n";
+        FileOutputStream out = new FileOutputStream(hivesiteLocation);
+        out.write(hivesite.getBytes());
+        out.close();
 
         HdfsConfig hdfsConfig = new HdfsConfig();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
@@ -74,7 +85,7 @@ public class TestIcebergMetadataListingHadoopMode
                         .setMetastoreUser("test"));
 
         queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
-        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.warehouse", baseHadoopDir.getAbsolutePath(), "iceberg.hadoopmode", "true"));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.hadoopmode", "true", "hive.config.resources", hivesiteLocation));
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
 
@@ -84,21 +95,20 @@ public class TestIcebergMetadataListingHadoopMode
     @BeforeClass
     public void setUp()
     {
-        assertQuerySucceeds("CREATE SCHEMA hive.test_schema");
         assertQuerySucceeds("CREATE SCHEMA iceberg.test_schema");
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
-        assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
+        //assertQuerySucceeds("CREATE TABLE iceberg.test_schema.hive_table (_double DOUBLE)");
         //assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        assertQuerySucceeds("DROP TABLE IF EXISTS hive.test_schema.hive_table");
+        //assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.hive_table");
         assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table2");
         assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table1");
-        assertQuerySucceeds("DROP SCHEMA IF EXISTS hive.test_schema");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS iceberg.test_schema");
     }
 
     @Test
@@ -126,6 +136,7 @@ public class TestIcebergMetadataListingHadoopMode
     {
         assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
         // jcc iceberg table not in hive catalog
-        // assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+        // what is returned is Table 'iceberg.test_schema.hive_table' does not exist"
+        //assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
@@ -70,7 +71,7 @@ public class TestIcebergMetadataListingHadoopMode
                 "</property>\n" +
                 "</configuration>\n";
         FileOutputStream out = new FileOutputStream(hivesiteLocation);
-        out.write(hivesite.getBytes());
+        out.write(hivesite.getBytes(StandardCharsets.UTF_8));
         out.close();
 
         HdfsConfig hdfsConfig = new HdfsConfig();


### PR DESCRIPTION
Add support for HDFS only iceberg tables issue: #5571

Added a flag iceberg.hadoopMode to use Iceberg's ability to leverage the file system to store the list of schema and table.

The location of the root directory is specified using a configuration property `hive.metastore.warehouse.dir` in the the hive-site.xml file.

Some operations are not yet supported:
setSchemaAuthorization
renameSchema
getSchemaProperties
getSchemaOwner