### PR TITLE
Temporarily disable failing test

### DIFF
--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMaterializedViews.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMaterializedViews.java
@@ -51,7 +51,7 @@ public class TestIcebergMaterializedViews
         assertQuery("SELECT count(*) FROM base_table2", "VALUES 3");
     }
 
-    @Test
+    @Test(enabled = false) // TODO https://github.com/prestosql/presto/issues/5892
     public void testCreateRefreshSelect()
     {
         Session session = getSession();
@@ -137,7 +137,7 @@ public class TestIcebergMaterializedViews
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_join_part");
     }
 
-    @Test
+    @Test(enabled = false) // TODO https://github.com/prestosql/presto/issues/5892
     public void testDetectStaleness()
     {
         // Base tables and materialized views for staleness check
@@ -191,7 +191,7 @@ public class TestIcebergMaterializedViews
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_join_part_stale");
     }
 
-    @Test
+    @Test(enabled = false) // TODO https://github.com/prestosql/presto/issues/5892
     public void testSqlFeatures()
     {
         Session session = getSession();
@@ -246,7 +246,7 @@ public class TestIcebergMaterializedViews
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_subquery");
     }
 
-    @Test
+    @Test(enabled = false) // TODO https://github.com/prestosql/presto/issues/5892
     public void testReplace()
     {
         // Materialized view to test 'replace' feature
@@ -263,7 +263,7 @@ public class TestIcebergMaterializedViews
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_replace");
     }
 
-    @Test
+    @Test(enabled = false) // TODO https://github.com/prestosql/presto/issues/5892
     public void testNestedMaterializedViews()
     {
         // Base table and materialized views for nested materialized view testing


### PR DESCRIPTION
Relates https://github.com/prestosql/presto/issues/5892

rationale from https://github.com/prestosql/presto/issues/5892#issuecomment-724628345

> Locally, this is failing consistently for me.
Since this has just been merged, i assume this is due to a logical merged conflict.
I don't what needs to be fixed, and I don't want to revert all of the https://github.com/prestosql/presto/pull/4832 PR, so i propose we disable the test for now and fix it ASAP.
