### PR TITLE
Add Druid unit test class against latest 0.20.0

### DIFF
--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/BaseDruidIntegrationSmokeTest.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/BaseDruidIntegrationSmokeTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.druid;
+
+import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.plugin.jdbc.JdbcTableHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.sql.planner.plan.AggregationNode;
+import io.prestosql.testing.AbstractTestIntegrationSmokeTest;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.assertions.Assert;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static io.prestosql.plugin.druid.DruidQueryRunner.copyAndIngestTpchData;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class BaseDruidIntegrationSmokeTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    protected static final String SELECT_FROM_ORDERS = "SELECT " +
+            "orderdate, " +
+            "orderdate AS orderdate_druid_ts, " + // Druid stores the orderdate_druid_ts column as __time column.
+            "orderkey, " +
+            "custkey, " +
+            "orderstatus, " +
+            "totalprice, " +
+            "orderpriority, " +
+            "clerk, " +
+            "shippriority, " +
+            "comment " +
+            "FROM tpch.tiny.orders";
+
+    protected static final String SELECT_FROM_LINEITEM = " SELECT " +
+            "orderkey, " +
+            "partkey, " +
+            "suppkey, " +
+            "linenumber, " +
+            "quantity, " +
+            "extendedprice, " +
+            "discount, " +
+            "tax, " +
+            "returnflag, " +
+            "linestatus, " +
+            "shipdate, " +
+            "shipdate AS shipdate_druid_ts, " +  // Druid stores the shipdate_druid_ts column as __time column.
+            "commitdate, " +
+            "receiptdate, " +
+            "shipinstruct, " +
+            "shipmode, " +
+            "comment " +
+            "FROM tpch.tiny.lineitem";
+
+    protected static final String SELECT_FROM_NATION = " SELECT " +
+            "nationkey, " +
+            "name, " +
+            "regionkey, " +
+            "comment, " +
+            "'1995-01-02' AS nation_druid_dummy_ts " + // Dummy timestamp for Druid __time column
+            "FROM tpch.tiny.nation";
+
+    protected static final String SELECT_FROM_REGION = " SELECT " +
+            "regionkey, " +
+            "name, " +
+            "comment, " +
+            "'1995-01-02' AS region_druid_dummy_ts " + // Dummy timestamp for Druid __time column
+            "FROM tpch.tiny.region";
+
+    protected static final String SELECT_FROM_PART = " SELECT " +
+            "partkey, " +
+            "name, " +
+            "mfgr, " +
+            "brand, " +
+            "type, " +
+            "size, " +
+            "container, " +
+            "retailprice, " +
+            "comment, " +
+            "'1995-01-02' AS part_druid_dummy_ts " + // Dummy timestamp for Druid __time column;
+            "FROM tpch.tiny.part";
+
+    protected static final String SELECT_FROM_CUSTOMER = " SELECT " +
+            "custkey, " +
+            "name, " +
+            "address, " +
+            "nationkey, " +
+            "phone, " +
+            "acctbal, " +
+            "mktsegment, " +
+            "comment, " +
+            "'1995-01-02' AS customer_druid_dummy_ts " +  // Dummy timestamp for Druid __time column
+            "FROM tpch.tiny.customer";
+
+    protected TestingDruidServer druidServer;
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        if (druidServer != null) {
+            druidServer.close();
+        }
+    }
+
+    @Test
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "varchar", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice", "double", "", "")
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE orders");
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Test
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo("CREATE TABLE druid.druid.orders (\n" +
+                        "   __time timestamp(3) NOT NULL,\n" +
+                        "   clerk varchar,\n" +
+                        "   comment varchar,\n" +
+                        "   custkey bigint NOT NULL,\n" +
+                        "   orderdate varchar,\n" +
+                        "   orderkey bigint NOT NULL,\n" +
+                        "   orderpriority varchar,\n" +
+                        "   orderstatus varchar,\n" +
+                        "   shippriority bigint NOT NULL,\n" +
+                        "   totalprice double NOT NULL\n" +
+                        ")");
+    }
+
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll(".$", "_");
+
+        @Language("SQL") String ordersTableWithColumns = "VALUES " +
+                "('orders', 'orderkey'), " +
+                "('orders', 'custkey'), " +
+                "('orders', 'orderstatus'), " +
+                "('orders', 'totalprice'), " +
+                "('orders', 'orderdate'), " +
+                "('orders', '__time'), " +
+                "('orders', 'orderpriority'), " +
+                "('orders', 'clerk'), " +
+                "('orders', 'shippriority'), " +
+                "('orders', 'comment')";
+
+        assertQuery("SELECT table_schema FROM information_schema.columns WHERE table_schema = '" + schema + "' GROUP BY table_schema", "VALUES '" + schema + "'");
+        assertQuery("SELECT table_name FROM information_schema.columns WHERE table_name = 'orders' GROUP BY table_name", "VALUES 'orders'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'orders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name LIKE '%rders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '_rder_'", ordersTableWithColumns);
+        assertQuery(
+                "SELECT table_name, column_name FROM information_schema.columns " +
+                        "WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '%orders%'",
+                ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+    }
+
+    @Test
+    @Override
+    public void testSelectAll()
+    {
+        // List columns explicitly, as Druid has an additional __time column
+        assertQuery("SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment  FROM orders");
+    }
+
+    /**
+     * This test verifies that the filtering we have in place to overcome Druid's limitation of
+     * not handling the escaping of search characters like % and _, works correctly.
+     * <p>
+     * See {@link DruidJdbcClient#getTableHandle(JdbcIdentity, SchemaTableName)} and
+     * {@link DruidJdbcClient#getColumns(ConnectorSession, JdbcTableHandle)}
+     */
+    @Test
+    public void testFilteringForTablesAndColumns()
+            throws Exception
+    {
+        String sql = SELECT_FROM_ORDERS + " LIMIT 10";
+        String datasourceA = "some_table";
+        MaterializedResult materializedRows = getQueryRunner().execute(sql);
+        copyAndIngestTpchData(materializedRows, druidServer, datasourceA);
+        String datasourceB = "somextable";
+        copyAndIngestTpchData(materializedRows, druidServer, datasourceB);
+
+        // Assert that only columns from datsourceA are returned
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "varchar", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice", "double", "", "")
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE " + datasourceA);
+        Assert.assertEquals(actualColumns, expectedColumns);
+
+        // Assert that only columns from datsourceB are returned
+        expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk_x", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment_x", "varchar", "", "")
+                .row("custkey_x", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate_x", "varchar", "", "")
+                .row("orderkey_x", "bigint", "", "")
+                .row("orderpriority_x", "varchar", "", "")
+                .row("orderstatus_x", "varchar", "", "")
+                .row("shippriority_x", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice_x", "double", "", "")
+                .build();
+        actualColumns = computeActual("DESCRIBE " + datasourceB);
+        Assert.assertEquals(actualColumns, expectedColumns);
+    }
+
+    @Test
+    public void testLimitPushdown()
+    {
+        assertThat(query("SELECT name FROM nation LIMIT 30")).isFullyPushedDown(); // Use high limit for result determinism
+
+        // with filter over numeric column
+        assertThat(query("SELECT name FROM nation WHERE regionkey = 3 LIMIT 5")).isFullyPushedDown();
+
+        // with filter over varchar column
+        assertThat(query("SELECT name FROM nation WHERE name < 'EEE' LIMIT 5")).isFullyPushedDown();
+
+        // with aggregation
+        assertThat(query("SELECT max(regionkey) FROM nation LIMIT 5")).isNotFullyPushedDown(AggregationNode.class); // global aggregation, LIMIT removed TODO https://github.com/prestosql/presto/pull/4313
+        assertThat(query("SELECT regionkey, max(name) FROM nation GROUP BY regionkey LIMIT 5")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
+        assertThat(query("SELECT DISTINCT regionkey FROM nation LIMIT 5")).isFullyPushedDown();
+
+        // with filter and aggregation
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
+        assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isNotFullyPushedDown(AggregationNode.class); // TODO https://github.com/prestosql/presto/pull/4313
+    }
+}

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTestLatest.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestDruidIntegrationSmokeTestLatest.java
@@ -23,14 +23,16 @@ import static io.prestosql.tpch.TpchTable.ORDERS;
 import static io.prestosql.tpch.TpchTable.PART;
 import static io.prestosql.tpch.TpchTable.REGION;
 
-public class TestDruidIntegrationSmokeTest
+public class TestDruidIntegrationSmokeTestLatest
         extends BaseDruidIntegrationSmokeTest
 {
+    private static final String LATEST_DRUID_DOCKER_IMAGE = "apache/druid:0.20.0";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.druidServer = new TestingDruidServer();
+        this.druidServer = new TestingDruidServer(LATEST_DRUID_DOCKER_IMAGE);
         QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer);
         copyAndIngestTpchData(runner.execute(SELECT_FROM_ORDERS), this.druidServer, ORDERS.getTableName());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_LINEITEM), this.druidServer, LINE_ITEM.getTableName());

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/TestingDruidServer.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/TestingDruidServer.java
@@ -64,6 +64,11 @@ public class TestingDruidServer
 
     public TestingDruidServer()
     {
+        this(DRUID_DOCKER_IMAGE);
+    }
+
+    public TestingDruidServer(String dockerImageName)
+    {
         try {
             // Cannot use Files.createTempDirectory() because on Mac by default it uses
             // /var/folders/ which is not visible to Docker for Mac
@@ -84,7 +89,7 @@ public class TestingDruidServer
                     .waitingFor(Wait.forListeningPort());
             zookeeper.start();
 
-            this.coordinator = new GenericContainer<>(DRUID_DOCKER_IMAGE)
+            this.coordinator = new GenericContainer<>(dockerImageName)
                     .withExposedPorts(DRUID_COORDINATOR_PORT)
                     .withNetwork(network)
                     .withCommand("coordinator")


### PR DESCRIPTION
Relates to #5804

This commit refactors the integration smoke test (there are no distributed tests) into a base with two implementations, the existing unit tests against the 0.18.0 of Druid and the latest 0.20.0 version.