### PR TITLE
Make query result HTTP compression configurable

### DIFF
--- a/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/io/prestosql/benchmark/driver/BenchmarkDriverOptions.java
@@ -94,6 +94,9 @@ public class BenchmarkDriverOptions
     @Option(names = "--client-request-timeout", paramLabel = "<timeout>", defaultValue = "2m", description = "Client request timeout " + DEFAULT_VALUE)
     public Duration clientRequestTimeout;
 
+    @Option(names = "--disable-compression", description = "Disable compression of query results")
+    public boolean disableCompression;
+
     public ClientSession getClientSession()
     {
         return new ClientSession(
@@ -115,7 +118,8 @@ public class BenchmarkDriverOptions
                 extraCredentials.stream()
                         .collect(toImmutableMap(ClientExtraCredential::getName, ClientExtraCredential::getValue)),
                 null,
-                clientRequestTimeout);
+                clientRequestTimeout,
+                disableCompression);
     }
 
     private static URI parseServer(String server)

--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -161,6 +161,9 @@ public class ClientOptions
     @Option(names = "--timezone", paramLabel = "<timezone>", description = "Session time zone " + DEFAULT_VALUE)
     public ZoneId timeZone = ZoneId.systemDefault();
 
+    @Option(names = "--disable-compression", description = "Disable compression of query results")
+    public boolean disableCompression;
+
     public enum OutputFormat
     {
         ALIGNED,
@@ -195,7 +198,8 @@ public class ClientOptions
                 emptyMap(),
                 toExtraCredentials(extraCredentials),
                 null,
-                clientRequestTimeout);
+                clientRequestTimeout,
+                disableCompression);
     }
 
     public static URI parseServer(String server)

--- a/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import static io.prestosql.cli.Presto.createCommandLine;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestClientOptions
 {
@@ -169,6 +170,18 @@ public class TestClientOptions
 
         ClientSession session = options.toClientSession();
         assertEquals(session.getTimeZone(), ZoneId.of("Europe/Vilnius"));
+    }
+
+    @Test
+    public void testDisableCompression()
+    {
+        Console console = createConsole("--disable-compression");
+
+        ClientOptions options = console.clientOptions;
+        assertTrue(options.disableCompression);
+
+        ClientSession session = options.toClientSession();
+        assertTrue(session.isCompressionDisabled());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QInvalid session property: foo.bar.baz=value\\E")

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -121,7 +121,8 @@ public class TestQueryRunner
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 null,
-                new Duration(2, MINUTES));
+                new Duration(2, MINUTES),
+                true);
     }
 
     static String createResults(MockWebServer server)

--- a/presto-client/src/main/java/io/prestosql/client/ClientSession.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientSession.java
@@ -51,6 +51,7 @@ public class ClientSession
     private final Map<String, String> extraCredentials;
     private final String transactionId;
     private final Duration clientRequestTimeout;
+    private final boolean compressionDisabled;
 
     public static Builder builder(ClientSession clientSession)
     {
@@ -82,7 +83,8 @@ public class ClientSession
             Map<String, ClientSelectedRole> roles,
             Map<String, String> extraCredentials,
             String transactionId,
-            Duration clientRequestTimeout)
+            Duration clientRequestTimeout,
+            boolean compressionDisabled)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = user;
@@ -102,6 +104,7 @@ public class ClientSession
         this.roles = ImmutableMap.copyOf(requireNonNull(roles, "roles is null"));
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
         this.clientRequestTimeout = clientRequestTimeout;
+        this.compressionDisabled = compressionDisabled;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -230,6 +233,11 @@ public class ClientSession
         return clientRequestTimeout;
     }
 
+    public boolean isCompressionDisabled()
+    {
+        return compressionDisabled;
+    }
+
     @Override
     public String toString()
     {
@@ -270,6 +278,7 @@ public class ClientSession
         private Map<String, String> credentials;
         private String transactionId;
         private Duration clientRequestTimeout;
+        private boolean compressionDisabled;
 
         private Builder(ClientSession clientSession)
         {
@@ -292,6 +301,7 @@ public class ClientSession
             credentials = clientSession.getExtraCredentials();
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
+            compressionDisabled = clientSession.isCompressionDisabled();
         }
 
         public Builder withCatalog(String catalog)
@@ -348,6 +358,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder withCompressionDisabled(boolean compressionDisabled)
+        {
+            this.compressionDisabled = compressionDisabled;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -368,7 +384,8 @@ public class ClientSession
                     roles,
                     credentials,
                     transactionId,
-                    clientRequestTimeout);
+                    clientRequestTimeout,
+                    compressionDisabled);
         }
     }
 }

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/ConnectionProperties.java
@@ -52,6 +52,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<HostAndPort> SOCKS_PROXY = new SocksProxy();
     public static final ConnectionProperty<HostAndPort> HTTP_PROXY = new HttpProxy();
     public static final ConnectionProperty<String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
