### PR TITLE
Refactor ValuesNode

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/io/prestosql/sql/planner/AbstractCostBasedPlanTest.java
@@ -224,7 +224,7 @@ public abstract class AbstractCostBasedPlanTest
         @Override
         public Void visitValues(ValuesNode node, Integer indent)
         {
-            output(indent, "values (%s rows)", node.getRows().size());
+            output(indent, "values (%s rows)", node.getRowCount());
 
             return null;
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionExtractor.java
@@ -135,7 +135,7 @@ public final class ExpressionExtractor
         @Override
         public Void visitValues(ValuesNode node, Void context)
         {
-            node.getRows().forEach(row -> row.forEach(consumer));
+            node.getRows().ifPresent(list -> list.forEach(consumer));
             return super.visitValues(node, context);
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
@@ -74,7 +74,6 @@ import io.prestosql.sql.tree.GenericLiteral;
 import io.prestosql.sql.tree.IfExpression;
 import io.prestosql.sql.tree.Insert;
 import io.prestosql.sql.tree.LambdaArgumentDeclaration;
-import io.prestosql.sql.tree.LongLiteral;
 import io.prestosql.sql.tree.NodeRef;
 import io.prestosql.sql.tree.NullLiteral;
 import io.prestosql.sql.tree.QualifiedName;
@@ -229,7 +228,7 @@ public class LogicalPlanner
         if ((statement instanceof CreateTableAsSelect && analysis.getCreate().get().isCreateTableAsSelectNoOp()) ||
                 statement instanceof RefreshMaterializedView && analysis.isSkipMaterializedViewRefresh()) {
             Symbol symbol = symbolAllocator.newSymbol("rows", BIGINT);
-            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(ImmutableList.of(new LongLiteral("0"))));
+            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "0"))));
             return new OutputNode(idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(symbol));
         }
         return createOutputPlan(planStatementWithoutOutput(analysis, statement), analysis);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LogicalPlanner.java
@@ -79,6 +79,7 @@ import io.prestosql.sql.tree.NullLiteral;
 import io.prestosql.sql.tree.QualifiedName;
 import io.prestosql.sql.tree.Query;
 import io.prestosql.sql.tree.RefreshMaterializedView;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.sql.tree.Statement;
 import io.prestosql.sql.tree.StringLiteral;
 import io.prestosql.type.TypeCoercion;
@@ -228,7 +229,7 @@ public class LogicalPlanner
         if ((statement instanceof CreateTableAsSelect && analysis.getCreate().get().isCreateTableAsSelectNoOp()) ||
                 statement instanceof RefreshMaterializedView && analysis.isSkipMaterializedViewRefresh()) {
             Symbol symbol = symbolAllocator.newSymbol("rows", BIGINT);
-            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "0"))));
+            PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "0")))));
             return new OutputNode(idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(symbol));
         }
         return createOutputPlan(planStatementWithoutOutput(analysis, statement), analysis);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanCopier.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanCopier.java
@@ -126,7 +126,7 @@ public final class PlanCopier
         @Override
         public PlanNode visitValues(ValuesNode node, RewriteContext<Void> context)
         {
-            return new ValuesNode(idAllocator.getNextId(), node.getOutputSymbols(), node.getRows());
+            return new ValuesNode(idAllocator.getNextId(), node.getOutputSymbols(), node.getRowCount(), node.getRows());
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
@@ -497,7 +497,7 @@ class QueryPlanner
 
         return new PlanBuilder(
                 new TranslationMap(outerContext, analysis.getImplicitFromScope(node), analysis, lambdaDeclarationToSymbolMap, ImmutableList.of()),
-                new ValuesNode(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(ImmutableList.of())));
+                new ValuesNode(idAllocator.getNextId(), 1));
     }
 
     private PlanBuilder filter(PlanBuilder subPlan, Expression predicate, Node node)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -23,7 +23,7 @@ import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
