### PR TITLE
Log if LogTestDurationListener

### DIFF
--- a/presto-testng-services/src/main/java/io/prestosql/testng/services/LogTestDurationListener.java
+++ b/presto-testng-services/src/main/java/io/prestosql/testng/services/LogTestDurationListener.java
@@ -71,6 +71,7 @@ public class LogTestDurationListener
     public LogTestDurationListener()
     {
         scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(daemonThreadsNamed("TestHangMonitor"));
+        LOG.info("LogTestDurationListener enabled: %s", enabled);
     }
 
     @Override


### PR DESCRIPTION
Log if LogTestDurationListener

This is helpful to diagnose tests that hung and where is no stack traces
captured in CI.
