### PR TITLE
Simplify HivePageSource bucket filtering

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HivePageSource.java
@@ -49,6 +49,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -278,8 +280,10 @@ public class HivePageSource
             }
 
             if (bucketAdapter.isPresent()) {
-                IntArrayList rowsToKeep = bucketAdapter.get().computeEligibleRowIds(dataPage);
-                dataPage = dataPage.getPositions(rowsToKeep.elements(), 0, rowsToKeep.size());
+                dataPage = bucketAdapter.get().filterPageToEligibleRowsOrDiscard(dataPage);
+                if (dataPage == null) {
+                    return null;
+                }
             }
 
             int batchSize = dataPage.getPositionCount();
@@ -585,16 +589,6 @@ public class HivePageSource
         }
     }
 
-    private static Page extractColumns(Page page, int[] columns)
-    {
-        Block[] blocks = new Block[columns.length];
-        for (int i = 0; i < columns.length; i++) {
-            int dataColumn = columns[i];
-            blocks[i] = page.getBlock(dataColumn);
-        }
-        return new Page(page.getPositionCount(), blocks);
-    }
-
     public static class BucketAdapter
     {
         private final int[] bucketColumns;
@@ -616,10 +610,11 @@ public class HivePageSource
             this.partitionBucketCount = bucketAdaptation.getPartitionBucketCount();
         }
 
-        public IntArrayList computeEligibleRowIds(Page page)
+        @Nullable
+        public Page filterPageToEligibleRowsOrDiscard(Page page)
         {
             IntArrayList ids = new IntArrayList(page.getPositionCount());
-            Page bucketColumnsPage = extractColumns(page, bucketColumns);
+            Page bucketColumnsPage = page.getColumns(bucketColumns);
             for (int position = 0; position < page.getPositionCount(); position++) {
                 int bucket = getHiveBucket(bucketingVersion, tableBucketCount, typeInfoList, bucketColumnsPage, position);
                 if ((bucket - bucketToKeep) % partitionBucketCount != 0) {
@@ -631,7 +626,14 @@ public class HivePageSource
                     ids.add(position);
                 }
             }
-            return ids;
+            int retainedRowCount = ids.size();
+            if (retainedRowCount == 0) {
+                return null;
+            }
+            if (retainedRowCount == page.getPositionCount()) {
+                return page;
+            }
+            return page.getPositions(ids.elements(), 0, retainedRowCount);
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/io/prestosql/testing/MaterializedResult.java
@@ -397,7 +397,7 @@ public class MaterializedResult
         while (!pageSource.isFinished()) {
             Page outputPage = pageSource.getNextPage();
             if (outputPage == null) {
-                break;
+                continue;
             }
             builder.page(outputPage);
         }


### PR DESCRIPTION
Extracted and adapted changes from https://github.com/prestodb/presto/pull/15373

Adds an early return path for when all rows or no rows are filtered as inelligible as part of bucket adaptation in `HivePageSource`