### PR TITLE
Improve readability of product tests execution logs

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/SuiteDescribe.java
@@ -153,7 +153,7 @@ public class SuiteDescribe
         {
             TestRun.TestRunOptions testRunOptions = new TestRun.TestRunOptions();
             testRunOptions.environment = suiteTestRun.getEnvironmentName();
-            testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments(environmentConfig);
+            testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments();
             testRunOptions.testJar = testJar;
             testRunOptions.reportsDir = Paths.get(format("presto-product-tests/target/%s/%s/%s", suiteName, environmentConfig.getConfigName(), suiteTestRun.getEnvironmentName()));
             testRunOptions.startupRetries = null;

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/cli/TestRun.java
@@ -225,7 +225,7 @@ public final class TestRun
                         .collect(toImmutableList());
                 testsContainer.dependsOn(environmentContainers);
 
-                log.info("Starting the environment '%s' with configuration %s", this.environment, environmentConfig);
+                log.info("Starting environment '%s' with config '%s'", this.environment, environmentConfig.getConfigName());
                 environment.start();
             }
             else {

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteTestRun.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/SuiteTestRun.java
@@ -89,7 +89,7 @@ public class SuiteTestRun
                 .build();
     }
 
-    public List<String> getTemptoRunArguments(EnvironmentConfig environmentConfig)
+    public List<String> getTemptoRunArguments()
     {
         ImmutableList.Builder<String> arguments = ImmutableList.builder();
         Joiner joiner = Joiner.on(",");
@@ -98,7 +98,6 @@ public class SuiteTestRun
             arguments.add(TEMPTO_GROUP_ARG, joiner.join(groups));
         }
 
-        Iterable<String> excludedGroups = Iterables.concat(getExcludedGroups(), environmentConfig.getExcludedGroups());
         if (!Iterables.isEmpty(excludedGroups)) {
             arguments.add(TEMPTO_EXCLUDE_GROUP_ARG, joiner.join(excludedGroups));
         }
@@ -107,12 +106,26 @@ public class SuiteTestRun
             arguments.add(TEMPTO_TEST_ARG, joiner.join(tests));
         }
 
-        Iterable<String> excludedTests = Iterables.concat(getExcludedTests(), environmentConfig.getExcludedTests());
         if (!Iterables.isEmpty(excludedTests)) {
             arguments.add(TEMPTO_EXCLUDE_TEST_ARG, joiner.join(excludedTests));
         }
 
         return arguments.build();
