### PR TITLE
concat_ws fixes

### DIFF
--- a/presto-docs/src/main/sphinx/functions/list.rst
+++ b/presto-docs/src/main/sphinx/functions/list.rst
@@ -95,6 +95,7 @@ C
 - :func:`color`
 - :func:`combinations`
 - :func:`concat`
+- :func:`concat_ws`
 - :func:`contains`
 - :func:`contains_sequence`
 - :func:`convex_hull_agg`

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ConcatWsFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ConcatWsFunction.java
@@ -37,7 +37,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.util.Reflection.methodHandle;
 import static java.lang.Math.addExact;
@@ -101,7 +101,7 @@ public final class ConcatWsFunction
                         VARCHAR.getTypeSignature(),
                         ImmutableList.of(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()),
                         true),
-                true,
+                false,
                 ImmutableList.of(new FunctionArgumentDefinition(false), new FunctionArgumentDefinition(true)),
                 false,
                 true,
@@ -122,7 +122,7 @@ public final class ConcatWsFunction
 
         return new ChoicesScalarFunctionImplementation(
                 binding,
-                NULLABLE_RETURN,
+                FAIL_ON_NULL,
                 ImmutableList.<InvocationConvention.InvocationArgumentConvention>builder()
                         .add(NEVER_NULL)
                         .addAll(Collections.nCopies(valueCount, BOXED_NULLABLE))


### PR DESCRIPTION
The nullability declaration is wrong.  The function never returns null itself.  Instead, the first argument is marked as non-nullable, which causes the engine to return null for an invocation of the function when that argument is null, but that is part of the engine and not a behavior of the function.

Also, we missed adding this to the function index in the docs.