### PR TITLE
Add applyTableScanRedirect SPI and ApplyTableScanRedirection rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -126,6 +126,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
     public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
+    public static final String TABLE_SCAN_REDIRECTION_ENABLED = "table_scan_redirection_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -561,6 +562,11 @@ public final class SystemSessionProperties
                         OMIT_DATETIME_TYPE_PRECISION,
                         "Omit precision when rendering datetime type names with default precision",
                         featuresConfig.isOmitDateTimeTypePrecision(),
+                        false),
+                booleanProperty(
+                        TABLE_SCAN_REDIRECTION_ENABLED,
+                        "Enable redirection of table scans by connectors",
+                        featuresConfig.isRedirectTableScansEnabled(),
                         false));
     }
 
@@ -1007,5 +1013,10 @@ public final class SystemSessionProperties
     public static boolean isOmitDateTimeTypePrecision(Session session)
     {
         return session.getSystemProperty(OMIT_DATETIME_TYPE_PRECISION, Boolean.class);
+    }
+
+    public static boolean isTableScanRedirectionEnabled(Session session)
+    {
+        return session.getSystemProperty(TABLE_SCAN_REDIRECTION_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -39,6 +39,7 @@ import io.prestosql.spi.connector.ProjectionApplicationResult;
 import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SortItem;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
 import io.prestosql.spi.connector.TopNApplicationResult;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.function.InvocationConvention;
@@ -581,4 +582,11 @@ public interface Metadata
      * The method is used by the engine to determine if a materialized view is current with respect to the tables it depends on.
      */
     MaterializedViewFreshness getMaterializedViewFreshness(Session session, TableHandle tableHandle);
+
+    /**
+     * Returns the result of redirecting the table scan on a given table to a different table.
+     * This method is used by the engine during the plan optimization phase to allow a connector to offload table scans to any other connector.
+     * This method is called after security checks against the original table.
+     */
+    Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle);
 }

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -79,6 +79,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SortItem;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
 import io.prestosql.spi.connector.TopNApplicationResult;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.expression.Variable;
@@ -1151,6 +1152,16 @@ public final class MetadataManager
         CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogName);
         ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
         return metadata.getMaterializedViewFreshness(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogName);
+        ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
+        ConnectorSession connectorSession = session.toConnectorSession(catalogName);
+        return metadata.applyTableScanRedirect(connectorSession, tableHandle.getConnectorHandle());
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -126,6 +126,7 @@ public class FeaturesConfig
     private boolean predicatePushdownUseTableProperties = true;
     private boolean ignoreDownstreamPreferences;
     private boolean iterativeRuleBasedColumnPruning = true;
+    private boolean redirectTableScansEnabled = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -961,6 +962,18 @@ public class FeaturesConfig
     public FeaturesConfig setIterativeRuleBasedColumnPruning(boolean iterativeRuleBasedColumnPruning)
     {
         this.iterativeRuleBasedColumnPruning = iterativeRuleBasedColumnPruning;
+        return this;
+    }
+
+    public boolean isRedirectTableScansEnabled()
+    {
+        return redirectTableScansEnabled;
+    }
+
+    @Config("optimizer.redirect-table-scans")
+    public FeaturesConfig setRedirectTableScansEnabled(boolean redirectTableScansEnabled)
+    {
+        this.redirectTableScansEnabled = redirectTableScansEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -29,6 +29,7 @@ import io.prestosql.sql.planner.iterative.IterativeOptimizer;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.iterative.rule.AddExchangesBelowPartialAggregationOverGroupIdRuleSet;
 import io.prestosql.sql.planner.iterative.rule.AddIntermediateAggregations;
+import io.prestosql.sql.planner.iterative.rule.ApplyTableScanRedirection;
 import io.prestosql.sql.planner.iterative.rule.CanonicalizeExpressions;
 import io.prestosql.sql.planner.iterative.rule.CreatePartialTopN;
 import io.prestosql.sql.planner.iterative.rule.DesugarArrayConstructor;
@@ -525,6 +526,21 @@ public class PlanOptimizers
                 new StatsRecordingPlanOptimizer(
                         optimizerStats,
                         new PredicatePushDown(metadata, typeOperators, typeAnalyzer, false, false)));
