### PR TITLE
Propagate more information from ConnectorSession to ConnectionFactory

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ConnectionFactory.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.plugin.jdbc;
 
+import io.prestosql.spi.connector.ConnectorSession;
+
 import javax.annotation.PreDestroy;
 
 import java.sql.Connection;
@@ -22,7 +24,7 @@ import java.sql.SQLException;
 public interface ConnectionFactory
         extends AutoCloseable
 {
-    Connection openConnection(JdbcIdentity identity)
+    Connection openConnection(ConnectorSession session)
             throws SQLException;
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/DriverConnectionFactory.java
@@ -16,6 +16,7 @@ package io.prestosql.plugin.jdbc;
 import io.prestosql.plugin.jdbc.credential.CredentialPropertiesProvider;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import io.prestosql.plugin.jdbc.credential.DefaultCredentialPropertiesProvider;
+import io.prestosql.spi.connector.ConnectorSession;
 
 import java.sql.Connection;
 import java.sql.Driver;
@@ -66,9 +67,10 @@ public class DriverConnectionFactory
     }
 
     @Override
-    public Connection openConnection(JdbcIdentity identity)
+    public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
+        JdbcIdentity identity = JdbcIdentity.from(session);
         Properties properties = getCredentialProperties(identity);
         Connection connection = driver.connect(connectionUrl.apply(identity), properties);
         checkState(connection != null, "Driver returned null connection");

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForwardingJdbcClient.java
@@ -56,27 +56,27 @@ public abstract class ForwardingJdbcClient
     protected abstract JdbcClient delegate();
 
     @Override
-    public boolean schemaExists(JdbcIdentity identity, String schema)
+    public boolean schemaExists(ConnectorSession session, String schema)
     {
-        return delegate().schemaExists(identity, schema);
+        return delegate().schemaExists(session, schema);
     }
 
     @Override
-    public Set<String> getSchemaNames(JdbcIdentity identity)
+    public Set<String> getSchemaNames(ConnectorSession session)
     {
-        return delegate().getSchemaNames(identity);
+        return delegate().getSchemaNames(session);
     }
 
     @Override
-    public List<SchemaTableName> getTableNames(JdbcIdentity identity, Optional<String> schema)
+    public List<SchemaTableName> getTableNames(ConnectorSession session, Optional<String> schema)
     {
-        return delegate().getTableNames(identity, schema);
+        return delegate().getTableNames(session, schema);
     }
 
     @Override
-    public Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName)
+    public Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        return delegate().getTableHandle(identity, schemaTableName);
+        return delegate().getTableHandle(session, schemaTableName);
     }
 
     @Override
@@ -122,10 +122,10 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public Connection getConnection(JdbcIdentity identity, JdbcSplit split)
+    public Connection getConnection(ConnectorSession session, JdbcSplit split)
             throws SQLException
     {
-        return delegate().getConnection(identity, split);
+        return delegate().getConnection(session, split);
     }
 
     @Override
@@ -149,9 +149,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        delegate().commitCreateTable(identity, handle);
+        delegate().commitCreateTable(session, handle);
     }
 
     @Override
@@ -161,21 +161,21 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void finishInsertTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        delegate().finishInsertTable(identity, handle);
+        delegate().finishInsertTable(session, handle);
     }
 
     @Override
-    public void dropTable(JdbcIdentity identity, JdbcTableHandle jdbcTableHandle)
+    public void dropTable(ConnectorSession session, JdbcTableHandle jdbcTableHandle)
     {
-        delegate().dropTable(identity, jdbcTableHandle);
+        delegate().dropTable(session, jdbcTableHandle);
     }
 
     @Override
-    public void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        delegate().rollbackCreateTable(identity, handle);
+        delegate().rollbackCreateTable(session, handle);
     }
 
     @Override