-import io.prestosql.sql.tree.LongLiteral;
+import io.prestosql.sql.tree.GenericLiteral;
 import io.prestosql.sql.tree.QualifiedName;
 
 import java.util.Map;
@@ -70,7 +70,7 @@ public class PruneCountAggregationOverScalar
             }
         }
         if (!assignments.isEmpty() && isScalar(parent.getSource(), context.getLookup())) {
-            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(ImmutableList.of(new LongLiteral("1")))));
+            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1")))));
         }
         return Result.empty();
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -25,6 +25,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.tree.GenericLiteral;
 import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.Row;
 
 import java.util.Map;
 
@@ -70,7 +71,7 @@ public class PruneCountAggregationOverScalar
             }
         }
         if (!assignments.isEmpty() && isScalar(parent.getSource(), context.getLookup())) {
-            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1")))));
+            return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))));
         }
         return Result.empty();
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneValuesColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneValuesColumns.java
@@ -46,13 +46,18 @@ public class PruneValuesColumns
             return Optional.empty();
         }
 
+        List<Symbol> newOutputs = filteredCopy(valuesNode.getOutputSymbols(), referencedOutputs::contains);
+
+        // no output symbols left
+        if (newOutputs.isEmpty()) {
+            return Optional.of(new ValuesNode(valuesNode.getId(), valuesNode.getRowCount()));
+        }
+
         checkState(valuesNode.getRows().isPresent(), "rows is empty");
         // if any of ValuesNode's rows is specified by expression other than Row, the redundant piece cannot be extracted and pruned
         if (!valuesNode.getRows().get().stream().allMatch(Row.class::isInstance)) {
             return Optional.empty();
         }
-
-        List<Symbol> newOutputs = filteredCopy(valuesNode.getOutputSymbols(), referencedOutputs::contains);
 
         // for each output of project, the corresponding column in the values node
         int[] mapping = new int[newOutputs.size()];

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -35,6 +35,7 @@ import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.tree.CoalesceExpression;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.NullLiteral;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.sql.tree.SymbolReference;
 
 import java.util.HashSet;
@@ -282,7 +283,7 @@ public class PushAggregationThroughOuterJoin
         ValuesNode nullRow = new ValuesNode(
                 idAllocator.getNextId(),
                 nullSymbols.build(),
-                ImmutableList.of(nullLiterals.build()));
+                ImmutableList.of(new Row(nullLiterals.build())));
         Map<Symbol, SymbolReference> sourcesSymbolMapping = sourcesSymbolMappingBuilder.build();
 
         // For each aggregation function in the reference node, create a corresponding aggregation function

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveEmptyDelete.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveEmptyDelete.java
@@ -19,7 +19,7 @@ import io.prestosql.matching.Pattern;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.plan.TableFinishNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
-import io.prestosql.sql.tree.LongLiteral;
+import io.prestosql.sql.tree.GenericLiteral;
 
 import static io.prestosql.matching.Pattern.empty;
 import static io.prestosql.sql.planner.plan.Patterns.Values.rows;
@@ -74,6 +74,6 @@ public class RemoveEmptyDelete
                 new ValuesNode(
                         node.getId(),
                         node.getOutputSymbols(),
-                        ImmutableList.of(ImmutableList.of(new LongLiteral("0")))));
+                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "0")))));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveEmptyDelete.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveEmptyDelete.java
@@ -20,9 +20,9 @@ import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.plan.TableFinishNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.tree.GenericLiteral;
+import io.prestosql.sql.tree.Row;
 
-import static io.prestosql.matching.Pattern.empty;
-import static io.prestosql.sql.planner.plan.Patterns.Values.rows;
+import static io.prestosql.sql.planner.plan.Patterns.Values.rowCount;
 import static io.prestosql.sql.planner.plan.Patterns.delete;
 import static io.prestosql.sql.planner.plan.Patterns.exchange;
 import static io.prestosql.sql.planner.plan.Patterns.source;