+
+        // Perform redirection before CBO rules to ensure stats from destination connector are used
+        // Perform redirection before agg, topN, limit, sample etc. push down into table scan as the destination connector may support a different set of push downs
+        // Perform redirection after at least one PredicatePushDown and PushPredicateIntoTableScan to allow connector to use pushed down predicates in redirection decision
+        // Perform redirection after at least table scan pruning rules because redirected table might have fewer columns
+        // PushPredicateIntoTableScan must be run after redirection
+        // Column pruning rules need to be run after redirection
+        builder.add(
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(
+                                new ApplyTableScanRedirection(metadata),
+                                new PushPredicateIntoTableScan(metadata, typeOperators, typeAnalyzer))));
 
         IterativeOptimizer pushIntoTableScanOptimizer = new IterativeOptimizer(
                 ruleStats,

--- a/presto-main/src/test/java/io/prestosql/connector/MockConnectorTableHandle.java
+++ b/presto-main/src/test/java/io/prestosql/connector/MockConnectorTableHandle.java
@@ -15,10 +15,15 @@ package io.prestosql.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -26,17 +31,42 @@ public class MockConnectorTableHandle
         implements ConnectorTableHandle
 {
     private final SchemaTableName tableName;
+    private final TupleDomain<ColumnHandle> constraint;
+    private final Optional<List<ColumnHandle>> columns;
+
+    public MockConnectorTableHandle(SchemaTableName tableName)
+    {
+        this(tableName, TupleDomain.all(), Optional.empty());
+    }
 
     @JsonCreator
-    public MockConnectorTableHandle(@JsonProperty SchemaTableName tableName)
+    public MockConnectorTableHandle(
+            @JsonProperty SchemaTableName tableName,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("columns") Optional<List<ColumnHandle>> columns)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.constraint = requireNonNull(constraint, "constraint is null");
+        requireNonNull(columns, "columns is null");
+        this.columns = columns.map(ImmutableList::copyOf);
     }
 
     @JsonProperty
     public SchemaTableName getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
+    @JsonProperty
+    public Optional<List<ColumnHandle>> getColumns()
+    {
+        return columns;
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -44,6 +44,7 @@ import io.prestosql.spi.connector.ProjectionApplicationResult;
 import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SortItem;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
 import io.prestosql.spi.connector.TopNApplicationResult;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.function.InvocationConvention;
@@ -801,6 +802,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public MaterializedViewFreshness getMaterializedViewFreshness(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -104,7 +104,8 @@ public class TestFeaturesConfig
                 .setPredicatePushdownUseTableProperties(true)
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
-                .setIterativeRuleBasedColumnPruning(true));
+                .setIterativeRuleBasedColumnPruning(true)
+                .setRedirectTableScansEnabled(true));
     }
 
     @Test