@@ -185,10 +185,10 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public Connection getConnection(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public Connection getConnection(ConnectorSession session, JdbcOutputTableHandle handle)
             throws SQLException
     {
-        return delegate().getConnection(identity, handle);
+        return delegate().getConnection(session, handle);
     }
 
     @Override
@@ -217,9 +217,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    public void setColumnComment(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
     {
-        delegate().setColumnComment(identity, handle, column, comment);
+        delegate().setColumnComment(session, handle, column, comment);
     }
 
     @Override
@@ -229,21 +229,21 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column)
+    public void dropColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column)
     {
-        delegate().dropColumn(identity, handle, column);
+        delegate().dropColumn(session, handle, column);
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
-        delegate().renameColumn(identity, handle, jdbcColumn, newColumnName);
+        delegate().renameColumn(session, handle, jdbcColumn, newColumnName);
     }
 
     @Override
-    public void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName)
+    public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName)
     {
-        delegate().renameTable(identity, handle, newTableName);
+        delegate().renameTable(session, handle, newTableName);
     }
 
     @Override
@@ -253,15 +253,15 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void createSchema(JdbcIdentity identity, String schemaName)
+    public void createSchema(ConnectorSession session, String schemaName)
     {
-        delegate().createSchema(identity, schemaName);
+        delegate().createSchema(session, schemaName);
     }
 
     @Override
-    public void dropSchema(JdbcIdentity identity, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName)
     {
-        delegate().dropSchema(identity, schemaName);
+        delegate().dropSchema(session, schemaName);
     }
 
     @Override
@@ -283,9 +283,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle)
     {
-        return delegate().getTableProperties(identity, tableHandle);
+        return delegate().getTableProperties(session, tableHandle);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcClient.java
@@ -39,16 +39,16 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface JdbcClient
 {
-    default boolean schemaExists(JdbcIdentity identity, String schema)
+    default boolean schemaExists(ConnectorSession session, String schema)
     {
-        return getSchemaNames(identity).contains(schema);
+        return getSchemaNames(session).contains(schema);
     }
 
-    Set<String> getSchemaNames(JdbcIdentity identity);
+    Set<String> getSchemaNames(ConnectorSession session);
 
-    List<SchemaTableName> getTableNames(JdbcIdentity identity, Optional<String> schema);
+    List<SchemaTableName> getTableNames(ConnectorSession session, Optional<String> schema);
 
-    Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName);
+    Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName);
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
@@ -73,7 +73,7 @@ public interface JdbcClient
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);
 
-    Connection getConnection(JdbcIdentity identity, JdbcSplit split)
+    Connection getConnection(ConnectorSession session, JdbcSplit split)
             throws SQLException;
 
     default void abortReadConnection(Connection connection)
@@ -89,36 +89,36 @@ public interface JdbcClient
 
     boolean isLimitGuaranteed(ConnectorSession session);
 
-    default void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    default void setColumnComment(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support setting column comments");
     }
 
     void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column);
 
-    void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column);
+    void dropColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column);
 
-    void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName);
+    void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName);
 
-    void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName);
+    void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName);
 
     void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
     JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata);
 
-    void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle);
 
     JdbcOutputTableHandle beginInsertTable(ConnectorSession session, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columns);
 
-    void finishInsertTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle);
 
-    void dropTable(JdbcIdentity identity, JdbcTableHandle jdbcTableHandle);
+    void dropTable(ConnectorSession session, JdbcTableHandle jdbcTableHandle);
 
-    void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle);
+    void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle);
 
     String buildInsertSql(JdbcOutputTableHandle handle);
 
-    Connection getConnection(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    Connection getConnection(ConnectorSession session, JdbcOutputTableHandle handle)
             throws SQLException;
 
     PreparedStatement getPreparedStatement(Connection connection, String sql)
@@ -126,9 +126,9 @@ public interface JdbcClient
 
     TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, TupleDomain<ColumnHandle> tupleDomain);
 
-    void createSchema(JdbcIdentity identity, String schemaName);
+    void createSchema(ConnectorSession session, String schemaName);
 
-    void dropSchema(JdbcIdentity identity, String schemaName);
+    void dropSchema(ConnectorSession session, String schemaName);
 
     default Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
@@ -139,7 +139,7 @@ public interface JdbcClient
 
     String quoted(RemoteTableName remoteTableName);
 
