### PR TITLE
Add version check in file metastore

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/DatabaseMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/DatabaseMetadata.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 public class DatabaseMetadata
 {
+    private final Optional<String> writerVersion;
     private final String ownerName;
     private final PrincipalType ownerType;
     private final Optional<String> comment;
@@ -33,23 +34,32 @@ public class DatabaseMetadata
 
     @JsonCreator
     public DatabaseMetadata(
+            @JsonProperty("writerVersion") Optional<String> writerVersion,
             @JsonProperty("ownerName") String ownerName,
             @JsonProperty("ownerType") PrincipalType ownerType,
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("parameters") Map<String, String> parameters)
     {
+        this.writerVersion = requireNonNull(writerVersion, "writerVersion is null");
         this.ownerName = requireNonNull(ownerName, "ownerName is null");
         this.ownerType = requireNonNull(ownerType, "ownerType is null");
         this.comment = requireNonNull(comment, "comment is null");
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
     }
 
-    public DatabaseMetadata(Database database)
+    public DatabaseMetadata(String currentVersion, Database database)
     {
+        this.writerVersion = Optional.of(requireNonNull(currentVersion, "currentVersion is null"));
         this.ownerName = database.getOwnerName();
         this.ownerType = database.getOwnerType();
         this.comment = database.getComment();
         this.parameters = database.getParameters();
+    }
+
+    @JsonProperty
+    public Optional<String> getWriterVersion()
+    {
+        return writerVersion;
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -570,9 +570,7 @@ public class FileHiveMetastore
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             comment.ifPresent(value -> parameters.put(TABLE_COMMENT, value));
 
-            return oldTable.withParameters(ImmutableMap.<String, String>builder()
-                    .putAll(parameters)
-                    .build());
+            return oldTable.withParameters(parameters);
         });
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -28,6 +28,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.HiveBasicStatistics;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.HiveType;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.PartitionNotFoundException;
 import io.prestosql.plugin.hive.PartitionStatistics;
 import io.prestosql.plugin.hive.SchemaAlreadyExistsException;
@@ -132,6 +133,7 @@ public class FileHiveMetastore
     private static final String ICEBERG_TABLE_TYPE_NAME = "table_type";
     private static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
 
+    private final String currentVersion;
     private final HdfsEnvironment hdfsEnvironment;
     private final Path catalogDirectory;
     private final HdfsContext hdfsContext;
@@ -153,6 +155,7 @@ public class FileHiveMetastore
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 hdfsEnvironment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()
@@ -161,8 +164,9 @@ public class FileHiveMetastore
     }
 
     @Inject
-    public FileHiveMetastore(HdfsEnvironment hdfsEnvironment, MetastoreConfig metastoreConfig, FileHiveMetastoreConfig config)
+    public FileHiveMetastore(NodeVersion nodeVersion, HdfsEnvironment hdfsEnvironment, MetastoreConfig metastoreConfig, FileHiveMetastoreConfig config)
     {
+        this.currentVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         requireNonNull(metastoreConfig, "metastoreConfig is null");
         requireNonNull(config, "config is null");

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -194,7 +194,7 @@ public class FileHiveMetastore
         verifyDatabaseNotExists(database.getDatabaseName());
 
         Path databaseMetadataDirectory = getDatabaseMetadataDirectory(database.getDatabaseName());
-        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(database), false);
+        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(currentVersion, database), false);
     }
 
     @Override
@@ -239,7 +239,7 @@ public class FileHiveMetastore
                 .setOwnerType(principal.getType())
                 .build();
 
-        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(newDatabase), true);
+        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(currentVersion, newDatabase), true);
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/FileHiveMetastoreConfig.java
@@ -18,9 +18,20 @@ import io.airlift.configuration.ConfigDescription;
 
 import javax.validation.constraints.NotNull;
 