@@ -174,6 +175,7 @@ public class TestFeaturesConfig
                 .put("optimizer.ignore-downstream-preferences", "true")
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
+                .put("optimizer.redirect-table-scans", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -239,7 +241,8 @@ public class TestFeaturesConfig
                 .setPredicatePushdownUseTableProperties(false)
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
-                .setIterativeRuleBasedColumnPruning(false);
+                .setIterativeRuleBasedColumnPruning(false)
+                .setRedirectTableScansEnabled(false);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestTableScanRedirectionWithPushdown.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestTableScanRedirectionWithPushdown.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.connector.MockConnectorColumnHandle;
+import io.prestosql.connector.MockConnectorFactory;
+import io.prestosql.connector.MockConnectorTableHandle;
+import io.prestosql.execution.warnings.WarningCollector;
+import io.prestosql.spi.connector.Assignment;
+import io.prestosql.spi.connector.CatalogSchemaTableName;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
+import io.prestosql.spi.connector.ProjectionApplicationResult;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
+import io.prestosql.spi.expression.ConnectorExpression;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.assertions.PlanAssert;
+import io.prestosql.sql.planner.assertions.PlanMatchPattern;
+import io.prestosql.sql.planner.optimizations.PlanOptimizer;
+import io.prestosql.testing.LocalQueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.connector.MockConnectorFactory.ApplyFilter;
+import static io.prestosql.connector.MockConnectorFactory.ApplyProjection;
+import static io.prestosql.connector.MockConnectorFactory.ApplyTableScanRedirect;
+import static io.prestosql.spi.predicate.Domain.singleValue;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.output;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class TestTableScanRedirectionWithPushdown
+{
+    private static final String MOCK_CATALOG = "mock_catalog";
+    private static final String TEST_SCHEMA = "test_schema";
+    private static final String TEST_TABLE = "test_table";
+    private static final SchemaTableName sourceTable = new SchemaTableName(TEST_SCHEMA, TEST_TABLE);
+
+    private static final Session MOCK_SESSION = testSessionBuilder().setCatalog(MOCK_CATALOG).setSchema(TEST_SCHEMA).build();
+
+    private static final String sourceColumnNameA = "source_col_a";
+    private static final ColumnHandle sourceColumnHandleA = new MockConnectorColumnHandle(sourceColumnNameA, INTEGER);
+    private static final String sourceColumnNameB = "source_col_b";
+    private static final ColumnHandle sourceColumnHandleB = new MockConnectorColumnHandle(sourceColumnNameB, INTEGER);
+
+    private static final SchemaTableName destinationTable = new SchemaTableName("target_schema", "target_table");
+    private static final String destinationColumnNameA = "destination_col_a";
+    private static final ColumnHandle destinationColumnHandleA = new MockConnectorColumnHandle(destinationColumnNameA, INTEGER);
+    private static final String destinationColumnNameB = "destination_col_b";
+    private static final ColumnHandle destinationColumnHandleB = new MockConnectorColumnHandle(destinationColumnNameB, INTEGER);
+
+    private static final Map<ColumnHandle, String> redirectionMappingA = ImmutableMap.of(sourceColumnHandleA, destinationColumnNameA);
+
+    private static final Map<ColumnHandle, String> redirectionMappingAB = ImmutableMap.of(
+            sourceColumnHandleA, destinationColumnNameA,
+            sourceColumnHandleB, destinationColumnNameB);
+
+    @Test
+    public void testRedirectionAfterProjectionPushdown()
+    {
+        // make the mock connector return a table scan on destination table only if
+        // the connector can detect that source_col_a is projected
+        ApplyTableScanRedirect tableScanRedirection =
+                (session, handle) -> {
+                    MockConnectorTableHandle mockConnectorTable = (MockConnectorTableHandle) handle;
+                    Optional<List<ColumnHandle>> projectedColumns = mockConnectorTable.getColumns();
+                    if (projectedColumns.isEmpty()) {
+                        return Optional.empty();
+                    }
+                    List<String> projectedColumnNames = projectedColumns.get().stream()
+                            .map(MockConnectorColumnHandle.class::cast)
+                            .map(MockConnectorColumnHandle::getName)
+                            .collect(toImmutableList());
+                    if (!projectedColumnNames.equals(ImmutableList.of(sourceColumnNameA))) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(
+                            new TableScanRedirectApplicationResult(
+                                    new CatalogSchemaTableName(MOCK_CATALOG, destinationTable),
+                                    redirectionMappingA));
+                };
+
+        try (LocalQueryRunner queryRunner = createLocalQueryRunner(tableScanRedirection, Optional.of(this::mockApplyProjection), Optional.empty())) {
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a FROM test_table",
+                    output(
+                            ImmutableList.of("DEST_COL"),
+                            tableScan("target_table", ImmutableMap.of("DEST_COL", destinationColumnNameA))));
+
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a, source_col_b FROM test_table",
+                    output(
+                            ImmutableList.of("SOURCE_COLA", "SOURCE_COLB"),
+                            tableScan(TEST_TABLE, ImmutableMap.of("SOURCE_COLA", sourceColumnNameA, "SOURCE_COLB", sourceColumnNameB))));
+
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a FROM test_table WHERE source_col_a > 0",
+                    output(
+                            ImmutableList.of("DEST_COL"),
+                            filter(
+                                    "DEST_COL > 0",
+                                    tableScan(
+                                            equalTo(new MockConnectorTableHandle(destinationTable)),
+                                            TupleDomain.all(),
+                                            ImmutableMap.of("DEST_COL", equalTo(destinationColumnHandleA))))));
+        }
+    }
+
+    @Test
+    public void testRedirectionAfterPredicatePushdownIntoTableScan()
+    {
+        // make the mock connector return a table scan on destination table only if
+        // the connector can detect a filter
+        try (LocalQueryRunner queryRunner = createLocalQueryRunner(
+                getMockApplyRedirectAfterPredicatePushdown(redirectionMappingA),
+                Optional.empty(),
+                Optional.of(this::mockApplyFilter))) {
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a FROM test_table WHERE source_col_a = 1",
+                    output(
+                            ImmutableList.of("DEST_COL"),
+                            tableScan(
+                                    equalTo(new MockConnectorTableHandle(destinationTable)),
+                                    TupleDomain.withColumnDomains(ImmutableMap.of(equalTo(destinationColumnHandleA), singleValue(INTEGER, 1L))),
+                                    ImmutableMap.of("DEST_COL", equalTo(destinationColumnHandleA)))));
+
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a FROM test_table",
+                    output(
+                            ImmutableList.of("SOURCE_COL"),
+                            tableScan(TEST_TABLE, ImmutableMap.of("SOURCE_COL", sourceColumnNameA))));
+
+            assertPlan(
+                    queryRunner,
+                    "SELECT (2 * source_col_a) + 1 FROM test_table WHERE source_col_a = 1",
+                    output(
+                            ImmutableList.of("expr"),
+                            project(
+                                    ImmutableMap.of("expr", expression("(DEST_COL * 2) + 1")),
+                                    tableScan(
+                                            equalTo(new MockConnectorTableHandle(destinationTable)),
+                                            TupleDomain.withColumnDomains(ImmutableMap.of(equalTo(destinationColumnHandleA), singleValue(INTEGER, 1L))),
+                                            ImmutableMap.of("DEST_COL", equalTo(destinationColumnHandleA))))));
+        }
+    }
+
+    @Test
+    public void testPredicatePushdownAfterRedirect()
+    {
+        try (LocalQueryRunner queryRunner = createLocalQueryRunner(
+                getMockApplyRedirectAfterPredicatePushdown(redirectionMappingAB),
+                Optional.empty(),
+                Optional.of(getMockApplyFilter(ImmutableSet.of(sourceColumnHandleA, destinationColumnHandleB))))) {
+            // Only 'source_col_a = 1' will get pushed down into source table scan
+            // Only 'source_col_b = 2' will get pushed down into destination table scan
+            // This test verifies that the Filter('source_col_a = 1') produced by redirection
+            // does not prevent pushdown of 'source_col_b = 2' into destination table scan
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_a, source_col_b FROM test_table WHERE source_col_a = 1 AND source_col_b = 2",
+                    output(
+                            ImmutableList.of("DEST_COL_A", "DEST_COL_B"),
+                            filter(
+                                    "DEST_COL_A = 1",
+                                    tableScan(
+                                            equalTo(new MockConnectorTableHandle(destinationTable)),
+                                            TupleDomain.withColumnDomains(ImmutableMap.of(equalTo(destinationColumnHandleB), singleValue(INTEGER, 2L))),
+                                            ImmutableMap.of(
+                                                    "DEST_COL_A", equalTo(destinationColumnHandleA),
+                                                    "DEST_COL_B", equalTo(destinationColumnHandleB))))));
+        }
+    }
+
+    @Test
+    public void testRedirectAfterColumnPruningOnPushedDownPredicate()
+    {
+        try (LocalQueryRunner queryRunner = createLocalQueryRunner(
+                getMockApplyRedirectAfterPredicatePushdown(redirectionMappingAB),
+                Optional.of(this::mockApplyProjection),
+                Optional.of(this::mockApplyFilter))) {
+            // After 'source_col_a = 1' is pushed into source table scan, it's possible for 'source_col_a' table scan assignment to be pruned
+            // Redirection results in Project('source_col_b') -> Filter('source_col_a = 1') -> TableScan for such case
+            // Subsequent PPD and column pruning rules simplify the above as supported by the destination connector
+            assertPlan(
+                    queryRunner,
+                    "SELECT source_col_b FROM test_table WHERE source_col_a = 1",
+                    output(
+                            ImmutableList.of("DEST_COL_B"),
+                            tableScan(
+                                    equalTo(new MockConnectorTableHandle(destinationTable)),
+                                    TupleDomain.withColumnDomains(ImmutableMap.of(equalTo(destinationColumnHandleA), singleValue(INTEGER, 1L))),
+                                    ImmutableMap.of("DEST_COL_B", equalTo(destinationColumnHandleB)))));
+        }
+    }
+
+    private LocalQueryRunner createLocalQueryRunner(
+            ApplyTableScanRedirect applyTableScanRedirect,
+            Optional<ApplyProjection> applyProjection,
+            Optional<ApplyFilter> applyFilter)
+    {
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(MOCK_SESSION);
+        MockConnectorFactory.Builder builder = MockConnectorFactory.builder()
+                .withGetTableHandle((session, schemaTableName) -> new MockConnectorTableHandle(schemaTableName))
+                .withGetColumns(name -> {
+                    if (name.equals(sourceTable)) {
+                        return ImmutableList.of(
+                                new ColumnMetadata(sourceColumnNameA, INTEGER),
+                                new ColumnMetadata(sourceColumnNameB, INTEGER));
+                    }
+                    else if (name.equals(destinationTable)) {
+                        return ImmutableList.of(
+                                new ColumnMetadata(destinationColumnNameA, INTEGER),
+                                new ColumnMetadata(destinationColumnNameB, INTEGER));
+                    }
+                    throw new IllegalArgumentException();
+                })
+                .withApplyTableScanRedirect(applyTableScanRedirect);
+        applyProjection.ifPresent(builder::withApplyProjection);
+        applyFilter.ifPresent(builder::withApplyFilter);
+
+        queryRunner.createCatalog(MOCK_CATALOG, builder.build(), ImmutableMap.of());
+        return queryRunner;
+    }
+
+    private Optional<ProjectionApplicationResult<ConnectorTableHandle>> mockApplyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        MockConnectorTableHandle handle = (MockConnectorTableHandle) tableHandle;
+
+        List<ColumnHandle> newColumns = assignments.values().stream()
+                .collect(toImmutableList());
+        if (handle.getColumns().isPresent() && newColumns.equals(handle.getColumns().get())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new ProjectionApplicationResult<>(
+                        new MockConnectorTableHandle(handle.getTableName(), handle.getConstraint(), Optional.of(newColumns)),
+                        projections,
+                        assignments.entrySet().stream()
+                                .map(assignment -> new Assignment(
+                                        assignment.getKey(),
+                                        assignment.getValue(),
+                                        ((MockConnectorColumnHandle) assignment.getValue()).getType()))
+                                .collect(toImmutableList())));
+    }
+
+    private Optional<ConstraintApplicationResult<ConnectorTableHandle>> mockApplyFilter(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint constraint)
+    {
+        MockConnectorTableHandle handle = (MockConnectorTableHandle) table;
+
+        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
+        if (oldDomain.equals(newDomain)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                new ConstraintApplicationResult<>(
+                        new MockConnectorTableHandle(handle.getTableName(), newDomain, Optional.empty()),
+                        TupleDomain.all()));
+    }
+
+    private ApplyFilter getMockApplyFilter(Set<ColumnHandle> pushdownColumns)
+    {
+        // returns a mock implementation of applyFilter which allows predicate pushdown only for pushdownColumns
+        return (ConnectorSession session, ConnectorTableHandle table, Constraint constraint) ->
+        {
+            MockConnectorTableHandle handle = (MockConnectorTableHandle) table;
+
+            TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+            TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary()
+                    .filter((columnHandle, domain) -> pushdownColumns.contains(columnHandle)));
+            if (oldDomain.equals(newDomain)) {
+                return Optional.empty();
+            }
+
+            return Optional.of(
+                    new ConstraintApplicationResult<>(
+                            new MockConnectorTableHandle(handle.getTableName(), newDomain, Optional.empty()),
+                            constraint.getSummary()
+                                    .filter((columnHandle, domain) -> !pushdownColumns.contains(columnHandle))));
+        };
+    }
+
+    private ApplyTableScanRedirect getMockApplyRedirectAfterPredicatePushdown(Map<ColumnHandle, String> redirectionMapping)
+    {
+        return (ConnectorSession session, ConnectorTableHandle handle) ->
+        {
+            MockConnectorTableHandle mockConnectorTable = (MockConnectorTableHandle) handle;
+            // make sure we do redirection after predicate is pushed down
+            if (mockConnectorTable.getConstraint().isAll()) {
+                return Optional.empty();
+            }
+            return Optional.of(
+                    new TableScanRedirectApplicationResult(
+                            new CatalogSchemaTableName(MOCK_CATALOG, destinationTable),
+                            redirectionMapping));
+        };
+    }
+
+    void assertPlan(LocalQueryRunner queryRunner, @Language("SQL") String sql, PlanMatchPattern pattern)
+    {
+        List<PlanOptimizer> optimizers = queryRunner.getPlanOptimizers(true);
+
+        queryRunner.inTransaction(transactionSession -> {
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers, OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP);
+            PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getStatsCalculator(), actualPlan, pattern);
+            return null;
+        });
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.Session;
+import io.prestosql.connector.CatalogName;
+import io.prestosql.connector.MockConnectorColumnHandle;
+import io.prestosql.connector.MockConnectorFactory;
+import io.prestosql.connector.MockConnectorTableHandle;
+import io.prestosql.metadata.TableHandle;
+import io.prestosql.spi.connector.CatalogSchemaTableName;
+import io.prestosql.spi.connector.ColumnHandle;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.RuleTester;
+import io.prestosql.testing.TestingTransactionHandle;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.google.common.base.Predicates.equalTo;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.connector.MockConnectorFactory.ApplyTableScanRedirect;
+import static io.prestosql.spi.predicate.Domain.singleValue;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class TestApplyTableScanRedirection
+{
+    private static final String MOCK_CATALOG = "mock_catalog";
+    private static final String TEST_SCHEMA = "test_schema";
+    private static final String TEST_TABLE = "test_table";
+    private static final SchemaTableName sourceTable = new SchemaTableName(TEST_SCHEMA, TEST_TABLE);
+    private static final TableHandle TEST_TABLE_HANDLE = createTableHandle(new MockConnectorTableHandle(sourceTable));
+
+    private static final Session MOCK_SESSION = testSessionBuilder().setCatalog(MOCK_CATALOG).setSchema(TEST_SCHEMA).build();
+
+    private static final String sourceColumnNameA = "source_col_a";
+    private static final ColumnHandle sourceColumnHandleA = new MockConnectorColumnHandle(sourceColumnNameA, INTEGER);
+    private static final String sourceColumnNameB = "source_col_b";
+    private static final ColumnHandle sourceColumnHandleB = new MockConnectorColumnHandle(sourceColumnNameB, INTEGER);
+
+    private static final SchemaTableName destinationTable = new SchemaTableName("target_schema", "target_table");
+    private static final String destinationColumnNameA = "destination_col_a";
+    private static final ColumnHandle destinationColumnHandleA = new MockConnectorColumnHandle(destinationColumnNameA, INTEGER);
+    private static final String destinationColumnNameB = "destination_col_b";
+    private static final ColumnHandle destinationColumnHandleB = new MockConnectorColumnHandle(destinationColumnNameB, INTEGER);
+
+    private static TableHandle createTableHandle(ConnectorTableHandle tableHandle)
+    {
+        return new TableHandle(
+                new CatalogName(MOCK_CATALOG),
+                tableHandle,
+                TestingTransactionHandle.create(),
+                Optional.empty());
+    }
+
+    @Test
+    public void testDoesNotFire()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            MockConnectorFactory mockFactory = createMockFactory(Optional.empty());
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, mockFactory, ImmutableMap.of());
+
+            ruleTester.assertThat(new ApplyTableScanRedirection(ruleTester.getMetadata()))
+                    .on(p -> {
+                        Symbol column = p.symbol(sourceColumnNameA, VARCHAR);
+                        return p.tableScan(TEST_TABLE_HANDLE,
+                                        ImmutableList.of(column),
+                                        ImmutableMap.of(column, sourceColumnHandleA));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .doesNotFire();
+        }
+    }
+
+    @Test
+    public void doesNotFireIfNoTableScan()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            ApplyTableScanRedirect applyTableScanRedirect =
+                    (session, handle) -> Optional.of(
+                            new TableScanRedirectApplicationResult(
+                                    new CatalogSchemaTableName(MOCK_CATALOG, destinationTable),
+                                    ImmutableMap.of(sourceColumnHandleA, destinationColumnNameA)));
+            MockConnectorFactory mockFactory = createMockFactory(Optional.of(applyTableScanRedirect));
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, mockFactory, ImmutableMap.of());
+
+            ruleTester.assertThat(new ApplyTableScanRedirection(ruleTester.getMetadata()))
+                    .on(p -> p.values(p.symbol("a", BIGINT)))
+                    .withSession(MOCK_SESSION)
+                    .doesNotFire();
+        }
+    }
+
+    @Test
+    public void testApplyTableScanRedirection()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            // make the mock connector return a table scan on different table
+            ApplyTableScanRedirect applyTableScanRedirect =
+                    (session, handle) -> Optional.of(
+                            new TableScanRedirectApplicationResult(
+                                    new CatalogSchemaTableName(MOCK_CATALOG, destinationTable),
+                                    ImmutableMap.of(sourceColumnHandleA, destinationColumnNameA)));
+            MockConnectorFactory mockFactory = createMockFactory(Optional.of(applyTableScanRedirect));
+
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, mockFactory, ImmutableMap.of());
+
+            ruleTester.assertThat(new ApplyTableScanRedirection(ruleTester.getMetadata()))
+                    .on(p -> {
+                        Symbol column = p.symbol(sourceColumnNameA, VARCHAR);
+                        return p.tableScan(TEST_TABLE_HANDLE,
+                                ImmutableList.of(column),
+                                ImmutableMap.of(column, sourceColumnHandleA));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .matches(
+                            tableScan(
+                                    equalTo(new MockConnectorTableHandle(destinationTable)),
+                                    TupleDomain.all(),
+                                    ImmutableMap.of("DEST_COL", equalTo(destinationColumnHandleA))));
+        }
+    }
+
+    @Test
+    public void testApplyTableScanRedirectionWithFilter()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            // make the mock connector return a table scan on different table
+            // source table handle has a pushed down predicate
+            ApplyTableScanRedirect applyTableScanRedirect =
+                    (session, handle) -> Optional.of(
+                            new TableScanRedirectApplicationResult(
+                                    new CatalogSchemaTableName(MOCK_CATALOG, destinationTable),
+                                    ImmutableMap.of(
+                                            sourceColumnHandleA, destinationColumnNameA,
+                                            sourceColumnHandleB, destinationColumnNameB)));
+            MockConnectorFactory mockFactory = createMockFactory(Optional.of(applyTableScanRedirect));
+
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, mockFactory, ImmutableMap.of());
+
+            ApplyTableScanRedirection applyTableScanRedirection = new ApplyTableScanRedirection(ruleTester.getMetadata());
+            ruleTester.assertThat(applyTableScanRedirection)
+                    .on(p -> {
+                        Symbol column = p.symbol(sourceColumnNameA, VARCHAR);
+                        return p.tableScan(
+                                TEST_TABLE_HANDLE,
+                                ImmutableList.of(column),
+                                ImmutableMap.of(column, sourceColumnHandleA),
+                                TupleDomain.withColumnDomains(
+                                        ImmutableMap.of(sourceColumnHandleA, singleValue(VARCHAR, utf8Slice("foo")))));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .matches(
+                            filter(
+                                    "DEST_COL = CAST('foo' AS varchar)",
+                                    tableScan(
+                                            equalTo(new MockConnectorTableHandle(destinationTable)),
+                                            TupleDomain.all(),
+                                            ImmutableMap.of("DEST_COL", equalTo(destinationColumnHandleA)))));
+
+            ruleTester.assertThat(applyTableScanRedirection)
+                    .on(p -> {
+                        Symbol column = p.symbol(sourceColumnNameB, VARCHAR);
+                        return p.tableScan(
+                                TEST_TABLE_HANDLE,
+                                ImmutableList.of(column),
+                                ImmutableMap.of(column, sourceColumnHandleB), // predicate on non-projected column
+                                TupleDomain.withColumnDomains(
+                                        ImmutableMap.of(sourceColumnHandleA, singleValue(VARCHAR, utf8Slice("foo")))));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .matches(
+                            project(
+                                    ImmutableMap.of("expr", expression("DEST_COL_B")),
+                                    filter(
+                                            "DEST_COL_A = CAST('foo' AS varchar)",
+                                            tableScan(
+                                                    equalTo(new MockConnectorTableHandle(destinationTable)),
+                                                    TupleDomain.all(),
+                                                    ImmutableMap.of(
+                                                            "DEST_COL_A", equalTo(destinationColumnHandleA),
+                                                            "DEST_COL_B", equalTo(destinationColumnHandleB))))));
+        }
+    }
+
+    private MockConnectorFactory createMockFactory(Optional<MockConnectorFactory.ApplyTableScanRedirect> applyTableScanRedirect)
+    {
+        MockConnectorFactory.Builder builder = MockConnectorFactory.builder()
+                .withGetColumns(schemaTableName -> {
+                    if (schemaTableName.equals(sourceTable)) {
+                        return ImmutableList.of(
+                                new ColumnMetadata(sourceColumnNameA, VARCHAR),
+                                new ColumnMetadata(sourceColumnNameB, VARCHAR));
+                    }
+                    else if (schemaTableName.equals(destinationTable)) {
+                        return ImmutableList.of(
+                                new ColumnMetadata(destinationColumnNameA, VARCHAR),
+                                new ColumnMetadata(destinationColumnNameB, VARCHAR));
+                    }
+                    throw new IllegalArgumentException();
+                });
+        applyTableScanRedirect.ifPresent(builder::withApplyTableScanRedirect);
+
+        return builder.build();
+    }
+}

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -46,6 +46,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SortItem;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
 import io.prestosql.spi.connector.TopNApplicationResult;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -809,6 +810,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getMaterializedViewFreshness(session, tableHandle);
+        }
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyTableScanRedirect(session, tableHandle);
         }
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -1037,4 +1037,9 @@ public interface ConnectorMetadata
     {
         return new MaterializedViewFreshness(false);
     }
