### PR TITLE
Stream container statistics

### DIFF
--- a/presto-product-tests-launcher/pom.xml
+++ b/presto-product-tests-launcher/pom.xml
@@ -44,12 +44,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-core</artifactId>
-            <version>${dep.docker-java.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DockerContainer.java
@@ -73,7 +73,6 @@ public class DockerContainer
             .with(Executors.newCachedThreadPool(daemonThreadsNamed("docker-container-%d")));
 
     private String logicalName;
-    private final StatisticsFetcher statistics;
     private List<String> logPaths = new ArrayList<>();
     private Optional<EnvironmentListener> listener = Optional.empty();
 
@@ -81,7 +80,6 @@ public class DockerContainer
     {
         super(dockerImageName);
         this.logicalName = requireNonNull(logicalName, "logicalName is null");
-        this.statistics = new StatisticsFetcher(this, executor);
 
         // workaround for https://github.com/testcontainers/testcontainers-java/pull/2861
         setCopyToFileContainerPathMap(new LinkedHashMap<>());
@@ -278,11 +276,6 @@ public class DockerContainer
         catch (ExecutionException | RuntimeException e) {
             log.warn(e, "Could not copy logs archive from %s", logicalName);
         }
-    }
-
-    public StatisticsFetcher.Stats getStats()
-    {
-        return statistics.get();
     }
 
     public DockerContainer waitingForAll(WaitStrategy... strategies)

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/StatisticsFetcher.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/StatisticsFetcher.java
@@ -13,66 +13,85 @@
  */
 package io.prestosql.tests.product.launcher.env;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.MemoryStatsConfig;
 import com.github.dockerjava.api.model.StatisticNetworksConfig;
 import com.github.dockerjava.api.model.Statistics;
-import com.github.dockerjava.core.InvocationBuilder;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
-import net.jodah.failsafe.FailsafeExecutor;
 import org.testcontainers.DockerClientFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.prestosql.tests.product.launcher.env.StatisticsFetcher.Stats.statisticsAreEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class StatisticsFetcher
+        implements AutoCloseable
 {
-    private final DockerContainer container;
-    private final FailsafeExecutor executor;
+    private final String containerId;
     private static final Logger log = Logger.get(StatisticsFetcher.class);
-    private AtomicReference<Stats> lastStats = new AtomicReference<>(new Stats());
+    private final String containerLogicalName;
+    private final AtomicReference<Stats> lastStats = new AtomicReference<>(new Stats());
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final StatisticsCallback callback;
 
-    public StatisticsFetcher(DockerContainer container, FailsafeExecutor executor)
+    StatisticsFetcher(String containerId, String containerLogicalName)
     {
-        this.container = requireNonNull(container, "container is null");
-        this.executor = requireNonNull(executor, "executor is null");
+        this.containerId = requireNonNull(containerId, "containerId is null");
+        this.containerLogicalName = requireNonNull(containerLogicalName, "containerLogicalName is null");
+        this.callback = new StatisticsCallback();
     }
 
     public Stats get()
     {
-        if (!container.isRunning()) {
-            log.warn("Could not get statistics for stopped container %s", container.getLogicalName());
-            return lastStats.get();
+        return lastStats.get();
+    }
+
+    public void start()
+    {
+        if (started.compareAndSet(false, true)) {
+            DockerClientFactory.lazyClient()
+                    .statsCmd(containerId)
+                    .exec(callback);
+
+            log.info("Started listening for container %s statistics stream...", containerLogicalName);
         }
+    }
 
-        try (InvocationBuilder.AsyncResultCallback<Statistics> callback = new InvocationBuilder.AsyncResultCallback<>()) {
-            DockerClientFactory.lazyClient().statsCmd(container.getContainerId()).exec(callback);
-
-            return lastStats.getAndUpdate(previousStats -> toStats((Statistics) executor.get(callback::awaitResult), previousStats));
+    @Override
+    public void close()
+    {
+        try {
+            callback.close();
         }
         catch (IOException e) {
-            throw new UncheckedIOException(e);
+            log.warn(e, "Caught exception while closing fetcher for container %s", containerLogicalName);
         }
-        catch (RuntimeException e) {
-            log.error(e, "Could not fetch container %s statistics", container.getLogicalName());
-            return lastStats.get();
-        }
+    }
+
+    public static StatisticsFetcher create(DockerContainer container)
+    {
+        return new StatisticsFetcher(container.getContainerId(), container.getLogicalName());
     }
 
     private Stats toStats(Statistics statistics, Stats previousStats)
     {
-        Stats stats = new Stats();
-
-        if (statistics == null || statistics.getCpuStats() == null) {
+        if (statisticsAreEmpty(statistics)) {
             return previousStats;
         }
 
+        Stats stats = new Stats();
         stats.systemCpuUsage = statistics.getCpuStats().getSystemCpuUsage();
         stats.totalCpuUsage = statistics.getCpuStats().getCpuUsage().getTotalUsage();
         stats.cpuUsagePerc = 0.0;
@@ -87,22 +106,82 @@ public class StatisticsFetcher
         }
 
         MemoryStatsConfig memoryStats = statistics.getMemoryStats();
-        stats.memoryLimit = DataSize.ofBytes(memoryStats.getLimit()).succinct();
-        stats.memoryUsage = DataSize.ofBytes(memoryStats.getUsage()).succinct();
-        stats.memoryMaxUsage = DataSize.ofBytes(memoryStats.getMaxUsage()).succinct();
+        stats.memoryLimit = DataSize.ofBytes(memoryStats.getLimit()).to(GIGABYTE);
+        stats.memoryUsage = DataSize.ofBytes(memoryStats.getUsage()).to(GIGABYTE);
+        stats.memoryMaxUsage = DataSize.ofBytes(memoryStats.getMaxUsage()).to(GIGABYTE);
         stats.memoryUsagePerc = 100.0 * memoryStats.getUsage() / memoryStats.getLimit();
 
         stats.pids = statistics.getPidsStats().getCurrent();
 
         Supplier<Stream<StatisticNetworksConfig>> stream = () -> statistics.getNetworks().values().stream();
         stats.networkReceived = DataSize.ofBytes(stream.get().map(StatisticNetworksConfig::getRxBytes).reduce(0L, Long::sum)).succinct();
-        stats.networkSent = DataSize.ofBytes(stream.get().map(StatisticNetworksConfig::getRxBytes).reduce(0L, Long::sum)).succinct();
+        stats.networkSent = DataSize.ofBytes(stream.get().map(StatisticNetworksConfig::getTxBytes).reduce(0L, Long::sum)).succinct();
 
         return stats;
     }
 
+    private class StatisticsCallback
+            implements ResultCallback<Statistics>
+    {
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+        private Closeable stream;
+
+        @Override
+        public void onNext(Statistics statistics)
+        {
+            lastStats.getAndUpdate(previousStats -> toStats(statistics, previousStats));
+        }
+
+        @Override
+        public void onStart(Closeable stream)
+        {
+            this.stream = requireNonNull(stream, "stream is null");
+        }
+
+        @Override
+        public void onError(Throwable throwable)
+        {
+            if (!closed.get()) {
+                log.warn(throwable, "Caught exception while processing statistics");
+
+                try {
+                    close();
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void onComplete()
+        {
+            try {
+                close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            if (closed.compareAndSet(false, true)) {
+                if (stream != null) {
+                    stream.close();
+                }
+
+                log.info("Stopped listening for container %s stats", containerLogicalName);
+            }
+        }
+    }
+
     public static class Stats
     {
+        private static final int COLUMN_PADDING = 8;
+
         private long systemCpuUsage = -1;
         private long totalCpuUsage = -1;
         private double cpuUsagePerc;
@@ -122,11 +201,48 @@ public class StatisticsFetcher
         @Override
         public String toString()
         {
-            return format("cpu: %s, memory: %s, pids: %d, network i/o: %s",
-                    format("%.2f%%", cpuUsagePerc),
-                    format("%s / %s (%.2f%%, max %s)", memoryUsage, memoryLimit, memoryUsagePerc, memoryMaxUsage),
-                    pids,
-                    format("%s / %s", networkReceived, networkSent));
+            if (!areCalculated()) {
+                return "n/a";
+            }
+
+            return Joiner.on(" | ").join(
+                pad("%.2f%%", cpuUsagePerc, COLUMN_PADDING),
+                pad("%s", memoryUsage, COLUMN_PADDING),
+                pad("%s", memoryLimit, COLUMN_PADDING),
+                pad("%.2f%%", memoryUsagePerc, COLUMN_PADDING),
+                pad("%s", memoryMaxUsage, COLUMN_PADDING),
+                pad("%d", pids, COLUMN_PADDING),
+                pad("%s", networkReceived, COLUMN_PADDING),
+                pad("%s", networkSent, COLUMN_PADDING));
+        }
+
+        private static String pad(String format, Object value, int length)
+        {
+            return Strings.padStart(format(format, value), length, ' ');
+        }
+
+        private static String pad(String value, int length)
+        {
+            return Strings.padStart(value, length, ' ');
+        }
+
+        public static String makeHeader(int containerNamePadding)
+        {
+            return Joiner.on(" | ").join(
+                    pad("container", containerNamePadding),
+                    pad("cpu", COLUMN_PADDING),
+                    pad("mem", COLUMN_PADDING),
+                    pad("max mem", COLUMN_PADDING),
+                    pad("mem %", COLUMN_PADDING),
+                    pad("peak mem", COLUMN_PADDING),
+                    pad("pids", COLUMN_PADDING),
+                    pad("net in", COLUMN_PADDING),
+                    pad("net out", COLUMN_PADDING));
+        }
+
+        public static boolean statisticsAreEmpty(Statistics statistics)
+        {
+            return statistics == null || statistics.getRead().equals("0001-01-01T00:00:00Z");
         }
     }
 }


### PR DESCRIPTION
This PR changes the way statistics are fetched from Docker: instead of closing the stream every time statistics are fetched, the stream remains open (docker sends them every 1s) until the environment is stopped. Arriving values are used to calculate deltas.

This PR also improves the formatting of statistics values so they are displayed in a table:

![Screenshot 2020-11-17 at 20 27 46](https://user-images.githubusercontent.com/66972/99437926-62954800-2913-11eb-9498-a8fded7bb5e0.png)
