### PR TITLE
Require calling convention for scalar functions

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionDependencies.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionDependencies.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -107,7 +106,7 @@ public class FunctionDependencies
         return metadata.getFunctionMetadata(resolvedFunction);
     }
 
-    public FunctionInvoker getFunctionInvoker(QualifiedName name, List<Type> parameterTypes, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getFunctionInvoker(QualifiedName name, List<Type> parameterTypes, InvocationConvention invocationConvention)
     {
         FunctionKey functionKey = new FunctionKey(name, toTypeSignatures(parameterTypes));
         ResolvedFunction resolvedFunction = functions.get(functionKey);
@@ -117,7 +116,7 @@ public class FunctionDependencies
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }
 
-    public FunctionInvoker getFunctionSignatureInvoker(QualifiedName name, List<TypeSignature> parameterTypes, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getFunctionSignatureInvoker(QualifiedName name, List<TypeSignature> parameterTypes, InvocationConvention invocationConvention)
     {
         FunctionKey functionKey = new FunctionKey(name, parameterTypes);
         ResolvedFunction resolvedFunction = functions.get(functionKey);
@@ -127,7 +126,7 @@ public class FunctionDependencies
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }
 
-    public FunctionInvoker getOperatorInvoker(OperatorType operatorType, List<Type> parameterTypes, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getOperatorInvoker(OperatorType operatorType, List<Type> parameterTypes, InvocationConvention invocationConvention)
     {
         OperatorKey operatorKey = new OperatorKey(operatorType, toTypeSignatures(parameterTypes));
         ResolvedFunction resolvedFunction = operators.get(operatorKey);
@@ -137,7 +136,7 @@ public class FunctionDependencies
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }
 
-    public FunctionInvoker getOperatorSignatureInvoker(OperatorType operatorType, List<TypeSignature> parameterTypes, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getOperatorSignatureInvoker(OperatorType operatorType, List<TypeSignature> parameterTypes, InvocationConvention invocationConvention)
     {
         OperatorKey operatorKey = new OperatorKey(operatorType, parameterTypes);
         ResolvedFunction resolvedFunction = operators.get(operatorKey);
@@ -147,7 +146,7 @@ public class FunctionDependencies
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }
 
-    public FunctionInvoker getCastInvoker(Type fromType, Type toType, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getCastInvoker(Type fromType, Type toType, InvocationConvention invocationConvention)
     {
         CastKey castKey = new CastKey(fromType.getTypeSignature(), toType.getTypeSignature());
         ResolvedFunction resolvedFunction = casts.get(castKey);
@@ -157,7 +156,7 @@ public class FunctionDependencies
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }
 
-    public FunctionInvoker getCastSignatureInvoker(TypeSignature fromType, TypeSignature toType, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getCastSignatureInvoker(TypeSignature fromType, TypeSignature toType, InvocationConvention invocationConvention)
     {
         CastKey castKey = new CastKey(fromType, toType);
         ResolvedFunction resolvedFunction = casts.get(castKey);

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -548,7 +548,7 @@ public interface Metadata
 
     InternalAggregationFunction getAggregateFunctionImplementation(ResolvedFunction resolvedFunction);
 
-    FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, Optional<InvocationConvention> invocationConvention);
+    FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention);
 
     ProcedureRegistry getProcedureRegistry();
 

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -86,7 +86,6 @@ import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.expression.Variable;
 import io.prestosql.spi.function.InvocationConvention;
 import io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention;
-import io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.GrantInfo;
@@ -109,7 +108,6 @@ import io.prestosql.sql.planner.PartitioningHandle;
 import io.prestosql.sql.tree.QualifiedName;
 import io.prestosql.transaction.TransactionManager;
 import io.prestosql.type.BlockTypeOperators;
-import io.prestosql.type.FunctionType;
 import io.prestosql.type.InternalTypeManager;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -156,7 +154,6 @@ import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.prestosql.spi.connector.ConnectorViewDefinition.ViewColumn;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
-import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
@@ -1943,12 +1940,11 @@ public final class MetadataManager
     }
 
     @Override
-    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention)
     {
-        InvocationConvention expectedConvention = invocationConvention.orElseGet(() -> getDefaultCallingConvention(resolvedFunction));
         FunctionDependencies functionDependencies = new FunctionDependencies(this, resolvedFunction.getTypeDependencies(), resolvedFunction.getFunctionDependencies());
-        FunctionInvoker functionInvoker = functions.getScalarFunctionInvoker(toFunctionBinding(resolvedFunction), functionDependencies, expectedConvention);
-        verifyMethodHandleSignature(resolvedFunction.getSignature(), functionInvoker, expectedConvention);
+        FunctionInvoker functionInvoker = functions.getScalarFunctionInvoker(toFunctionBinding(resolvedFunction), functionDependencies, invocationConvention);
+        verifyMethodHandleSignature(resolvedFunction.getSignature(), functionInvoker, invocationConvention);
         return functionInvoker;
     }
 
@@ -2040,25 +2036,6 @@ public final class MetadataManager
         if (!check) {
             throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, format(message, args));
         }
-    }
-
-    /**
-     * Default calling convention is no nulls and null is never returned. Since the no nulls adaptation strategy is to fail, the scalar must have this
-     * exact convention or convention must be specified.
-     */
-    private InvocationConvention getDefaultCallingConvention(ResolvedFunction resolvedFunction)
-    {
-        FunctionMetadata functionMetadata = getFunctionMetadata(resolvedFunction);
-        List<InvocationArgumentConvention> argumentConventions = functionMetadata.getSignature().getArgumentTypes().stream()
-                .map(typeSignature -> typeSignature.getBase().equalsIgnoreCase(FunctionType.NAME) ? FUNCTION : NEVER_NULL)
-                .collect(toImmutableList());
-        InvocationReturnConvention returnConvention = functionMetadata.isNullable() ? NULLABLE_RETURN : FAIL_ON_NULL;
-
-        return new InvocationConvention(
-                argumentConventions,
-                returnConvention,
-                true,
-                false);
     }
 
     private FunctionBinding toFunctionBinding(ResolvedFunction resolvedFunction)

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -140,7 +140,7 @@ public abstract class AbstractMinMaxAggregationFunction
             invocationConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
         }
 
