### PR TITLE
Stop Suite execution when time limit exhausted

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteRun.java
@@ -51,6 +51,7 @@ import static io.prestosql.tests.product.launcher.cli.Commands.runCommand;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @Command(
@@ -214,6 +215,15 @@ public class SuiteRun
         public TestRunResult executeSuiteTestRun(int runId, String suiteName, SuiteTestRun suiteTestRun, EnvironmentConfig environmentConfig)
         {
             TestRun.TestRunOptions testRunOptions = createTestRunOptions(runId, suiteName, suiteTestRun, environmentConfig, suiteRunOptions.logsDirBase);
+            if (testRunOptions.timeout.toMillis() == 0) {
+                return new TestRunResult(
+                        runId,
+                        suiteTestRun,
+                        environmentConfig,
+                        new Duration(0, MILLISECONDS),
+                        Optional.of(new Exception("Test execution not attempted because suite total running time limit was exhausted")));
+            }
+
             log.info("Starting test run #%02d %s with config %s and remaining timeout %s", runId, suiteTestRun, environmentConfig, testRunOptions.timeout);
             log.info("Execute this test run using:\n%s test run %s", environmentOptions.launcherBin, OptionsPrinter.format(environmentOptions, testRunOptions));
 


### PR DESCRIPTION
Attempting to invoke a test run with no time limit remaining would have
no chance to succeed, and more importantly would lead to a immediate
failure like

```
io.prestosql.tests.product.launcher.cli.TestRun	Failure: java.lang.IllegalArgumentException: timeout must be > 0
	at net.jodah.failsafe.internal.util.Assert.isTrue(Assert.java:27)
	at net.jodah.failsafe.Timeout.of(Timeout.java:109)
	at io.prestosql.tests.product.launcher.cli.TestRun$Execution.call(TestRun.java:176)
	at io.prestosql.tests.product.launcher.cli.SuiteRun$Execution.runTest(SuiteRun.java:229)
	at io.prestosql.tests.product.launcher.cli.SuiteRun$Execution.executeSuiteTestRun(SuiteRun.java:221)
	at io.prestosql.tests.product.launcher.cli.SuiteRun$Execution.call(SuiteRun.java:168)
	at io.prestosql.tests.product.launcher.cli.SuiteRun$Execution.call(SuiteRun.java:118)
```

Follows https://github.com/prestosql/presto/pull/5866