### PR TITLE
Push complex expression filters into Glue metastore

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/MetastoreUtil.java
@@ -441,7 +441,7 @@ public final class MetastoreUtil
         for (HiveColumnHandle partitionKey : partitionKeys) {
             String name = partitionKey.getName();
             Domain domain = effectivePredicate.getDomains().get().get(partitionKey);
-            if (domain != null && domain.isNullableSingleValue()) {
+            if (domain != null) {
                 domains.put(name, domain);
             }
         }


### PR DESCRIPTION
Previously, only single value equality filters were pushed down.