-        MethodHandle compareMethodHandle = getMinMaxCompare(functionDependencies, type, Optional.of(invocationConvention), min);
+        MethodHandle compareMethodHandle = getMinMaxCompare(functionDependencies, type, invocationConvention, min);
 
         return generateAggregation(type, compareMethodHandle);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateCountDistinctAggregation.java
@@ -24,6 +24,7 @@ import io.prestosql.spi.function.AggregationState;
 import io.prestosql.spi.function.BlockIndex;
 import io.prestosql.spi.function.BlockPosition;
 import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.Convention;
 import io.prestosql.spi.function.InputFunction;
 import io.prestosql.spi.function.OperatorDependency;
 import io.prestosql.spi.function.OutputFunction;
@@ -34,6 +35,8 @@ import io.prestosql.spi.type.StandardTypes;
 import java.lang.invoke.MethodHandle;
 
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.OperatorType.XX_HASH_64;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.util.Failures.checkCondition;
@@ -60,7 +63,11 @@ public final class ApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") long value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)
@@ -81,7 +88,11 @@ public final class ApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") double value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)
@@ -102,7 +113,11 @@ public final class ApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") Object value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -22,6 +22,7 @@ import io.prestosql.spi.function.AggregationState;
 import io.prestosql.spi.function.BlockIndex;
 import io.prestosql.spi.function.BlockPosition;
 import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.Convention;
 import io.prestosql.spi.function.InputFunction;
 import io.prestosql.spi.function.OperatorDependency;
 import io.prestosql.spi.function.OutputFunction;
@@ -31,6 +32,8 @@ import io.prestosql.spi.type.StandardTypes;
 
 import java.lang.invoke.MethodHandle;
 
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.OperatorType.XX_HASH_64;
 
 @AggregationFunction("approx_distinct")
