### PR TITLE
Fix indeterminism in PlanNodeStats mergeability check

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/HashCollisionPlanNodeStats.java
@@ -19,7 +19,6 @@ import io.prestosql.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.max;
 import static java.lang.Math.sqrt;
 import static java.util.Objects.requireNonNull;
@@ -83,7 +82,7 @@ public class HashCollisionPlanNodeStats
     @Override
     public PlanNodeStats mergeWith(PlanNodeStats other)
     {
-        checkArgument(other instanceof HashCollisionPlanNodeStats, "other is not an instanceof HashCollisionPlanNodeStats: %s", other);
+        checkMergeable(other);
         PlanNodeStats merged = super.mergeWith(other);
 
         return new HashCollisionPlanNodeStats(

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStats.java
@@ -137,6 +137,7 @@ public class PlanNodeStats
     public PlanNodeStats mergeWith(PlanNodeStats other)
     {
         checkArgument(planNodeId.equals(other.getPlanNodeId()), "planNodeIds do not match. %s != %s", planNodeId, other.getPlanNodeId());
+        checkMergeable(other);
 
         long planNodeInputPositions = this.planNodeInputPositions + other.planNodeInputPositions;
         DataSize planNodeInputDataSize = succinctBytes(this.planNodeInputDataSize.toBytes() + other.planNodeInputDataSize.toBytes());
@@ -152,5 +153,10 @@ public class PlanNodeStats
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
                 operatorInputStats);
+    }
+
+    protected void checkMergeable(PlanNodeStats other)
+    {
+        checkArgument(this.getClass() == other.getClass(), "Cannot merge stats %s and %s, make sure all worker nodes have consistent configuration", this, other);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/WindowPlanNodeStats.java
@@ -19,8 +19,6 @@ import io.prestosql.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 public class WindowPlanNodeStats
         extends PlanNodeStats
 {
@@ -49,7 +47,7 @@ public class WindowPlanNodeStats
     @Override
     public PlanNodeStats mergeWith(PlanNodeStats other)
     {
-        checkArgument(other instanceof WindowPlanNodeStats, "other is not an instanceof WindowPlanNodeStats: %s", other);
+        checkMergeable(other);
         PlanNodeStats merged = super.mergeWith(other);
 
         return new WindowPlanNodeStats(


### PR DESCRIPTION
For example `HashCollisionPlanNodeStats#mergeWith` requires that the
object being merged with is also `HashCollisionPlanNodeStats`  and not
e.g. plain `PlanNodeStats`. However,
the same validation logic is not applied when the first stats found are
`PlanNodeStats` and `HashCollisionPlanNodeStats` are being merged with.
Thus, whether we were getting a result or a failure was not fully
deterministic.