### PR TITLE
Implement getRow for AbstractPrestoResultSet

### DIFF
--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -751,6 +751,36 @@ public abstract class BaseTestJdbcResultSet
         }
     }
 
+    @Test
+    public void testGetRow()
+            throws Exception
+    {
+        try (ConnectedStatement connectedStatement = newStatement()) {
+            try (ResultSet rs = connectedStatement.getStatement().executeQuery("SELECT * FROM (VALUES (1), (2), (3))")) {
+                assertEquals(rs.getRow(), 0);
+                int currentRow = 0;
+                while (rs.next()) {
+                    currentRow++;
+                    assertEquals(rs.getRow(), currentRow);
+                }
+                assertEquals(rs.getRow(), 0);
+            }
+        }
+    }
+
+    @Test
+    public void testGetRowException()
+            throws Exception
+    {
+        try (ConnectedStatement connectedStatement = newStatement()) {
+            ResultSet rs = connectedStatement.getStatement().executeQuery("SELECT * FROM (VALUES (1), (2), (3))");
+            rs.close();
+            assertThatThrownBy(rs::getRow)
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("ResultSet is closed");
+        }
+    }
+
     private static long countRows(ResultSet rs)
             throws SQLException
     {


### PR DESCRIPTION
This PR fixed the issue #5745. It implements the `getRow` method in `AbstractPrestoResultSet` class which returns the current number of row in ResultSet (indexing from 1). The method specification can be found in this java [doc](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html#getRow--). 

Fixes #5745