@@ -58,7 +58,7 @@ public class RemoveEmptyDelete
 
     private static Pattern<ValuesNode> emptyValues()
     {
-        return values().with(empty(rows()));
+        return values().with(rowCount().equalTo(0));
     }
 
     @Override
@@ -74,6 +74,6 @@ public class RemoveEmptyDelete
                 new ValuesNode(
                         node.getId(),
                         node.getOutputSymbols(),
-                        ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "0")))));
+                        ImmutableList.of(new Row(ImmutableList.of(new GenericLiteral("BIGINT", "0"))))));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -95,6 +95,6 @@ public class TransformCorrelatedSingleRowSubqueryToProject
 
     private static boolean isSingleRowValuesWithNoColumns(ValuesNode values)
     {
-        return values.getRows().size() == 1 && values.getRows().get(0).size() == 0;
+        return values.getRowCount() == 1 && values.getOutputSymbols().isEmpty();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/DistinctOutputQueryUtil.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/DistinctOutputQueryUtil.java
@@ -112,7 +112,7 @@ public final class DistinctOutputQueryUtil
         @Override
         public Boolean visitValues(ValuesNode node, Void context)
         {
-            return node.getRows().size() == 1;
+            return node.getRowCount() == 1;
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/DistinctOutputQueryUtil.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/DistinctOutputQueryUtil.java
@@ -112,7 +112,7 @@ public final class DistinctOutputQueryUtil
         @Override
         public Boolean visitValues(ValuesNode node, Void context)
         {
-            return node.getRowCount() == 1;
+            return node.getRowCount() <= 1;
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -73,6 +73,7 @@ import io.prestosql.sql.planner.plan.UnnestNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
 import io.prestosql.sql.planner.plan.WindowNode;
 import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.Row;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -763,10 +764,20 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitValues(ValuesNode node, RewriteContext<Set<Symbol>> context)
         {
+            // nothing to prune: no output symbols and no expressions
+            if (node.getRows().isEmpty()) {
+                return node;
+            }
+
+            // if any of ValuesNode's rows is specified by expression other than Row, the redundant piece cannot be extracted and pruned
+            if (!node.getRows().get().stream().allMatch(Row.class::isInstance)) {
+                return node;
+            }
+
             ImmutableList.Builder<Symbol> rewrittenOutputSymbolsBuilder = ImmutableList.builder();
             ImmutableList.Builder<ImmutableList.Builder<Expression>> rowBuildersBuilder = ImmutableList.builder();
             // Initialize builder for each row
-            for (int i = 0; i < node.getRows().size(); i++) {
+            for (int i = 0; i < node.getRowCount(); i++) {
                 rowBuildersBuilder.add(ImmutableList.builder());
             }
             ImmutableList<ImmutableList.Builder<Expression>> rowBuilders = rowBuildersBuilder.build();
@@ -776,13 +787,14 @@ public class PruneUnreferencedOutputs
                 if (context.get().contains(outputSymbol)) {
                     rewrittenOutputSymbolsBuilder.add(outputSymbol);
                     // Add the value of the output symbol for each row
-                    for (int j = 0; j < node.getRows().size(); j++) {
-                        rowBuilders.get(j).add(node.getRows().get(j).get(i));
+                    for (int j = 0; j < node.getRowCount(); j++) {
+                        rowBuilders.get(j).add(((Row) node.getRows().get().get(j)).getItems().get(i));
                     }
                 }
             }
-            List<List<Expression>> rewrittenRows = rowBuilders.stream()
+            List<Expression> rewrittenRows = rowBuilders.stream()
                     .map(ImmutableList.Builder::build)
+                    .map(Row::new)
                     .collect(toImmutableList());
             return new ValuesNode(node.getId(), rewrittenOutputSymbolsBuilder.build(), rewrittenRows);
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -769,6 +769,11 @@ public class PruneUnreferencedOutputs
                 return node;
             }
 
+            // handle the case of all output symbols pruned
+            if (node.getOutputSymbols().stream().noneMatch(context.get()::contains)) {
+                return new ValuesNode(node.getId(), node.getRowCount());
+            }
+
             // if any of ValuesNode's rows is specified by expression other than Row, the redundant piece cannot be extracted and pruned
             if (!node.getRows().get().stream().allMatch(Row.class::isInstance)) {
                 return node;

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -170,7 +170,7 @@ public final class QueryCardinalityUtil
         @Override
         public Range<Long> visitValues(ValuesNode node, Void context)
         {
-            return Range.singleton((long) node.getRows().size());
+            return Range.singleton((long) node.getRowCount());
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
@@ -320,9 +320,14 @@ public final class Patterns
 
     public static final class Values
     {
-        public static Property<ValuesNode, Lookup, List<List<Expression>>> rows()
+        public static Property<ValuesNode, Lookup, Optional<List<Expression>>> rows()
         {
             return property("rows", ValuesNode::getRows);
+        }
+
+        public static Property<ValuesNode, Lookup, Integer> rowCount()
+        {
+            return property("rowCount", ValuesNode::getRowCount);
         }
     }
 

--- a/presto-main/src/test/java/io/prestosql/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestStageStateMachine.java
@@ -24,6 +24,7 @@ import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.PlanFragmentId;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 import io.prestosql.sql.planner.plan.ValuesNode;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.sql.tree.StringLiteral;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -393,7 +394,7 @@ public class TestStageStateMachine
                 new PlanFragmentId("plan"),
                 new ValuesNode(valuesNodeId,
                         ImmutableList.of(symbol),
-                        ImmutableList.of(ImmutableList.of(new StringLiteral("foo")))),
+                        ImmutableList.of(new Row(ImmutableList.of(new StringLiteral("foo"))))),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(valuesNodeId),

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestAnalyzer.java
@@ -2625,6 +2625,28 @@ public class TestAnalyzer
                 .hasErrorCode(NOT_SUPPORTED);
     }
 
+    @Test
+    public void testValues()
+    {
+        assertFails("VALUES (1, 2, 3), (1, 2)")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:1: Values rows have mismatched sizes: 3 vs 2");
+
+        assertFails("VALUES (1, 2), 1")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:1: Values rows have mismatched sizes: 2 vs 1");
+
+        assertFails("VALUES (1, 2), CAST(ROW(1, 2, 3) AS row(bigint, bigint, bigint))")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:1: Values rows have mismatched sizes: 2 vs 3");
+
+        assertFails("VALUES (1, 2), ('a', 'b')")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:1: Values rows have mismatched types: row(integer, integer) vs row(varchar(1), varchar(1))");
+
+        analyze("VALUES 'a', ('a'), ROW('a'), CAST(ROW('a') AS row(char(5)))");
+    }
+
     @BeforeClass
     public void setup()
     {

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
@@ -75,6 +75,7 @@ import io.prestosql.sql.tree.LongLiteral;
 import io.prestosql.sql.tree.NotExpression;
 import io.prestosql.sql.tree.NullLiteral;
 import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.testing.TestingMetadata.TestingColumnHandle;
 import io.prestosql.testing.TestingSession;
 import io.prestosql.testing.TestingTransactionHandle;
@@ -590,8 +591,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(A),
                                 ImmutableList.of(
-                                        ImmutableList.of(bigintLiteral(1)),
-                                        ImmutableList.of(bigintLiteral(2)))),
+                                        new Row(ImmutableList.of(bigintLiteral(1))),
+                                        new Row(ImmutableList.of(bigintLiteral(2))))),
                         types,
                         typeAnalyzer),
                 new InPredicate(AE, new InListExpression(ImmutableList.of(bigintLiteral(1), bigintLiteral(2)))));
