### PR TITLE
disable socket factory pre JDK8u242

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/io/prestosql/client/OkHttpUtil.java
@@ -14,7 +14,6 @@
 package io.prestosql.client;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
@@ -246,22 +245,16 @@ public final class OkHttpUtil
 
     public static void setupChannelSocket(OkHttpClient.Builder clientBuilder)
     {
-        // Enable socket factory only for pre JDK 11
-        if (!isAtLeastJava11()) {
+        // Enable socket factory only for pre JDK8u242
+        if (!isAtLeastJava8u242()) {
             clientBuilder.socketFactory(new SocketChannelSocketFactory());
             clientBuilder.protocols(ImmutableList.of(Protocol.HTTP_1_1));
         }
     }
 
-    private static boolean isAtLeastJava11()
+    private static boolean isAtLeastJava8u242()
     {
-        String feature = Splitter.on(".").split(StandardSystemProperty.JAVA_VERSION.value()).iterator().next();
-        try {
-            return Integer.parseInt(feature) >= 11;
-        }
-        catch (NumberFormatException e) {
-            return false;
-        }
+        return StandardSystemProperty.JAVA_VERSION.value().compareTo("1.8.0_242") > 0;
     }
 
     private static void validateCertificates(KeyStore keyStore)


### PR DESCRIPTION
Hi, my presto version is 0.214 and my upgrade plan is  in progress . At 0.214 , I hit the same issue: https://github.com/prestosql/presto/issues/1169  and it was fixed by this PR :https://github.com/prestosql/presto/pull/2633 . But this PR is ok for JDK11 or later,  It will slow down of presto-cli and presto-jdbc in some JDK8  environment, for example JDK8u261. 
The codes still need to be optimized. According to this link: https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html , I think It shoud be like this :`return StandardSystemProperty.JAVA_VERSION.value().compareTo("1.8.0_242") > 0;`   so I commit this PR.
I tested the code ,it works fine in JDK8u261.
I know the prestosql current version no longer supports jdk8, so I don't know wether  this PR is necessary or not .
Please review , thx!