### PR TITLE
Make filterColumns to be coherent with other filter methods

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/LegacyAccessControl.java
@@ -17,7 +17,6 @@ import io.prestosql.plugin.hive.HiveTransactionHandle;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.plugin.hive.metastore.Table;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -29,7 +28,6 @@ import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -178,7 +176,7 @@ public class LegacyAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SqlStandardAccessControl.java
@@ -13,7 +13,7 @@
  */
 package io.prestosql.plugin.hive.security;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.base.CatalogName;
 import io.prestosql.plugin.hive.HiveTransactionHandle;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
@@ -22,7 +22,6 @@ import io.prestosql.plugin.hive.metastore.HivePrincipal;
 import io.prestosql.plugin.hive.metastore.HivePrivilegeInfo;
 import io.prestosql.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.prestosql.spi.PrestoException;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -37,7 +36,6 @@ import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -235,10 +233,10 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         if (!hasAnyTablePermission(context, tableName)) {
-            return ImmutableList.of();
+            return ImmutableSet.of();
         }
         return columns;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SystemTableAwareAccessControl.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/security/SystemTableAwareAccessControl.java
@@ -15,13 +15,11 @@
 package io.prestosql.plugin.hive.security;
 
 import io.prestosql.plugin.base.security.ForwardingConnectorAccessControl;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.AccessDeniedException;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -64,7 +62,7 @@ public class SystemTableAwareAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         Optional<SchemaTableName> sourceTableName = getSourceTableNameFromSystemTable(tableName);
         if (sourceTableName.isPresent()) {

--- a/presto-main/src/main/java/io/prestosql/security/AccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControl.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.Identity;
@@ -224,7 +223,7 @@ public interface AccessControl
     /**
      * Filter the list of columns to those visible to the identity.
      */
-    List<ColumnMetadata> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns);
+    Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns);
 
     /**
      * Check if identity is allowed to add columns to the specified table.

--- a/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
+++ b/presto-main/src/main/java/io/prestosql/security/AccessControlManager.java
@@ -31,7 +31,6 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
@@ -513,13 +512,13 @@ public class AccessControlManager
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SecurityContext securityContext, CatalogSchemaTableName table, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SecurityContext securityContext, CatalogSchemaTableName table, Set<String> columns)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(table, "tableName is null");
 
         if (filterTables(securityContext, table.getCatalogName(), ImmutableSet.of(table.getSchemaTableName())).isEmpty()) {
-            return ImmutableList.of();
+            return ImmutableSet.of();
         }
 
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {

--- a/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/AllowAllAccessControl.java
@@ -16,14 +16,12 @@ package io.prestosql.security;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.Identity;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.security.Privilege;
 
 import java.security.Principal;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -160,7 +158,7 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/DenyAllAccessControl.java
@@ -13,19 +13,16 @@
  */
 package io.prestosql.security;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.Identity;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.security.Privilege;
 
 import java.security.Principal;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -223,9 +220,9 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
-        return ImmutableList.of();
+        return ImmutableSet.of();
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/ForwardingAccessControl.java
@@ -16,7 +16,6 @@ package io.prestosql.security;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.Identity;
 import io.prestosql.spi.security.PrestoPrincipal;
@@ -202,7 +201,7 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
         return delegate().filterColumns(context, tableName, columns);
     }

--- a/presto-main/src/main/java/io/prestosql/security/InjectedConnectorAccessControl.java
+++ b/presto-main/src/main/java/io/prestosql/security/InjectedConnectorAccessControl.java
@@ -17,7 +17,6 @@ import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -27,7 +26,6 @@ import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -162,7 +160,7 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         checkArgument(context == null, "context must be null");
         return accessControl.filterColumns(securityContext, new CatalogSchemaTableName(catalogName, tableName), columns);

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -14,7 +14,6 @@
 package io.prestosql.plugin.base.classloader;
 
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -26,7 +25,6 @@ import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -174,7 +172,7 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.filterColumns(context, tableName, columns);

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllAccessControl.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.plugin.base.security;
 
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -23,7 +22,6 @@ import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -113,7 +111,7 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/AllowAllSystemAccessControl.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableSet;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaRoutineName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.eventlistener.EventListener;
 import io.prestosql.spi.security.PrestoPrincipal;
@@ -29,7 +28,6 @@ import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
 import java.security.Principal;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -202,7 +200,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/FileBasedAccessControl.java
@@ -13,10 +13,8 @@
  */
 package io.prestosql.plugin.base.security;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.plugin.base.security.TableAccessControlRule.TablePrivilege;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -34,7 +32,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.plugin.base.security.TableAccessControlRule.TablePrivilege.DELETE;
 import static io.prestosql.plugin.base.security.TableAccessControlRule.TablePrivilege.GRANT_SELECT;
