### PR TITLE
Fix Hive applyProjection performance issue

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -2166,7 +2166,7 @@ public class HiveMetadata
         }
 
         Map<String, Assignment> newAssignments = new HashMap<>();
-        ImmutableMap.Builder<ConnectorExpression, Variable> expressionToVariableMappings = ImmutableMap.builder();
+        ImmutableMap.Builder<ConnectorExpression, Variable> newVariablesBuilder = ImmutableMap.builder();
 
         for (Map.Entry<ConnectorExpression, ProjectedColumnRepresentation> entry : columnProjections.entrySet()) {
             ConnectorExpression expression = entry.getKey();
@@ -2193,12 +2193,13 @@ public class HiveMetadata
             Assignment newAssignment = new Assignment(projectedColumnName, projectedColumnHandle, expression.getType());
             newAssignments.put(projectedColumnName, newAssignment);
 
-            expressionToVariableMappings.put(expression, projectedColumnVariable);
+            newVariablesBuilder.put(expression, projectedColumnVariable);
         }
 
         // Modify projections to refer to new variables
+        Map<ConnectorExpression, Variable> newVariables = newVariablesBuilder.build();
         List<ConnectorExpression> newProjections = projections.stream()
-                .map(expression -> replaceWithNewVariables(expression, expressionToVariableMappings.build()))
+                .map(expression -> replaceWithNewVariables(expression, newVariables))
                 .collect(toImmutableList());
 
         List<Assignment> outputAssignments = newAssignments.values().stream().collect(toImmutableList());


### PR DESCRIPTION
Issue: 

A query of the form `SELECT * FROM V`, where `V` is a view flattenning out nested columns, exhausts the optimizer limit of `180s`. The number of output columns in `V` is ~1.5k. ([slack thread](https://prestosql.slack.com/archives/CGB0QHWSW/p1604003388200000))

CPU profiling and data in `system.runtime.optimizer_rule_stats` table show that `HiveMetadata#applyProjection` takes too long to complete. Within the method, most time is spent building maps and sets of `ConnectorExpression`.

1) One very obvious issue is building of the map [repeatedly](https://github.com/prestosql/presto/commit/d693a2d55881f8c9dc0298f00c650aa263aa866b#diff-248c4242c1644b7b87e80b26197897f7b967c2999b8b97f82ec626bb379db5e3L2201) within the stream. 

2) Secondly, even a single build of a map/set (size ~1.5k) involving `ConnectorExpressions` takes too long. This is because `ConnectorExpression` subclasses use `type` field for hashcode/equals. The comparisons become quite expensive in case of nested types (RowType falls back to `TypeSignature` for `hashcode` and `equals`). Also, in case of FieldDereference, the # of comparisons blow up because `target` itself can be a `ConnectorExpression`.

The following table shows a comparison of the time taken to build a set of ConnectorExpressions for (1) different set-cardinalities and (2) lengths of field dereference objects. 

| Number of elements in the set | Example elements in the set                         | walltime (ms)  Current master | walltime (ms)  Implement RowType  equals and hashCode (using "fields") | walltime (ms)  Remove Type usage  from equalsTo and hashCode |
|-------------------------------|-----------------------------------------------------|-------------------------------|------------------------------------------------------------------------|--------------------------------------------------------------|
| 2 (levels=1)                  | a.f0, a.f1                                          | 0.114                         | 0.103                                                                  | 0.002                                                        |
| 4 (levels=2)                  | a.f0.f0, a.f0.f1, a.f1.f0, f.f1.f1                  | 0.058                         | 0.037                                                                  | 0.030                                                        |
| 8 (levels=3)                  | a.f0.f0.f0, a.f0.f0.f1, a.f0.f1.f0, a.f0.f1.f1, ... | 0.159                         | 0.059                                                                  | 0.052                                                        |
| 16 (levels=4)                 | a.f0.f0.f0.f0, a.f0.f0.f0.f1, ....                  | 0.422                         | 0.165                                                                  | 0.055                                                        |
| 32 (levels=5)                 | a.f0.f0.f0.f0.f0, a.f0.f0.f0.f0.f1, ...             | 0.756                         | 0.444                                                                  | 0.093                                                        |
| 64 (levels=6)                 | a.f0.f0.f0.f0.f0.f0, ...                            | 2.941                         | 0.718                                                                  | 0.109                                                        |
| 128 (levels=7)                | ...                                                 | 13.556                        | 4.308                                                                  | 0.167                                                        |
| 256 (levels=8)                | ...                                                 | 44.139                        | 16.475                                                                 | 0.291                                                        |
| 512 (levels=9)                | ...                                                 | 118.056                       | 54.680                                                                 | 0.772                                                        |
| 1024 (levels=10)              | ...                                                 | 484.896                       | 184.495                                                                | 0.894                                                        |
| 2048 (levels=11)              | ...                                                 | 1874.596                      | 714.558                                                                | 2.675                                                        |
| 4096 (levels=12)              | ...                                                 | 8909.578                      | 2780.157                                                               | 9.345                                                        |

** I haven't tried to differentiate between which one of `equals` and `hashcode` is problematic, and whether optimizing `hashCode` of them improves performance. (The hashcode values seem to be distinct, haven't looked into what buckets they fall in)

** The numbers here are _not_ generated through `JMH`, but just a simple script comparing walltimes. So while the results may not be accurate, they've been averaged over 100 runs each. 

However,, it'd be good to first have an agreement on whether it is okay to ignore `type` in context of equivalence of `ConnectorExpression` objects. @martint 