### PR TITLE
Improve serde performance for Long blocks

### DIFF
--- a/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkBlockSerde.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/BenchmarkBlockSerde.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.execution.buffer;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.OutputStreamSliceOutput;
+import io.airlift.slice.Slice;
+import io.prestosql.execution.buffer.PagesSerde.PagesSerdeContext;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.PageBuilder;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.TestingBlockEncodingSerde;
+import io.prestosql.spi.type.DecimalType;
+import io.prestosql.spi.type.Decimals;
+import io.prestosql.spi.type.SqlDecimal;
+import io.prestosql.spi.type.Type;
+import io.prestosql.spi.type.VarcharType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.execution.buffer.PagesSerdeUtil.readPages;
+import static io.prestosql.execution.buffer.PagesSerdeUtil.writePages;
+import static io.prestosql.plugin.tpch.TpchTables.getTablePages;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.DecimalType.createDecimalType;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.spi.type.Varchars.truncateToLength;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+@Warmup(iterations = 30, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OperationsPerInvocation(BenchmarkBlockSerde.ROWS)
+public class BenchmarkBlockSerde
+{
+    private static final DecimalType LONG_DECIMAL_TYPE = createDecimalType(30, 5);
+
+    public static final int ROWS = 10_000_000;
+    private static final int MAX_STRING = 19;
+
+    @Benchmark
+    public Object serializeLongDecimalNoNull(LongDecimalNoNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeLongDecimalNoNull(LongDecimalNoNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeLongDecimalWithNull(LongDecimalWithNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeLongDecimalWithNull(LongDecimalWithNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeLongNoNull(BigintNoNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeLongNoNull(BigintNoNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeLongWithNull(BigintWithNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeLongWithNull(BigintWithNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeSliceDirectNoNull(VarcharDirectNoNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeSliceDirectNoNull(VarcharDirectNoNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeSliceDirectWithNull(VarcharDirectWithNullBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeSliceDirectWithNull(VarcharDirectWithNullBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    @Benchmark
+    public Object serializeLineitem(LineitemBenchmarkData data)
+    {
+        return serializePages(data);
+    }
+
+    @Benchmark
+    public Object deserializeLineitem(LineitemBenchmarkData data)
+    {
+        return ImmutableList.copyOf(readPages(data.getPagesSerde(), new BasicSliceInput(data.getDataSource())));
+    }
+
+    private static List<SerializedPage> serializePages(BenchmarkData data)
+    {
+        PagesSerdeContext context = new PagesSerdeContext();
+        return data.getPages().stream()
+                .map(page -> data.getPagesSerde().serialize(context, page))
+                .collect(toImmutableList());
+    }
+
+    public abstract static class BenchmarkData
+    {
+        protected final Random random = new Random(0);
+        private Slice dataSource;
+        private PagesSerde pagesSerde;
+        private List<Page> pages;
+
+        public void setup(Iterator<Page> pagesIterator)
+                throws Exception
+        {
+            pagesSerde = new TestingPagesSerdeFactory(new TestingBlockEncodingSerde(), false).createPagesSerde();
+
+            this.pages = ImmutableList.copyOf(pagesIterator);
+            DynamicSliceOutput sliceOutput = new DynamicSliceOutput(0);
+            writePages(pagesSerde, new OutputStreamSliceOutput(sliceOutput), pages.listIterator());
+            dataSource = sliceOutput.slice();
+        }
+
+        public void setup(Type type, Iterator<?> values)
+                throws Exception
+        {
+            pagesSerde = new TestingPagesSerdeFactory(new TestingBlockEncodingSerde(), false).createPagesSerde();
+            PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+            BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+            ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builder();
+            while (values.hasNext()) {
+                Object value = values.next();
+                if (value == null) {
+                    blockBuilder.appendNull();
+                }
+                else if (BIGINT.equals(type)) {
+                    BIGINT.writeLong(blockBuilder, ((Number) value).longValue());
+                }
+                else if (Decimals.isLongDecimal(type)) {
+                    type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(((SqlDecimal) value).toBigDecimal().unscaledValue()));
+                }
+                else if (type instanceof VarcharType) {
+                    Slice slice = truncateToLength(utf8Slice((String) value), type);
+                    type.writeSlice(blockBuilder, slice);
+                }
+                else {
+                    throw new IllegalArgumentException("Unsupported type " + type);
+                }
+                pageBuilder.declarePosition();
+                if (pageBuilder.isFull()) {
+                    pagesBuilder.add(pageBuilder.build());
+                    pageBuilder.reset();
+                    blockBuilder = pageBuilder.getBlockBuilder(0);
+                }
+            }
+            if (pageBuilder.getPositionCount() > 0) {
+                pagesBuilder.add(pageBuilder.build());
+            }
+
+            pages = pagesBuilder.build();
+            DynamicSliceOutput sliceOutput = new DynamicSliceOutput(0);
+            writePages(pagesSerde, new OutputStreamSliceOutput(sliceOutput), pages.iterator());
+            dataSource = sliceOutput.slice();
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+
+        public PagesSerde getPagesSerde()
+        {
+            return pagesSerde;
+        }
+
+        public Slice getDataSource()
+        {
+            return dataSource;
+        }
+    }
+
+    @State(Thread)
+    public static class LongDecimalNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(LONG_DECIMAL_TYPE, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<SqlDecimal> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(new SqlDecimal(new BigInteger(96, random), 30, 5));
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class LongDecimalWithNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(LONG_DECIMAL_TYPE, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<SqlDecimal> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(new SqlDecimal(new BigInteger(96, random), 30, 5));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class BigintNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(BIGINT, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<Long> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(random.nextLong());
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class BigintWithNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(BIGINT, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<Long> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(random.nextLong());
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class VarcharDirectNoNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(VARCHAR, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<String> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(randomAsciiString(random));
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class VarcharDirectWithNullBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(VARCHAR, createValues());
+        }
+
+        private Iterator<?> createValues()
+        {
+            List<String> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(randomAsciiString(random));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values.iterator();
+        }
+    }
+
+    @State(Thread)
+    public static class LineitemBenchmarkData
+            extends BenchmarkData
+    {
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            setup(getTablePages("lineitem", 0.1));
+        }
+    }
+
+    private static String randomAsciiString(Random random)
+    {
+        char[] value = new char[random.nextInt(MAX_STRING)];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = (char) random.nextInt(Byte.MAX_VALUE);
+        }
+        return new String(value);
+    }
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        LineitemBenchmarkData data = new LineitemBenchmarkData();
+        data.setup();
+        deserializeLineitem(data);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkBlockSerde.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestPagesSerde.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestPagesSerde.java
@@ -68,7 +68,7 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(BIGINT), page);
-        assertEquals(pageSize, 48); // page overhead ideally 35 but since a 0 sized block will be a RLEBlock we have an overhead of 13
+        assertEquals(pageSize, 52); // page overhead ideally 35 but since a 0 sized block will be a RLEBlock we have an overhead of 17
 
         // page with one value
         BIGINT.writeLong(builder, 123);

--- a/presto-main/src/test/java/io/prestosql/execution/buffer/TestingPagesSerdeFactory.java
+++ b/presto-main/src/test/java/io/prestosql/execution/buffer/TestingPagesSerdeFactory.java
@@ -31,7 +31,12 @@ public class TestingPagesSerdeFactory
     public TestingPagesSerdeFactory()
     {
         // compression should be enabled in as many tests as possible
-        super(createTestMetadataManager().getBlockEncodingSerde(), true);
+        this(createTestMetadataManager().getBlockEncodingSerde(), true);
+    }
+
+    public TestingPagesSerdeFactory(BlockEncodingSerde blockEncodingSerde, boolean compressionEnabled)
+    {
+        super(blockEncodingSerde, compressionEnabled);
     }
 
     public static PagesSerde testingPagesSerde()

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.prestosql.hadoop</groupId>
             <artifactId>hadoop-apache</artifactId>
             <scope>test</scope>

--- a/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
@@ -75,9 +74,10 @@ import static java.nio.file.Files.readAllBytes;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.joda.time.DateTimeZone.UTC;
+import static org.openjdk.jmh.annotations.Scope.Thread;
 
 @SuppressWarnings("MethodMayBeStatic")
-@State(Scope.Thread)
+@State(Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(3)
 @Warmup(iterations = 30, time = 500, timeUnit = MILLISECONDS)
@@ -397,7 +397,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class AllNullBenchmarkData
             extends BenchmarkData
     {
@@ -434,7 +434,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class BooleanNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -455,7 +455,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class BooleanWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -476,7 +476,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class TinyIntNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -497,7 +497,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class TinyIntWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -523,7 +523,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class ShortDecimalNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -544,7 +544,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class ShortDecimalWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -570,7 +570,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class LongDecimalNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -591,7 +591,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class LongDecimalWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -617,7 +617,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class DoubleNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -638,7 +638,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class DoubleWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -664,7 +664,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class FloatNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -685,7 +685,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class FloatWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -711,7 +711,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class BigintNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -740,7 +740,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class BigintWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -774,7 +774,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class IntegerNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -803,7 +803,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class IntegerWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -837,7 +837,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class SmallintNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -866,7 +866,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class SmallintWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -900,7 +900,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class VarcharDirectNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -921,7 +921,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class VarcharDirectWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -947,7 +947,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class VarcharDictionaryNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -970,7 +970,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class VarcharDictionaryWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -1017,7 +1017,7 @@ public class BenchmarkColumnReaders
         return new String(value);
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class TimestampNoNullBenchmarkData
             extends BenchmarkData
     {
@@ -1038,7 +1038,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class TimestampWithNullBenchmarkData
             extends BenchmarkData
     {
@@ -1064,7 +1064,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    @State(Scope.Thread)
+    @State(Thread)
     public static class LineitemBenchmarkData
             extends BenchmarkData
     {

--- a/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/BenchmarkColumnReaders.java
@@ -15,6 +15,7 @@ package io.prestosql.orc;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
+import io.prestosql.orc.metadata.CompressionKind;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.block.Block;
 import io.prestosql.spi.type.DecimalType;
@@ -340,7 +341,7 @@ public class BenchmarkColumnReaders
         return blocks;
     }
 
-    private abstract static class BenchmarkData
+    public abstract static class BenchmarkData
     {
         protected final Random random = new Random(0);
         private List<Type> types;
@@ -348,13 +349,16 @@ public class BenchmarkColumnReaders
         private File orcFile;
         private OrcDataSource dataSource;
 
+        @Param({"NONE", "ZLIB"})
+        private String compression = "NONE";
+
         public void setup(List<Type> types, Iterator<Page> pages)
                 throws Exception
         {
             this.types = types;
             temporaryDirectory = createTempDir();
             orcFile = new File(temporaryDirectory, randomUUID().toString());
-            OrcTester.writeOrcPages(orcFile, NONE, types, pages, new OrcWriterStats());
+            OrcTester.writeOrcPages(orcFile, CompressionKind.valueOf(compression), types, pages, new OrcWriterStats());
 
             dataSource = new MemoryOrcDataSource(new OrcDataSourceId(orcFile.getPath()), Slices.wrappedBuffer(readAllBytes(orcFile.toPath())));
         }

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -635,10 +635,6 @@ public class OrcTester
     public static void writeOrcColumnPresto(File outputFile, CompressionKind compression, Type type, Iterator<?> values, OrcWriterStats stats)
             throws Exception
     {
-        ImmutableMap.Builder<String, String> metadata = ImmutableMap.builder();
-        metadata.put("columns", "test");
-        metadata.put("columns.types", createSettableStructObjectInspector("test", type).getTypeName());
-
         List<String> columnNames = ImmutableList.of("test");
         List<Type> types = ImmutableList.of(type);
 

--- a/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -262,6 +264,11 @@ public class LongArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(values, arrayOffset, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/LongArrayBlockBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -332,6 +334,11 @@ public class LongArrayBlockBuilder
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(values, 0, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/test/java/io/prestosql/spi/block/BlockTestUtils.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/BlockTestUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.block;
+
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.block.TestingSession.SESSION;
+import static org.testng.Assert.assertEquals;
+
+public class BlockTestUtils
+{
+    private BlockTestUtils() {}
+
+    public static void assertBlockEquals(Type type, Block actual, Block expected)
+    {
+        for (int position = 0; position < actual.getPositionCount(); position++) {
+            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
+        }
+    }
+}

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestDictionaryBlockEncoding.java
@@ -14,10 +14,9 @@
 package io.prestosql.spi.block;
 
 import io.airlift.slice.DynamicSliceOutput;
-import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
-import static io.prestosql.spi.block.TestingSession.SESSION;
+import static io.prestosql.spi.block.BlockTestUtils.assertBlockEquals;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -58,12 +57,5 @@ public class TestDictionaryBlockEncoding
             assertEquals(actualDictionaryBlock.getId(position), ids[position]);
         }
         assertEquals(actualDictionaryBlock.getDictionarySourceId(), dictionaryBlock.getDictionarySourceId());
-    }
-
-    private static void assertBlockEquals(Type type, Block actual, Block expected)
-    {
-        for (int position = 0; position < actual.getPositionCount(); position++) {
-            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
-        }
     }
 }

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestLongArrayBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestLongArrayBlockEncoding.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.block;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.prestosql.spi.type.Type;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.block.TestingSession.SESSION;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestLongArrayBlockEncoding
+{
+    private final BlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();
+
+    @Test
+    public void testRoundTripNoNull()
+    {
+        BlockBuilder expectedBlockBuilder = BIGINT.createBlockBuilder(null, 4);
+        BIGINT.writeLong(expectedBlockBuilder, 1);
+        BIGINT.writeLong(expectedBlockBuilder, 2);
+        BIGINT.writeLong(expectedBlockBuilder, 3);
+        BIGINT.writeLong(expectedBlockBuilder, 4);
+        Block expectedBlock = expectedBlockBuilder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
+        blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
+        Block actualBlock = blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
+        assertBlockEquals(BIGINT, actualBlock, expectedBlock);
+    }
+
+    @Test
+    public void testRoundTripWithNull()
+    {
+        BlockBuilder expectedBlockBuilder = BIGINT.createBlockBuilder(null, 7);
+        expectedBlockBuilder.appendNull();
+        expectedBlockBuilder.appendNull();
+        BIGINT.writeLong(expectedBlockBuilder, 1);
+        expectedBlockBuilder.appendNull();
+        BIGINT.writeLong(expectedBlockBuilder, 3);
+        expectedBlockBuilder.appendNull();
+        expectedBlockBuilder.appendNull();
+        Block expectedBlock = expectedBlockBuilder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
+        blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
+        Block actualBlock = blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
+        assertBlockEquals(BIGINT, actualBlock, expectedBlock);
+    }
+
+    private static void assertBlockEquals(Type type, Block actual, Block expected)
+    {
+        for (int position = 0; position < actual.getPositionCount(); position++) {
+            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
+        }
+    }
+}

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestLongArrayBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestLongArrayBlockEncoding.java
@@ -14,12 +14,10 @@
 package io.prestosql.spi.block;
 
 import io.airlift.slice.DynamicSliceOutput;
-import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
-import static io.prestosql.spi.block.TestingSession.SESSION;
+import static io.prestosql.spi.block.BlockTestUtils.assertBlockEquals;
 import static io.prestosql.spi.type.BigintType.BIGINT;
-import static org.testng.Assert.assertEquals;
 
 public class TestLongArrayBlockEncoding
 {
@@ -58,12 +56,5 @@ public class TestLongArrayBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
         Block actualBlock = blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
         assertBlockEquals(BIGINT, actualBlock, expectedBlock);
-    }
-
-    private static void assertBlockEquals(Type type, Block actual, Block expected)
-    {
-        for (int position = 0; position < actual.getPositionCount(); position++) {
-            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
-        }
     }
 }

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestVariableWidthBlockEncoding.java
@@ -14,12 +14,10 @@
 package io.prestosql.spi.block;
 
 import io.airlift.slice.DynamicSliceOutput;
-import io.prestosql.spi.type.Type;
 import org.testng.annotations.Test;
 
-import static io.prestosql.spi.block.TestingSession.SESSION;
+import static io.prestosql.spi.block.BlockTestUtils.assertBlockEquals;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
-import static org.testng.Assert.assertEquals;
 
 public class TestVariableWidthBlockEncoding
 {
@@ -39,12 +37,5 @@ public class TestVariableWidthBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, expectedBlock);
         Block actualBlock = blockEncodingSerde.readBlock(sliceOutput.slice().getInput());
         assertBlockEquals(VARCHAR, actualBlock, expectedBlock);
-    }
-
-    private static void assertBlockEquals(Type type, Block actual, Block expected)
-    {
-        for (int position = 0; position < actual.getPositionCount(); position++) {
-            assertEquals(type.getObjectValue(SESSION, actual, position), type.getObjectValue(SESSION, expected, position));
-        }
     }
 }

--- a/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchTables.java
+++ b/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchTables.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.tpch;
+
+import com.google.common.collect.AbstractIterator;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.RecordPageSource;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.type.Type;
+import io.prestosql.tpch.TpchTable;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.tpch.TpchRecordSet.createTpchRecordSet;
+
+public final class TpchTables
+{
+    private TpchTables()
+    {
+    }
+
+    public static List<Type> getTableColumns(String tableName)
+    {
+        TpchTable<?> table = TpchTable.getTable(tableName);
+        return table.getColumns().stream()
+                .map(TpchMetadata::getPrestoType)
+                .collect(toImmutableList());
+    }
+
+    public static Iterator<Page> getTablePages(
+            String tableName,
+            double scaleFactor)
+    {
+        TpchTable table = TpchTable.getTable(tableName);
+        ConnectorPageSource pageSource = new RecordPageSource(
+                createTpchRecordSet(table, table.getColumns(), scaleFactor, 1, 1, TupleDomain.all()));
+        return new AbstractIterator<>()
+        {
+            @Override
+            protected Page computeNext()
+            {
+                if (pageSource.isFinished()) {
+                    return endOfData();
+                }
+
+                Page page = pageSource.getNextPage();
+                if (page == null) {
+                    return computeNext();
+                }
+
+                return page.getLoadedPage();
+            }
+        };
+    }
+}


### PR DESCRIPTION
```
AFTER (no null)

Benchmark                                    Mode  Cnt  Score   Error  Units
BenchmarkBlockSerde.deserializeLongNoNull    avgt   60  1,125 ± 0,011  ns/op

BEFORE (no null)

Benchmark                                    Mode  Cnt  Score   Error  Units
BenchmarkBlockSerde.deserializeLongNoNull    avgt   60  2,548 ± 0,023  ns/op

AFTER (no null)

Benchmark                                    Mode  Cnt  Score   Error  Units
BenchmarkBlockSerde.deserializeLineitem      avgt   60  1,212 ± 0,015  ns/op
BenchmarkBlockSerde.deserializeLongWithNull  avgt   60  2,500 ± 0,038  ns/op
BenchmarkBlockSerde.serializeLineitem        avgt   60  3,645 ± 0,039  ns/op
BenchmarkBlockSerde.serializeLongWithNull    avgt   60  3,351 ± 0,016  ns/op

BEFORE (no null)

Benchmark                                    Mode  Cnt  Score   Error  Units
BenchmarkBlockSerde.deserializeLineitem      avgt   60  1,219 ± 0,016  ns/op
BenchmarkBlockSerde.deserializeLongWithNull  avgt   60  5,524 ± 0,062  ns/op
BenchmarkBlockSerde.serializeLineitem        avgt   60  3,671 ± 0,041  ns/op
BenchmarkBlockSerde.serializeLongWithNull    avgt   60  8,844 ± 0,086  ns/op
```