@@ -52,7 +55,11 @@ public final class DefaultApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") long value)
     {
@@ -62,7 +69,11 @@ public final class DefaultApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") double value)
     {
@@ -72,7 +83,11 @@ public final class DefaultApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
-            @OperatorDependency(operator = XX_HASH_64, argumentTypes = "T") MethodHandle methodHandle,
+            @OperatorDependency(
+                    operator = XX_HASH_64,
+                    argumentTypes = "T",
+                    convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                    MethodHandle methodHandle,
             @AggregationState HyperLogLogState state,
             @SqlType("T") Object value)
     {

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/minmaxby/AbstractMinMaxBy.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/minmaxby/AbstractMinMaxBy.java
@@ -77,6 +77,9 @@ import static io.prestosql.operator.aggregation.AggregationMetadata.ParameterMet
 import static io.prestosql.operator.aggregation.AggregationUtils.generateAggregationName;
 import static io.prestosql.operator.aggregation.minmaxby.TwoNullableValueStateMapping.getStateClass;
 import static io.prestosql.operator.aggregation.minmaxby.TwoNullableValueStateMapping.getStateSerializer;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.prestosql.spi.function.InvocationConvention.simpleConvention;
 import static io.prestosql.spi.function.OperatorType.COMPARISON;
 import static io.prestosql.sql.gen.BytecodeUtils.loadConstant;
 import static io.prestosql.sql.gen.SqlTypeBytecodeExpression.constantType;
@@ -178,7 +181,7 @@ public abstract class AbstractMinMaxBy
         List<Type> inputTypes = ImmutableList.of(valueType, keyType);
 
         CallSiteBinder binder = new CallSiteBinder();
-        MethodHandle compareMethod = MinMaxCompare.getMinMaxCompare(functionDependencies, keyType, Optional.empty(), min);
+        MethodHandle compareMethod = MinMaxCompare.getMinMaxCompare(functionDependencies, keyType, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL), min);
 
         ClassDefinition definition = new ClassDefinition(
                 a(PUBLIC, FINAL),

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/CastImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/CastImplementationDependency.java
@@ -21,7 +21,6 @@ import io.prestosql.spi.function.InvocationConvention;
 import io.prestosql.spi.type.TypeSignature;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import static io.prestosql.metadata.SignatureBinder.applyBoundVariables;
 import static java.util.Objects.requireNonNull;
@@ -32,7 +31,7 @@ public final class CastImplementationDependency
     private final TypeSignature fromType;
     private final TypeSignature toType;
 
-    public CastImplementationDependency(TypeSignature fromType, TypeSignature toType, Optional<InvocationConvention> invocationConvention, Class<?> type)
+    public CastImplementationDependency(TypeSignature fromType, TypeSignature toType, InvocationConvention invocationConvention, Class<?> type)
     {
         super(invocationConvention, type);
         this.fromType = requireNonNull(fromType, "fromType is null");
@@ -56,7 +55,7 @@ public final class CastImplementationDependency
     }
 
     @Override
-    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, Optional<InvocationConvention> invocationConvention)
+    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, InvocationConvention invocationConvention)
     {
         TypeSignature from = applyBoundVariables(fromType, functionBinding);
         TypeSignature to = applyBoundVariables(toType, functionBinding);

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/FunctionImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/FunctionImplementationDependency.java
@@ -23,7 +23,6 @@ import io.prestosql.sql.tree.QualifiedName;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static io.prestosql.metadata.SignatureBinder.applyBoundVariables;
 import static java.util.Objects.requireNonNull;
@@ -34,7 +33,7 @@ public final class FunctionImplementationDependency
     private final QualifiedName name;
     private final List<TypeSignature> argumentTypes;
 
-    public FunctionImplementationDependency(QualifiedName name, List<TypeSignature> argumentTypes, Optional<InvocationConvention> invocationConvention, Class<?> type)
+    public FunctionImplementationDependency(QualifiedName name, List<TypeSignature> argumentTypes, InvocationConvention invocationConvention, Class<?> type)
     {
         super(invocationConvention, type);
         this.name = requireNonNull(name, "name is null");
@@ -48,7 +47,7 @@ public final class FunctionImplementationDependency
     }
 
     @Override
-    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, Optional<InvocationConvention> invocationConvention)
+    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, InvocationConvention invocationConvention)
     {
         List<TypeSignature> types = applyBoundVariables(argumentTypes, functionBinding);
         return functionDependencies.getFunctionSignatureInvoker(name, types, invocationConvention);

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/ImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/ImplementationDependency.java
@@ -142,14 +142,11 @@ public interface ImplementationDependency
             throw new IllegalArgumentException("Unsupported annotation " + annotation.getClass().getSimpleName());
         }
 
