### PR TITLE
Add catalog name and deserializer class name to split information

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplit.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.prestosql.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
 
 public class HiveSplit
@@ -247,6 +248,7 @@ public class HiveSplit
                 .put("table", table)
                 .put("forceLocalScheduling", forceLocalScheduling)
                 .put("partitionName", partitionName)
+                .put("deserializerClassName", getDeserializerClassName(schema))
                 .put("s3SelectPushdownEnabled", s3SelectPushdownEnabled)
                 .build();
     }

--- a/presto-main/src/main/java/io/prestosql/operator/SplitOperatorInfo.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SplitOperatorInfo.java
@@ -15,17 +15,23 @@ package io.prestosql.operator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.prestosql.connector.CatalogName;
+
+import static java.util.Objects.requireNonNull;
 
 public class SplitOperatorInfo
         implements OperatorInfo
 {
+    private final CatalogName catalogName;
     // NOTE: this deserializes to a map instead of the expected type
     private final Object splitInfo;
 
     @JsonCreator
     public SplitOperatorInfo(
+            @JsonProperty("catalogName") CatalogName catalogName,
             @JsonProperty("splitInfo") Object splitInfo)
     {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.splitInfo = splitInfo;
     }
 
@@ -39,5 +45,11 @@ public class SplitOperatorInfo
     public Object getSplitInfo()
     {
         return splitInfo;
+    }
+
+    @JsonProperty
+    public CatalogName getCatalogName()
+    {
+        return catalogName;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TableScanOperator.java
@@ -198,7 +198,7 @@ public class TableScanOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
         }
 
         blocked.set(null);

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorPipelineSourceOperator.java
@@ -356,7 +356,7 @@ public class WorkProcessorPipelineSourceOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
         }
 
         pendingSplits.add(split);

--- a/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/presto-main/src/main/java/io/prestosql/operator/WorkProcessorSourceOperatorAdapter.java
@@ -102,7 +102,7 @@ public class WorkProcessorSourceOperatorAdapter
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
         }
 
         splitBuffer.add(split);

--- a/presto-main/src/main/java/io/prestosql/operator/index/IndexSourceOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/index/IndexSourceOperator.java
@@ -131,7 +131,7 @@ public class IndexSourceOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
         }
 
         return Optional::empty;

--- a/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestOperatorStats.java
@@ -16,6 +16,7 @@ package io.prestosql.operator;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.prestosql.connector.CatalogName;
 import io.prestosql.operator.PartitionedOutputOperator.PartitionedOutputInfo;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 import org.testng.annotations.Test;
@@ -28,7 +29,7 @@ import static org.testng.Assert.assertNull;
 
 public class TestOperatorStats
 {
-    private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo("some_info");
+    private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo(new CatalogName("some_catalog"), "some_info");
     private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1, 2, 1024);
 
     public static final OperatorStats EXPECTED = new OperatorStats(

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/SplitCompletedEvent.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/SplitCompletedEvent.java
@@ -24,6 +24,7 @@ public class SplitCompletedEvent
     private final String queryId;
     private final String stageId;
     private final String taskId;
+    private final Optional<String> catalogName;
 
     private final Instant createTime;
     private final Optional<Instant> startTime;
@@ -38,6 +39,7 @@ public class SplitCompletedEvent
             String queryId,
             String stageId,
             String taskId,
+            Optional<String> catalogName,
             Instant createTime,
             Optional<Instant> startTime,
             Optional<Instant> endTime,
@@ -48,6 +50,7 @@ public class SplitCompletedEvent
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.stageId = requireNonNull(stageId, "stageId is null");
         this.taskId = requireNonNull(taskId, "taskId is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.createTime = requireNonNull(createTime, "createTime is null");
         this.startTime = requireNonNull(startTime, "startTime is null");
         this.endTime = requireNonNull(endTime, "endTime is null");
@@ -99,6 +102,11 @@ public class SplitCompletedEvent
     public String getPayload()
     {
         return payload;
+    }
+
+    public Optional<String> getCatalogName()
+    {
+        return catalogName;
     }
 
     @Override


### PR DESCRIPTION
with these changes, splitinfo emitted through the splitcompletedevent payload changes to the following. The changes are useful for classifying splits corresponding to different connectors and tracking file format usage.

```
      "info": {
        "@type": "splitOperator",
        "catalogName": "hive2",
        "splitInfo": {
          "path": "....",
          "start": 0,
          "length": 321,
          "estimatedFileSize": 321,
          "hosts": ["....","....", ..... ],
          "database": "test_db",
          "table": "test_table",
          "forceLocalScheduling": false,
          "partitionName": "<UNPARTITIONED>",
          "deserializerClassName": "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
          "s3SelectPushdownEnabled": false
        }
      }
```

The catalog is also stored at top level in `SplitCompletedEvent`. 