### PR TITLE
Add copy to clipboard from docs

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -62,7 +62,7 @@ def get_version():
 
 needs_sphinx = '3.0'
 
-extensions = ['myst_parser', 'backquote', 'download', 'issue']
+extensions = ['myst_parser', 'backquote', 'download', 'issue', 'sphinx_copybutton']
 
 templates_path = ['templates']
 
@@ -80,6 +80,8 @@ exclude_patterns = ['_build']
 highlight_language = 'sql'
 
 default_role = 'backquote'
+
+copybutton_image_path = 'copy-icon.svg'
 
 rst_epilog = """
 .. |presto_server_release| replace:: ``presto-server-{release}``

--- a/presto-docs/src/main/sphinx/static/copy-icon.svg
+++ b/presto-docs/src/main/sphinx/static/copy-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2.0" stroke="#607D8B" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <rect x="8" y="8" width="12" height="12" rx="2" />
+  <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
+</svg>

--- a/presto-docs/src/main/sphinx/static/copy-icon.svg
+++ b/presto-docs/src/main/sphinx/static/copy-icon.svg
@@ -1,5 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2.0" stroke="#607D8B" fill="none" stroke-linecap="round" stroke-linejoin="round">
-  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-  <rect x="8" y="8" width="12" height="12" rx="2" />
-  <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8 7h11v14H8z" opacity=".3"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/presto-docs/src/main/sphinx/static/presto.css
+++ b/presto-docs/src/main/sphinx/static/presto.css
@@ -35,3 +35,18 @@ pre.literal-block {
         margin-left: 61rem;
     }
 }
+
+.o-tooltip--left:after {
+    font-size: 0.6rem;
+}
+
+a.copybtn {
+    opacity: 1.0;
+    width: 1.5em;
+    height: 1.5em;
+}
+
+.copybtn:hover {
+    opacity: 0.6 !important;
+    cursor: pointer;
+}

--- a/presto-docs/src/main/sphinx/static/presto.css
+++ b/presto-docs/src/main/sphinx/static/presto.css
@@ -42,11 +42,18 @@ pre.literal-block {
 
 a.copybtn {
     opacity: 1.0;
-    width: 1.5em;
-    height: 1.5em;
+    width: 1.1em;
+    height: 1.1em;
+    top: .4em;
+    right: .4em;
+}
+
+.highlight {
+    padding: 1em 0.5em;
 }
 
 .copybtn:hover {
-    opacity: 0.6 !important;
+    opacity: 0.3 !important;
     cursor: pointer;
 }
+


### PR DESCRIPTION
This PR adds https://github.com/executablebooks/sphinx-copybutton/ to the docs which make "code blocks" copyable 

Adjusted CSS over default ones to make copy button more visible and "Copy"/"Copied" text smaller.

It looks like this:

![Screenshot 2020-11-04 at 19 49 25](https://user-images.githubusercontent.com/66972/98155730-05db6b80-1ed7-11eb-89f5-899d0bf64c5a.png)

![Screenshot 2020-11-04 at 19 49 35](https://user-images.githubusercontent.com/66972/98155736-083dc580-1ed7-11eb-8638-efd4abc44b3d.png)

(copy icon is the same size when hovered - it looks weird here due to different screenshot sizes)

Thanks @jaceklaskowski for the inspiration 😁 