### PR TITLE
Execute queries from redirected input stream in presto-cli

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -15,7 +15,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <main-class>io.prestosql.cli.Presto</main-class>
-        <dep.jline.version>3.12.1</dep.jline.version>
+        <dep.jline.version>3.17.1</dep.jline.version>
     </properties>
 
     <dependencies>

--- a/presto-cli/src/main/java/io/prestosql/cli/AbstractWarningsPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/AbstractWarningsPrinter.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.OptionalInt;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.cli.ConsolePrinter.REAL_TERMINAL;
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.jline.utils.AttributedStyle.DEFAULT;
@@ -41,7 +41,7 @@ abstract class AbstractWarningsPrinter
     private String getWarningMessage(Warning warning)
     {
         // If this is a real terminal color the warnings yellow
-        if (REAL_TERMINAL) {
+        if (isRealTerminal()) {
             return new AttributedStringBuilder()
                     .style(DEFAULT.foreground(YELLOW))
                     .append("WARNING: ")

--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -58,9 +58,9 @@ import static com.google.common.io.ByteStreams.nullOutputStream;
 import static com.google.common.io.Files.asCharSource;
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static io.prestosql.cli.Completion.commandCompleter;
-import static io.prestosql.cli.ConsolePrinter.detectRealTerminal;
 import static io.prestosql.cli.Help.getHelpText;
 import static io.prestosql.cli.QueryPreprocessor.preprocessQuery;
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static io.prestosql.client.ClientSession.stripTransactionId;
 import static io.prestosql.sql.parser.StatementSplitter.Statement;
 import static io.prestosql.sql.parser.StatementSplitter.isEmptyStatement;
@@ -130,7 +130,7 @@ public class Console
         }
 
         // Read queries from stdin
-        if (!hasQuery && !detectRealTerminal()) {
+        if (!hasQuery && !isRealTerminal()) {
             try {
                 if (System.in.available() > 0) {
                     query = new String(ByteStreams.toByteArray(System.in), terminal().encoding()) + ";";

--- a/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
@@ -19,13 +19,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
 
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.util.Objects.requireNonNull;
 import static org.jline.terminal.TerminalBuilder.terminal;
 
 public class ConsolePrinter
 {
-    public static final boolean REAL_TERMINAL = detectRealTerminal();
-
     private static final String ERASE_SCREEN_FORWARD = "\033[0J";
     private static final String ERASE_LINE_ALL = "\033[2K";
 
@@ -84,22 +83,6 @@ public class ConsolePrinter
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-    }
-
-    public boolean isRealTerminal()
-    {
-        return REAL_TERMINAL;
-    }
-
-    protected static boolean detectRealTerminal()
-    {
-        try (Terminal terminal = terminal()) {
-            return !Terminal.TYPE_DUMB.equals(terminal.getType()) &&
-                    !Terminal.TYPE_DUMB_COLOR.equals(terminal.getType());
-        }
-        catch (IOException e) {
-            return false;
         }
     }
 

--- a/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
@@ -92,7 +92,7 @@ public class ConsolePrinter
         return REAL_TERMINAL;
     }
 
-    private static boolean detectRealTerminal()
+    protected static boolean detectRealTerminal()
     {
         try (Terminal terminal = terminal()) {
             return !Terminal.TYPE_DUMB.equals(terminal.getType()) &&

--- a/presto-cli/src/main/java/io/prestosql/cli/InputHighlighter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/InputHighlighter.java
@@ -24,6 +24,7 @@ import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.cli.Console.STATEMENT_DELIMITERS;
@@ -87,6 +88,12 @@ public class InputHighlighter
 
         return builder.toAttributedString();
     }
+
+    @Override
+    public void setErrorPattern(Pattern pattern) {}
+
+    @Override
+    public void setErrorIndex(int i) {}
 
     private static boolean isKeyword(String text)
     {

--- a/presto-cli/src/main/java/io/prestosql/cli/Query.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Query.java
@@ -48,11 +48,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.prestosql.cli.ConsolePrinter.REAL_TERMINAL;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_HEADER_AND_QUOTES;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.NO_QUOTES;
 import static io.prestosql.cli.CsvPrinter.CsvOutputFormat.STANDARD;
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -373,7 +373,7 @@ public class Query
             bad = " <EOF>";
         }
 
-        if (REAL_TERMINAL) {
+        if (isRealTerminal()) {
             AttributedStringBuilder builder = new AttributedStringBuilder();
 
             builder.style(DEFAULT.foreground(CYAN));

--- a/presto-cli/src/main/java/io/prestosql/cli/QueryPreprocessor.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryPreprocessor.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Throwables.propagateIfPossible;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
-import static io.prestosql.cli.ConsolePrinter.REAL_TERMINAL;
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -77,14 +77,14 @@ public final class QueryPreprocessor
         Thread clientThread = Thread.currentThread();
         SignalHandler oldHandler = terminal.handle(Signal.INT, signal -> clientThread.interrupt());
         try {
-            if (REAL_TERMINAL) {
+            if (isRealTerminal()) {
                 System.out.print(PREPROCESSING_QUERY_MESSAGE);
                 System.out.flush();
             }
             return preprocessQueryInternal(catalog, schema, query, preprocessorCommand, timeout);
         }
         finally {
-            if (REAL_TERMINAL) {
+            if (isRealTerminal()) {
                 System.out.print("\r" + Strings.repeat(" ", PREPROCESSING_QUERY_MESSAGE.length()) + "\r");
                 System.out.flush();
             }

--- a/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
@@ -42,6 +42,7 @@ import static io.prestosql.cli.FormatUtils.formatFinalTime;
 import static io.prestosql.cli.FormatUtils.formatProgressBar;
 import static io.prestosql.cli.FormatUtils.formatTime;
 import static io.prestosql.cli.FormatUtils.pluralize;
+import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.lang.Character.toUpperCase;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -240,7 +241,7 @@ Spilled: 20GB
         // cap progress at 99%, otherwise it looks weird when the query is still running and it says 100%
         int progressPercentage = (int) min(99, stats.getProgressPercentage().orElse(0.0));
 
-        if (console.isRealTerminal()) {
+        if (isRealTerminal()) {
             // blank line
             reprintLine("");
 

--- a/presto-cli/src/main/java/io/prestosql/cli/TerminalUtils.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/TerminalUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cli;
+
+import org.jline.terminal.Terminal;
+
+import java.io.IOException;
+
+import static org.jline.terminal.TerminalBuilder.terminal;
+
+public class TerminalUtils
+{
+    private static final boolean REAL_TERMINAL = detectRealTerminal();
+
+    private TerminalUtils() {}
+
+    public static boolean isRealTerminal()
+    {
+        return REAL_TERMINAL;
+    }
+
+    private static boolean detectRealTerminal()
+    {
+        try (Terminal terminal = terminal()) {
+            return !Terminal.TYPE_DUMB.equals(terminal.getType()) &&
+                    !Terminal.TYPE_DUMB_COLOR.equals(terminal.getType());
+        }
+        catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Launcher.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/Launcher.java
@@ -31,6 +31,7 @@ import static io.prestosql.tests.product.launcher.cli.Launcher.EnvironmentComman
 import static io.prestosql.tests.product.launcher.cli.Launcher.SuiteCommand;
 import static io.prestosql.tests.product.launcher.cli.Launcher.TestCommand;
 import static io.prestosql.tests.product.launcher.cli.Launcher.VersionProvider;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.IVersionProvider;
@@ -157,12 +158,15 @@ public class Launcher
         @Override
         protected Object[][] getContents()
         {
+            String projectVersion = readProjectVersion();
+
             return new Object[][] {
                     {"project.version", readProjectVersion()},
                     {"product-tests.module", "presto-product-tests"},
                     {"server.module", "presto-server"},
                     {"server.name", "presto-server"},
                     {"launcher.bin", "presto-product-tests-launcher/bin/run-launcher"},
+                    {"cli.bin", format("presto-cli/target/presto-cli-%s-executable.jar", projectVersion)}
             };
         }
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
@@ -116,6 +116,9 @@ public class SuiteRun
         @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.module}-${project.version}-executable.jar")
         public File testJar;
 
+        @Option(names = "--cli-executable", paramLabel = "<jar>", description = "Path to CLI executable " + DEFAULT_VALUE, defaultValue = "${cli.bin}")
+        public File cliJar;
+
         @Option(names = "--logs-dir", paramLabel = "<dir>", description = "Location of the exported logs directory " + DEFAULT_VALUE, converter = OptionalPathConverter.class, defaultValue = "")
         public Optional<Path> logsDirBase;
 
@@ -294,6 +297,7 @@ public class SuiteRun
             testRunOptions.environment = suiteTestRun.getEnvironmentName();
             testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments(environmentConfig);
             testRunOptions.testJar = suiteRunOptions.testJar;
+            testRunOptions.cliJar = suiteRunOptions.cliJar;
             String suiteRunId = suiteRunId(runId, suiteName, suiteTestRun, environmentConfig);
             testRunOptions.reportsDir = Paths.get("presto-product-tests/target/reports/" + suiteRunId);
             testRunOptions.logsDirBase = logsDirBase.map(dir -> dir.resolve(suiteRunId));

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/set-presto-cli.sh
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/set-presto-cli.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export PATH=$PATH:/docker

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -20,11 +20,6 @@
     <dependencies>
         <dependency>
             <groupId>io.prestosql</groupId>
-            <artifactId>presto-cli</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.prestosql</groupId>
             <artifactId>presto-hive</artifactId>
             <exclusions>
                 <exclusion>

--- a/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliLauncher.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/cli/PrestoCliLauncher.java
@@ -16,10 +16,9 @@ package io.prestosql.tests.cli;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import io.prestosql.cli.Presto;
+import io.airlift.log.Logger;
 import io.prestosql.tempto.ProductTest;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -31,12 +30,11 @@ import static java.util.Arrays.asList;
 public class PrestoCliLauncher
         extends ProductTest
 {
+    private static final Logger log = Logger.get(PrestoCliLauncher.class);
+
     protected static final long TIMEOUT = 300 * 1000; // 30 secs per test
-    protected static final String EXIT_COMMAND = "exit";
     protected final List<String> nationTableInteractiveLines;
     protected final List<String> nationTableBatchLines;
-    private static final String CLASSPATH = System.getProperty("java.class.path");
-    private static final String JAVA_BIN = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
 
     @Inject
     @Named("databases.presto.host")
@@ -78,9 +76,12 @@ public class PrestoCliLauncher
 
     protected ProcessBuilder getProcessBuilder(List<String> arguments)
     {
-        return new ProcessBuilder(ImmutableList.<String>builder()
-                .add(JAVA_BIN, "-Xmx50m", "-cp", CLASSPATH, Presto.class.getCanonicalName())
+        List<String> command = ImmutableList.<String>builder()
+                .add("/docker/presto-cli")
                 .addAll(arguments)
-                .build());
+                .build();
+
+        log.info("Running command %s", command);
+        return new ProcessBuilder(command);
     }
 }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/cli/TestPrestoCli.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/cli/TestPrestoCli.java
@@ -25,6 +25,7 @@ import io.prestosql.tempto.configuration.Configuration;
 import io.prestosql.tempto.fulfillment.table.ImmutableTableRequirement;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -124,6 +125,39 @@ public class TestPrestoCli
         launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
         presto.waitForWithTimeoutAndKill();
+    }
+
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldRunBatchQueryWithStdinRedirect()
+            throws Exception
+    {
+        try (TempFile file = new TempFile()) {
+            Files.write("select * from hive.default.nation;", file.file(), UTF_8);
+
+            launchPrestoCliWithRedirectedStdin(file.file());
+            assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+            presto.waitForWithTimeoutAndKill();
+        }
+    }
+
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldRunMultipleBatchQueriesWithStdinRedirect()
+            throws Exception
+    {
+        try (TempFile file = new TempFile()) {
+            Files.write("select * from hive.default.nation;select 1;select 2", file.file(), UTF_8);
+
+            launchPrestoCliWithRedirectedStdin(file.file());
+
+            List<String> expectedLines = ImmutableList.<String>builder()
+                    .addAll(nationTableBatchLines)
+                    .add("\"1\"")
+                    .add("\"2\"")
+                    .build();
+
+            assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(expectedLines);
+            presto.waitForWithTimeoutAndKill();
+        }
     }
 
     @Test(groups = CLI, timeOut = TIMEOUT)
@@ -316,6 +350,19 @@ public class TestPrestoCli
     private void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException
     {
+        launchPrestoCli(getPrestoCliArguments(arguments));
+    }
+
+    private void launchPrestoCliWithRedirectedStdin(File inputFile)
+            throws IOException
+    {
+        ProcessBuilder processBuilder = getProcessBuilder(getPrestoCliArguments());
+        processBuilder.redirectInput(inputFile);
+        presto = new PrestoCliProcess(processBuilder.start());
+    }
+
+    private List<String> getPrestoCliArguments(String... arguments)
+    {
         ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
         prestoClientOptions.add("--server", serverAddress);
         prestoClientOptions.add("--user", jdbcUser);
@@ -345,7 +392,7 @@ public class TestPrestoCli
         }
 
         prestoClientOptions.add(arguments);
-        launchPrestoCli(prestoClientOptions.build());
+        return prestoClientOptions.build();
     }
 
     private static String removePrefix(String line)

--- a/presto-product-tests/src/main/java/io/prestosql/tests/cli/TestPrestoCli.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/cli/TestPrestoCli.java
@@ -18,7 +18,6 @@ import com.google.common.io.Files;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.airlift.testing.TempFile;
-import io.prestosql.cli.Presto;
 import io.prestosql.tempto.AfterTestWithContext;
 import io.prestosql.tempto.Requirement;
 import io.prestosql.tempto.RequirementsProvider;
@@ -105,7 +104,7 @@ public class TestPrestoCli
             throws IOException
     {
         launchPrestoCli("--version");
-        String version = firstNonNull(Presto.class.getPackage().getImplementationVersion(), "(version unknown)");
+        String version = firstNonNull(TestPrestoCli.class.getPackage().getImplementationVersion(), "(version unknown)");
         assertThat(presto.readRemainingOutputLines()).containsExactly("Presto CLI " + version);
     }
 


### PR DESCRIPTION
Testes with following invocations styles:

- `echo "SELECT 1; SELECT 2; SELECT 3" | ./presto-cli-executable.jar`
- `./presto-cli-executable.jar < file.sql`
- `./presto-cli-executable.jar < <(echo "SELECT 1; SELECT 2; SELECT 3")`