@@ -216,7 +213,7 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
             return columns;
@@ -228,7 +225,7 @@ public class FileBasedAccessControl
                 .findFirst()
                 .orElse(null);
         if (rule == null || rule.getPrivileges().isEmpty()) {
-            return ImmutableList.of();
+            return ImmutableSet.of();
         }
 
         // if user has privileges other than select, show all columns
@@ -238,8 +235,8 @@ public class FileBasedAccessControl
 
         Set<String> restrictedColumns = rule.getRestrictedColumns();
         return columns.stream()
-                .filter(columnMetadata -> !restrictedColumns.contains(columnMetadata.getName()))
-                .collect(toImmutableList());
+                .filter(column -> !restrictedColumns.contains(column))
+                .collect(toImmutableSet());
     }
 
     @Override

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.plugin.base.security;
 
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaRoutineName;
@@ -23,7 +22,6 @@ import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -145,7 +143,7 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         return delegate().filterColumns(context, tableName, columns);
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ForwardingSystemAccessControl.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.base.security;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaRoutineName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.eventlistener.EventListener;
 import io.prestosql.spi.security.PrestoPrincipal;
@@ -27,7 +26,6 @@ import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
 import java.security.Principal;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -215,7 +213,7 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
         return delegate().filterColumns(context, tableName, columns);
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlyAccessControl.java
@@ -13,14 +13,12 @@
  */
 package io.prestosql.plugin.base.security;
 
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.security.Privilege;
 
-import java.util.List;
 import java.util.Set;
 
 import static io.prestosql.spi.security.AccessDeniedException.denyAddColumn;
@@ -123,7 +121,7 @@ public class ReadOnlyAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlySystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/security/ReadOnlySystemAccessControl.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.base.security;
 
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.security.SystemAccessControl;
@@ -23,7 +22,6 @@ import io.prestosql.spi.security.SystemAccessControlFactory;
 import io.prestosql.spi.security.SystemSecurityContext;
 
 import java.security.Principal;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -131,7 +129,7 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public List<ColumnMetadata> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    public Set<String> filterColumns(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
     {
         return columns;
     }

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedAccessControl.java
@@ -13,10 +13,8 @@
  */
 package io.prestosql.plugin.base.security;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.spi.QueryId;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.ConnectorAccessControl;
 import io.prestosql.spi.connector.ConnectorSecurityContext;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
@@ -26,7 +24,6 @@ import io.prestosql.spi.security.ConnectorIdentity;
 import io.prestosql.spi.security.PrestoPrincipal;
 import io.prestosql.spi.security.PrincipalType;
 import io.prestosql.spi.security.Privilege;
-import io.prestosql.spi.type.VarcharType;
 import org.testng.Assert.ThrowingRunnable;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -251,13 +248,13 @@ public class TestFileBasedAccessControl
 
         accessControl.checkCanShowColumns(ALICE, bobTable);
         assertEquals(
-                accessControl.filterColumns(ALICE, bobTable, ImmutableList.of(column("a"))),
-                ImmutableList.of(column("a")));
+                accessControl.filterColumns(ALICE, bobTable, ImmutableSet.of("a")),
+                ImmutableSet.of("a"));
         accessControl.checkCanSelectFromColumns(BOB, bobTable, ImmutableSet.of());
         accessControl.checkCanShowColumns(BOB, bobTable);
         assertEquals(
-                accessControl.filterColumns(BOB, bobTable, ImmutableList.of(column("a"))),
-                ImmutableList.of(column("a")));
+                accessControl.filterColumns(BOB, bobTable, ImmutableSet.of("a")),
+                ImmutableSet.of("a"));
 
         accessControl.checkCanInsertIntoTable(BOB, bobTable);
         accessControl.checkCanDeleteFromTable(BOB, bobTable);
@@ -348,8 +345,8 @@ public class TestFileBasedAccessControl
         assertDenied(() -> accessControl.checkCanShowColumns(BOB, new SchemaTableName("bobschema", "bobtable")));
         assertDenied(() -> accessControl.checkCanShowTables(BOB, "bobschema"));
         assertEquals(
-                accessControl.filterColumns(BOB, new SchemaTableName("bobschema", "bobtable"), ImmutableList.of(column("a"))),
-                ImmutableList.of());
+                accessControl.filterColumns(BOB, new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of("a")),
+                ImmutableSet.of());
 
         Set<SchemaTableName> tables = ImmutableSet.<SchemaTableName>builder()
                 .add(new SchemaTableName("restricted", "any"))
@@ -450,10 +447,5 @@ public class TestFileBasedAccessControl
                 .isInstanceOf(AccessDeniedException.class)
                 // TODO test expected message precisely, as in TestFileBasedSystemAccessControl
                 .hasMessageStartingWith("Access Denied");
