### PR TITLE
Fix Launcher failure when suite remaining time is zero

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -175,9 +175,15 @@ public final class TestRun
         @Override
         public Integer call()
         {
+            long timeoutMillis = timeout.toMillis();
+            if (timeoutMillis == 0) {
+                log.error("Timeout %s exhausted", timeout);
+                return ExitCode.SOFTWARE;
+            }
+
             try {
                 int exitCode = Failsafe
-                        .with(Timeout.of(java.time.Duration.ofMillis(timeout.toMillis()))
+                        .with(Timeout.of(java.time.Duration.ofMillis(timeoutMillis))
                                 .withCancel(true))
                         .get(this::tryExecuteTests);
 


### PR DESCRIPTION
`net.jodah.failsafe.Timeout.of()` only accepts values > 0 so we use the
smallest possible timeout to ensure we get a meaningful error