### PR TITLE
Add Mongo unit test classes for latest 3.6.20 and 4.4.1

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -6,7 +6,7 @@ The ``mongodb`` connector allows the use of `MongoDB <https://www.mongodb.com/>`
 
 .. note::
 
-    MongoDB 2.6+ is supported, although it is highly recommend to use 3.0 or later.
+    The connector is tested against MongoDB 3.4 and 4.4, but any intermediate or newer versions are expected to work.
 
 Configuration
 -------------

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/BaseMongoDistributedQueries.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/BaseMongoDistributedQueries.java
@@ -13,40 +13,19 @@
  */
 package io.prestosql.plugin.mongodb;
 
-import com.google.common.collect.ImmutableMap;
 import io.prestosql.testing.AbstractTestDistributedQueries;
-import io.prestosql.testing.QueryRunner;
 import io.prestosql.testing.sql.TestTable;
-import io.prestosql.tpch.TpchTable;
 import org.testng.SkipException;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.prestosql.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test
-public class TestMongoDistributedQueries
+public abstract class BaseMongoDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    private MongoServer server;
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        this.server = new MongoServer();
-        return createMongoQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
-    }
-
-    @AfterClass(alwaysRun = true)
-    public final void destroy()
-    {
-        server.close();
-    }
-
     @Override
     protected boolean supportsDelete()
     {

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoServer.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/MongoServer.java
@@ -27,7 +27,12 @@ public class MongoServer
 
     public MongoServer()
     {
-        this.dockerContainer = new MongoDBContainer("mongo:3.4.0")
+        this("3.4.0");
+    }
+
+    public MongoServer(String mongoVersion)
+    {
+        this.dockerContainer = new MongoDBContainer("mongo:" + mongoVersion)
                 .withEnv("MONGO_INITDB_DATABASE", "tpch")
                 .withCommand("--bind_ip 0.0.0.0");
         this.dockerContainer.start();

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongo3DistributedQueriesLatest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongo3DistributedQueriesLatest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tpch.TpchTable;
+
+import static io.prestosql.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+
+public class TestMongo3DistributedQueriesLatest
+        extends BaseMongoDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MongoServer server = closeAfterClass(new MongoServer("3.6.20"));
+        return createMongoQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
+    }
+}

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongo4DistributedQueriesLatest.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongo4DistributedQueriesLatest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tpch.TpchTable;
+
+import static io.prestosql.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+
+public class TestMongo4DistributedQueriesLatest
+        extends BaseMongoDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MongoServer server = closeAfterClass(new MongoServer("4.4.1"));
+        return createMongoQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
+    }
+}

--- a/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoDistributedQueries.java
+++ b/presto-mongodb/src/test/java/io/prestosql/plugin/mongodb/TestMongoDistributedQueries.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.tpch.TpchTable;
+
+import static io.prestosql.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+
+public class TestMongoDistributedQueries
+        extends BaseMongoDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MongoServer server = closeAfterClass(new MongoServer());
+        return createMongoQueryRunner(server, ImmutableMap.of(), TpchTable.getTables());
+    }
+}


### PR DESCRIPTION
Relates to #5804

This commit refactors the distributed query test into a base with three implementations, the existing unit tests against the original 3.4.0, then two classes against the latest in the 3.x line, 3.6.20, and the latest in 4.x, 4.4.1.