+    }
+
+    public SuiteTestRun withConfigApplied(EnvironmentConfig config)
+    {
+        return new SuiteTestRun(
+                environment,
+                getGroups(),
+                merge(getExcludedGroups(), config.getExcludedGroups()),
+                getTests(),
+                merge(getExcludedTests(), config.getExcludedTests()));
+    }
+
+    private static List<String> merge(List<String> first, List<String> second)
+    {
+        return ImmutableList.copyOf(Iterables.concat(first, second));
     }
 
     @Override

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/util/ConsoleTable.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/util/ConsoleTable.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.util;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static io.prestosql.tests.product.launcher.util.ConsoleTable.Alignment.RIGHT;
+import static java.util.Objects.requireNonNull;
+
+public class ConsoleTable
+{
+    private ImmutableList.Builder<TableElement> builder = ImmutableList.builder();
+
+    public void addSeparator()
+    {
+        builder.add(new TableSeparator());
+    }
+
+    public void addHeader(Object... values)
+    {
+        builder.add(new TableSeparator(), new TableRow(RIGHT, values), new TableSeparator());
+    }
+
+    public void addRow(Object... values)
+    {
+        builder.add(new TableRow(RIGHT, values));
+    }
+
+    public void addRow(Alignment alignment, Object... values)
+    {
+        builder.add(new TableRow(alignment, values));
+    }
+
+    public String render()
+    {
+        List<TableElement> elements = builder.build();
+        int[] columnsWidth = columnsWidth(elements);
+
+        return elements.stream()
+                .map(element -> element.render(columnsWidth))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private int[] columnsWidth(List<TableElement> elements)
+    {
+        int numberOfColumns = columns(elements);
+        int[] widths = new int[numberOfColumns];
+
+        for (TableElement element : elements) {
+            if (element instanceof TableRow) {
+                int[] columnsLength = ((TableRow) element).columnsLength();
+                for (int i = 0; i < ((TableRow) element).getColumns(); i++) {
+                    widths[i] = Integer.max(widths[i], columnsLength[i]);
+                }
+            }
+        }
+
+        return widths;
+    }
+
+    private int columns(List<TableElement> elements)
+    {
+        return elements.stream()
+                .filter(element -> element instanceof TableRow)
+                .map(element -> (TableRow) element)
+                .map(TableRow::getColumns)
+                .max(Integer::compareTo)
+                .orElse(0);
+    }
+
+    @Override
+    public String toString()
+    {
+        return render();
+    }
+
+    private interface TableElement
+    {
+        String render(int[] columnLengths);
+    }
+
+    private static class TableRow
+            implements TableElement
+    {
+        private final Object[] values;
+        private final int columns;
+        private final Alignment alignment;
+
+        public TableRow(Alignment alignment, Object[] values)
+        {
+            this.values = requireNonNull(values, "values is null");
+            this.alignment = alignment;
+            this.columns = this.values.length;
+        }
+
+        public Object getValue(int column)
+        {
+            if (column < 0 || column >= getColumns()) {
+                return "";
+            }
+
+            return values[column];
+        }
+
+        public int getColumns()
+        {
+            return columns;
+        }
+
+        public int columnLength(int column)
+        {
+            return getValue(column).toString().length();
+        }
+
+        public int[] columnsLength()
+        {
+            int[] lengths = new int[columns];
+
+            for (int i = 0; i < columns; i++) {
+                lengths[i] = columnLength(i);
+            }
+            return lengths;
+        }
+
+        @Override
+        public String render(int[] columnsWidth)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            for (int i = 0; i < columnsWidth.length; i++) {
+                builder.append("|").append(" " + pad(getValue(i), columnsWidth[i], alignment) + " ");
+                if (i == columnsWidth.length - 1) {
+                    builder.append("|");
+                }
+            }
+
+            return builder.toString();
+        }
+
+        private String pad(Object obj, int length, Alignment alignment)
+        {
+            String value = Objects.toString(obj);
+            if (value.length() < length) {
+                int diff = length - value.length();
+
+                switch (alignment) {
+                    case LEFT:
+                        return Strings.padEnd(value, length, ' ');
+
+                    case RIGHT:
+                        return Strings.padStart(value, length, ' ');
+
+                    case CENTER:
+                        int leftPadding = (diff / 2);
+                        int rightPadding = diff - leftPadding;
+
+                        return " ".repeat(leftPadding) + value + " ".repeat(rightPadding);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    private static class TableSeparator
+            implements TableElement
+    {
+        @Override
+        public String render(int[] columnsWidth)
+        {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < columnsWidth.length; i++) {
+                builder.append("+").append("-".repeat(columnsWidth[i] + 2));
+                if (i == columnsWidth.length - 1) {
+                    builder.append("+");
+                }
+            }
+
+            return builder.toString();
+        }
+    }
+
+    public enum Alignment
+    {
+        LEFT,
+        CENTER,
+        RIGHT;
+    }
+}

--- a/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/util/TestConsoleTable.java
+++ b/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/util/TestConsoleTable.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.util;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class TestConsoleTable
+{
+    @Test
+    public void testRenderTableWithSingleElement()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addRow("hello");
+        assertThat(table.render()).isEqualTo("| hello |");
+    }
+
+    @Test
+    public void testRenderTableWithMultipleElements()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addRow("hello", "world");
+        assertThat(table.render()).isEqualTo("| hello | world |");
+    }
+
+    @Test
+    public void testRenderTableWithSimpleLine()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addSeparator();
+        table.addRow("hello", "world");
+        table.addSeparator();
+
+        assertThat(table.render()).isEqualTo(
+                "+-------+-------+\n" +
+                "| hello | world |\n" +
+                "+-------+-------+");
+    }
+
+    @Test
+    public void testRenderTableWithDifferentColumnWidths()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addSeparator();
+        table.addRow("hello", "world");
+        table.addRow("a", "b");
+        table.addRow("prestosql", "rocks");
+        table.addSeparator();
+
+        assertThat(table.render()).isEqualTo(
+                "+-----------+-------+\n" +
+                "|     hello | world |\n" +
+                "|         a |     b |\n" +
+                "| prestosql | rocks |\n" +
+                "+-----------+-------+");
+    }
+
+    @Test
+    public void testRenderTableWithMissingColumns()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addSeparator();
+        table.addRow("hello", "world");
+        table.addRow("a", "b");
+        table.addRow("prestosql");
+        table.addSeparator();
+
+        assertThat(table.render()).isEqualTo(
+                "+-----------+-------+\n" +
+                "|     hello | world |\n" +
+                "|         a |     b |\n" +
+                "| prestosql |       |\n" +
+                "+-----------+-------+");
+    }
+
+    @Test
+    public void testRenderTableWithDifferentRowPaddings()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addSeparator();
+        table.addRow(ConsoleTable.Alignment.RIGHT, "hello", "world");
+        table.addSeparator();
+        table.addRow(ConsoleTable.Alignment.CENTER, "a", "b");
+        table.addRow("prestosql", "rocks");
+        table.addSeparator();
+
+        assertThat(table.render()).isEqualTo(
+                "+-----------+-------+\n" +
+                "|     hello | world |\n" +
+                "+-----------+-------+\n" +
+                "|     a     |   b   |\n" +
+                "| prestosql | rocks |\n" +
+                "+-----------+-------+");
+    }
+}