-    Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle);
+    Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle);
 
     default Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
     {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -51,7 +51,7 @@ public class JdbcPageSink
     public JdbcPageSink(ConnectorSession session, JdbcOutputTableHandle handle, JdbcClient jdbcClient)
     {
         try {
-            connection = jdbcClient.getConnection(JdbcIdentity.from(session), handle);
+            connection = jdbcClient.getConnection(session, handle);
         }
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcRecordCursor.java
@@ -67,7 +67,7 @@ public class JdbcRecordCursor
         objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
 
         try {
-            connection = jdbcClient.getConnection(JdbcIdentity.from(session), split);
+            connection = jdbcClient.getConnection(session, split);
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryingConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryingConnectionFactory.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.jdbc;
 
 import com.google.common.base.Throwables;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ConnectorSession;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.FailsafeException;
 import net.jodah.failsafe.RetryPolicy;
@@ -45,12 +46,12 @@ public class RetryingConnectionFactory
     }
 
     @Override
-    public Connection openConnection(JdbcIdentity identity)
+    public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
         try {
             return Failsafe.with(RETRY_POLICY)
-                    .get(() -> delegate.openConnection(identity));
+                    .get(() -> delegate.openConnection(session));
         }
         catch (FailsafeException ex) {
             if (ex.getCause() instanceof SQLException) {

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
@@ -14,7 +14,7 @@
 package io.prestosql.plugin.jdbc.jmx;
 
 import io.prestosql.plugin.jdbc.ConnectionFactory;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.spi.connector.ConnectorSession;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -36,10 +36,10 @@ public class StatisticsAwareConnectionFactory
     }
 
     @Override
-    public Connection openConnection(JdbcIdentity identity)
+    public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
-        return openConnection.wrap(() -> delegate.openConnection(identity));
+        return openConnection.wrap(() -> delegate.openConnection(session));
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -17,7 +17,6 @@ import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.JdbcClient;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcExpression;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
 import io.prestosql.plugin.jdbc.JdbcSplit;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
@@ -73,27 +72,27 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public boolean schemaExists(JdbcIdentity identity, String schema)
+    public boolean schemaExists(ConnectorSession session, String schema)
     {
-        return stats.getSchemaExists().wrap(() -> delegate().schemaExists(identity, schema));
+        return stats.getSchemaExists().wrap(() -> delegate().schemaExists(session, schema));
     }
 
     @Override
-    public Set<String> getSchemaNames(JdbcIdentity identity)
+    public Set<String> getSchemaNames(ConnectorSession session)
     {
-        return stats.getGetSchemaNames().wrap(() -> delegate().getSchemaNames(identity));
+        return stats.getGetSchemaNames().wrap(() -> delegate().getSchemaNames(session));
     }
 
     @Override
-    public List<SchemaTableName> getTableNames(JdbcIdentity identity, Optional<String> schema)
+    public List<SchemaTableName> getTableNames(ConnectorSession session, Optional<String> schema)
     {
-        return stats.getGetTableNames().wrap(() -> delegate().getTableNames(identity, schema));
+        return stats.getGetTableNames().wrap(() -> delegate().getTableNames(session, schema));
     }
 
     @Override
-    public Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName)
+    public Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        return stats.getGetTableHandle().wrap(() -> delegate().getTableHandle(identity, schemaTableName));
+        return stats.getGetTableHandle().wrap(() -> delegate().getTableHandle(session, schemaTableName));
     }
 
     @Override
@@ -139,10 +138,10 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public Connection getConnection(JdbcIdentity identity, JdbcSplit split)
+    public Connection getConnection(ConnectorSession session, JdbcSplit split)
             throws SQLException
     {
-        return stats.getGetConnectionWithSplit().wrap(() -> delegate().getConnection(identity, split));
+        return stats.getGetConnectionWithSplit().wrap(() -> delegate().getConnection(session, split));
     }
 
     @Override
@@ -160,9 +159,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    public void setColumnComment(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
     {
-        stats.getSetColumnComment().wrap(() -> delegate().setColumnComment(identity, handle, column, comment));
+        stats.getSetColumnComment().wrap(() -> delegate().setColumnComment(session, handle, column, comment));
     }
 
     @Override
@@ -172,21 +171,21 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column)
+    public void dropColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column)
     {
-        stats.getDropColumn().wrap(() -> delegate().dropColumn(identity, handle, column));
+        stats.getDropColumn().wrap(() -> delegate().dropColumn(session, handle, column));
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
-        stats.getRenameColumn().wrap(() -> delegate().renameColumn(identity, handle, jdbcColumn, newColumnName));
+        stats.getRenameColumn().wrap(() -> delegate().renameColumn(session, handle, jdbcColumn, newColumnName));
     }
 
     @Override
