### PR TITLE
Add Cassandra unit test class against latest 3.11.9

### DIFF
--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
@@ -13,42 +13,21 @@
  */
 package io.prestosql.plugin.cassandra;
 
-import com.google.common.collect.ImmutableMap;
 import io.prestosql.testing.AbstractTestDistributedQueries;
 import io.prestosql.testing.MaterializedResult;
-import io.prestosql.testing.QueryRunner;
 import io.prestosql.testing.sql.TestTable;
-import io.prestosql.tpch.TpchTable;
 import org.testng.SkipException;
-import org.testng.annotations.AfterClass;
 
 import java.util.Optional;
 
-import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.MaterializedResult.resultBuilder;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestCassandraDistributedQueries
+public abstract class BaseCassandraDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    private CassandraServer server;
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        this.server = new CassandraServer();
-        return createCassandraQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-    {
-        server.close();
-    }
-
     @Override
     protected boolean supportsDelete()
     {

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraServer.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/CassandraServer.java
@@ -60,9 +60,15 @@ public class CassandraServer
     public CassandraServer()
             throws Exception
     {
+        this("2.2");
+    }
+
+    public CassandraServer(String cassandraVersion)
+            throws Exception
+    {
         log.info("Starting cassandra...");
 
-        this.dockerContainer = new GenericContainer<>("cassandra:2.2")
+        this.dockerContainer = new GenericContainer<>("cassandra:" + cassandraVersion)
                 .withExposedPorts(PORT)
                 .withCopyFileToContainer(forHostPath(prepareCassandraYaml()), "/etc/cassandra/cassandra.yaml");
         this.dockerContainer.start();

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueries.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tpch.TpchTable;
+
+import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
+
+public class TestCassandraDistributedQueries
+        extends BaseCassandraDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        CassandraServer server = closeAfterClass(new CassandraServer());
+        return createCassandraQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
+    }
+}

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueriesLatest.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/TestCassandraDistributedQueriesLatest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tpch.TpchTable;
+
+import static io.prestosql.plugin.cassandra.CassandraQueryRunner.createCassandraQueryRunner;
+
+public class TestCassandraDistributedQueriesLatest
+        extends BaseCassandraDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        CassandraServer server = closeAfterClass(new CassandraServer("3.11.9"));
+        return createCassandraQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
+    }
+}

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -8,7 +8,7 @@ The Cassandra connector allows querying data stored in
 Compatibility
 -------------
 
-Connector is compatible with all Cassandra versions newer than 2.1.5.
+Connector is tested against Cassandra version 2.2 and 3.11, but any intermediate or newer versions are expected to work.
 
 Configuration
 -------------


### PR DESCRIPTION
Relates to #5804 

This commit refactors the distributed query tests into a base with two implementations, the existing unit tests against the 2.2.x version of Cassandra and a new test class against the latest 3.11.9 version.