### PR TITLE
Ensure no operator info is ignored

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
+++ b/presto-main/src/main/java/io/prestosql/operator/OperatorStats.java
@@ -27,6 +27,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -521,7 +522,8 @@ public class OperatorStats
             }
 
             OperatorInfo info = operator.getInfo();
-            if (base != null && info != null && base.getClass() == info.getClass()) {
+            if (base != null && info != null) {
+                verify(base.getClass() == info.getClass(), "Cannot merge operator infos: %s and %s", base, info);
                 base = mergeInfo(base, info);
             }
         }


### PR DESCRIPTION
Ensure the operator infos can be merged, rather than ignoring the
inconsistencies and returning a "random" one.