-    public void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName)
+    public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName)
     {
-        stats.getRenameTable().wrap(() -> delegate().renameTable(identity, handle, newTableName));
+        stats.getRenameTable().wrap(() -> delegate().renameTable(session, handle, newTableName));
     }
 
     @Override
@@ -202,9 +201,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        stats.getCommitCreateTable().wrap(() -> delegate().commitCreateTable(identity, handle));
+        stats.getCommitCreateTable().wrap(() -> delegate().commitCreateTable(session, handle));
     }
 
     @Override
@@ -214,21 +213,21 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void finishInsertTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        stats.getFinishInsertTable().wrap(() -> delegate().finishInsertTable(identity, handle));
+        stats.getFinishInsertTable().wrap(() -> delegate().finishInsertTable(session, handle));
     }
 
     @Override
-    public void dropTable(JdbcIdentity identity, JdbcTableHandle jdbcTableHandle)
+    public void dropTable(ConnectorSession session, JdbcTableHandle jdbcTableHandle)
     {
-        stats.getDropTable().wrap(() -> delegate().dropTable(identity, jdbcTableHandle));
+        stats.getDropTable().wrap(() -> delegate().dropTable(session, jdbcTableHandle));
     }
 
     @Override
-    public void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
-        stats.getRollbackCreateTable().wrap(() -> delegate().rollbackCreateTable(identity, handle));
+        stats.getRollbackCreateTable().wrap(() -> delegate().rollbackCreateTable(session, handle));
     }
 
     @Override
@@ -238,10 +237,10 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public Connection getConnection(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public Connection getConnection(ConnectorSession session, JdbcOutputTableHandle handle)
             throws SQLException
     {
-        return stats.getGetConnectionWithHandle().wrap(() -> delegate().getConnection(identity, handle));
+        return stats.getGetConnectionWithHandle().wrap(() -> delegate().getConnection(session, handle));
     }
 
     @Override
@@ -270,15 +269,15 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void createSchema(JdbcIdentity identity, String schemaName)
+    public void createSchema(ConnectorSession session, String schemaName)
     {
-        stats.getCreateSchema().wrap(() -> delegate().createSchema(identity, schemaName));
+        stats.getCreateSchema().wrap(() -> delegate().createSchema(session, schemaName));
     }
 
     @Override
-    public void dropSchema(JdbcIdentity identity, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName)
     {
-        stats.getDropSchema().wrap(() -> delegate().dropSchema(identity, schemaName));
+        stats.getDropSchema().wrap(() -> delegate().dropSchema(session, schemaName));
     }
 
     @Override
@@ -300,9 +299,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public Map<String, Object> getTableProperties(JdbcIdentity identity, JdbcTableHandle tableHandle)
+    public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle)
     {
-        return delegate().getTableProperties(identity, tableHandle);
+        return delegate().getTableProperties(session, tableHandle);
     }
 
     @Override

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcClient.java
@@ -64,18 +64,17 @@ public class TestJdbcClient
     @Test
     public void testMetadata()
     {
-        JdbcIdentity identity = JdbcIdentity.from(session);
-        assertTrue(jdbcClient.getSchemaNames(identity).containsAll(ImmutableSet.of("example", "tpch")));
-        assertEquals(jdbcClient.getTableNames(identity, Optional.of("example")), ImmutableList.of(
+        assertTrue(jdbcClient.getSchemaNames(session).containsAll(ImmutableSet.of("example", "tpch")));
+        assertEquals(jdbcClient.getTableNames(session, Optional.of("example")), ImmutableList.of(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
-        assertEquals(jdbcClient.getTableNames(identity, Optional.of("tpch")), ImmutableList.of(
+        assertEquals(jdbcClient.getTableNames(session, Optional.of("tpch")), ImmutableList.of(
                 new SchemaTableName("tpch", "lineitem"),
                 new SchemaTableName("tpch", "orders")));
 
         SchemaTableName schemaTableName = new SchemaTableName("example", "numbers");
-        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(identity, schemaTableName);
+        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertTrue(table.isPresent(), "table is missing");
         assertEquals(table.get().getCatalogName(), catalogName.toUpperCase(ENGLISH));
         assertEquals(table.get().getSchemaName(), "EXAMPLE");
@@ -91,7 +90,7 @@ public class TestJdbcClient
     public void testMetadataWithSchemaPattern()
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "num_ers");
-        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertTrue(table.isPresent(), "table is missing");
         assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
                 new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
@@ -102,7 +101,7 @@ public class TestJdbcClient
     public void testMetadataWithFloatAndDoubleCol()
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "table_with_float_col");
-        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(JdbcIdentity.from(session), schemaTableName);
+        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertTrue(table.isPresent(), "table is missing");
         assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
                 new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryingConnectionFactory.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryingConnectionFactory.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.jdbc;
 
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.StandardErrorCode;
+import io.prestosql.spi.connector.ConnectorSession;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -40,8 +41,6 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestRetryingConnectionFactory
 {
-    private static final JdbcIdentity IDENTITY = JdbcIdentity.from(SESSION);
-
     @Test
     public void testEverythingImplemented()
     {
@@ -54,7 +53,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(IDENTITY));
+        assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 1);
     }
 
@@ -63,7 +62,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_RECOVERABLE_EXCEPTION, THROW_PRESTO_EXCEPTION);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertThatThrownBy(() -> factory.openConnection(IDENTITY))
+        assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(PrestoException.class)
                 .hasMessage("Testing presto exception");
         assertEquals(mock.getCallCount(), 2);
@@ -74,7 +73,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_RECOVERABLE_EXCEPTION, THROW_SQL_EXCEPTION);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertThatThrownBy(() -> factory.openConnection(IDENTITY))
+        assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(SQLException.class)
                 .hasMessage("Testing sql exception");
         assertEquals(mock.getCallCount(), 2);
@@ -85,7 +84,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_NPE);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertThatThrownBy(() -> factory.openConnection(IDENTITY))
+        assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Testing NPE");
         assertEquals(mock.getCallCount(), 1);
@@ -97,7 +96,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_RECOVERABLE_EXCEPTION, RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(IDENTITY));
+        assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 2);
     }
 