+
+    default Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/TableScanRedirectApplicationResult.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/TableScanRedirectApplicationResult.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.connector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableScanRedirectApplicationResult
+{
+    private final CatalogSchemaTableName destinationTable;
+    // mapping of source table handles to destination table columns
+    private final Map<ColumnHandle, String> destinationColumns;
+
+    public TableScanRedirectApplicationResult(CatalogSchemaTableName destinationTable, Map<ColumnHandle, String> destinationColumns)
+    {
+        this.destinationTable = requireNonNull(destinationTable, "destinationTable is null");
+        this.destinationColumns = Map.copyOf(requireNonNull(destinationColumns, "destinationColumns is null"));
+    }
+
+    public CatalogSchemaTableName getDestinationTable()
+    {
+        return destinationTable;
+    }
+
+    public Map<ColumnHandle, String> getDestinationColumns()
+    {
+        return destinationColumns;
+    }
+}

--- a/presto-tests/src/test/java/io/prestosql/tests/TestTpchTableScanRedirection.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestTpchTableScanRedirection.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import io.prestosql.Session;
+import io.prestosql.plugin.memory.MemoryPlugin;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.Test;
+
+import static io.prestosql.SystemSessionProperties.TABLE_SCAN_REDIRECTION_ENABLED;
+import static org.testng.Assert.assertEquals;
+
+public class TestTpchTableScanRedirection
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
+                .withTableScanRedirectionCatalog("memory")
+                .withTableScanRedirectionSchema("test")
+                .build();
+        queryRunner.installPlugin(new MemoryPlugin());
+        queryRunner.createCatalog("memory", "memory");
+        return queryRunner;
+    }
+
+    @Test(timeOut = 20_000)
+    public void testTableScanRedirection()
+    {
+        assertQuerySucceeds("CREATE SCHEMA memory.test");
+        assertUpdate(
+                Session.builder(getSession())
+                        .setSystemProperty(TABLE_SCAN_REDIRECTION_ENABLED, "false")
+                        .build(),
+                "CREATE TABLE memory.test.orders AS SELECT * FROM tpch.tiny.orders LIMIT 100", 100L);
+        assertEquals(computeActual("SELECT * FROM tpch.tiny.orders WHERE orderkey > 0").getRowCount(), 100L);
+    }
+}

