### PR TITLE
Fix ATDQ.testDataMappingSmokeTest for MemSQL

### DIFF
--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
@@ -97,6 +97,13 @@ public class TestMemSqlDistributedQueries
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getPrestoTypeName();
+
+        if (typeName.equals("boolean")) {
+            // MemSQL does not have built-in support for boolean type. MemSQL provides BOOLEAN as the synonym of TINYINT(1)
+            // Querying the column with a boolean predicate subsequently fails with "Cannot apply operator: tinyint = boolean"
+            return Optional.empty();
+        }
+
         if (typeName.equals("time")
                 || typeName.equals("timestamp(3) with time zone")) {
             return Optional.of(dataMappingTestSetup.asUnsupported());

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
@@ -149,6 +149,7 @@ public class TestMySqlDistributedQueries
 
         if (typeName.equals("boolean")) {
             // MySql does not have built-in support for boolean type. MySQL provides BOOLEAN as the synonym of TINYINT(1)
+            // Querying the column with a boolean predicate subsequently fails with "Cannot apply operator: tinyint = boolean"
             return Optional.empty();
         }
 


### PR DESCRIPTION
It was broken since 8508bfd85eab29a95f0d28a77d78234293e28d8a, because
MemSQL tests do not run as part of CI for PR builds.