@@ -107,7 +106,7 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_WRAPPED_SQL_RECOVERABLE_EXCEPTION, RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(IDENTITY));
+        assertNotNull(factory.openConnection(SESSION));
         assertEquals(mock.getCallCount(), 2);
     }
 
@@ -129,7 +128,7 @@ public class TestRetryingConnectionFactory
         }
 
         @Override
-        public Connection openConnection(JdbcIdentity identity)
+        public Connection openConnection(ConnectorSession session)
                 throws SQLException
         {
             callCount++;

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingDatabase.java
@@ -90,7 +90,7 @@ final class TestingDatabase
 
     public JdbcTableHandle getTableHandle(ConnectorSession session, SchemaTableName table)
     {
-        return jdbcClient.getTableHandle(JdbcIdentity.from(session), table)
+        return jdbcClient.getTableHandle(session, table)
                 .orElseThrow(() -> new IllegalArgumentException("table not found: " + table));
     }
 

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
@@ -19,7 +19,6 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
 import io.prestosql.plugin.jdbc.JdbcSplit;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
@@ -79,9 +78,9 @@ public class DruidJdbcClient
 
     //Overridden to filter out tables that don't match schemaTableName
     @Override
-    public Optional<JdbcTableHandle> getTableHandle(JdbcIdentity identity, SchemaTableName schemaTableName)
+    public Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        try (Connection connection = connectionFactory.openConnection(identity)) {
+        try (Connection connection = connectionFactory.openConnection(session)) {
             String jdbcSchemaName = schemaTableName.getSchemaName();
             String jdbcTableName = schemaTableName.getTableName();
             try (ResultSet resultSet = getTables(connection, Optional.of(jdbcSchemaName), Optional.of(jdbcTableName))) {
@@ -218,31 +217,31 @@ public class DruidJdbcClient
     }
 
     @Override
-    public void commitCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
 
     @Override
-    public void dropColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column)
+    public void dropColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
 
     @Override
-    public void dropTable(JdbcIdentity identity, JdbcTableHandle handle)
+    public void dropTable(ConnectorSession session, JdbcTableHandle handle)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
 
     @Override
-    public void rollbackCreateTable(JdbcIdentity identity, JdbcOutputTableHandle handle)
+    public void rollbackCreateTable(ConnectorSession session, JdbcOutputTableHandle handle)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
@@ -254,13 +253,13 @@ public class DruidJdbcClient
     }
 
     @Override
-    public void createSchema(JdbcIdentity identity, String schemaName)
+    public void createSchema(ConnectorSession session, String schemaName)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }
 
     @Override