-    }
-
-    private static ColumnMetadata column(String columnName)
-    {
-        return new ColumnMetadata(columnName, VarcharType.VARCHAR);
     }
 }

--- a/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/io/prestosql/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -13,14 +13,12 @@
  */
 package io.prestosql.plugin.base.security;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.security.AccessDeniedException;
 import io.prestosql.spi.security.Identity;
@@ -412,20 +410,20 @@ public class TestFileBasedSystemAccessControl
                 accessControl.filterColumns(
                         ALICE,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
-                        ImmutableList.of(column("private"), column("a"), column("restricted"), column("b"))),
-                ImmutableList.of(column("private"), column("a"), column("restricted"), column("b")));
+                        ImmutableSet.of("private", "a", "restricted", "b")),
+                ImmutableSet.of("private", "a", "restricted", "b"));
         assertEquals(
                 accessControl.filterColumns(
                         BOB,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
-                        ImmutableList.of(column("private"), column("a"), column("restricted"), column("b"))),
-                ImmutableList.of(column("private"), column("a"), column("restricted"), column("b")));
+                        ImmutableSet.of("private", "a", "restricted", "b")),
+                ImmutableSet.of("private", "a", "restricted", "b"));
         assertEquals(
                 accessControl.filterColumns(
                         CHARLIE,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
-                        ImmutableList.of(column("private"), column("a"), column("restricted"), column("b"))),
-                ImmutableList.of(column("a"), column("b")));
+                        ImmutableSet.of("private", "a", "restricted", "b")),
+                ImmutableSet.of("a", "b"));
     }
 
     @Test
@@ -478,8 +476,8 @@ public class TestFileBasedSystemAccessControl
     {
         SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-no-access.json");
         assertEquals(
-                accessControl.filterColumns(BOB, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), ImmutableList.of(column("a"))),
-                ImmutableList.of());
+                accessControl.filterColumns(BOB, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), ImmutableSet.of("a")),
+                ImmutableSet.of());
     }
 
     @Test
@@ -1204,10 +1202,5 @@ public class TestFileBasedSystemAccessControl
         assertThatThrownBy(callable)
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageMatching(expectedMessage);
-    }
-
-    private static ColumnMetadata column(String columnName)
-    {
-        return new ColumnMetadata(columnName, VARCHAR);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorAccessControl.java
@@ -18,8 +18,6 @@ import io.prestosql.spi.security.Privilege;
 import io.prestosql.spi.security.ViewExpression;
 import io.prestosql.spi.type.Type;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -239,9 +237,9 @@ public interface ConnectorAccessControl
     /**
      * Filter the list of columns to those visible to the identity.
      */
-    default List<ColumnMetadata> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnMetadata> columns)
+    default Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
-        return Collections.emptyList();
+        return emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
@@ -123,7 +123,7 @@ public interface SystemAccessControl
      */
     default Set<String> filterViewQueryOwnedBy(SystemSecurityContext context, Set<String> queryOwners)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**
@@ -185,7 +185,7 @@ public interface SystemAccessControl
      */
     default Set<String> filterCatalogs(SystemSecurityContext context, Set<String> catalogs)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**
@@ -247,7 +247,7 @@ public interface SystemAccessControl
      */
     default Set<String> filterSchemas(SystemSecurityContext context, String catalogName, Set<String> schemaNames)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**
@@ -339,7 +339,7 @@ public interface SystemAccessControl
      */
     default Set<SchemaTableName> filterTables(SystemSecurityContext context, String catalogName, Set<SchemaTableName> tableNames)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**

--- a/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/SystemAccessControl.java
@@ -16,14 +16,11 @@ package io.prestosql.spi.security;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.CatalogSchemaRoutineName;
 import io.prestosql.spi.connector.CatalogSchemaTableName;
-import io.prestosql.spi.connector.ColumnMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.eventlistener.EventListener;
 import io.prestosql.spi.type.Type;
 
 import java.security.Principal;
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
@@ -359,9 +356,9 @@ public interface SystemAccessControl
     /**
      * Filter the list of columns to those visible to the identity.
      */
-    default List<ColumnMetadata> filterColumns(SystemSecurityContext context, CatalogSchemaTableName table, List<ColumnMetadata> columns)
+    default Set<String> filterColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
-        return Collections.emptyList();
+        return emptySet();
     }
 
     /**


### PR DESCRIPTION
Make filterColumns to be coherent with other filter methods

We should not pass column metadata to filterColumns like we do not pass
TableMetadata to filterTables method.

Requiring ColumnMetadata makes it cumbersome to call filterColumns
method as it requires to have column metadata in hand which not always
is trivial.

Motivation: I want to call filterColumns here: #6017

