### PR TITLE
Remove leftover directories during rpm uninstall

### DIFF
--- a/presto-server-rpm/src/main/rpm/postremove
+++ b/presto-server-rpm/src/main/rpm/postremove
@@ -10,6 +10,10 @@ then
     # rpm -e wont remove it, because this directory may later contain files not
     # deployed by the rpm
     rm -rf /var/lib/presto
+    # The RPM instead of linking to /usr/lib/presto/ as a directory attribute
+    # now links to all the individual jar files in /usr/lib/presto/lib/ and
+    # /usr/lib/presto/plugin/. So remove the parent dir manually during uninstall
+    rm -rf /usr/lib/presto
     # Remove /etc/presto directory if no other files present
     if [ -z "$(ls -A /etc/presto)" ]
     then


### PR DESCRIPTION
Now that the Presto lib directories
are modified outside of rpm install (we create symlinks in
/usr/lib/presto/lib and plugin location), a rpm uninstall
leaves these empty directories behind if not explicitly
cleaned up in "postremove" step.