### PR TITLE
Update to ZooKeeper 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1205,12 +1205,8 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.14</version>
+                <version>3.5.8</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>jline</groupId>
-                        <artifactId>jline</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -255,6 +255,10 @@
                     <artifactId>netty</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>


### PR DESCRIPTION
The older 3.4 branch does not work on JDK 14+ due to [ZOOKEEPER-3779](https://issues.apache.org/jira/browse/ZOOKEEPER-3779).