--- a/presto-tests/src/test/java/io/prestosql/tests/tpch/TpchQueryRunnerBuilder.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/tpch/TpchQueryRunnerBuilder.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 
 import static io.prestosql.plugin.tpch.TpchConnectorFactory.TPCH_MAX_ROWS_PER_PAGE_PROPERTY;
 import static io.prestosql.plugin.tpch.TpchConnectorFactory.TPCH_PRODUCE_PAGES;
+import static io.prestosql.plugin.tpch.TpchConnectorFactory.TPCH_TABLE_SCAN_REDIRECTION_CATALOG;
+import static io.prestosql.plugin.tpch.TpchConnectorFactory.TPCH_TABLE_SCAN_REDIRECTION_SCHEMA;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
 
 public final class TpchQueryRunnerBuilder
@@ -36,6 +38,8 @@ public final class TpchQueryRunnerBuilder
 
     private Optional<Integer> maxRowsPerPage = Optional.empty();
     private Optional<Boolean> producePages = Optional.empty();
+    private Optional<String> destinationCatalog = Optional.empty();
+    private Optional<String> destinationSchema = Optional.empty();
 
     private TpchQueryRunnerBuilder()
     {
@@ -60,6 +64,18 @@ public final class TpchQueryRunnerBuilder
         return this;
     }
 