@@ -604,9 +605,9 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(A),
                                 ImmutableList.of(
-                                        ImmutableList.of(bigintLiteral(1)),
-                                        ImmutableList.of(bigintLiteral(2)),
-                                        ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT))))),
+                                        new Row(ImmutableList.of(bigintLiteral(1))),
+                                        new Row(ImmutableList.of(bigintLiteral(2))),
+                                        new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)))))),
                         types,
                         typeAnalyzer),
                 or(
@@ -620,15 +621,16 @@ public class TestEffectivePredicateExtractor
                         new ValuesNode(
                                 newId(),
                                 ImmutableList.of(A),
-                                ImmutableList.of(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT))))),
+                                ImmutableList.of(new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)))))),
                         types,
                         typeAnalyzer),
                 new IsNullPredicate(AE));
 
         // many rows
-        List<List<Expression>> rows = IntStream.range(0, 500)
+        List<Expression> rows = IntStream.range(0, 500)
                 .mapToObj(TestEffectivePredicateExtractor::bigintLiteral)
                 .map(ImmutableList::of)
+                .map(Row::new)
                 .collect(toImmutableList());
         assertEquals(
                 effectivePredicateExtractor.extract(
@@ -648,7 +650,7 @@ public class TestEffectivePredicateExtractor
                         new ValuesNode(
                                 newId(),
                                 ImmutableList.of(D),
-                                ImmutableList.of(ImmutableList.of(doubleLiteral(Double.NaN)))),
+                                ImmutableList.of(new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
                         typeAnalyzer),
                 new NotExpression(new IsNullPredicate(DE)));
@@ -661,8 +663,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(D),
                                 ImmutableList.of(
-                                        ImmutableList.of(new Cast(new NullLiteral(), toSqlType(DOUBLE))),
-                                        ImmutableList.of(doubleLiteral(Double.NaN)))),
+                                        new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(DOUBLE)))),
+                                        new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
                         typeAnalyzer),
                 TRUE_LITERAL);
