### PR TITLE
Cleanup styling for copy icon

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -81,8 +81,6 @@ highlight_language = 'sql'
 
 default_role = 'backquote'
 
-copybutton_image_path = 'copy-icon.svg'
-
 rst_epilog = """
 .. |presto_server_release| replace:: ``presto-server-{release}``
 """.replace('{release}', release)

--- a/presto-docs/src/main/sphinx/static/copy-icon.svg
+++ b/presto-docs/src/main/sphinx/static/copy-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8 7h11v14H8z" opacity=".3"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/presto-docs/src/main/sphinx/static/presto.css
+++ b/presto-docs/src/main/sphinx/static/presto.css
@@ -40,20 +40,6 @@ pre.literal-block {
     font-size: 0.6rem;
 }
 
-a.copybtn {
-    opacity: 1.0;
-    width: 1.1em;
-    height: 1.1em;
-    top: .4em;
-    right: .4em;
-}
-
-.highlight {
-    padding: 1em 0.5em;
-}
-
 .copybtn:hover {
-    opacity: 0.3 !important;
-    cursor: pointer;
+    cursor: copy;
 }
-


### PR DESCRIPTION
This uses the default icon and opacity, without any additional padding, so the icon is much less distracting. It also changes the cursor to the "copy" cursor (though I can't screenshot that).

### Normal

<img width="778" alt="normal" src="https://user-images.githubusercontent.com/9230/98877018-61a47800-2434-11eb-9ace-89bd2644e8ca.png">

### Hover over the text box

<img width="774" alt="hover" src="https://user-images.githubusercontent.com/9230/98877036-6a954980-2434-11eb-9810-bef0e844b09f.png">