--- a/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/util/TestConsoleTable.java
+++ b/presto-product-tests-launcher/src/test/java/io/prestosql/tests/product/launcher/util/TestConsoleTable.java
@@ -104,4 +104,30 @@ public class TestConsoleTable
                 "| prestosql | rocks |\n" +
                 "+-----------+-------+");
     }
+
+    @Test
+    public void testRenderMultilineTable()
+    {
+        ConsoleTable table = new ConsoleTable();
+        table.addSeparator();
+        table.addRow(ConsoleTable.Alignment.RIGHT, "hello\npresto", "world\nawaits");
+        table.addSeparator();
+        table.addRow(ConsoleTable.Alignment.LEFT, "a", "b");
+        table.addSeparator();
+        table.addRow(ConsoleTable.Alignment.CENTER, "prestosql\nhas\nawesome\ndocs", "and\nrocks");
+        table.addSeparator();
+
+        assertThat(table.render()).isEqualTo(
+                "+-----------+--------+\n" +
+                "|     hello |  world |\n" +
+                "|    presto | awaits |\n" +
+                "+-----------+--------+\n" +
+                "| a         | b      |\n" +
+                "+-----------+--------+\n" +
+                "| prestosql |  and   |\n" +
+                "|    has    | rocks  |\n" +
+                "|  awesome  |        |\n" +
+                "|   docs    |        |\n" +
+                "+-----------+--------+");
+    }
 }


### PR DESCRIPTION
This PR modifies how different information is displayed while running product tests. Here are the examples:

* List of containers that are created during the environment startup:

```
+---------------+-------------------+---------------------------+---------+----------------------------------------------------------------------------+
|     container |              name |                     image | startup |                                                                      ports |
+---------------+-------------------+---------------------------+---------+----------------------------------------------------------------------------+
|         tests |         ptl-tests |  prestodev/centos6-oj8:34 |  7.77ms |                                                                            |
| presto-master | ptl-presto-master | prestodev/centos7-oj11:34 |  44.02s |                                                                       8080 |
| hadoop-master | ptl-hadoop-master |  prestodev/hdp2.6-hive:34 |  22.89s | 1180, 8020, 8042, 8088, 9000, 9083, 9864, 9870, 10000, 19888, 50070, 50075 |
+---------------+-------------------+---------------------------+---------+----------------------------------------------------------------------------+
```

* List of test runs in a suite:

```
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
|                                                 environment |             groups | excluded groups |                                              tests | excluded tests |
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
|                                               multinode-tls |              smoke |     skip_on_cdh |                                                    |                |
|                                                             |                cli |         iceberg |                                                    |                |
|                                                             |           group-by |                 |                                                    |                |
|                                                             |               join |                 |                                                    |                |
|                                                             |                tls |                 |                                                    |                |
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
|                                      multinode-tls-kerberos |                cli |     skip_on_cdh |                                                    |                |
|                                                             |           group-by |         iceberg |                                                    |                |
|                                                             |               join |                 |                                                    |                |
|                                                             |                tls |                 |                                                    |                |
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
| singlenode-kerberos-hdfs-impersonation-with-wire-encryption |    storage_formats |     skip_on_cdh |                                                    |                |
|                                                             |                cli |         iceberg |                                                    |                |
|                                                             | hdfs_impersonation |                 |                                                    |                |
|                                                             |      authorization |                 |                                                    |                |
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
| singlenode-kerberos-hdfs-impersonation-with-data-protection |                    |     skip_on_cdh | TestHiveStorageFormats.testOrcTableCreatedInPresto |                |
|                                                             |                    |         iceberg |                TestHiveCreateTable.testCreateTable |                |
+-------------------------------------------------------------+--------------------+-----------------+----------------------------------------------------+----------------+
```

* Suite results:

```
+----------------------------------+------------+-------------+----------------+---------+---------+--------------------------+
|                               id |      suite | environment |         config |  status | elapsed |                    error |
+----------------------------------+------------+-------------+----------------+---------+---------+--------------------------+
| 86c31ba456914714acb8d4b3f795876e | suite-test |  singlenode | config-default | SUCCESS |   1.39m |                        - |
| 65254e18fad84b84bb68d16847b1119e | suite-test |   multinode | config-default |  FAILED |   1.60m | Tests exited with code 1 |
+----------------------------------+------------+-------------+----------------+---------+---------+--------------------------+
```

The `suite run id` was changed from a numeric index to a random UUID. I've added a marker in the suite execution that allows to quickly find where the suite started and finished.