### PR TITLE
Fix caching for TableHandle in CachingJdbcClient

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
@@ -189,7 +189,7 @@ public class CachingJdbcClient
             return cachedTableHandle;
         }
         Optional<JdbcTableHandle> tableHandle = delegate.getTableHandle(identity, schemaTableName);
-        if (tableHandle.isEmpty() || cacheMissing) {
+        if (tableHandle.isPresent() || cacheMissing) {
             tableHandleCache.put(key, tableHandle);
         }
         return tableHandle;


### PR DESCRIPTION
TableHandle should be cached if there is a value,
or tableHandle is empty but missing value cashing is expected.