+    public static final ConnectionProperty<Boolean> DISABLE_COMPRESSION = new DisableCompression();
     public static final ConnectionProperty<Boolean> SSL = new Ssl();
     public static final ConnectionProperty<SslVerificationMode> SSL_VERIFICATION = new SslVerification();
     public static final ConnectionProperty<String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
@@ -82,6 +83,7 @@ final class ConnectionProperties
             .add(SOCKS_PROXY)
             .add(HTTP_PROXY)
             .add(APPLICATION_NAME_PREFIX)
+            .add(DISABLE_COMPRESSION)
             .add(SSL)
             .add(SSL_VERIFICATION)
             .add(SSL_KEY_STORE_PATH)
@@ -243,6 +245,15 @@ final class ConnectionProperties
         public TraceToken()
         {
             super("traceToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class DisableCompression
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public DisableCompression()
+        {
+            super("disableCompression", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoConnection.java
@@ -89,6 +89,7 @@ public class PrestoConnection
     private final URI jdbcUri;
     private final URI httpUri;
     private final String user;
+    private final boolean compressionDisabled;
     private final Map<String, String> extraCredentials;
     private final Optional<String> applicationNamePrefix;
     private final Optional<String> source;
@@ -111,6 +112,7 @@ public class PrestoConnection
         this.applicationNamePrefix = uri.getApplicationNamePrefix();
         this.source = uri.getSource();
         this.extraCredentials = uri.getExtraCredentials();
+        this.compressionDisabled = uri.isCompressionDisabled();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));
@@ -720,7 +722,8 @@ public class PrestoConnection
                 ImmutableMap.copyOf(roles),
                 extraCredentials,
                 transactionId.get(),
-                timeout);
+                timeout,
+                compressionDisabled);
 
         return queryExecutor.startQuery(session, sql);
     }

--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoDriverUri.java
@@ -46,6 +46,7 @@ import static io.prestosql.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static io.prestosql.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
 import static io.prestosql.jdbc.ConnectionProperties.CLIENT_INFO;
 import static io.prestosql.jdbc.ConnectionProperties.CLIENT_TAGS;
+import static io.prestosql.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static io.prestosql.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.prestosql.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.prestosql.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
@@ -195,6 +196,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return SOURCE.getValue(properties);
+    }
+
+    public boolean isCompressionDisabled()
+            throws SQLException
+    {
+        return DISABLE_COMPRESSION.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/TestPrestoDriverUri.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import static io.prestosql.jdbc.ConnectionProperties.CLIENT_TAGS;
+import static io.prestosql.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static io.prestosql.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.prestosql.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.prestosql.jdbc.ConnectionProperties.SOCKS_PROXY;
@@ -33,6 +34,7 @@ import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestPrestoDriverUri
@@ -203,6 +205,17 @@ public class TestPrestoDriverUri
 
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(HTTP_PROXY.getKey()), "localhost:5678");
+    }
+
+    @Test
+    public void testUriWithoutCompression()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?disableCompression=true");
+        assertTrue(parameters.isCompressionDisabled());
+
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(DISABLE_COMPRESSION.getKey()), "true");
     }
 
     @Test

--- a/presto-main/src/main/java/io/prestosql/server/ServerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerConfig.java
@@ -23,6 +23,7 @@ public class ServerConfig
     private boolean coordinator = true;
     private boolean includeExceptionInResponse = true;
     private Duration gracePeriod = new Duration(2, MINUTES);