+import static io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompatibility.NOT_SUPPORTED;
+
 public class FileHiveMetastoreConfig
 {
+    public static final String VERSION_COMPATIBILITY_CONFIG = "hive.metastore.version-compatibility";
+
+    public enum VersionCompatibility
+    {
+        NOT_SUPPORTED,
+        UNSAFE_ASSUME_COMPATIBILITY,
+    }
+
     private String catalogDirectory;
+    private VersionCompatibility versionCompatibility = NOT_SUPPORTED;
     private String metastoreUser = "presto";
     private boolean assumeCanonicalPartitionKeys;
 
@@ -35,6 +46,19 @@ public class FileHiveMetastoreConfig
     public FileHiveMetastoreConfig setCatalogDirectory(String catalogDirectory)
     {
         this.catalogDirectory = catalogDirectory;
+        return this;
+    }
+
+    @NotNull
+    public VersionCompatibility getVersionCompatibility()
+    {
+        return versionCompatibility;
+    }
+
+    @Config(VERSION_COMPATIBILITY_CONFIG)
+    public FileHiveMetastoreConfig setVersionCompatibility(VersionCompatibility versionCompatibility)
+    {
+        this.versionCompatibility = versionCompatibility;
         return this;
     }
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/TableMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/TableMetadata.java
@@ -38,6 +38,7 @@ import static java.util.Objects.requireNonNull;
 
 public class TableMetadata
 {
+    private final Optional<String> writerVersion;
     private final String owner;
     private final String tableType;
     private final List<Column> dataColumns;
@@ -57,6 +58,7 @@ public class TableMetadata
 
     @JsonCreator
     public TableMetadata(
+            @JsonProperty("writerVersion") Optional<String> writerVersion,
             @JsonProperty("owner") String owner,
             @JsonProperty("tableType") String tableType,
             @JsonProperty("dataColumns") List<Column> dataColumns,
@@ -70,6 +72,7 @@ public class TableMetadata
             @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
             @JsonProperty("columnStatistics") Map<String, HiveColumnStatistics> columnStatistics)
     {
+        this.writerVersion = requireNonNull(writerVersion, "writerVersion is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
         this.dataColumns = ImmutableList.copyOf(requireNonNull(dataColumns, "dataColumns is null"));
@@ -93,8 +96,9 @@ public class TableMetadata
         checkArgument(partitionColumns.isEmpty() || columnStatistics.isEmpty(), "column statistics cannot be set for partitioned table");
     }
 
-    public TableMetadata(Table table)
+    public TableMetadata(String currentVersion, Table table)
     {
+        writerVersion = Optional.of(requireNonNull(currentVersion, "currentVersion is null"));
         owner = table.getOwner();
         tableType = table.getTableType();
         dataColumns = table.getDataColumns();
@@ -118,6 +122,12 @@ public class TableMetadata
         viewOriginalText = table.getViewOriginalText();
         viewExpandedText = table.getViewExpandedText();
         columnStatistics = ImmutableMap.of();
+    }
+
+    @JsonProperty
+    public Optional<String> getWriterVersion()
+    {
+        return writerVersion;
     }
 
     @JsonProperty
@@ -207,9 +217,10 @@ public class TableMetadata
         return columnStatistics;
     }
 
-    public TableMetadata withDataColumns(List<Column> dataColumns)
+    public TableMetadata withDataColumns(String currentVersion, List<Column> dataColumns)
     {
         return new TableMetadata(
+                Optional.of(requireNonNull(currentVersion, "currentVersion is null")),
                 owner,
                 tableType,
                 dataColumns,
@@ -224,9 +235,10 @@ public class TableMetadata
                 columnStatistics);
     }
 
-    public TableMetadata withParameters(Map<String, String> parameters)
+    public TableMetadata withParameters(String currentVersion, Map<String, String> parameters)
     {
         return new TableMetadata(
+                Optional.of(requireNonNull(currentVersion, "currentVersion is null")),
                 owner,
                 tableType,
                 dataColumns,
@@ -241,9 +253,10 @@ public class TableMetadata
                 columnStatistics);
     }
 
-    public TableMetadata withColumnStatistics(Map<String, HiveColumnStatistics> columnStatistics)
+    public TableMetadata withColumnStatistics(String currentVersion, Map<String, HiveColumnStatistics> columnStatistics)
     {
         return new TableMetadata(
+                Optional.of(requireNonNull(currentVersion, "currentVersion is null")),
                 owner,
                 tableType,
                 dataColumns,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/TableMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/file/TableMetadata.java
@@ -95,11 +95,6 @@ public class TableMetadata
 
     public TableMetadata(Table table)
     {
-        this(table, ImmutableMap.of());
-    }
-
-    public TableMetadata(Table table, Map<String, HiveColumnStatistics> columnStatistics)
-    {
         owner = table.getOwner();
         tableType = table.getTableType();
         dataColumns = table.getDataColumns();
@@ -122,7 +117,7 @@ public class TableMetadata
 
         viewOriginalText = table.getViewOriginalText();
         viewExpandedText = table.getViewExpandedText();
-        this.columnStatistics = ImmutableMap.copyOf(requireNonNull(columnStatistics, "columnStatistics is null"));
+        columnStatistics = ImmutableMap.of();
     }
 
     @JsonProperty

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/HiveQueryRunner.java
@@ -93,6 +93,7 @@ public final class HiveQueryRunner
         private Function<DistributedQueryRunner, HiveMetastore> metastore = queryRunner -> {
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
             return new FileHiveMetastore(
+                    new NodeVersion("test_version"),
                     HDFS_ENVIRONMENT,
                     new MetastoreConfig(),
                     new FileHiveMetastoreConfig()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveFileMetastore.java
@@ -31,6 +31,7 @@ public class TestHiveFileMetastore
     {
         File baseDir = new File(tempDir, "metastore");
         return new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 HDFS_ENVIRONMENT,
                 new MetastoreConfig()
                         .setHideDeltaLakeTables(true),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/file/TestFileHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/file/TestFileHiveMetastoreConfig.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompatibility.NOT_SUPPORTED;
+import static io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompatibility.UNSAFE_ASSUME_COMPATIBILITY;
 
 public class TestFileHiveMetastoreConfig
 {
@@ -29,6 +31,7 @@ public class TestFileHiveMetastoreConfig
     {
         assertRecordedDefaults(recordDefaults(FileHiveMetastoreConfig.class)
                 .setCatalogDirectory(null)
+                .setVersionCompatibility(NOT_SUPPORTED)
                 .setMetastoreUser("presto")
                 .setAssumeCanonicalPartitionKeys(false));
     }
@@ -38,12 +41,14 @@ public class TestFileHiveMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.catalog.dir", "some path")
+                .put("hive.metastore.version-compatibility", "UNSAFE_ASSUME_COMPATIBILITY")
                 .put("hive.metastore.user", "some user")
                 .put("hive.metastore.assume-canonical-partition-keys", "true")
                 .build();
 
         FileHiveMetastoreConfig expected = new FileHiveMetastoreConfig()
                 .setCatalogDirectory("some path")
+                .setVersionCompatibility(UNSAFE_ASSUME_COMPATIBILITY)
                 .setMetastoreUser("some user")
                 .setAssumeCanonicalPartitionKeys(true);
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -29,6 +29,7 @@ import io.prestosql.plugin.hive.HiveColumnProjectionInfo;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.HiveTableHandle;
 import io.prestosql.plugin.hive.HiveTransactionHandle;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Database;
@@ -103,6 +104,7 @@ public class TestConnectorPushdownRulesWithHive
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
 
         metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 environment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -27,6 +27,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveColumnHandle;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
 import io.prestosql.plugin.hive.HiveTableHandle;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.Database;
@@ -88,6 +89,7 @@ public class TestHiveProjectionPushdownIntoTableScan
         HdfsEnvironment environment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
 
         HiveMetastore metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 environment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.MetastoreConfig;
@@ -65,6 +66,7 @@ public class TestIcebergMetadataListing
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
 
         metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 hdfsEnvironment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.MetastoreConfig;
@@ -71,6 +72,7 @@ public class TestIcebergOrcMetricsCollection
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
 
         HiveMetastore metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 hdfsEnvironment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergSystemTables.java
@@ -20,6 +20,7 @@ import io.prestosql.plugin.hive.HdfsConfiguration;
 import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.NodeVersion;
 import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
 import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.plugin.hive.metastore.MetastoreConfig;
@@ -62,6 +63,7 @@ public class TestIcebergSystemTables
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
 
         HiveMetastore metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
                 hdfsEnvironment,
                 new MetastoreConfig(),
                 new FileHiveMetastoreConfig()


### PR DESCRIPTION
File metastore implementation is tailored for testing purposes and we
make no backward compatibility guarantees for the internal structures
used by it. However, this is not reflected in code behavior, as we make
the implementation available and selectable by the users. Prevent
accidental usage of metadata persisted with one file metastore version
and being read with a different version to avoid potential incorrect results.
Users can still opt in into previous unsafe behavior with a
configuration property.

Relates to: https://github.com/prestosql/presto/issues/5714