### PR TITLE
Properly enable LogTestDurationListener in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ env:
   # An envar that signals to tests we are executing in the CI environment
   CONTINUOUS_INTEGRATION: true
   # maven.wagon.rto is in millis, defaults to 30m
-  MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000 -DLogTestDurationListener.enabled=true"
+  MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
   MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all"
-  MAVEN_TEST: "-B -Dair.check.skip-all"
+  MAVEN_TEST: "-B -Dair.check.skip-all -DLogTestDurationListener.enabled=true"
 
 jobs:
   maven-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000 -DLogTestDurationListener.enabled=true"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000"
   MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all"
+  MAVEN_TEST: "-B -Dair.check.skip-all"
 
 jobs:
   maven-checks:
@@ -62,7 +63,7 @@ jobs:
       - name: Error Prone Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw -B -T C1 clean test-compile -Dair.check.skip-all -P errorprone-compiler-presto \
+          ./mvnw ${MAVEN_TEST} -T C1 clean test-compile -P errorprone-compiler-presto \
             -pl '!presto-docs,!presto-server,!presto-server-rpm'
 
   web-ui-checks:
@@ -91,7 +92,7 @@ jobs:
         run: presto-test-jdbc-compatibility-old-driver/bin/run_tests.sh
       - name: Test current JDBC vs old server
         if: always()
-        run: ./mvnw test -B -Dair.check.skip-all -pl presto-test-jdbc-compatibility-old-server
+        run: ./mvnw test ${MAVEN_TEST} -pl presto-test-jdbc-compatibility-old-server
 
   hive-tests:
     runs-on: ubuntu-latest
@@ -134,7 +135,7 @@ jobs:
           AWS_REGION: us-east-2
         run: |
           if [ "${AWS_ACCESS_KEY_ID}" != "" ]; then
-            ./mvnw test -B -Dair.check.skip-all -pl presto-hive -P test-hive-glue
+            ./mvnw test ${MAVEN_TEST} -pl presto-hive -P test-hive-glue
           fi
       - name: Run Hive Azure ABFS Access Key Tests
         if: matrix.config != 'config-empty' # Hive 1.x does not support Azure storage
@@ -202,7 +203,7 @@ jobs:
           ./bin/retry ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!presto-docs,!presto-server,!presto-server-rpm'
       - name: Maven Tests
         run: |
-          ./mvnw test -B -fae -Dair.check.skip-all -pl '
+          ./mvnw test ${MAVEN_TEST} -fae -pl '
             !presto-main,
             !presto-tests,
             !presto-raptor-legacy,
@@ -249,7 +250,7 @@ jobs:
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./bin/retry ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
-        run: ./mvnw test -B -fae -Dair.check.skip-all -pl ${{ matrix.modules }}
+        run: ./mvnw test ${MAVEN_TEST} -fae -pl ${{ matrix.modules }}
 
   test-memsql:
     runs-on: ubuntu-latest
@@ -270,7 +271,7 @@ jobs:
           MEMSQL_LICENSE: ${{ secrets.MEMSQL_LICENSE }}
         run: |
           if [ "${MEMSQL_LICENSE}" != "" ]; then
-            ./mvnw test -B -fae -Dair.check.skip-all -pl presto-memsql -Dmemsql.license=${MEMSQL_LICENSE}
+            ./mvnw test ${MAVEN_TEST} -fae -pl presto-memsql -Dmemsql.license=${MEMSQL_LICENSE}
           fi
 
   pt:


### PR DESCRIPTION
Properly enable LogTestDurationListener in GHA

Previously it was a set as system property to maven, while now it is
given as argument to maven so it will be set to JVM started by surefire
plugin.
