### PR TITLE
Separate tested behavior from mechanics in the test

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
@@ -32,796 +32,345 @@ public class TestUnwrapCastInComparison
     public void testEquals()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1'",
-                output(
-                        filter("A = SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '1'", "a = SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '1'",
-                output(
-                        filter("A = BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '1'", "a = BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1.9'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '1.1'", "a IS NULL AND NULL");
+        testUnwrap("smallint", "a = DOUBLE '1.9'", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '1.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '1.1'", "a IS NULL AND NULL");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32766'",
-                output(
-                        filter("A = SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '32766'", "a = SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32766.9'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '32766.9'", "a IS NULL AND NULL");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32767'",
-                output(
-                        filter("A = SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '32767'", "a = SMALLINT '32767'");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '32768.1'", "a IS NULL AND NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32767'",
-                output(
-                        filter("A = SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '-32767'", "a = SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32767.9'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '-32767.9'", "a IS NULL AND NULL");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32768'",
-                output(
-                        filter("A = SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '-32768'", "a = SMALLINT '-32768'");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = DOUBLE '-32768.1'", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '-18446744073709551616'", // -2^64 constant
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        // -2^64 constant
+        testUnwrap("bigint", "a = DOUBLE '-18446744073709551616'", "a IS NULL AND NULL");
     }
 
     @Test
     public void testNotEquals()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1'",
-                output(
-                        filter("A <> SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '1'", "a <> SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '1'",
-                output(
-                        filter("A <> BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a <> DOUBLE '1'", "a <> BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1.9'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR NULL");
+        testUnwrap("smallint", "a <> DOUBLE '1.9'", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '1.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("bigint", "a <> DOUBLE '1.1'", "NOT (a IS NULL) OR NULL");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32766'",
-                output(
-                        filter("A <> SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '32766'", "a <> SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32766.9'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '32766.9'", "NOT (a IS NULL) OR NULL");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32767'",
-                output(
-                        filter("A <> SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '32767'", "a <> SMALLINT '32767'");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '18446744073709551616'", // 2^64 constant
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        // 2^64 constant
+        testUnwrap("bigint", "a <> DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32767'",
-                output(
-                        filter("A <> SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '-32767'", "a <> SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32767.9'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '-32767.9'", "NOT (a IS NULL) OR NULL");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32768'",
-                output(
-                        filter("A <> SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '-32768'", "a <> SMALLINT '-32768'");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
     }
 
     @Test
     public void testLessThan()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1'",
-                output(
-                        filter("A < SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '1'", "a < SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '1'",
-                output(
-                        filter("A < BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a < DOUBLE '1'", "a < BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1.1'",
-                output(
-                        filter("A <= SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '1.1'", "a <= SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '1.1'",
-                output(
-                        filter("A <= BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a < DOUBLE '1.1'", "a <= BIGINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1.9'",
-                output(
-                        filter("A < SMALLINT '2'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '1.9'", "a < SMALLINT '2'");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32766'",
-                output(
-                        filter("A < SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '32766'", "a < SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32766.9'",
-                output(
-                        filter("A < SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '32766.9'", "a < SMALLINT '32767'");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32767'",
-                output(
-                        filter("A <> SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '32767'", "a <> SMALLINT '32767'");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32767'",
-                output(
-                        filter("A < SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '-32767'", "a < SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32767.9'",
-                output(
-                        filter("A = SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '-32767.9'", "a = SMALLINT '-32768'");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32768'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '-32768'", "a IS NULL AND NULL");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a < DOUBLE '-32768.1'", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '-18446744073709551616'", // -2^64 constant
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        // -2^64 constant
+        testUnwrap("bigint", "a < DOUBLE '-18446744073709551616'", "a IS NULL AND NULL");
     }
 
     @Test
     public void testLessThanOrEqual()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1'",
-                output(
-                        filter("A <= SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '1'", "a <= SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '1'",
-                output(
-                        filter("A <= BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a <= DOUBLE '1'", "a <= BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1.1'",
-                output(
-                        filter("A <= SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '1.1'", "a <= SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '1.1'",
-                output(
-                        filter("A <= BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a <= DOUBLE '1.1'", "a <= BIGINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1.9'",
-                output(
-                        filter("A < SMALLINT '2'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '1.9'", "a < SMALLINT '2'");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32766'",
-                output(
-                        filter("A <= SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '32766'", "a <= SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32766.9'",
-                output(
-                        filter("A < SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '32766.9'", "a < SMALLINT '32767'");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32767'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '32767'", "NOT (a IS NULL) OR NULL");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '32768.1'", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '18446744073709551616'", // 2^64 constant
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        // 2^64 constant
+        testUnwrap("bigint", "a <= DOUBLE '18446744073709551616'", "NOT (a IS NULL) OR NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32767'",
-                output(
-                        filter("A <= SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '-32767'", "a <= SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32767.9'",
-                output(
-                        filter("A = SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '-32767.9'", "a = SMALLINT '-32768'");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32768'",
-                output(
-                        filter("A = SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '-32768'", "a = SMALLINT '-32768'");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <= DOUBLE '-32768.1'", "a IS NULL AND NULL");
     }
 
     @Test
     public void testGreaterThan()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1'",
-                output(
-                        filter("A > SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '1'", "a > SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '1'",
-                output(
-                        filter("A > BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a > DOUBLE '1'", "a > BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1.1'",
-                output(
-                        filter("A > SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '1.1'", "a > SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1.9'",
-                output(
-                        filter("A >= SMALLINT '2'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '1.9'", "a >= SMALLINT '2'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '1.9'",
-                output(
-                        filter("A >= BIGINT '2'",
-                                values("A"))));
+        testUnwrap("bigint", "a > DOUBLE '1.9'", "a >= BIGINT '2'");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32766'",
-                output(
-                        filter("A > SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '32766'", "a > SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32766.9'",
-                output(
-                        filter("A = SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '32766.9'", "a = SMALLINT '32767'");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32767'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '32767'", "a IS NULL AND NULL");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '32768.1'", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '18446744073709551616'", // 2^64 constant
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        // 2^64 constant
+        testUnwrap("bigint", "a > DOUBLE '18446744073709551616'", "a IS NULL AND NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32767'",
-                output(
-                        filter("A > SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '-32767'", "a > SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32767.9'",
-                output(
-                        filter("A > SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '-32767.9'", "a > SMALLINT '-32768'");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32768'",
-                output(
-                        filter("A <> SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '-32768'", "a <> SMALLINT '-32768'");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a > DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
     }
 
     @Test
     public void testGreaterThanOrEqual()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1'",
-                output(
-                        filter("A >= SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '1'", "a >= SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a >= DOUBLE '1'",
-                output(
-                        filter("A >= BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a >= DOUBLE '1'", "a >= BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1.1'",
-                output(
-                        filter("A > SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '1.1'", "a > SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a >= DOUBLE '1.1'",
-                output(
-                        filter("A > BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a >= DOUBLE '1.1'", "a > BIGINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1.9'",
-                output(
-                        filter("A >= SMALLINT '2'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '1.9'", "a >= SMALLINT '2'");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32766'",
-                output(
-                        filter("A >= SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '32766'", "a >= SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32766.9'",
-                output(
-                        filter("A = SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '32766.9'", "a = SMALLINT '32767'");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32767'",
-                output(
-                        filter("A = SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '32767'", "a = SMALLINT '32767'");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32768.1'",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '32768.1'", "a IS NULL AND NULL");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32767'",
-                output(
-                        filter("A >= SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '-32767'", "a >= SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32767.9'",
-                output(
-                        filter("A > SMALLINT '-32768' ",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '-32767.9'", "a > SMALLINT '-32768' ");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32768'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '-32768'", "NOT (a IS NULL) OR NULL");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32768.1'",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a >= DOUBLE '-32768.1'", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a >= DOUBLE '-18446744073709551616'", // -2^64 constant
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        // -2^64 constant
+        testUnwrap("bigint", "a >= DOUBLE '-18446744073709551616'", "NOT (a IS NULL) OR NULL");
     }
 
     @Test
     public void testDistinctFrom()
     {
         // representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1'",
-                output(
-                        filter("A IS DISTINCT FROM SMALLINT '1'",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM DOUBLE '1'", "a IS DISTINCT FROM SMALLINT '1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1'",
-                output(
-                        filter("A IS DISTINCT FROM BIGINT '1'",
-                                values("A"))));
+        testUnwrap("bigint", "a IS DISTINCT FROM DOUBLE '1'", "a IS DISTINCT FROM BIGINT '1'");
 
         // non-representable
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1.1'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '1.1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1.9'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '1.9'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1.9'",
-                output(
-                        values("A")));
+        testRemoveFilter("bigint", "a IS DISTINCT FROM DOUBLE '1.9'");
 
         // below top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32766'",
-                output(
-                        filter("A IS DISTINCT FROM SMALLINT '32766'",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM DOUBLE '32766'", "a IS DISTINCT FROM SMALLINT '32766'");
 
         // round to top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32766.9'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '32766.9'");
 
         // top of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32767'",
-                output(
-                        filter("A IS DISTINCT FROM SMALLINT '32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM DOUBLE '32767'", "a IS DISTINCT FROM SMALLINT '32767'");
 
         // above range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32768.1'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '32768.1'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a IS DISTINCT FROM DOUBLE '18446744073709551616'", // 2^64 constant
-                output(
-                        values("A")));
+        // 2^64 constant
+        testRemoveFilter("bigint", "a IS DISTINCT FROM DOUBLE '18446744073709551616'");
 
         // above bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32767'",
-                output(
-                        filter("A IS DISTINCT FROM SMALLINT '-32767'",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM DOUBLE '-32767'", "a IS DISTINCT FROM SMALLINT '-32767'");
 
         // round to bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32767.9'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '-32767.9'");
 
         // bottom of range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32768'",
-                output(
-                        filter("A IS DISTINCT FROM SMALLINT '-32768'",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM DOUBLE '-32768'", "a IS DISTINCT FROM SMALLINT '-32768'");
 
         // below range
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32768.1'",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM DOUBLE '-32768.1'");
     }
 
     @Test
     public void testNull()
     {
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a = CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("bigint", "a = CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a <> CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a > CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a < CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a >= CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= CAST(NULL AS DOUBLE)",
-                output(
-                        filter("CAST(NULL AS BOOLEAN)",
-                                values("A"))));
+        testUnwrap("smallint", "a <= CAST(NULL AS DOUBLE)", "CAST(NULL AS BOOLEAN)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM CAST(NULL AS DOUBLE)",
-                output(
-                        filter("NOT (CAST(A AS DOUBLE) IS NULL)",
-                                values("A"))));
+        testUnwrap("smallint", "a IS DISTINCT FROM CAST(NULL AS DOUBLE)", "NOT (CAST(a AS DOUBLE) IS NULL)");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a IS DISTINCT FROM CAST(NULL AS DOUBLE)",
-                output(
-                        filter("NOT (CAST(A AS DOUBLE) IS NULL)",
-                                values("A"))));
+        testUnwrap("bigint", "a IS DISTINCT FROM CAST(NULL AS DOUBLE)", "NOT (CAST(a AS DOUBLE) IS NULL)");
     }
 
     @Test
     public void testNaN()
     {
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = nan()",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a = nan()", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = nan()",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("bigint", "a = nan()", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < nan()",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a < nan()", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> nan()",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("smallint", "a <> nan()", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM nan()",
-                output(
-                        values("A")));
+        testRemoveFilter("smallint", "a IS DISTINCT FROM nan()");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a IS DISTINCT FROM nan()",
-                output(
-                        values("A")));
+        testRemoveFilter("bigint", "a IS DISTINCT FROM nan()");
 
-        assertPlan(
-                "SELECT * FROM (VALUES REAL '0.0') t(a) WHERE a = nan()",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("real", "a = nan()", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES REAL '0.0') t(a) WHERE a < nan()",
-                output(
-                        filter("A IS NULL AND NULL",
-                                values("A"))));
+        testUnwrap("real", "a < nan()", "a IS NULL AND NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES REAL '0.0') t(a) WHERE a <> nan()",
-                output(
-                        filter("NOT (A IS NULL) OR NULL",
-                                values("A"))));
+        testUnwrap("real", "a <> nan()", "NOT (a IS NULL) OR NULL");
 
-        assertPlan(
-                "SELECT * FROM (VALUES REAL '0.0') t(a) WHERE a IS DISTINCT FROM nan()",
-                output(
-                        filter("A IS DISTINCT FROM CAST(nan() AS REAL)",
-                                values("A"))));
+        testUnwrap("real", "a IS DISTINCT FROM nan()", "a IS DISTINCT FROM CAST(nan() AS REAL)");
     }
 
     @Test
@@ -829,33 +378,18 @@ public class TestUnwrapCastInComparison
     {
         // smoke tests for various type combinations
         for (String type : asList("SMALLINT", "INTEGER", "BIGINT", "REAL", "DOUBLE")) {
-            assertPlan(
-                    format("SELECT * FROM (VALUES TINYINT '1') t(a) WHERE a = %s '1'", type),
-                    output(
-                            filter("A = TINYINT '1'",
-                                    values("A"))));
+            testUnwrap("tinyint", format("a = %s '1'", type), "a = TINYINT '1'");
         }
 
         for (String type : asList("INTEGER", "BIGINT", "REAL", "DOUBLE")) {
-            assertPlan(
-                    format("SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = %s '1'", type),
-                    output(
-                            filter("A = SMALLINT '1'",
-                                    values("A"))));
+            testUnwrap("smallint", format("a = %s '1'", type), "a = SMALLINT '1'");
         }
 
         for (String type : asList("BIGINT", "DOUBLE")) {
-            assertPlan(
-                    format("SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = %s '1'", type),
-                    output(
-                            filter("A = 1",
-                                    values("A"))));
+            testUnwrap("integer", format("a = %s '1'", type), "a = 1");
         }
 
-        assertPlan("SELECT * FROM (VALUES REAL '1') t(a) WHERE a = DOUBLE '1'",
-                output(
-                        filter("A = REAL '1.0'",
-                                values("A"))));
+        testUnwrap("real", "a = DOUBLE '1'", "a = REAL '1.0'");
     }
 
     @Test
@@ -965,110 +499,46 @@ public class TestUnwrapCastInComparison
     public void testNoEffect()
     {
         // BIGINT->DOUBLE implicit cast is not injective if the double constant is >= 2^53 and <= double(2^63 - 1)
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '9007199254740992'",
-                output(
-                        filter("CAST(A AS DOUBLE) = 9.007199254740992E15",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '9007199254740992'", "CAST(a AS DOUBLE) = 9.007199254740992E15");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '9223372036854775807'",
-                output(
-                        filter("CAST(A AS DOUBLE) = 9.223372036854776E18",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '9223372036854775807'", "CAST(a AS DOUBLE) = 9.223372036854776E18");
 
         // BIGINT->DOUBLE implicit cast is not injective if the double constant is <= -2^53 and >= double(-2^63 + 1)
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '-9007199254740992'",
-                output(
-                        filter("CAST(A AS DOUBLE) = -9.007199254740992E15",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '-9007199254740992'", "CAST(a AS DOUBLE) = -9.007199254740992E15");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '-9223372036854775807'",
-                output(
-                        filter("CAST(A AS DOUBLE) = -9.223372036854776E18",
-                                values("A"))));
+        testUnwrap("bigint", "a = DOUBLE '-9223372036854775807'", "CAST(a AS DOUBLE) = -9.223372036854776E18");
 
         // BIGINT->REAL implicit cast is not injective if the real constant is >= 2^23 and <= real(2^63 - 1)
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '8388608'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '8388608.0'",
-                                values("A"))));
+        testUnwrap("bigint", "a = REAL '8388608'", "CAST(a AS REAL) = REAL '8388608.0'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '9223372036854775807'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '9.223372E18'",
-                                values("A"))));
+        testUnwrap("bigint", "a = REAL '9223372036854775807'", "CAST(a AS REAL) = REAL '9.223372E18'");
 
         // BIGINT->REAL implicit cast is not injective if the real constant is <= -2^23 and >= real(-2^63 + 1)
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '-8388608'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '-8388608.0'",
-                                values("A"))));
+        testUnwrap("bigint", "a = REAL '-8388608'", "CAST(a AS REAL) = REAL '-8388608.0'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '-9223372036854775807'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '-9.223372E18'",
-                                values("A"))));
+        testUnwrap("bigint", "a = REAL '-9223372036854775807'", "CAST(a AS REAL) = REAL '-9.223372E18'");
 
         // INTEGER->REAL implicit cast is not injective if the real constant is >= 2^23 and <= 2^31 - 1
-        assertPlan(
-                "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '8388608'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '8388608.0'",
-                                values("A"))));
+        testUnwrap("integer", "a = REAL '8388608'", "CAST(a AS REAL) = REAL '8388608.0'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '2147483647'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '2.14748365E9'",
-                                values("A"))));
+        testUnwrap("integer", "a = REAL '2147483647'", "CAST(a AS REAL) = REAL '2.14748365E9'");
 
         // INTEGER->REAL implicit cast is not injective if the real constant is <= -2^23 and >= -2^31 + 1
-        assertPlan(
-                "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '-8388608'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '-8388608.0'",
-                                values("A"))));
+        testUnwrap("integer", "a = REAL '-8388608'", "CAST(a AS REAL) = REAL '-8388608.0'");
 
-        assertPlan(
-                "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '-2147483647'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '-2.14748365E9'",
-                                values("A"))));
+        testUnwrap("integer", "a = REAL '-2147483647'", "CAST(a AS REAL) = REAL '-2.14748365E9'");
 
         // DECIMAL(p)->DOUBLE not injective for p > 15
-        assertPlan(
-                "SELECT * FROM (VALUES CAST('1' AS DECIMAL(16))) t(a) WHERE a = DOUBLE '1'",
-                output(
-                        filter("CAST(A AS DOUBLE) = 1E0",
-                                values("A"))));
+        testUnwrap("decimal(16)", "a = DOUBLE '1'", "CAST(a AS DOUBLE) = 1E0");
 
         // DECIMAL(p)->REAL not injective for p > 7
-        assertPlan(
-                "SELECT * FROM (VALUES CAST('1' AS DECIMAL(8))) t(a) WHERE a = REAL '1'",
-                output(
-                        filter("CAST(A AS REAL) = REAL '1.0'",
-                                values("A"))));
+        testUnwrap("decimal(8)", "a = REAL '1'", "CAST(a AS REAL) = REAL '1.0'");
 
         // no implicit cast between VARCHAR->INTEGER
-        assertPlan(
-                "SELECT * FROM (VALUES VARCHAR '1') t(a) WHERE CAST(a AS INTEGER) = INTEGER '1'",
-                output(
-                        filter("CAST(A AS INTEGER) = 1",
-                                values("A"))));
+        testUnwrap("varchar", "CAST(a AS INTEGER) = INTEGER '1'", "CAST(a AS INTEGER) = 1");
 
         // no implicit cast between DOUBLE->INTEGER
-        assertPlan(
-                "SELECT * FROM (VALUES DOUBLE '1') t(a) WHERE CAST(a AS INTEGER) = INTEGER '1'",
-                output(
-                        filter("CAST(A AS INTEGER) = 1",
-                                values("A"))));
+        testUnwrap("double", "CAST(a AS INTEGER) = INTEGER '1'", "CAST(a AS INTEGER) = 1");
     }
 
     private void testNoUnwrap(Session session, String inputType, String inputPredicate, String expectedCastType)
@@ -1078,13 +548,32 @@ public class TestUnwrapCastInComparison
             assertPlan(sql,
                     session,
                     output(
-                            filter(format("CAST(A AS %s) %s", expectedCastType, inputPredicate),
+                            filter(format("CAST(a AS %s) %s", expectedCastType, inputPredicate),
                                     values("A"))));
         }
         catch (Throwable e) {
             e.addSuppressed(new Exception("Query: " + sql));
             throw e;
         }
+    }
+
+    private void testRemoveFilter(String inputType, String inputPredicate)
+    {
+        String sql = format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE %s", inputType, inputPredicate);
+        try {
+            assertPlan(sql,
+                    output(
+                            values("a")));
+        }
+        catch (Throwable e) {
+            e.addSuppressed(new Exception("Query: " + sql));
+            throw e;
+        }
+    }
+
+    private void testUnwrap(String inputType, String inputPredicate, String expectedPredicate)
+    {
+        testUnwrap(getQueryRunner().getDefaultSession(), inputType, inputPredicate, expectedPredicate);
     }
 
     private void testUnwrap(Session session, String inputType, String inputPredicate, String expectedPredicate)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
@@ -882,39 +882,39 @@ public class TestUnwrapCastInComparison
         Session losAngelesSession = withZone(session, TimeZoneKey.getTimeZoneKey("America/Los_Angeles"));
 
         // same zone
-        testUnwrap(utcSession, "timestamp(0)", "> TIMESTAMP '2020-10-26 11:02:18 UTC'", "> TIMESTAMP '2020-10-26 11:02:18'");
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-26 11:02:18 Europe/Warsaw'", "> TIMESTAMP '2020-10-26 11:02:18'");
-        testUnwrap(losAngelesSession, "timestamp(0)", "> TIMESTAMP '2020-10-26 11:02:18 America/Los_Angeles'", "> TIMESTAMP '2020-10-26 11:02:18'");
+        testUnwrap(utcSession, "timestamp(0)", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", "a > TIMESTAMP '2020-10-26 11:02:18'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-26 11:02:18 Europe/Warsaw'", "a > TIMESTAMP '2020-10-26 11:02:18'");
+        testUnwrap(losAngelesSession, "timestamp(0)", "a > TIMESTAMP '2020-10-26 11:02:18 America/Los_Angeles'", "a > TIMESTAMP '2020-10-26 11:02:18'");
 
         // different zone
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-26 11:02:18 UTC'", "> TIMESTAMP '2020-10-26 12:02:18'");
-        testUnwrap(losAngelesSession, "timestamp(0)", "> TIMESTAMP '2020-10-26 11:02:18 UTC'", "> TIMESTAMP '2020-10-26 04:02:18'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", "a > TIMESTAMP '2020-10-26 12:02:18'");
+        testUnwrap(losAngelesSession, "timestamp(0)", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", "a > TIMESTAMP '2020-10-26 04:02:18'");
 
         // short timestamp, short timestamp with time zone being coerced to long timestamp with time zone
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "> TIMESTAMP '2020-10-26 12:02:18.120000'");
-        testUnwrap(losAngelesSession, "timestamp(6)", "> TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "> TIMESTAMP '2020-10-26 04:02:18.120000'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "a > TIMESTAMP '2020-10-26 12:02:18.120000'");
+        testUnwrap(losAngelesSession, "timestamp(6)", "a > TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "a > TIMESTAMP '2020-10-26 04:02:18.120000'");
 
         // long timestamp, short timestamp with time zone being coerced to long timestamp with time zone
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "> TIMESTAMP '2020-10-26 12:02:18.120000000'");
-        testUnwrap(losAngelesSession, "timestamp(9)", "> TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "> TIMESTAMP '2020-10-26 04:02:18.120000000'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "a > TIMESTAMP '2020-10-26 12:02:18.120000000'");
+        testUnwrap(losAngelesSession, "timestamp(9)", "a > TIMESTAMP '2020-10-26 11:02:18.12 UTC'", "a > TIMESTAMP '2020-10-26 04:02:18.120000000'");
 
         // long timestamp, long timestamp with time zone
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-26 11:02:18.123456 UTC'", "> TIMESTAMP '2020-10-26 12:02:18.123456000'");
-        testUnwrap(losAngelesSession, "timestamp(9)", "> TIMESTAMP '2020-10-26 11:02:18.123456 UTC'", "> TIMESTAMP '2020-10-26 04:02:18.123456000'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-26 11:02:18.123456 UTC'", "a > TIMESTAMP '2020-10-26 12:02:18.123456000'");
+        testUnwrap(losAngelesSession, "timestamp(9)", "a > TIMESTAMP '2020-10-26 11:02:18.123456 UTC'", "a > TIMESTAMP '2020-10-26 04:02:18.123456000'");
 
         // maximum precision
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", "> TIMESTAMP '2020-10-26 12:02:18.123456789321'");
-        testUnwrap(losAngelesSession, "timestamp(12)", "> TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", "> TIMESTAMP '2020-10-26 04:02:18.123456789321'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", "a > TIMESTAMP '2020-10-26 12:02:18.123456789321'");
+        testUnwrap(losAngelesSession, "timestamp(12)", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", "a > TIMESTAMP '2020-10-26 04:02:18.123456789321'");
 
         // DST forward -- Warsaw changed clock 1h forward on 2020-03-29T01:00 UTC (2020-03-29T02:00 local time)
         // Note that in given session input TIMESTAMP values  2020-03-29 02:31 and 2020-03-29 03:31 produce the same value 2020-03-29 01:31 UTC (conversion is not monotonic)
         // last before
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-03-29 00:59:59 UTC'", "> TIMESTAMP '2020-03-29 01:59:59'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-03-29 00:59:59.999 UTC'", "> TIMESTAMP '2020-03-29 01:59:59.999'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-03-29 00:59:59.13 UTC'", "> TIMESTAMP '2020-03-29 01:59:59.130000'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-03-29 00:59:59.999999 UTC'", "> TIMESTAMP '2020-03-29 01:59:59.999999'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-03-29 00:59:59.999999999 UTC'", "> TIMESTAMP '2020-03-29 01:59:59.999999999'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-03-29 00:59:59.999999999999 UTC'", "> TIMESTAMP '2020-03-29 01:59:59.999999999999'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-03-29 00:59:59 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-03-29 00:59:59.999 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59.999'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-03-29 00:59:59.13 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59.130000'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-03-29 00:59:59.999999 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59.999999'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-03-29 00:59:59.999999999 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59.999999999'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-03-29 00:59:59.999999999999 UTC'", "a > TIMESTAMP '2020-03-29 01:59:59.999999999999'");
         // first within
         testNoUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-03-29 01:00:00 UTC'", "timestamp(0) with time zone");
         testNoUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-03-29 01:00:00.000 UTC'", "timestamp(3) with time zone");
@@ -928,38 +928,38 @@ public class TestUnwrapCastInComparison
         testNoUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-03-29 01:59:59.999999999 UTC'", "timestamp(9) with time zone");
         testNoUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-03-29 01:59:59.999999999999 UTC'", "timestamp(12) with time zone");
         // first after
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-03-29 02:00:00 UTC'", "> TIMESTAMP '2020-03-29 04:00:00'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-03-29 02:00:00.000 UTC'", "> TIMESTAMP '2020-03-29 04:00:00.000'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-03-29 02:00:00.000000 UTC'", "> TIMESTAMP '2020-03-29 04:00:00.000000'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-03-29 02:00:00.000000000 UTC'", "> TIMESTAMP '2020-03-29 04:00:00.000000000'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-03-29 02:00:00.000000000000 UTC'", "> TIMESTAMP '2020-03-29 04:00:00.000000000000'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-03-29 02:00:00 UTC'", "a > TIMESTAMP '2020-03-29 04:00:00'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-03-29 02:00:00.000 UTC'", "a > TIMESTAMP '2020-03-29 04:00:00.000'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-03-29 02:00:00.000000 UTC'", "a > TIMESTAMP '2020-03-29 04:00:00.000000'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-03-29 02:00:00.000000000 UTC'", "a > TIMESTAMP '2020-03-29 04:00:00.000000000'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-03-29 02:00:00.000000000000 UTC'", "a > TIMESTAMP '2020-03-29 04:00:00.000000000000'");
 
         // DST backward -- Warsaw changed clock 1h backward on 2020-10-25T01:00 UTC (2020-03-29T03:00 local time)
         // Note that in given session no input TIMESTAMP value can produce TIMESTAMP WITH TIME ZONE within [2020-10-25 00:00:00 UTC, 2020-10-25 01:00:00 UTC], so '>=' is OK
         // last before
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-25 00:59:59 UTC'", ">= TIMESTAMP '2020-10-25 02:59:59'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-10-25 00:59:59.999 UTC'", ">= TIMESTAMP '2020-10-25 02:59:59.999'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-10-25 00:59:59.999999 UTC'", ">= TIMESTAMP '2020-10-25 02:59:59.999999'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-25 00:59:59.999999999 UTC'", ">= TIMESTAMP '2020-10-25 02:59:59.999999999'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-10-25 00:59:59.999999999999 UTC'", ">= TIMESTAMP '2020-10-25 02:59:59.999999999999'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-25 00:59:59 UTC'", "a >= TIMESTAMP '2020-10-25 02:59:59'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-10-25 00:59:59.999 UTC'", "a >= TIMESTAMP '2020-10-25 02:59:59.999'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-10-25 00:59:59.999999 UTC'", "a >= TIMESTAMP '2020-10-25 02:59:59.999999'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-25 00:59:59.999999999 UTC'", "a >= TIMESTAMP '2020-10-25 02:59:59.999999999'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-25 00:59:59.999999999999 UTC'", "a >= TIMESTAMP '2020-10-25 02:59:59.999999999999'");
         // first within
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-25 01:00:00 UTC'", "> TIMESTAMP '2020-10-25 02:00:00'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-10-25 01:00:00.000 UTC'", "> TIMESTAMP '2020-10-25 02:00:00.000'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-10-25 01:00:00.000000 UTC'", "> TIMESTAMP '2020-10-25 02:00:00.000000'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-25 01:00:00.000000000 UTC'", "> TIMESTAMP '2020-10-25 02:00:00.000000000'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-10-25 01:00:00.000000000000 UTC'", "> TIMESTAMP '2020-10-25 02:00:00.000000000000'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-25 01:00:00 UTC'", "a > TIMESTAMP '2020-10-25 02:00:00'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-10-25 01:00:00.000 UTC'", "a > TIMESTAMP '2020-10-25 02:00:00.000'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-10-25 01:00:00.000000 UTC'", "a > TIMESTAMP '2020-10-25 02:00:00.000000'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-25 01:00:00.000000000 UTC'", "a > TIMESTAMP '2020-10-25 02:00:00.000000000'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-25 01:00:00.000000000000 UTC'", "a > TIMESTAMP '2020-10-25 02:00:00.000000000000'");
         // last within
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-25 01:59:59 UTC'", "> TIMESTAMP '2020-10-25 02:59:59'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-10-25 01:59:59.999 UTC'", "> TIMESTAMP '2020-10-25 02:59:59.999'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-10-25 01:59:59.999999 UTC'", "> TIMESTAMP '2020-10-25 02:59:59.999999'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-25 01:59:59.999999999 UTC'", "> TIMESTAMP '2020-10-25 02:59:59.999999999'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-10-25 01:59:59.999999999999 UTC'", "> TIMESTAMP '2020-10-25 02:59:59.999999999999'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-25 01:59:59 UTC'", "a > TIMESTAMP '2020-10-25 02:59:59'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-10-25 01:59:59.999 UTC'", "a > TIMESTAMP '2020-10-25 02:59:59.999'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-10-25 01:59:59.999999 UTC'", "a > TIMESTAMP '2020-10-25 02:59:59.999999'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-25 01:59:59.999999999 UTC'", "a > TIMESTAMP '2020-10-25 02:59:59.999999999'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-25 01:59:59.999999999999 UTC'", "a > TIMESTAMP '2020-10-25 02:59:59.999999999999'");
         // first after
-        testUnwrap(warsawSession, "timestamp(0)", "> TIMESTAMP '2020-10-25 02:00:00 UTC'", "> TIMESTAMP '2020-10-25 03:00:00'");
-        testUnwrap(warsawSession, "timestamp(3)", "> TIMESTAMP '2020-10-25 02:00:00.000 UTC'", "> TIMESTAMP '2020-10-25 03:00:00.000'");
-        testUnwrap(warsawSession, "timestamp(6)", "> TIMESTAMP '2020-10-25 02:00:00.000000 UTC'", "> TIMESTAMP '2020-10-25 03:00:00.000000'");
-        testUnwrap(warsawSession, "timestamp(9)", "> TIMESTAMP '2020-10-25 02:00:00.000000000 UTC'", "> TIMESTAMP '2020-10-25 03:00:00.000000000'");
-        testUnwrap(warsawSession, "timestamp(12)", "> TIMESTAMP '2020-10-25 02:00:00.000000000000 UTC'", "> TIMESTAMP '2020-10-25 03:00:00.000000000000'");
+        testUnwrap(warsawSession, "timestamp(0)", "a > TIMESTAMP '2020-10-25 02:00:00 UTC'", "a > TIMESTAMP '2020-10-25 03:00:00'");
+        testUnwrap(warsawSession, "timestamp(3)", "a > TIMESTAMP '2020-10-25 02:00:00.000 UTC'", "a > TIMESTAMP '2020-10-25 03:00:00.000'");
+        testUnwrap(warsawSession, "timestamp(6)", "a > TIMESTAMP '2020-10-25 02:00:00.000000 UTC'", "a > TIMESTAMP '2020-10-25 03:00:00.000000'");
+        testUnwrap(warsawSession, "timestamp(9)", "a > TIMESTAMP '2020-10-25 02:00:00.000000000 UTC'", "a > TIMESTAMP '2020-10-25 03:00:00.000000000'");
+        testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-25 02:00:00.000000000000 UTC'", "a > TIMESTAMP '2020-10-25 03:00:00.000000000000'");
     }
 
     @Test
@@ -1090,13 +1090,13 @@ public class TestUnwrapCastInComparison
 
     private void testUnwrap(Session session, String inputType, String inputPredicate, String expectedPredicate)
     {
-        String sql = format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE a %s", inputType, inputPredicate);
+        String sql = format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE %s", inputType, inputPredicate);
         try {
             assertPlan(sql,
                     session,
                     anyTree(
-                            filter("A " + expectedPredicate,
-                                    values("A"))));
+                            filter(expectedPredicate,
+                                    values("a"))));
         }
         catch (Throwable e) {
             e.addSuppressed(new Exception("Query: " + sql));

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestUnwrapCastInComparison.java
@@ -18,7 +18,6 @@ import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.sql.planner.assertions.BasePlanTest;
 import org.testng.annotations.Test;
 
-import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.output;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
@@ -35,93 +34,93 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A = BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '32767'",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '-32768'",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a = DOUBLE '-18446744073709551616'", // -2^64 constant
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
     }
@@ -132,93 +131,93 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A <> BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '32767'",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <> DOUBLE '18446744073709551616'", // 2^64 constant
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '-32768'",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <> DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
     }
@@ -229,94 +228,94 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A < BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A <= SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A <= BIGINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '2'",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '32767'",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '32767'",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '-32768'",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a < DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a < DOUBLE '-18446744073709551616'", // -2^64 constant
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
     }
@@ -327,94 +326,94 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A <= SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A <= BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A <= SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A <= BIGINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '2'",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A <= SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("A < SMALLINT '32767'",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a <= DOUBLE '18446744073709551616'", // 2^64 constant
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A <= SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '-32768'",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '-32768'",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a <= DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
     }
@@ -425,94 +424,94 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A > BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A >= SMALLINT '2'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A >= BIGINT '2'",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '32767'",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a > DOUBLE '18446744073709551616'", // 2^64 constant
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '-32768'",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A <> SMALLINT '-32768'",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a > DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
     }
@@ -523,94 +522,94 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A >= SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a >= DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A >= BIGINT '1'",
                                 values("A"))));
 
         // non-representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a >= DOUBLE '1.1'",
-                anyTree(
+                output(
                         filter("A > BIGINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '1.9'",
-                anyTree(
+                output(
                         filter("A >= SMALLINT '2'",
                                 values("A"))));
 
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A >= SMALLINT '32766'",
                                 values("A"))));
 
         // round to top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32766.9'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '32767'",
                                 values("A"))));
 
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A = SMALLINT '32767'",
                                 values("A"))));
 
         // above range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '32768.1'",
-                anyTree(
+                output(
                         filter("A IS NULL AND NULL",
                                 values("A"))));
 
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A >= SMALLINT '-32767'",
                                 values("A"))));
 
         // round to bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32767.9'",
-                anyTree(
+                output(
                         filter("A > SMALLINT '-32768' ",
                                 values("A"))));
 
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         // below range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a >= DOUBLE '-32768.1'",
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a >= DOUBLE '-18446744073709551616'", // -2^64 constant
-                anyTree(
+                output(
                         filter("NOT (A IS NULL) OR NULL",
                                 values("A"))));
     }
@@ -621,13 +620,13 @@ public class TestUnwrapCastInComparison
         // representable
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM SMALLINT '1'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM BIGINT '1'",
                                 values("A"))));
 
@@ -650,7 +649,7 @@ public class TestUnwrapCastInComparison
         // below top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32766'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM SMALLINT '32766'",
                                 values("A"))));
 
@@ -663,7 +662,7 @@ public class TestUnwrapCastInComparison
         // top of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '32767'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM SMALLINT '32767'",
                                 values("A"))));
 
@@ -681,7 +680,7 @@ public class TestUnwrapCastInComparison
         // above bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32767'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM SMALLINT '-32767'",
                                 values("A"))));
 
@@ -694,7 +693,7 @@ public class TestUnwrapCastInComparison
         // bottom of range
         assertPlan(
                 "SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a IS DISTINCT FROM DOUBLE '-32768'",
-                anyTree(
+                output(
                         filter("A IS DISTINCT FROM SMALLINT '-32768'",
                                 values("A"))));
 
@@ -832,7 +831,7 @@ public class TestUnwrapCastInComparison
         for (String type : asList("SMALLINT", "INTEGER", "BIGINT", "REAL", "DOUBLE")) {
             assertPlan(
                     format("SELECT * FROM (VALUES TINYINT '1') t(a) WHERE a = %s '1'", type),
-                    anyTree(
+                    output(
                             filter("A = TINYINT '1'",
                                     values("A"))));
         }
@@ -840,7 +839,7 @@ public class TestUnwrapCastInComparison
         for (String type : asList("INTEGER", "BIGINT", "REAL", "DOUBLE")) {
             assertPlan(
                     format("SELECT * FROM (VALUES SMALLINT '0') t(a) WHERE a = %s '1'", type),
-                    anyTree(
+                    output(
                             filter("A = SMALLINT '1'",
                                     values("A"))));
         }
@@ -848,13 +847,13 @@ public class TestUnwrapCastInComparison
         for (String type : asList("BIGINT", "DOUBLE")) {
             assertPlan(
                     format("SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = %s '1'", type),
-                    anyTree(
+                    output(
                             filter("A = 1",
                                     values("A"))));
         }
 
         assertPlan("SELECT * FROM (VALUES REAL '1') t(a) WHERE a = DOUBLE '1'",
-                anyTree(
+                output(
                         filter("A = REAL '1.0'",
                                 values("A"))));
     }
@@ -865,7 +864,7 @@ public class TestUnwrapCastInComparison
         // ensure the optimization works when the terms of the comparison are reversed
         // vs the canonical <expr> <op> <literal> form
         assertPlan("SELECT * FROM (VALUES REAL '1') t(a) WHERE DOUBLE '1' = a",
-                anyTree(
+                output(
                         filter("A = REAL '1.0'",
                                 values("A"))));
     }
@@ -968,106 +967,106 @@ public class TestUnwrapCastInComparison
         // BIGINT->DOUBLE implicit cast is not injective if the double constant is >= 2^53 and <= double(2^63 - 1)
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '9007199254740992'",
-                anyTree(
+                output(
                         filter("CAST(A AS DOUBLE) = 9.007199254740992E15",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '9223372036854775807'",
-                anyTree(
+                output(
                         filter("CAST(A AS DOUBLE) = 9.223372036854776E18",
                                 values("A"))));
 
         // BIGINT->DOUBLE implicit cast is not injective if the double constant is <= -2^53 and >= double(-2^63 + 1)
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '-9007199254740992'",
-                anyTree(
+                output(
                         filter("CAST(A AS DOUBLE) = -9.007199254740992E15",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = DOUBLE '-9223372036854775807'",
-                anyTree(
+                output(
                         filter("CAST(A AS DOUBLE) = -9.223372036854776E18",
                                 values("A"))));
 
         // BIGINT->REAL implicit cast is not injective if the real constant is >= 2^23 and <= real(2^63 - 1)
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '8388608'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '8388608.0'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '9223372036854775807'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '9.223372E18'",
                                 values("A"))));
 
         // BIGINT->REAL implicit cast is not injective if the real constant is <= -2^23 and >= real(-2^63 + 1)
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '-8388608'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '-8388608.0'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES BIGINT '1') t(a) WHERE a = REAL '-9223372036854775807'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '-9.223372E18'",
                                 values("A"))));
 
         // INTEGER->REAL implicit cast is not injective if the real constant is >= 2^23 and <= 2^31 - 1
         assertPlan(
                 "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '8388608'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '8388608.0'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '2147483647'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '2.14748365E9'",
                                 values("A"))));
 
         // INTEGER->REAL implicit cast is not injective if the real constant is <= -2^23 and >= -2^31 + 1
         assertPlan(
                 "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '-8388608'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '-8388608.0'",
                                 values("A"))));
 
         assertPlan(
                 "SELECT * FROM (VALUES INTEGER '1') t(a) WHERE a = REAL '-2147483647'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '-2.14748365E9'",
                                 values("A"))));
 
         // DECIMAL(p)->DOUBLE not injective for p > 15
         assertPlan(
                 "SELECT * FROM (VALUES CAST('1' AS DECIMAL(16))) t(a) WHERE a = DOUBLE '1'",
-                anyTree(
+                output(
                         filter("CAST(A AS DOUBLE) = 1E0",
                                 values("A"))));
 
         // DECIMAL(p)->REAL not injective for p > 7
         assertPlan(
                 "SELECT * FROM (VALUES CAST('1' AS DECIMAL(8))) t(a) WHERE a = REAL '1'",
-                anyTree(
+                output(
                         filter("CAST(A AS REAL) = REAL '1.0'",
                                 values("A"))));
 
         // no implicit cast between VARCHAR->INTEGER
         assertPlan(
                 "SELECT * FROM (VALUES VARCHAR '1') t(a) WHERE CAST(a AS INTEGER) = INTEGER '1'",
-                anyTree(
+                output(
                         filter("CAST(A AS INTEGER) = 1",
                                 values("A"))));
 
         // no implicit cast between DOUBLE->INTEGER
         assertPlan(
                 "SELECT * FROM (VALUES DOUBLE '1') t(a) WHERE CAST(a AS INTEGER) = INTEGER '1'",
-                anyTree(
+                output(
                         filter("CAST(A AS INTEGER) = 1",
                                 values("A"))));
     }
@@ -1078,7 +1077,7 @@ public class TestUnwrapCastInComparison
         try {
             assertPlan(sql,
                     session,
-                    anyTree(
+                    output(
                             filter(format("CAST(A AS %s) %s", expectedCastType, inputPredicate),
                                     values("A"))));
         }
@@ -1094,7 +1093,7 @@ public class TestUnwrapCastInComparison
         try {
             assertPlan(sql,
                     session,
-                    anyTree(
+                    output(
                             filter(expectedPredicate,
                                     values("a"))));
         }


### PR DESCRIPTION
Factor out the repetitive stanzas so that tested aspects are easier to
see. Since upon failure the actual failing query is reported, it does
not limit ability to hand-test selected cases.

Relates to: https://github.com/prestosql/presto/pull/5692#discussion_r515308716