### PR TITLE
Remove Docker image mention

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -33,9 +33,7 @@ such as 11.0.2 do not work, nor will earlier major versions such as Java 8. Newe
 versions such as Java 12 or 13 are not supported -- they may work, but are not tested.
 
 We recommend using `Azul Zulu <https://www.azul.com/downloads/zulu-community/>`_
-as the JDK for Presto, as Presto is tested against that distribution.
-Zulu is also the JDK used by the
-`Presto Docker image <https://hub.docker.com/r/prestosql/presto>`_.
+as the JDK, as Presto is tested against that OpenJDK distribution.
 
 Python
 ^^^^^^


### PR DESCRIPTION
We also dont talk about java configured for the RPM archive here .. it should just keep it to the requirements. The docker image docs can talk about Java distro used when we create that documentation.

Also update wording on prior sentence