### PR TITLE
Safe-guard invalid waitingFor usage in DockerContainer

### DIFF
--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Hadoop.java
@@ -99,7 +99,8 @@ public final class Hadoop
                 .withCommand("/usr/local/hadoop-run.sh")
                 .withExposedLogPaths("/var/log/hadoop-yarn", "/var/log/hadoop-hdfs", "/var/log/hive", "/var/log/container-health.log")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .waitingForAll(forSelectedPorts(10000), forHealthcheck()) // HiveServer2
+                .waitingFor(forSelectedPorts(10000)) // HiveServer2
+                .waitingFor(forHealthcheck())
                 .withStartupTimeout(Duration.ofMinutes(5))
                 .withHealthCheck(dockerFiles.getDockerFilesHostPath("health-checks/health.sh"));
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kafka.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Kafka.java
@@ -21,6 +21,8 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 
 import javax.inject.Inject;
 
+import java.time.Duration;
+
 import static io.prestosql.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
@@ -52,7 +54,8 @@ public class Kafka
                 .withEnv("ZOOKEEPER_CLIENT_PORT", "2181")
                 .withEnv("ZOOKEEPER_TICK_TIME", "2000")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .waitingFor(forSelectedPorts(2181));
+                .waitingFor(forSelectedPorts(2181))
+                .withStartupTimeout(Duration.ofMinutes(5));
 
         portBinder.exposePort(container, 2181);
 
@@ -69,7 +72,9 @@ public class Kafka
                 .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
                 .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .waitingForAll(forSelectedPorts(9092), forLogMessage(".*started \\(kafka.server.KafkaServer\\).*", 1));
+                .waitingFor(forSelectedPorts(9092))
+                .waitingFor(forLogMessage(".*started \\(kafka.server.KafkaServer\\).*", 1))
+                .withStartupTimeout(Duration.ofMinutes(5));
 
         portBinder.exposePort(container, 9092);
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/common/Standard.java
@@ -131,7 +131,8 @@ public final class Standard
                 .withFileSystemBind(serverPackage.getPath(), "/docker/presto-server.tar.gz", READ_ONLY)
                 .withCommand("/docker/presto-product-tests/run-presto.sh")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .waitingForAll(forLogMessage(".*======== SERVER STARTED ========.*", 1), forHealthcheck())
+                .waitingFor(forLogMessage(".*======== SERVER STARTED ========.*", 1))
+                .waitingFor(forHealthcheck())
                 .withStartupTimeout(Duration.ofMinutes(5));
         if (debug) {
             enablePrestoJavaDebugger(container);


### PR DESCRIPTION
Consecutive `waitingFor` calls will override previously defined wait strategies. The correct way of adding multiple wait strategies is to use `waitingForAll` method.

Probably this PR will blow up in the first run. I'll fix invalid usage after first pass.