+    public TpchQueryRunnerBuilder withTableScanRedirectionCatalog(String destinationCatalog)
+    {
+        this.destinationCatalog = Optional.of(destinationCatalog);
+        return this;
+    }
+
+    public TpchQueryRunnerBuilder withTableScanRedirectionSchema(String destinationSchema)
+    {
+        this.destinationSchema = Optional.of(destinationSchema);
+        return this;
+    }
+
     public static TpchQueryRunnerBuilder builder()
     {
         return new TpchQueryRunnerBuilder();
@@ -74,6 +90,8 @@ public final class TpchQueryRunnerBuilder
             ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
             maxRowsPerPage.ifPresent(value -> properties.put(TPCH_MAX_ROWS_PER_PAGE_PROPERTY, value.toString()));
             producePages.ifPresent(value -> properties.put(TPCH_PRODUCE_PAGES, value.toString()));
+            destinationCatalog.ifPresent(value -> properties.put(TPCH_TABLE_SCAN_REDIRECTION_CATALOG, value));
+            destinationSchema.ifPresent(value -> properties.put(TPCH_TABLE_SCAN_REDIRECTION_SCHEMA, value));
             queryRunner.createCatalog("tpch", "tpch", properties.build());
             return queryRunner;
         }

--- a/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchConnectorFactory.java
+++ b/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchConnectorFactory.java
@@ -27,6 +27,7 @@ import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.Boolean.FALSE;
@@ -38,6 +39,8 @@ public class TpchConnectorFactory
     public static final String TPCH_COLUMN_NAMING_PROPERTY = "tpch.column-naming";
     public static final String TPCH_PRODUCE_PAGES = "tpch.produce-pages";
     public static final String TPCH_MAX_ROWS_PER_PAGE_PROPERTY = "tpch.max-rows-per-page";