-    public void dropSchema(JdbcIdentity identity, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName)
     {
         throw new PrestoException(DruidErrorCode.DRUID_DDL_NOT_SUPPORTED, "DDL operations are not supported in the presto-druid connector");
     }

--- a/presto-druid/src/test/java/io/prestosql/plugin/druid/BaseDruidIntegrationSmokeTest.java
+++ b/presto-druid/src/test/java/io/prestosql/plugin/druid/BaseDruidIntegrationSmokeTest.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.plugin.druid;
 
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
@@ -205,7 +204,7 @@ public abstract class BaseDruidIntegrationSmokeTest
      * This test verifies that the filtering we have in place to overcome Druid's limitation of
      * not handling the escaping of search characters like % and _, works correctly.
      * <p>
-     * See {@link DruidJdbcClient#getTableHandle(JdbcIdentity, SchemaTableName)} and
+     * See {@link DruidJdbcClient#getTableHandle(ConnectorSession, SchemaTableName)} and
      * {@link DruidJdbcClient#getColumns(ConnectorSession, JdbcTableHandle)}
      */
     @Test

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -19,7 +19,6 @@ import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.PredicatePushdownController;
@@ -206,18 +205,18 @@ public class MemSqlClient
     }
 
     @Override
-    public void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName)
+    public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName)
     {
         // MemSQL doesn't support specifying the catalog name in a rename. By setting the
         // catalogName parameter to null, it will be omitted in the ALTER TABLE statement.
         verify(handle.getSchemaName() == null);
-        renameTable(identity, null, handle.getCatalogName(), handle.getTableName(), newTableName);
+        renameTable(session, null, handle.getCatalogName(), handle.getTableName(), newTableName);
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
-        try (Connection connection = connectionFactory.openConnection(identity)) {
+        try (Connection connection = connectionFactory.openConnection(session)) {
             DatabaseMetaData metadata = connection.getMetaData();
             if (metadata.storesUpperCaseIdentifiers()) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -21,7 +21,6 @@ import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcExpression;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.PredicatePushdownController;
@@ -313,9 +312,9 @@ public class MySqlClient
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
-        try (Connection connection = connectionFactory.openConnection(identity)) {
+        try (Connection connection = connectionFactory.openConnection(session)) {
             DatabaseMetaData metadata = connection.getMetaData();
             if (metadata.storesUpperCaseIdentifiers()) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);
@@ -351,12 +350,12 @@ public class MySqlClient
     }
 
     @Override
-    public void renameTable(JdbcIdentity identity, JdbcTableHandle handle, SchemaTableName newTableName)
+    public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName)
     {
         // MySQL doesn't support specifying the catalog name in a rename. By setting the
         // catalogName parameter to null, it will be omitted in the ALTER TABLE statement.
         verify(handle.getSchemaName() == null);
-        renameTable(identity, null, handle.getCatalogName(), handle.getTableName(), newTableName);
+        renameTable(session, null, handle.getCatalogName(), handle.getTableName(), newTableName);
     }
 
     @Override

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlClient.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlClient.java
@@ -62,7 +62,7 @@ public class TestMySqlClient
 
     private static final JdbcClient JDBC_CLIENT = new MySqlClient(
             new BaseJdbcConfig(),
-            identity -> {
+            session -> {
                 throw new UnsupportedOperationException();
             },
             TYPE_MANAGER);

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OracleClient.java
@@ -21,7 +21,6 @@ import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DoubleWriteFunction;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.LongWriteFunction;
@@ -211,7 +210,7 @@ public class OracleClient
     }
 
     @Override
-    protected void renameTable(JdbcIdentity identity, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
+    protected void renameTable(ConnectorSession session, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
     {
         if (!schemaName.equalsIgnoreCase(newTable.getSchemaName())) {
             throw new PrestoException(NOT_SUPPORTED, "Table rename across schemas is not supported in Oracle");
@@ -223,7 +222,7 @@ public class OracleClient
                 quoted(catalogName, schemaName, tableName),
                 quoted(newTableName));
 
-        try (Connection connection = connectionFactory.openConnection(identity)) {
+        try (Connection connection = connectionFactory.openConnection(session)) {
             execute(connection, sql);
         }
         catch (SQLException e) {
@@ -232,7 +231,7 @@ public class OracleClient
     }
 
     @Override
-    public void createSchema(JdbcIdentity identity, String schemaName)
+    public void createSchema(ConnectorSession session, String schemaName)
     {
         // ORA-02420: missing schema authorization clause
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support creating schemas");
@@ -468,13 +467,13 @@ public class OracleClient
     }
 
     @Override
-    public void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    public void setColumnComment(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
     {
         String sql = format(
                 "COMMENT ON COLUMN %s.%s IS '%s'",
                 quoted(handle.getRemoteTableName()),
                 quoted(column.getColumnName()),
                 comment.orElse(""));
-        execute(identity, sql);
+        execute(session, sql);
     }
 }

--- a/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OraclePoolConnectionFactory.java
+++ b/presto-oracle/src/main/java/io/prestosql/plugin/oracle/OraclePoolConnectionFactory.java
@@ -15,8 +15,8 @@ package io.prestosql.plugin.oracle;
 
 import io.airlift.units.Duration;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
+import io.prestosql.spi.connector.ConnectorSession;
 import oracle.jdbc.pool.OracleDataSource;
 import oracle.ucp.jdbc.PoolDataSource;
 import oracle.ucp.jdbc.PoolDataSourceFactory;
@@ -77,7 +77,7 @@ public class OraclePoolConnectionFactory
     }
 
     @Override
-    public Connection openConnection(JdbcIdentity identity)
+    public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
         return dataSource.getConnection();

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestingOracleServer.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/TestingOracleServer.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.oracle;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.RetryingConnectionFactory;
 import io.prestosql.plugin.jdbc.credential.StaticCredentialProvider;
 import oracle.jdbc.OracleDriver;
@@ -37,7 +36,6 @@ public class TestingOracleServer
         implements Closeable
 {
     private static final String TEST_TABLESPACE = "presto_test";
-    private static final JdbcIdentity IDENTITY = JdbcIdentity.from(SESSION);
 
     public static final String TEST_USER = "presto_test";
     public static final String TEST_SCHEMA = TEST_USER; // schema and user is the same thing in Oracle
@@ -51,7 +49,7 @@ public class TestingOracleServer
 
         start();
 
-        try (Connection connection = getConnectionFactory().openConnection(IDENTITY);
+        try (Connection connection = getConnectionFactory().openConnection(SESSION);
                 Statement statement = connection.createStatement()) {
             // this is added to allow more processes on database, otherwise the tests end up giving
             // ORA-12519, TNS:no appropriate service handler found
@@ -72,7 +70,7 @@ public class TestingOracleServer
         }
 
         waitUntilContainerStarted();
-        try (Connection connection = getConnectionFactory().openConnection(IDENTITY);
+        try (Connection connection = getConnectionFactory().openConnection(SESSION);
                 Statement statement = connection.createStatement()) {
             statement.execute(format("CREATE TABLESPACE %s DATAFILE 'test_db.dat' SIZE 100M ONLINE", TEST_TABLESPACE));
             statement.execute(format("CREATE USER %s IDENTIFIED BY %s DEFAULT TABLESPACE %s", TEST_USER, TEST_PASS, TEST_TABLESPACE));
@@ -97,7 +95,7 @@ public class TestingOracleServer
 
     public void execute(String sql, String user, String password)
     {
-        try (Connection connection = getConnectionFactory(user, password).openConnection(IDENTITY);
+        try (Connection connection = getConnectionFactory(user, password).openConnection(SESSION);
                 Statement statement = connection.createStatement()) {
             statement.execute(sql);
         }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixSplitManager.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixSplitManager.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.phoenix;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.QueryBuilder;
 import io.prestosql.spi.HostAddress;
@@ -79,7 +78,7 @@ public class PhoenixSplitManager
             DynamicFilter dynamicFilter)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        try (PhoenixConnection connection = phoenixClient.getConnection(JdbcIdentity.from(session))) {
+        try (PhoenixConnection connection = phoenixClient.getConnection(session)) {
             List<JdbcColumnHandle> columns = tableHandle.getColumns()
                     .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
                     .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlClient.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlClient.java
@@ -63,7 +63,7 @@ public class TestPostgreSqlClient
     private static final JdbcClient JDBC_CLIENT = new PostgreSqlClient(
             new BaseJdbcConfig(),
             new PostgreSqlConfig(),
-            identity -> { throw new UnsupportedOperationException(); },
+            session -> { throw new UnsupportedOperationException(); },
             TYPE_MANAGER);
 
     @Test

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -17,7 +17,6 @@ import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
@@ -44,7 +43,7 @@ public class RedshiftClient
     }
 
     @Override
-    protected void renameTable(JdbcIdentity identity, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
+    protected void renameTable(ConnectorSession session, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
     {
         if (!schemaName.equals(newTable.getSchemaName())) {
             throw new PrestoException(NOT_SUPPORTED, "Table rename across schemas is not supported");
@@ -54,7 +53,7 @@ public class RedshiftClient
                 "ALTER TABLE %s RENAME TO %s",
                 quoted(catalogName, schemaName, tableName),
                 quoted(newTable.getTableName()));
-        execute(identity, sql);
+        execute(session, sql);
     }
 
     @Override
@@ -80,13 +79,13 @@ public class RedshiftClient
     }
 
     @Override
-    public void setColumnComment(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
+    public void setColumnComment(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Optional<String> comment)
     {
         String sql = format(
                 "COMMENT ON COLUMN %s.%s IS %s",
                 quoted(handle.getRemoteTableName()),
                 quoted(column.getColumnName()),
                 comment.isPresent() ? format("'%s'", comment.get()) : "NULL");
-        execute(identity, sql);
+        execute(session, sql);
     }
 }

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -22,7 +22,6 @@ import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcExpression;
-import io.prestosql.plugin.jdbc.JdbcIdentity;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.SliceWriteFunction;
@@ -105,7 +104,7 @@ public class SqlServerClient
     }
 
     @Override
-    protected void renameTable(JdbcIdentity identity, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
+    protected void renameTable(ConnectorSession session, String catalogName, String schemaName, String tableName, SchemaTableName newTable)
     {
         if (!schemaName.equals(newTable.getSchemaName())) {
             throw new PrestoException(NOT_SUPPORTED, "Table rename across schemas is not supported");
@@ -115,17 +114,17 @@ public class SqlServerClient
                 "sp_rename %s, %s",
                 singleQuote(catalogName, schemaName, tableName),
                 singleQuote(newTable.getTableName()));
-        execute(identity, sql);
+        execute(session, sql);
     }
 
     @Override
-    public void renameColumn(JdbcIdentity identity, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
+    public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         String sql = format(
                 "sp_rename %s, %s, 'COLUMN'",
                 singleQuote(handle.getCatalogName(), handle.getSchemaName(), handle.getTableName(), jdbcColumn.getColumnName()),
                 singleQuote(newColumnName));
-        execute(identity, sql);
+        execute(session, sql);
     }
 
     @Override

--- a/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerClient.java
+++ b/presto-sqlserver/src/test/java/io/prestosql/plugin/sqlserver/TestSqlServerClient.java
@@ -56,7 +56,7 @@ public class TestSqlServerClient
 
     private static final JdbcClient JDBC_CLIENT = new SqlServerClient(
             new BaseJdbcConfig(),
-            identity -> {
+            session -> {
                 throw new UnsupportedOperationException();
             });
 


### PR DESCRIPTION
Additional information from ConnectorSession is required
to support audit in not public connectors
to correlate query in Presto with query w RDBMS

is based on https://github.com/prestosql/presto/pull/6110 