@@ -675,8 +677,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(D),
                                 ImmutableList.of(
-                                        ImmutableList.of(doubleLiteral(42.)),
-                                        ImmutableList.of(doubleLiteral(Double.NaN)))),
+                                        new Row(ImmutableList.of(doubleLiteral(42.))),
+                                        new Row(ImmutableList.of(doubleLiteral(Double.NaN))))),
                         types,
                         typeAnalyzer),
                 new NotExpression(new IsNullPredicate(DE)));
@@ -688,7 +690,7 @@ public class TestEffectivePredicateExtractor
                         new ValuesNode(
                                 newId(),
                                 ImmutableList.of(D),
-                                ImmutableList.of(ImmutableList.of(new Cast(doubleLiteral(Double.NaN), toSqlType(REAL))))),
+                                ImmutableList.of(new Row(ImmutableList.of(new Cast(doubleLiteral(Double.NaN), toSqlType(REAL)))))),
                         TypeProvider.copyOf(ImmutableMap.of(D, REAL)),
                         typeAnalyzer),
                 new NotExpression(new IsNullPredicate(DE)));
@@ -701,8 +703,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(A, B),
                                 ImmutableList.of(
-                                        ImmutableList.of(bigintLiteral(1), bigintLiteral(100)),
-                                        ImmutableList.of(bigintLiteral(2), bigintLiteral(200)))),
+                                        new Row(ImmutableList.of(bigintLiteral(1), bigintLiteral(100))),
+                                        new Row(ImmutableList.of(bigintLiteral(2), bigintLiteral(200))))),
                         types,
                         typeAnalyzer),
                 and(
@@ -717,8 +719,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(A, B),
                                 ImmutableList.of(
-                                        ImmutableList.of(bigintLiteral(1), new Cast(new NullLiteral(), toSqlType(BIGINT))),
-                                        ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)), bigintLiteral(200)))),
+                                        new Row(ImmutableList.of(bigintLiteral(1), new Cast(new NullLiteral(), toSqlType(BIGINT)))),
+                                        new Row(ImmutableList.of(new Cast(new NullLiteral(), toSqlType(BIGINT)), bigintLiteral(200))))),
                         types,
                         typeAnalyzer),
                 and(
@@ -730,7 +732,7 @@ public class TestEffectivePredicateExtractor
         ValuesNode node = new ValuesNode(
                 newId(),
                 ImmutableList.of(A, B),
-                ImmutableList.of(ImmutableList.of(bigintLiteral(1), new FunctionCall(rand.toQualifiedName(), ImmutableList.of()))));
+                ImmutableList.of(new Row(ImmutableList.of(bigintLiteral(1), new FunctionCall(rand.toQualifiedName(), ImmutableList.of())))));
         assertEquals(extract(types, node), new ComparisonExpression(EQUAL, AE, bigintLiteral(1)));
 
         // non-constant