+    public static final String TPCH_TABLE_SCAN_REDIRECTION_CATALOG = "tpch.table-scan-redirection-catalog";
+    public static final String TPCH_TABLE_SCAN_REDIRECTION_SCHEMA = "tpch.table-scan-redirection-schema";
     private static final int DEFAULT_MAX_ROWS_PER_PAGE = 1_000_000;
 
     private final int defaultSplitsPerNode;
@@ -91,7 +94,12 @@ public class TpchConnectorFactory
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
             {
-                return new TpchMetadata(columnNaming, predicatePushdownEnabled, partitioningEnabled);
+                return new TpchMetadata(
+                        columnNaming,
+                        predicatePushdownEnabled,
+                        partitioningEnabled,
+                        getTpchTableScanRedirectionCatalog(properties),
+                        getTpchTableScanRedirectionSchema(properties));
             }
 
             @Override
@@ -151,5 +159,15 @@ public class TpchConnectorFactory
         catch (NumberFormatException e) {
             throw new IllegalArgumentException(format("Invalid property %s", TPCH_MAX_ROWS_PER_PAGE_PROPERTY));
         }
+    }
+
+    private Optional<String> getTpchTableScanRedirectionCatalog(Map<String, String> properties)
+    {
+        return Optional.ofNullable(properties.get(TPCH_TABLE_SCAN_REDIRECTION_CATALOG));
+    }
+
+    private Optional<String> getTpchTableScanRedirectionSchema(Map<String, String> properties)
+    {
+        return Optional.ofNullable(properties.get(TPCH_TABLE_SCAN_REDIRECTION_SCHEMA));
     }
 }