+    private boolean queryResultsCompressionEnabled = true;
 
     public boolean isCoordinator()
     {
@@ -57,6 +58,18 @@ public class ServerConfig
     public ServerConfig setGracePeriod(Duration gracePeriod)
     {
         this.gracePeriod = gracePeriod;
+        return this;
+    }
+
+    public boolean isQueryResultsCompressionEnabled()
+    {
+        return queryResultsCompressionEnabled;
+    }
+
+    @Config("query-results.compression-enabled")
+    public ServerConfig setQueryResultsCompressionEnabled(boolean queryResultsCompressionEnabled)
+    {
+        this.queryResultsCompressionEnabled = queryResultsCompressionEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
@@ -27,6 +27,7 @@ import io.prestosql.memory.context.SimpleLocalMemoryContext;
 import io.prestosql.operator.ExchangeClient;
 import io.prestosql.operator.ExchangeClientSupplier;
 import io.prestosql.server.ForStatementResource;
+import io.prestosql.server.ServerConfig;
 import io.prestosql.server.security.ResourceSecurity;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.block.BlockEncodingSerde;
@@ -99,6 +100,7 @@ public class ExecutingStatementResource
 
     private final ConcurrentMap<QueryId, Query> queries = new ConcurrentHashMap<>();
     private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("execution-query-purger"));
+    private final boolean compressionEnabled;
 
     @Inject
     public ExecutingStatementResource(
@@ -106,13 +108,15 @@ public class ExecutingStatementResource
             ExchangeClientSupplier exchangeClientSupplier,
             BlockEncodingSerde blockEncodingSerde,
             @ForStatementResource BoundedExecutor responseExecutor,
-            @ForStatementResource ScheduledExecutorService timeoutExecutor)
+            @ForStatementResource ScheduledExecutorService timeoutExecutor,
+            ServerConfig serverConfig)
     {
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
         this.exchangeClientSupplier = requireNonNull(exchangeClientSupplier, "exchangeClientSupplier is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
         this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
+        this.compressionEnabled = requireNonNull(serverConfig, "serverConfig is null").isQueryResultsCompressionEnabled();
 
         queryPurger.scheduleWithFixedDelay(
                 () -> {
@@ -215,12 +219,12 @@ public class ExecutingStatementResource
         }
         ListenableFuture<QueryResults> queryResultsFuture = query.waitForResults(token, uriInfo, wait, targetResultSize);
 
-        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, queryResults -> toResponse(query, queryResults), directExecutor());
+        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, queryResults -> toResponse(query, queryResults, compressionEnabled), directExecutor());
 
         bindAsyncResponse(asyncResponse, response, responseExecutor);
     }
 
-    private static Response toResponse(Query query, QueryResults queryResults)
+    private static Response toResponse(Query query, QueryResults queryResults, boolean compressionEnabled)
     {
         ResponseBuilder response = Response.ok(queryResults);
 
@@ -259,6 +263,10 @@ public class ExecutingStatementResource
         // add clear transaction ID directive
         if (query.isClearTransactionId()) {
             response.header(PRESTO_CLEAR_TRANSACTION_ID, true);
+        }
+
+        if (!compressionEnabled) {
+            response.encoding("identity");
         }
 
         return response.build();

--- a/presto-main/src/test/java/io/prestosql/server/TestServerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestServerConfig.java
@@ -32,7 +32,8 @@ public class TestServerConfig
         assertRecordedDefaults(recordDefaults(ServerConfig.class)
                 .setCoordinator(true)
                 .setIncludeExceptionInResponse(true)
-                .setGracePeriod(new Duration(2, MINUTES)));
+                .setGracePeriod(new Duration(2, MINUTES))
+                .setQueryResultsCompressionEnabled(true));
     }
 
     @Test
@@ -42,12 +43,14 @@ public class TestServerConfig
                 .put("coordinator", "false")
                 .put("http.include-exception-in-response", "false")
                 .put("shutdown.grace-period", "5m")
+                .put("query-results.compression-enabled", "false")
                 .build();
 
         ServerConfig expected = new ServerConfig()
                 .setCoordinator(false)
                 .setIncludeExceptionInResponse(false)
-                .setGracePeriod(new Duration(5, MINUTES));
+                .setGracePeriod(new Duration(5, MINUTES))
+                .setQueryResultsCompressionEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestingPrestoClient.java
@@ -165,7 +165,8 @@ public abstract class AbstractTestingPrestoClient<T>
                                         entry.getValue().getRole()))),
                 session.getIdentity().getExtraCredentials(),
                 session.getTransactionId().map(Object::toString).orElse(null),
-                clientRequestTimeout);
+                clientRequestTimeout,
+                true);
     }
 
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)

--- a/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestFinalQueryInfo.java
@@ -81,7 +81,8 @@ public class TestFinalQueryInfo
                     ImmutableMap.of(),
                     ImmutableMap.of(),
                     null,
-                    new Duration(2, MINUTES));
+                    new Duration(2, MINUTES),
+                    true);
 
             // start query
             StatementClient client = newStatementClient(httpClient, clientSession, sql);


### PR DESCRIPTION
Adapted changes from https://github.com/prestodb/presto/pull/15393

Before this change, query result JSON responses were generally compressed (assuming the response met the minimum size threshold and passed the user agent checks), so that behavior is still the default. However, disabling GZIP compression can significantly improve throughput of sending query results, especially over localhost links where the overhead of compressing the response and then uncompressing it again on the client side is never worth the bandwidth savings.

Clients are allowed to opt-out of compression, but not request compression from a server which has decided to disable compressed query result responses. Both sides ultimately negotiate the result based on their Accept-Encoding or Content-Encoding headers and the way that the gzip compression middleware interprets them.

For queries that are bound only by result processing throughput (eg: `SELECT * FROM <large table>`) execution time can reduced by 20-50% when submitted over a localhost connection with compression disabled.