@@ -741,8 +743,8 @@ public class TestEffectivePredicateExtractor
                                 newId(),
                                 ImmutableList.of(A),
                                 ImmutableList.of(
-                                        ImmutableList.of(bigintLiteral(1)),
-                                        ImmutableList.of(BE))),
+                                        new Row(ImmutableList.of(bigintLiteral(1))),
+                                        new Row(ImmutableList.of(BE)))),
                         types,
                         typeAnalyzer),
                 TRUE_LITERAL);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
@@ -928,7 +928,7 @@ public class TestLogicalPlanner
         assertPlan(
                 "SELECT count(*) FROM (SELECT sum(orderkey) FROM orders)",
                 output(
-                        values(ImmutableList.of("_col0"), ImmutableList.of(ImmutableList.of(new LongLiteral("1"))))));
+                        values(ImmutableList.of("_col0"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1"))))));
         assertPlan(
                 "SELECT count(s) FROM (SELECT sum(orderkey) AS s FROM orders)",
                 anyTree(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -725,6 +725,11 @@ public final class PlanMatchPattern
         return values(ImmutableList.copyOf(aliases));
     }
 
+    public static PlanMatchPattern values(int rowCount)
+    {
+        return values(ImmutableList.of(), nCopies(rowCount, ImmutableList.of()));
+    }
+
     public static PlanMatchPattern values(List<String> aliases, List<List<Expression>> expectedRows)
     {
         return values(aliases, Optional.of(expectedRows));

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -65,6 +65,7 @@ import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FrameBound;
 import io.prestosql.sql.tree.FunctionCall;
 import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.sql.tree.SortItem;
 import io.prestosql.sql.tree.WindowFrame;
 
@@ -691,10 +692,10 @@ public final class PlanMatchPattern
                 groupIdSymbol));
     }
 
-    private static PlanMatchPattern values(
+    public static PlanMatchPattern values(
             Map<String, Integer> aliasToIndex,
             Optional<Integer> expectedOutputSymbolCount,
-            Optional<List<List<Expression>>> expectedRows)
+            Optional<List<Expression>> expectedRows)
     {
         return node(ValuesNode.class).with(new ValuesMatcher(aliasToIndex, expectedOutputSymbolCount, expectedRows));
     }
@@ -702,9 +703,16 @@ public final class PlanMatchPattern
     private static PlanMatchPattern values(List<String> aliases, Optional<List<List<Expression>>> expectedRows)
     {
         return values(
-                Maps.uniqueIndex(IntStream.range(0, aliases.size()).boxed().iterator(), aliases::get),
+                aliasToIndex(aliases),
                 Optional.of(aliases.size()),
-                expectedRows);
+                expectedRows.map(list -> list.stream()
+                        .map(Row::new)
+                        .collect(toImmutableList())));
+    }
+
+    public static Map<String, Integer> aliasToIndex(List<String> aliases)
+    {
+        return Maps.uniqueIndex(IntStream.range(0, aliases.size()).boxed().iterator(), aliases::get);
     }
 
     public static PlanMatchPattern values(Map<String, Integer> aliasToIndex)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ValuesMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ValuesMatcher.java
