### PR TITLE
Improve build times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1419,9 +1419,9 @@
                     <configuration>
                         <!-- Include only required properties to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
                         <includeOnlyProperties>
-                            <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
-                            <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
-                            <includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.build.time</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id</includeOnlyProperty>
+                            <includeOnlyProperty>\Qgit.commit.id.describe</includeOnlyProperty>
                         </includeOnlyProperties>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1416,6 +1416,14 @@
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>4.0.0</version>
+                    <configuration>
+                        <!-- Include only required properties to speed up build (https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/462) -->
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
+                        </includeOnlyProperties>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
git-commit-id plugin performs git operations multiple times during
plugin execution. It also does the equivalent of `git fetch` for some
properties.

We only request the required properties so that less time in spent in
git-commit-id plugin.