--- a/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchMetadata.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.tpch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -25,6 +26,7 @@ import io.prestosql.plugin.tpch.statistics.ColumnStatisticsData;
 import io.prestosql.plugin.tpch.statistics.StatisticsEstimator;
 import io.prestosql.plugin.tpch.statistics.TableStatisticsData;
 import io.prestosql.plugin.tpch.statistics.TableStatisticsDataRepository;
+import io.prestosql.spi.connector.CatalogSchemaTableName;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorMetadata;
@@ -40,6 +42,7 @@ import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SortOrder;
 import io.prestosql.spi.connector.SortingProperty;
+import io.prestosql.spi.connector.TableScanRedirectApplicationResult;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.NullableValue;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -125,13 +128,20 @@ public class TpchMetadata
     private final StatisticsEstimator statisticsEstimator;
     private final boolean predicatePushdownEnabled;
     private final boolean partitioningEnabled;
+    private final Optional<String> destinationCatalog;
+    private final Optional<String> destinationSchema;
 
     public TpchMetadata()
     {
-        this(ColumnNaming.SIMPLIFIED, true, true);
+        this(ColumnNaming.SIMPLIFIED, true, true, Optional.empty(), Optional.empty());
     }
 
-    public TpchMetadata(ColumnNaming columnNaming, boolean predicatePushdownEnabled, boolean partitioningEnabled)
+    public TpchMetadata(
+            ColumnNaming columnNaming,
+            boolean predicatePushdownEnabled,
+            boolean partitioningEnabled,
+            Optional<String> destinationCatalog,
+            Optional<String> destinationSchema)
     {
         ImmutableSet.Builder<String> tableNames = ImmutableSet.builder();
         for (TpchTable<?> tpchTable : TpchTable.getTables()) {
@@ -142,6 +152,8 @@ public class TpchMetadata
         this.predicatePushdownEnabled = predicatePushdownEnabled;
         this.partitioningEnabled = partitioningEnabled;
         this.statisticsEstimator = createStatisticsEstimator();
+        this.destinationCatalog = destinationCatalog;
+        this.destinationSchema = destinationSchema;
     }
 
     private static StatisticsEstimator createStatisticsEstimator()
@@ -501,6 +513,24 @@ public class TpchMetadata
                         handle.getScaleFactor(),
                         oldDomain.intersect(predicate)),
                 unenforcedConstraint));
+    }
+
+    @Override
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table)
+    {
+        TpchTableHandle handle = (TpchTableHandle) table;
+        if (destinationCatalog.isEmpty()) {
+            return Optional.empty();
+        }
+
+        CatalogSchemaTableName destinationTable = new CatalogSchemaTableName(
+                destinationCatalog.get(),
+                destinationSchema.orElse(scaleFactorSchemaName(handle.getScaleFactor())),
+                handle.getTableName());
+        return Optional.of(
+                new TableScanRedirectApplicationResult(
+                        destinationTable,
+                        ImmutableBiMap.copyOf(getColumnHandles(session, table)).inverse()));
     }
 
     private TupleDomain<ColumnHandle> toTupleDomain(Map<TpchColumnHandle, Set<NullableValue>> predicate)


### PR DESCRIPTION
Allows connectors to offload table scans to any other connector during
the plan optimization phase. The connector may choose to delegate
based on criteria like selected columns and applied predicates.