@@ -37,12 +37,12 @@ public class ValuesMatcher
 {
     private final Map<String, Integer> outputSymbolAliases;
     private final Optional<Integer> expectedOutputSymbolCount;
-    private final Optional<List<List<Expression>>> expectedRows;
+    private final Optional<List<Expression>> expectedRows;
 
     public ValuesMatcher(
             Map<String, Integer> outputSymbolAliases,
             Optional<Integer> expectedOutputSymbolCount,
-            Optional<List<List<Expression>>> expectedRows)
+            Optional<List<Expression>> expectedRows)
     {
         this.outputSymbolAliases = ImmutableMap.copyOf(outputSymbolAliases);
         this.expectedOutputSymbolCount = requireNonNull(expectedOutputSymbolCount, "expectedOutputSymbolCount is null");
@@ -62,8 +62,15 @@ public class ValuesMatcher
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         ValuesNode valuesNode = (ValuesNode) node;
 
-        if (!expectedRows.map(rows -> rows.equals(valuesNode.getRows())).orElse(true)) {
-            return NO_MATCH;
+        if (expectedRows.isPresent()) {
+            if (expectedRows.get().size() != valuesNode.getRowCount()) {
+                return NO_MATCH;
+            }
+            if (outputSymbolAliases.size() > 0) {
+                if (!expectedRows.equals(valuesNode.getRows())) {
+                    return NO_MATCH;
+                }
+            }
         }
 
         return match(SymbolAliases.builder()

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneValuesColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneValuesColumns.java
@@ -59,4 +59,17 @@ public class TestPruneValuesColumns
                                 p.values(p.symbol("x"))))
                 .doesNotFire();
     }
+
+    @Test
+    public void testDoNotPruneWhenValuesExpressionIsNotRow()
+    {
+        tester().assertThat(new PruneValuesColumns())
+                .on(p ->
+                        p.project(
+                                Assignments.of(),
+                                p.valuesOfExpressions(
+                                        ImmutableList.of(p.symbol("x")),
+                                        ImmutableList.of(expression("CAST(ROW(1) AS row(bigint))")))))
+                .doesNotFire();
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneValuesColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneValuesColumns.java
@@ -61,7 +61,21 @@ public class TestPruneValuesColumns
     }
 
     @Test
-    public void testDoNotPruneWhenValuesExpressionIsNotRow()
+    public void testPruneAllOutputs()
+    {
+        tester().assertThat(new PruneValuesColumns())
+                .on(p ->
+                        p.project(
+                                Assignments.of(),
+                                p.values(5, p.symbol("x"))))
+                .matches(
+                        project(
+                                ImmutableMap.of(),
+                                values(5)));
+    }
+
+    @Test
+    public void testPruneAllOutputsWhenValuesExpressionIsNotRow()
     {
         tester().assertThat(new PruneValuesColumns())
                 .on(p ->
@@ -70,6 +84,22 @@ public class TestPruneValuesColumns
                                 p.valuesOfExpressions(
                                         ImmutableList.of(p.symbol("x")),
                                         ImmutableList.of(expression("CAST(ROW(1) AS row(bigint))")))))