-        private static Optional<InvocationConvention> toInvocationConvention(Convention convention)
+        private static InvocationConvention toInvocationConvention(Convention convention)
         {
-            if (convention.$notSpecified()) {
-                return Optional.empty();
-            }
             List<InvocationConvention.InvocationArgumentConvention> argumentConventions = new ArrayList<>();
             Collections.addAll(argumentConventions, convention.arguments());
-            return Optional.of(new InvocationConvention(argumentConventions, convention.result(), convention.session(), false));
+            return new InvocationConvention(argumentConventions, convention.result(), convention.session(), false);
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/OperatorImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/OperatorImplementationDependency.java
@@ -24,7 +24,6 @@ import io.prestosql.spi.type.TypeSignature;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.metadata.SignatureBinder.applyBoundVariables;
@@ -38,7 +37,7 @@ public final class OperatorImplementationDependency
     private final OperatorType operator;
     private final List<TypeSignature> argumentTypes;
 
-    public OperatorImplementationDependency(OperatorType operator, List<TypeSignature> argumentTypes, Optional<InvocationConvention> invocationConvention, Class<?> type)
+    public OperatorImplementationDependency(OperatorType operator, List<TypeSignature> argumentTypes, InvocationConvention invocationConvention, Class<?> type)
     {
         super(invocationConvention, type);
         this.operator = requireNonNull(operator, "operator is null");
@@ -63,7 +62,7 @@ public final class OperatorImplementationDependency
     }
 
     @Override
-    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, Optional<InvocationConvention> invocationConvention)
+    protected FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, InvocationConvention invocationConvention)
     {
         List<TypeSignature> types = applyBoundVariables(argumentTypes, functionBinding);
         return functionDependencies.getOperatorSignatureInvoker(operator, types, invocationConvention);

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/ScalarImplementationDependency.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/ScalarImplementationDependency.java
@@ -20,26 +20,25 @@ import io.prestosql.spi.function.InvocationConvention;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 public abstract class ScalarImplementationDependency
         implements ImplementationDependency
 {
-    private final Optional<InvocationConvention> invocationConvention;
+    private final InvocationConvention invocationConvention;
     private final Class<?> type;
 
-    protected ScalarImplementationDependency(Optional<InvocationConvention> invocationConvention, Class<?> type)
+    protected ScalarImplementationDependency(InvocationConvention invocationConvention, Class<?> type)
     {
         this.invocationConvention = requireNonNull(invocationConvention, "invocationConvention is null");
         this.type = requireNonNull(type, "type is null");
-        if (invocationConvention.map(InvocationConvention::supportsInstanceFactor).orElse(false)) {
+        if (invocationConvention.supportsInstanceFactor()) {
             throw new IllegalArgumentException(getClass().getSimpleName() + " does not support instance functions");
         }
     }
 
-    protected abstract FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, Optional<InvocationConvention> invocationConvention);
+    protected abstract FunctionInvoker getInvoker(FunctionBinding functionBinding, FunctionDependencies functionDependencies, InvocationConvention invocationConvention);
 
     @Override
     public Object resolve(FunctionBinding functionBinding, FunctionDependencies functionDependencies)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/AbstractGreatestLeast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/AbstractGreatestLeast.java
@@ -37,7 +37,6 @@ import io.prestosql.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -58,7 +57,10 @@ import static io.prestosql.metadata.FunctionKind.SCALAR;
 import static io.prestosql.metadata.Signature.orderableTypeParameter;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.prestosql.spi.function.InvocationConvention.simpleConvention;
 import static io.prestosql.spi.function.OperatorType.COMPARISON;
 import static io.prestosql.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static io.prestosql.util.CompilerUtils.defineClass;
@@ -108,7 +110,7 @@ public abstract class AbstractGreatestLeast
         Type type = functionBinding.getTypeVariable("E");
         checkArgument(type.isOrderable(), "Type must be orderable");
 
-        MethodHandle compareMethod = getMinMaxCompare(functionDependencies, type, Optional.empty(), min);
+        MethodHandle compareMethod = getMinMaxCompare(functionDependencies, type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL), min);
 
         List<Class<?>> javaTypes = IntStream.range(0, functionBinding.getArity())
                 .mapToObj(i -> wrap(type.getJavaType()))

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayJoin.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayJoin.java
@@ -184,7 +184,7 @@ public final class ArrayJoin
         else {
             try {
                 InvocationConvention convention = new InvocationConvention(ImmutableList.of(BLOCK_POSITION), NULLABLE_RETURN, true, false);
-                MethodHandle cast = functionDependencies.getCastInvoker(type, VARCHAR, Optional.of(convention)).getMethodHandle();
+                MethodHandle cast = functionDependencies.getCastInvoker(type, VARCHAR, convention).getMethodHandle();
 
                 // if the cast doesn't take a ConnectorSession, create an adapter that drops the provided session
                 if (cast.type().parameterArray()[0] != ConnectorSession.class) {

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayToArrayCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/ArrayToArrayCast.java
@@ -38,7 +38,6 @@ import io.prestosql.sql.gen.CachedInstanceBinder;
 import io.prestosql.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -90,7 +89,7 @@ public class ArrayToArrayCast
         Type toType = functionBinding.getTypeVariable("T");
 
         FunctionMetadata castMetadata = functionDependencies.getCastMetadata(fromType, toType);
-        Function<InvocationConvention, FunctionInvoker> castInvokerProvider = invocationConvention -> functionDependencies.getCastInvoker(fromType, toType, Optional.of(invocationConvention));
+        Function<InvocationConvention, FunctionInvoker> castInvokerProvider = invocationConvention -> functionDependencies.getCastInvoker(fromType, toType, invocationConvention);
         Class<?> castOperatorClass = generateArrayCast(fromType, toType, castMetadata, castInvokerProvider);
         MethodHandle methodHandle = methodHandle(castOperatorClass, "castArray", ConnectorSession.class, Block.class);
         return new ChoicesScalarFunctionImplementation(

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/FormatFunction.java
@@ -43,7 +43,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.IllegalFormatException;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -54,6 +53,7 @@ import static io.prestosql.metadata.Signature.withVariadicBound;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.prestosql.spi.function.InvocationConvention.simpleConvention;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.Chars.padSpaces;
@@ -217,7 +217,7 @@ public final class FormatFunction
         }
         // TODO: support TIME WITH TIME ZONE by https://github.com/prestosql/presto/issues/191 + mapping to java.time.OffsetTime
         if (type.equals(JSON)) {
-            MethodHandle handle = functionDependencies.getFunctionInvoker(QualifiedName.of("json_format"), ImmutableList.of(JSON), Optional.empty()).getMethodHandle();
+            MethodHandle handle = functionDependencies.getFunctionInvoker(QualifiedName.of("json_format"), ImmutableList.of(JSON), simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
             return (session, block) -> convertToString(handle, type.getSlice(block, position));
         }
         if (isShortDecimal(type)) {
@@ -253,7 +253,7 @@ public final class FormatFunction
             function = (session, block) -> type.getObject(block, position);
         }
 
-        MethodHandle handle = functionDependencies.getCastInvoker(type, VARCHAR, Optional.empty()).getMethodHandle();
+        MethodHandle handle = functionDependencies.getCastInvoker(type, VARCHAR, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
         return (session, block) -> convertToString(handle, function.apply(session, block));
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/MapElementAtFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/MapElementAtFunction.java
@@ -29,7 +29,6 @@ import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static io.prestosql.metadata.FunctionKind.SCALAR;
 import static io.prestosql.metadata.Signature.typeVariable;
@@ -45,10 +44,10 @@ public class MapElementAtFunction
 {
     public static final MapElementAtFunction MAP_ELEMENT_AT = new MapElementAtFunction();
 
-    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(MapElementAtFunction.class, "elementAt", MethodHandle.class, Type.class, Type.class, Block.class, boolean.class);
-    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(MapElementAtFunction.class, "elementAt", MethodHandle.class, Type.class, Type.class, Block.class, long.class);
-    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(MapElementAtFunction.class, "elementAt", MethodHandle.class, Type.class, Type.class, Block.class, double.class);
-    private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(MapElementAtFunction.class, "elementAt", MethodHandle.class, Type.class, Type.class, Block.class, Object.class);
+    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(MapElementAtFunction.class, "elementAt", Type.class, Block.class, boolean.class);
+    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(MapElementAtFunction.class, "elementAt", Type.class, Block.class, long.class);
+    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(MapElementAtFunction.class, "elementAt", Type.class, Block.class, double.class);
+    private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(MapElementAtFunction.class, "elementAt", Type.class, Block.class, Object.class);
 
     protected MapElementAtFunction()
     {
@@ -84,8 +83,6 @@ public class MapElementAtFunction
         Type keyType = functionBinding.getTypeVariable("K");
         Type valueType = functionBinding.getTypeVariable("V");
 
-        MethodHandle keyEqualsMethod = functionDependencies.getOperatorInvoker(EQUAL, ImmutableList.of(keyType, keyType), Optional.empty()).getMethodHandle();
-
         MethodHandle methodHandle;
         if (keyType.getJavaType() == boolean.class) {
             methodHandle = METHOD_HANDLE_BOOLEAN;
@@ -99,7 +96,7 @@ public class MapElementAtFunction
         else {
             methodHandle = METHOD_HANDLE_OBJECT;
         }
-        methodHandle = methodHandle.bindTo(keyEqualsMethod).bindTo(keyType).bindTo(valueType);
+        methodHandle = methodHandle.bindTo(valueType);
         methodHandle = methodHandle.asType(methodHandle.type().changeReturnType(Primitives.wrap(valueType.getJavaType())));
 
         return new ChoicesScalarFunctionImplementation(
@@ -110,7 +107,7 @@ public class MapElementAtFunction
     }
 
     @UsedByGeneratedCode
-    public static Object elementAt(MethodHandle keyEqualsMethod, Type keyType, Type valueType, Block map, boolean key)
+    public static Object elementAt(Type valueType, Block map, boolean key)
     {
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition = mapBlock.seekKeyExact(key);
@@ -121,7 +118,7 @@ public class MapElementAtFunction
     }
 
     @UsedByGeneratedCode
-    public static Object elementAt(MethodHandle keyEqualsMethod, Type keyType, Type valueType, Block map, long key)
+    public static Object elementAt(Type valueType, Block map, long key)
     {
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition = mapBlock.seekKeyExact(key);
@@ -132,7 +129,7 @@ public class MapElementAtFunction
     }
 
     @UsedByGeneratedCode
-    public static Object elementAt(MethodHandle keyEqualsMethod, Type keyType, Type valueType, Block map, double key)
+    public static Object elementAt(Type valueType, Block map, double key)
     {
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition = mapBlock.seekKeyExact(key);
@@ -143,7 +140,7 @@ public class MapElementAtFunction
     }
 
     @UsedByGeneratedCode
-    public static Object elementAt(MethodHandle keyEqualsMethod, Type keyType, Type valueType, Block map, Object key)
+    public static Object elementAt(Type valueType, Block map, Object key)
     {
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition = mapBlock.seekKeyExact(key);

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/MapSubscriptOperator.java
@@ -32,12 +32,13 @@ import io.prestosql.spi.type.TypeSignature;
 import io.prestosql.sql.InterpretedFunctionInvoker;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static io.prestosql.metadata.Signature.typeVariable;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.prestosql.spi.function.InvocationConvention.simpleConvention;
 import static io.prestosql.spi.function.OperatorType.SUBSCRIPT;
 import static io.prestosql.spi.type.TypeSignature.mapType;
 import static io.prestosql.spi.type.TypeUtils.readNativeValue;
@@ -156,7 +157,7 @@ public class MapSubscriptOperator
             FunctionInvoker castFunction = null;
             try {
                 castMetadata = functionDependencies.getCastMetadata(keyType, VARCHAR);
-                castFunction = functionDependencies.getCastInvoker(keyType, VARCHAR, Optional.empty());
+                castFunction = functionDependencies.getCastInvoker(keyType, VARCHAR, simpleConvention(FAIL_ON_NULL, NEVER_NULL));
             }
             catch (PrestoException ignored) {
             }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/MapToMapCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/MapToMapCast.java
@@ -35,7 +35,6 @@ import io.prestosql.type.BlockTypeOperators.BlockPositionHashCode;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -130,7 +129,7 @@ public final class MapToMapCast
         // Get block position cast, with optional connector session
         FunctionMetadata functionMetadata = functionDependencies.getCastMetadata(fromType, toType);
         InvocationConvention invocationConvention = new InvocationConvention(ImmutableList.of(BLOCK_POSITION), functionMetadata.isNullable() ? NULLABLE_RETURN : FAIL_ON_NULL, true, false);
-        MethodHandle cast = functionDependencies.getCastInvoker(fromType, toType, Optional.of(invocationConvention)).getMethodHandle();
+        MethodHandle cast = functionDependencies.getCastInvoker(fromType, toType, invocationConvention).getMethodHandle();
         // Normalize cast to have connector session as first argument
         if (cast.type().parameterArray()[0] != ConnectorSession.class) {
             cast = MethodHandles.dropArguments(cast, 0, ConnectorSession.class);

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/RowToRowCast.java
@@ -48,7 +48,6 @@ import io.prestosql.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -176,7 +175,7 @@ public class RowToRowCast
             Type toElementType = toTypes.get(i);
             FunctionMetadata castMetadata = functionDependencies.getCastMetadata(fromElementType, toElementType);
             Function<InvocationConvention, FunctionInvoker> castInvokerProvider = invocationConvention ->
-                    functionDependencies.getCastInvoker(fromElementType, toElementType, Optional.of(invocationConvention));
+                    functionDependencies.getCastInvoker(fromElementType, toElementType, invocationConvention);
 
             Type currentFromType = fromElementType;
             if (currentFromType.equals(UNKNOWN)) {

--- a/presto-main/src/main/java/io/prestosql/sql/InterpretedFunctionInvoker.java
+++ b/presto-main/src/main/java/io/prestosql/sql/InterpretedFunctionInvoker.java
@@ -27,7 +27,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
@@ -61,7 +60,7 @@ public class InterpretedFunctionInvoker
     public Object invoke(ResolvedFunction function, ConnectorSession session, List<Object> arguments)
     {
         FunctionMetadata functionMetadata = metadata.getFunctionMetadata(function);
-        FunctionInvoker invoker = metadata.getScalarFunctionInvoker(function, Optional.of(getInvocationConvention(function, functionMetadata)));
+        FunctionInvoker invoker = metadata.getScalarFunctionInvoker(function, getInvocationConvention(function, functionMetadata));
         return invoke(functionMetadata, invoker, session, arguments);
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeGeneratorContext.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeGeneratorContext.java
@@ -77,8 +77,7 @@ public class BytecodeGeneratorContext
         return rowExpressionCompiler.compile(expression, scope);
     }
 
-    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction,
-            Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention)
     {
         return metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
     }

--- a/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BytecodeUtils.java
@@ -181,7 +181,7 @@ public final class BytecodeUtils
         return generateInvocation(
                 scope,
                 metadata.getFunctionMetadata(resolvedFunction),
-                invocationConvention -> metadata.getScalarFunctionInvoker(resolvedFunction, Optional.of(invocationConvention)),
+                invocationConvention -> metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention),
                 arguments,
                 binder);
     }
@@ -225,7 +225,7 @@ public final class BytecodeUtils
         return generateFullInvocation(
                 scope,
                 metadata.getFunctionMetadata(resolvedFunction),
-                invocationConvention -> metadata.getScalarFunctionInvoker(resolvedFunction, Optional.of(invocationConvention)),
+                invocationConvention -> metadata.getScalarFunctionInvoker(resolvedFunction, invocationConvention),
                 instanceFactory,
                 argumentCompilers,
                 binder);

--- a/presto-main/src/main/java/io/prestosql/util/MinMaxCompare.java
+++ b/presto-main/src/main/java/io/prestosql/util/MinMaxCompare.java
@@ -22,7 +22,6 @@ import io.prestosql.type.BlockTypeOperators.BlockPositionComparison;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
-import java.util.Optional;
 
 import static io.prestosql.spi.function.OperatorType.COMPARISON;
 import static io.prestosql.spi.type.DoubleType.DOUBLE;
@@ -41,7 +40,7 @@ public final class MinMaxCompare
 
     private MinMaxCompare() {}
 
-    public static MethodHandle getMinMaxCompare(FunctionDependencies dependencies, Type type, Optional<InvocationConvention> convention, boolean min)
+    public static MethodHandle getMinMaxCompare(FunctionDependencies dependencies, Type type, InvocationConvention convention, boolean min)
     {
         if (!min && type.equals(REAL)) {
             return MAX_REAL_FUNCTION;

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -723,7 +723,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, Optional<InvocationConvention> invocationConvention)
+    public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/io/prestosql/operator/TestAnnotationEngineForAggregates.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestAnnotationEngineForAggregates.java
@@ -44,6 +44,7 @@ import io.prestosql.spi.function.AggregationState;
 import io.prestosql.spi.function.BlockIndex;
 import io.prestosql.spi.function.BlockPosition;
 import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.Convention;
 import io.prestosql.spi.function.Description;
 import io.prestosql.spi.function.InputFunction;
 import io.prestosql.spi.function.LiteralParameter;
@@ -72,6 +73,8 @@ import static io.prestosql.operator.aggregation.AggregationFromAnnotationsParser
 import static io.prestosql.operator.aggregation.AggregationFromAnnotationsParser.parseFunctionDefinitions;
 import static io.prestosql.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
 import static io.prestosql.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.OperatorType.LESS_THAN;
 import static io.prestosql.spi.type.StandardTypes.ARRAY;
 import static io.prestosql.spi.type.StandardTypes.DOUBLE;
@@ -739,7 +742,11 @@ public class TestAnnotationEngineForAggregates
     {
         @InputFunction
         public static void input(
-                @OperatorDependency(operator = LESS_THAN, argumentTypes = {DOUBLE, DOUBLE}) MethodHandle methodHandle,
+                @OperatorDependency(
+                        operator = LESS_THAN,
+                        argumentTypes = {DOUBLE, DOUBLE},
+                        convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = FAIL_ON_NULL))
+                        MethodHandle methodHandle,
                 @AggregationState NullableDoubleState state,
                 @SqlType(DOUBLE) double value)
         {
@@ -748,7 +755,11 @@ public class TestAnnotationEngineForAggregates
 
         @CombineFunction
         public static void combine(
-                @OperatorDependency(operator = LESS_THAN, argumentTypes = {DOUBLE, DOUBLE}) MethodHandle methodHandle,
+                @OperatorDependency(
+                        operator = LESS_THAN,
+                        argumentTypes = {DOUBLE, DOUBLE},
+                        convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = FAIL_ON_NULL))
+                        MethodHandle methodHandle,
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
@@ -757,7 +768,11 @@ public class TestAnnotationEngineForAggregates
 
         @OutputFunction(DOUBLE)
         public static void output(
-                @OperatorDependency(operator = LESS_THAN, argumentTypes = {DOUBLE, DOUBLE}) MethodHandle methodHandle,
+                @OperatorDependency(
+                        operator = LESS_THAN,
+                        argumentTypes = {DOUBLE, DOUBLE},
+                        convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = FAIL_ON_NULL))
+                        MethodHandle methodHandle,
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
@@ -180,7 +180,7 @@ public class TestEffectivePredicateExtractor
         }
 
         @Override
-        public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, Optional<InvocationConvention> invocationConvention)
+        public FunctionInvoker getScalarFunctionInvoker(ResolvedFunction resolvedFunction, InvocationConvention invocationConvention)
         {
             return delegate.getScalarFunctionInvoker(resolvedFunction, invocationConvention);
         }

--- a/presto-main/src/test/java/io/prestosql/type/TestCastDependencies.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestCastDependencies.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.prestosql.operator.scalar.AbstractTestFunctions;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.function.CastDependency;
+import io.prestosql.spi.function.Convention;
 import io.prestosql.spi.function.OperatorDependency;
 import io.prestosql.spi.function.ScalarFunction;
 import io.prestosql.spi.function.SqlType;
@@ -29,6 +30,9 @@ import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.IntegerType.INTEGER;
@@ -60,7 +64,11 @@ public class TestCastDependencies
     {
         @SqlType(StandardTypes.INTEGER)
         public static long castVarcharToInteger(
-                @CastDependency(fromType = StandardTypes.VARCHAR, toType = StandardTypes.INTEGER) MethodHandle cast,
+                @CastDependency(
+                        fromType = StandardTypes.VARCHAR,
+                        toType = StandardTypes.INTEGER,
+                        convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                        MethodHandle cast,
                 @SqlType(StandardTypes.VARCHAR) Slice value)
         {
             try {
@@ -80,7 +88,11 @@ public class TestCastDependencies
         @TypeParameter("V")
         @SqlType(StandardTypes.VARCHAR)
         public static Slice castAnyToVarchar(
-                @CastDependency(fromType = "V", toType = StandardTypes.VARCHAR) MethodHandle cast,
+                @CastDependency(
+                        fromType = "V",
+                        toType = StandardTypes.VARCHAR,
+                        convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                        MethodHandle cast,
                 @SqlType("V") long value)
         {
             try {
@@ -100,8 +112,16 @@ public class TestCastDependencies
         @TypeParameter("V")
         @SqlType(StandardTypes.BOOLEAN)
         public static boolean castAnyFromVarchar(
-                @CastDependency(fromType = StandardTypes.VARCHAR, toType = "V") MethodHandle cast,
-                @OperatorDependency(operator = EQUAL, argumentTypes = {"V", "V"}) MethodHandle equals,
+                @CastDependency(
+                        fromType = StandardTypes.VARCHAR,
+                        toType = "V",
+                        convention = @Convention(arguments = NEVER_NULL, result = FAIL_ON_NULL))
+                        MethodHandle cast,
+                @OperatorDependency(
+                        operator = EQUAL,
+                        argumentTypes = {"V", "V"},
+                        convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = NULLABLE_RETURN))
+                        MethodHandle equals,
                 @SqlType("V") long left,
                 @SqlType(StandardTypes.VARCHAR) Slice right)
         {

--- a/presto-main/src/test/java/io/prestosql/type/TestMapOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestMapOperators.java
@@ -819,6 +819,7 @@ public class TestMapOperators
     @Test
     public void testMapToMapCast()
     {
+        assertFunction("CAST(MAP(ARRAY[1], ARRAY[MAP(ARRAY[1.0E0], ARRAY[false])]) AS MAP<varchar, MAP(bigint,bigint)>)", mapType(VARCHAR, mapType(BIGINT, BIGINT)), ImmutableMap.of("1", ImmutableMap.of(1L, 0L)));
         assertFunction("CAST(MAP(ARRAY['1', '100'], ARRAY[true, false]) AS MAP<varchar,bigint>)", mapType(VARCHAR, BIGINT), ImmutableMap.of("1", 1L, "100", 0L));
         assertFunction("CAST(MAP(ARRAY[1,2], ARRAY[1,2]) AS MAP<bigint, boolean>)", mapType(BIGINT, BOOLEAN), ImmutableMap.of(1L, true, 2L, true));
         assertFunction("CAST(MAP(ARRAY[1,2], ARRAY[array[1],array[2]]) AS MAP<bigint, array<boolean>>)", mapType(BIGINT, new ArrayType(BOOLEAN)), ImmutableMap.of(1L, ImmutableList.of(true), 2L, ImmutableList.of(true)));

--- a/presto-spi/src/main/java/io/prestosql/spi/function/CastDependency.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/function/CastDependency.java
@@ -16,7 +16,6 @@ package io.prestosql.spi.function;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -28,5 +27,5 @@ public @interface CastDependency
 
     String toType();
 
-    Convention convention() default @Convention($notSpecified = true, arguments = {}, result = FAIL_ON_NULL);
+    Convention convention();
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/function/Convention.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/function/Convention.java
@@ -23,6 +23,4 @@ public @interface Convention
     InvocationReturnConvention result();
 
     boolean session() default false;
-
-    boolean $notSpecified() default false;
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/function/FunctionDependency.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/function/FunctionDependency.java
@@ -16,7 +16,6 @@ package io.prestosql.spi.function;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -28,5 +27,5 @@ public @interface FunctionDependency
 
     String[] argumentTypes();
 
-    Convention convention() default @Convention($notSpecified = true, arguments = {}, result = FAIL_ON_NULL);
+    Convention convention();
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/function/OperatorDependency.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/function/OperatorDependency.java
@@ -16,7 +16,6 @@ package io.prestosql.spi.function;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -28,5 +27,5 @@ public @interface OperatorDependency
 
     String[] argumentTypes();
 
-    Convention convention() default @Convention($notSpecified = true, arguments = {}, result = FAIL_ON_NULL);
+    Convention convention();
 }

--- a/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataStringFunctions.java
+++ b/presto-teradata-functions/src/main/java/io/prestosql/teradata/functions/TeradataStringFunctions.java
@@ -17,6 +17,7 @@ import com.google.common.io.BaseEncoding;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.function.Convention;
 import io.prestosql.spi.function.Description;
 import io.prestosql.spi.function.FunctionDependency;
 import io.prestosql.spi.function.ScalarFunction;
@@ -27,6 +28,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static java.nio.charset.StandardCharsets.UTF_16BE;
 
 public final class TeradataStringFunctions
@@ -39,7 +42,8 @@ public final class TeradataStringFunctions
     public static long index(
             @FunctionDependency(
                     name = "strpos",
-                    argumentTypes = {StandardTypes.VARCHAR, StandardTypes.VARCHAR})
+                    argumentTypes = {StandardTypes.VARCHAR, StandardTypes.VARCHAR},
+                    convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = FAIL_ON_NULL))
                     MethodHandle method,
             @SqlType(StandardTypes.VARCHAR) Slice string,
             @SqlType(StandardTypes.VARCHAR) Slice substring)


### PR DESCRIPTION
Implicit calling conventions are not well defined.  For example, a caller must know that hash code will never return null, whereas equals is nullable. This PR requires explicit declaration of calling conventions when fetching a function implementation.  This also lets the reader know exactly how the function should be invoked, and if another invocation style is better, it is obvious that you can simply change this.