### PR TITLE
Avoid lowering memory limit in resource overcommit case

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
@@ -373,20 +373,21 @@ public class SqlTaskManager
         requireNonNull(sources, "sources is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
 
-        long sessionQueryMaxMemoryPerNode = getQueryMaxMemoryPerNode(session).toBytes();
-        long sessionQueryTotalMaxMemoryPerNode = getQueryMaxTotalMemoryPerNode(session).toBytes();
-        // Session property query_max_memory_per_node is used to only decrease memory limit
-        if (sessionQueryMaxMemoryPerNode <= queryMaxMemoryPerNode) {
-            queryContexts.getUnchecked(taskId.getQueryId()).setMaxUserMemory(sessionQueryMaxMemoryPerNode);
-        }
-
-        if (sessionQueryTotalMaxMemoryPerNode <= queryMaxTotalMemoryPerNode) {
-            queryContexts.getUnchecked(taskId.getQueryId()).setMaxTotalMemory(sessionQueryTotalMaxMemoryPerNode);
-        }
-
         if (resourceOvercommit(session)) {
             // TODO: This should have been done when the QueryContext was created. However, the session isn't available at that point.
             queryContexts.getUnchecked(taskId.getQueryId()).setResourceOvercommit();
+        }
+        else {
+            long sessionQueryMaxMemoryPerNode = getQueryMaxMemoryPerNode(session).toBytes();
+            long sessionQueryTotalMaxMemoryPerNode = getQueryMaxTotalMemoryPerNode(session).toBytes();
+            // Session property query_max_memory_per_node is used to only decrease memory limit
+            if (sessionQueryMaxMemoryPerNode <= queryMaxMemoryPerNode) {
+                queryContexts.getUnchecked(taskId.getQueryId()).setMaxUserMemory(sessionQueryMaxMemoryPerNode);
+            }
+
+            if (sessionQueryTotalMaxMemoryPerNode <= queryMaxTotalMemoryPerNode) {
+                queryContexts.getUnchecked(taskId.getQueryId()).setMaxTotalMemory(sessionQueryTotalMaxMemoryPerNode);
+            }
         }
 
         SqlTask sqlTask = tasks.getUnchecked(taskId);


### PR DESCRIPTION
Even when resource_overcommit is set to true, SqlTaskManager#updateTask
first attempts to lower the memory limit based on the values from the
session. This can cause memory reservation to fail, if bytes are
updated before setResourceOvercommit is invoked. This commit fixes the
race condition by avoiding the memory limit updates from session values
when resource overcommit is set.

Ran the TestMemoryManager#testResourceOverCommit with invocation count 500, 
and all succeeded. Without this change, they fail almost consistently at least once 
in 100 invocations.

cc @findepi 