+                .matches(
+                        project(
+                                ImmutableMap.of(),
+                                values(1)));
+    }
+
+    @Test
+    public void testDoNotPruneWhenValuesExpressionIsNotRow()
+    {
+        tester().assertThat(new PruneValuesColumns())
+                .on(p ->
+                        p.project(
+                                Assignments.of(p.symbol("x"), expression("x")),
+                                p.valuesOfExpressions(
+                                        ImmutableList.of(p.symbol("x"), p.symbol("y")),
+                                        ImmutableList.of(expression("CAST(ROW(1, 'a') AS row(bigint, char(2)))")))))
                 .doesNotFire();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -90,6 +90,7 @@ import io.prestosql.sql.planner.plan.WindowNode.Specification;
 import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.FunctionCall;
 import io.prestosql.sql.tree.NullLiteral;
+import io.prestosql.sql.tree.Row;
 import io.prestosql.testing.TestingHandle;
 import io.prestosql.testing.TestingMetadata;
 import io.prestosql.testing.TestingMetadata.TestingTableHandle;
@@ -219,7 +220,12 @@ public class PlanBuilder
 
     public ValuesNode values(PlanNodeId id, List<Symbol> columns, List<List<Expression>> rows)
     {
-        return new ValuesNode(id, columns, rows);
+        return new ValuesNode(id, columns, rows.stream().map(Row::new).collect(toImmutableList()));
+    }
+
+    public ValuesNode valuesOfExpressions(List<Symbol> columns, List<Expression> rows)
+    {
+        return new ValuesNode(idAllocator.getNextId(), columns, rows);
     }
 
     public EnforceSingleRowNode enforceSingleRow(PlanNode source)

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestValues.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestValues.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestValues
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testRowSpecifications()
+    {
+        assertThat(assertions.query("VALUES 1, 2"))
+                .matches("VALUES ROW(1), ROW(2)");
+
+        assertThat(assertions.query("VALUES (1, 'a')"))
+                .matches("VALUES ROW(1, 'a')");
+
+        assertThat(assertions.query("VALUES CAST(ROW(1, 'TruE') AS row(double, boolean))"))
+                .matches("VALUES ROW(1e0, true)");
+
+        // mixed specifications
+        assertThat(assertions.query("VALUES " +
+                "CAST(ROW(1, 'TruE') AS row(double, boolean)), " +
+                "ROW(2e0, false), " +
+                "(3e0, null)"))
+                .matches("VALUES " +
+                        "ROW(1e0, true)," +
+                        "ROW(2e0, false), " +
+                        "ROW(3e0, null)");
+
+        assertThat(assertions.query("SELECT key FROM " +
+                "(VALUES " +
+                "CAST(ROW(1, 'TruE') AS row(double, boolean)), " +
+                "ROW(2e0, false), " +
+                "(3e0, null)) T(key, value)"))
+                .matches("VALUES 1e0, 2e0, 3e0");
+    }
+
+    @Test
+    public void testCoercions()
+    {
+        assertThat(assertions.query("VALUES 1, 2e0"))
+                .matches("VALUES ROW(1e0), ROW(2e0)");
+
+        assertThat(assertions.query("VALUES (1, 2), (3, 4e0)"))
+                .matches("VALUES ROW(1, 2e0), ROW(3, 4e0)");
+
+        assertThat(assertions.query("VALUES CAST(ROW(1, 2) AS row(integer, smallint)), (3, 4e0)"))
+                .matches("VALUES ROW(1, 2e0), ROW(3, 4e0)");
+
+        assertThat(assertions.query("VALUES CAST(ROW(1, 2) AS row(integer, double)), (3, 4)"))
+                .matches("VALUES ROW(1, 2e0), ROW(3, 4e0)");
+
+        assertThat(assertions.query("VALUES CAST(ROW(1, null) AS row(integer, double)), (3, 4)"))
+                .matches("VALUES ROW(1, null), ROW(3, 4e0)");
+    }
+
+    @Test
+    public void testNulls()
+    {
+        assertThat(assertions.query("VALUES null"))
+                .matches("VALUES ROW(null)");
+
+        assertThat(assertions.query("VALUES (null, null)"))
+                .matches("VALUES ROW(null, null)");
+
+        assertThat(assertions.query("VALUES (null, null), ('a', 'b')"))
+                .matches("VALUES ROW(null, null), ROW('a', 'b')");
+
+        assertThat(assertions.query("VALUES " +
+                "CAST(ROW(null, null) AS row(real, double)), " +
+                "(1, 1)"))
+                .matches("VALUES " +
+                        "ROW(null, null), " +
+                        "ROW(REAL '1', DOUBLE '1')");
+    }
+}


### PR DESCRIPTION
Change inner rows structure of `ValuesNode` from `List<List<Expression>>`
to `List<Expression>`.
Fix the issue of Values rows specified by expressions other than Row
but evaluating to RowType.
In that case, Values node failed at Planning, as the expression
was considered a single field specification instead of
row specification.

Fixes https://github.com/prestosql/presto/issues/3398