### PR TITLE
Fix incorrect correlation mapping

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -786,9 +786,12 @@ public class UnaliasSymbolReferences
 
             // extract new mappings for correlation symbols to apply in Subquery
             Set<Symbol> correlationSymbols = ImmutableSet.copyOf(node.getCorrelation());
-            Map<Symbol, Symbol> correlationMapping = inputMapping.entrySet().stream()
-                    .filter(mapping -> correlationSymbols.contains(mapping.getKey()))
-                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<Symbol, Symbol> correlationMapping = new HashMap<>();
+            for (Map.Entry<Symbol, Symbol> entry : inputMapping.entrySet()) {
+                if (correlationSymbols.contains(entry.getKey())) {
+                    correlationMapping.put(entry.getKey(), mapper.map(entry.getKey()));
+                }
+            }
 
             Map<Symbol, Symbol> mappingForSubquery = new HashMap<>();
             mappingForSubquery.putAll(context.getCorrelationMapping());
@@ -848,9 +851,12 @@ public class UnaliasSymbolReferences
 
             // extract new mappings for correlation symbols to apply in Subquery
             Set<Symbol> correlationSymbols = ImmutableSet.copyOf(node.getCorrelation());
-            Map<Symbol, Symbol> correlationMapping = inputMapping.entrySet().stream()
-                    .filter(mapping -> correlationSymbols.contains(mapping.getKey()))
-                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<Symbol, Symbol> correlationMapping = new HashMap<>();
+            for (Map.Entry<Symbol, Symbol> entry : inputMapping.entrySet()) {
+                if (correlationSymbols.contains(entry.getKey())) {
+                    correlationMapping.put(entry.getKey(), mapper.map(entry.getKey()));
+                }
+            }
 
             Map<Symbol, Symbol> mappingForSubquery = new HashMap<>();
             mappingForSubquery.putAll(context.getCorrelationMapping());

--- a/presto-tests/src/test/java/io/prestosql/tests/AbstractTestEngineOnlyQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/AbstractTestEngineOnlyQueries.java
@@ -3120,6 +3120,52 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testCorrelationSymbolMapping()
+    {
+        // Corelation symbol of ApplyNode mapped in UnaliasSymbolReferences
+        assertQuery("WITH T AS ( " +
+                "SELECT name, min(regionkey) AS key " +
+                "FROM nation " +
+                "GROUP BY name " +
+                ") " +
+                "SELECT a.name " +
+                "FROM T a " +
+                "JOIN T b ON a.name = b.name " +
+                "AND EXISTS (SELECT * FROM T c WHERE b.name = c.name)");
+
+        assertQuery("WITH T AS ( " +
+                "SELECT name, min(regionkey) AS key " +
+                "FROM nation " +
+                "GROUP BY name " +
+                ") " +
+                "SELECT a.name " +
+                "FROM T a " +
+                "JOIN T b ON a.name = b.name " +
+                "AND 4 IN (SELECT key FROM T c WHERE b.name = c.name)");
+
+        assertQuery("WITH T AS ( " +
+                "SELECT name, min(regionkey) AS key " +
+                "FROM nation " +
+                "GROUP BY name " +
+                ") " +
+                "SELECT a.name " +
+                "FROM T a " +
+                "JOIN T b ON a.name = b.name " +
+                "AND 4 > ALL (SELECT key FROM T c WHERE b.name = c.name)");
+
+        // Corelation symbol of CorrelatedJoinNode mapped in UnaliasSymbolReferences
+        assertQuery("WITH T AS ( " +
+                "SELECT name, min(regionkey) AS key " +
+                "FROM nation " +
+                "GROUP BY name " +
+                ") " +
+                "SELECT a.name " +
+                "FROM T a " +
+                "JOIN T b ON a.name = b.name " +
+                "AND 4 = (SELECT key FROM T c WHERE b.name = c.name)");
+    }
+
+    @Test
     public void testGrouping()
     {
         assertQuery(


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/5846

In `UnaliasSymbolReferences`, when mapping correlated subquery
of ApplyNode or CorrelatedJoinNode, only a single mapping was applied
for correlation symbols instead of mapping them through the whole
mapping path.
However, the `correlation` list of ApplyNode / CorrelatedJoinNode
was mapped correctly.
As a result, `correlation` list contained different symbols than
subquery. Subquery was then considered not correlated and wasn't
decorrelated properly.
The error of missing dependencies came from correlated filter being
left behind in the subquery.