### PR TITLE
Improve block serde for int, short, byte and int128 blocks

### DIFF
--- a/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -215,6 +217,11 @@ public class ByteArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedBuffer(values, arrayOffset, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ByteArrayBlockBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -285,6 +287,11 @@ public class ByteArrayBlockBuilder
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedBuffer(values, 0, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -223,6 +225,11 @@ public class Int128ArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(values, positionOffset * 2, positionCount * 2);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/Int128ArrayBlockBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -306,6 +308,11 @@ public class Int128ArrayBlockBuilder
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(values, 0, positionCount * 2);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -215,6 +217,11 @@ public class IntArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedIntArray(values, arrayOffset, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/IntArrayBlockBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -285,6 +287,11 @@ public class IntArrayBlockBuilder
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedIntArray(values, 0, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -215,6 +217,11 @@ public class ShortArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedShortArray(values, arrayOffset, positionCount);
     }
 
     private void checkReadablePosition(int position)

--- a/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/block/ShortArrayBlockBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -285,6 +287,11 @@ public class ShortArrayBlockBuilder
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
+    }
+
+    Slice getValuesSlice()
+    {
+        return Slices.wrappedShortArray(values, 0, positionCount);
     }
 
     private void checkReadablePosition(int position)


### PR DESCRIPTION
Benchmark from https://github.com/prestosql/presto/pull/5972 results:

edit: benchmarks moved to commit messages

Deserializing very sparse data (a lot of nulls) is slower than before. That was probably the case on long blocks too. I have few ideas to fixed it later.

