### PR TITLE
Gather plan node auxiliary statistics separately

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/HashCollisionPlanNodeStats.java
@@ -50,7 +50,7 @@ public class HashCollisionPlanNodeStats
         return operatorHashCollisionsStats.entrySet().stream()
                 .collect(toMap(
                         Map.Entry::getKey,
-                        entry -> entry.getValue().getWeightedHashCollisions() / operatorInputStats.get(entry.getKey()).getInputPositions()));
+                        entry -> entry.getValue().getWeightedHashCollisions() / entry.getValue().getInputPositions()));
     }
 
     public Map<String, Double> getOperatorHashCollisionsStdDevs()
@@ -61,7 +61,7 @@ public class HashCollisionPlanNodeStats
                         entry -> computedWeightedStdDev(
                                 entry.getValue().getWeightedSumSquaredHashCollisions(),
                                 entry.getValue().getWeightedHashCollisions(),
-                                operatorInputStats.get(entry.getKey()).getInputPositions())));
+                                entry.getValue().getInputPositions())));
     }
 
     private static double computedWeightedStdDev(double sumSquared, double sum, double totalWeight)
@@ -77,7 +77,7 @@ public class HashCollisionPlanNodeStats
         return operatorHashCollisionsStats.entrySet().stream()
                 .collect(toMap(
                         Map.Entry::getKey,
-                        entry -> entry.getValue().getWeightedExpectedHashCollisions() / operatorInputStats.get(entry.getKey()).getInputPositions()));
+                        entry -> entry.getValue().getWeightedExpectedHashCollisions() / entry.getValue().getInputPositions()));
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/OperatorHashCollisionsStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/OperatorHashCollisionsStats.java
@@ -18,12 +18,18 @@ class OperatorHashCollisionsStats
     private final double weightedHashCollisions;
     private final double weightedSumSquaredHashCollisions;
     private final double weightedExpectedHashCollisions;
+    private final long inputPositions;
 
-    public OperatorHashCollisionsStats(double weightedHashCollisions, double weightedSumSquaredHashCollisions, double weightedExpectedHashCollisions)
+    public OperatorHashCollisionsStats(
+            double weightedHashCollisions,
+            double weightedSumSquaredHashCollisions,
+            double weightedExpectedHashCollisions,
+            long inputPositions)
     {
         this.weightedHashCollisions = weightedHashCollisions;
         this.weightedSumSquaredHashCollisions = weightedSumSquaredHashCollisions;
         this.weightedExpectedHashCollisions = weightedExpectedHashCollisions;
+        this.inputPositions = inputPositions;
     }
 
     public double getWeightedHashCollisions()
@@ -41,11 +47,17 @@ class OperatorHashCollisionsStats
         return weightedExpectedHashCollisions;
     }
 
+    public long getInputPositions()
+    {
+        return inputPositions;
+    }
+
     public static OperatorHashCollisionsStats merge(OperatorHashCollisionsStats first, OperatorHashCollisionsStats second)
     {
         return new OperatorHashCollisionsStats(
                 first.weightedHashCollisions + second.weightedHashCollisions,
                 first.weightedSumSquaredHashCollisions + second.weightedSumSquaredHashCollisions,
-                first.weightedExpectedHashCollisions + second.weightedExpectedHashCollisions);
+                first.weightedExpectedHashCollisions + second.weightedExpectedHashCollisions,
+                first.inputPositions + second.inputPositions);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -120,25 +120,6 @@ public final class PlanNodeStatsSummarizer
                                         operatorStats.getSumSquaredInputPositions())),
                         (map1, map2) -> mergeMaps(map1, map2, OperatorInputStats::merge));
 
-                if (operatorStats.getInfo() instanceof HashCollisionsInfo) {
-                    HashCollisionsInfo hashCollisionsInfo = (HashCollisionsInfo) operatorStats.getInfo();
-                    operatorHashCollisionsStats.merge(planNodeId,
-                            ImmutableMap.of(
-                                    operatorStats.getOperatorType(),
-                                    new OperatorHashCollisionsStats(
-                                            hashCollisionsInfo.getWeightedHashCollisions(),
-                                            hashCollisionsInfo.getWeightedSumSquaredHashCollisions(),
-                                            hashCollisionsInfo.getWeightedExpectedHashCollisions(),
-                                            operatorStats.getInputPositions())),
-                            (map1, map2) -> mergeMaps(map1, map2, OperatorHashCollisionsStats::merge));
-                }
-
-                // The only statistics we have for Window Functions are very low level, thus displayed only in VERBOSE mode
-                if (operatorStats.getInfo() instanceof WindowInfo) {
-                    WindowInfo windowInfo = (WindowInfo) operatorStats.getInfo();
-                    windowNodeStats.merge(planNodeId, WindowOperatorStats.create(windowInfo), WindowOperatorStats::mergeWith);
-                }
-
                 planNodeInputPositions.merge(planNodeId, operatorStats.getInputPositions(), Long::sum);
                 planNodeInputBytes.merge(planNodeId, operatorStats.getInputDataSize().toBytes(), Long::sum);
                 processedNodes.add(planNodeId);
@@ -160,6 +141,30 @@ public final class PlanNodeStatsSummarizer
                 planNodeOutputPositions.merge(planNodeId, operatorStats.getOutputPositions(), Long::sum);
                 planNodeOutputBytes.merge(planNodeId, operatorStats.getOutputDataSize().toBytes(), Long::sum);
                 processedNodes.add(planNodeId);
+            }
+
+            // Gather auxiliary statistics
+            for (OperatorStats operatorStats : pipelineStats.getOperatorSummaries()) {
+                PlanNodeId planNodeId = operatorStats.getPlanNodeId();
+
+                if (operatorStats.getInfo() instanceof HashCollisionsInfo) {
+                    HashCollisionsInfo hashCollisionsInfo = (HashCollisionsInfo) operatorStats.getInfo();
+                    operatorHashCollisionsStats.merge(planNodeId,
+                            ImmutableMap.of(
+                                    operatorStats.getOperatorType(),
+                                    new OperatorHashCollisionsStats(
+                                            hashCollisionsInfo.getWeightedHashCollisions(),
+                                            hashCollisionsInfo.getWeightedSumSquaredHashCollisions(),
+                                            hashCollisionsInfo.getWeightedExpectedHashCollisions(),
+                                            operatorStats.getInputPositions())),
+                            (map1, map2) -> mergeMaps(map1, map2, OperatorHashCollisionsStats::merge));
+                }
+
+                // The only statistics we have for Window Functions are very low level, thus displayed only in VERBOSE mode
+                if (operatorStats.getInfo() instanceof WindowInfo) {
+                    WindowInfo windowInfo = (WindowInfo) operatorStats.getInfo();
+                    windowNodeStats.merge(planNodeId, WindowOperatorStats.create(windowInfo), WindowOperatorStats::mergeWith);
+                }
             }
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -128,7 +128,8 @@ public final class PlanNodeStatsSummarizer
                                     new OperatorHashCollisionsStats(
                                             hashCollisionsInfo.getWeightedHashCollisions(),
                                             hashCollisionsInfo.getWeightedSumSquaredHashCollisions(),
-                                            hashCollisionsInfo.getWeightedExpectedHashCollisions())),
+                                            hashCollisionsInfo.getWeightedExpectedHashCollisions(),
+                                            operatorStats.getInputPositions())),
                             (map1, map2) -> mergeMaps(map1, map2, OperatorHashCollisionsStats::merge));
                 }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/TextRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/TextRenderer.java
@@ -29,13 +29,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isNaN;
 import static java.lang.String.format;
-import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -132,6 +132,7 @@ public class TextRenderer
         output.append(format(", Output: %s (%s)\n", formatPositions(nodeStats.getPlanNodeOutputPositions()), nodeStats.getPlanNodeOutputDataSize().toString()));
 
         printDistributions(output, nodeStats);
+        printCollisions(output, nodeStats);
 
         if (nodeStats instanceof WindowPlanNodeStats) {
             printWindowOperatorStats(output, ((WindowPlanNodeStats) nodeStats).getWindowOperatorStats());
@@ -144,16 +145,6 @@ public class TextRenderer
     {
         Map<String, Double> inputAverages = stats.getOperatorInputPositionsAverages();
         Map<String, Double> inputStdDevs = stats.getOperatorInputPositionsStdDevs();
-
-        Map<String, Double> hashCollisionsAverages = emptyMap();
-        Map<String, Double> hashCollisionsStdDevs = emptyMap();
-        Map<String, Double> expectedHashCollisionsAverages = emptyMap();
-        if (stats instanceof HashCollisionPlanNodeStats) {
-            hashCollisionsAverages = ((HashCollisionPlanNodeStats) stats).getOperatorHashCollisionsAverages();
-            hashCollisionsStdDevs = ((HashCollisionPlanNodeStats) stats).getOperatorHashCollisionsStdDevs();
-            expectedHashCollisionsAverages = ((HashCollisionPlanNodeStats) stats).getOperatorExpectedCollisionsAverages();
-        }
-
         Map<String, String> translatedOperatorTypes = translateOperatorTypes(stats.getOperatorTypes());
 
         for (String operator : translatedOperatorTypes.keySet()) {
@@ -163,28 +154,32 @@ public class TextRenderer
             output.append(translatedOperatorType);
             output.append(format(Locale.US, "Input avg.: %s rows, Input std.dev.: %s%%\n",
                     formatDouble(inputAverage), formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
+        }
+    }
 
-            double hashCollisionsAverage = hashCollisionsAverages.getOrDefault(operator, 0.0d);
-            double expectedHashCollisionsAverage = expectedHashCollisionsAverages.getOrDefault(operator, 0.0d);
-            if (hashCollisionsAverage != 0.0d) {
-                double hashCollisionsStdDevRatio = hashCollisionsStdDevs.get(operator) / hashCollisionsAverage;
+    private void printCollisions(StringBuilder output, PlanNodeStats stats)
+    {
+        if (!(stats instanceof HashCollisionPlanNodeStats)) {
+            return;
+        }
 
-                if (!translatedOperatorType.isEmpty()) {
-                    output.append(indentString(2));
-                }
+        HashCollisionPlanNodeStats collisionStats = (HashCollisionPlanNodeStats) stats;
+        Map<String, Double> hashCollisionsAverages = collisionStats.getOperatorHashCollisionsAverages();
+        verify(hashCollisionsAverages.keySet().size() == 1, "Multiple hash collision operator stats %s", hashCollisionsAverages);
 
-                if (expectedHashCollisionsAverage != 0.0d) {
-                    double hashCollisionsRatio = hashCollisionsAverage / expectedHashCollisionsAverage;
-                    output.append(format(Locale.US, "Collisions avg.: %s (%s%% est.), Collisions std.dev.: %s%%",
-                            formatDouble(hashCollisionsAverage), formatDouble(hashCollisionsRatio * 100.0d), formatDouble(hashCollisionsStdDevRatio * 100.0d)));
-                }
-                else {
-                    output.append(format(Locale.US, "Collisions avg.: %s, Collisions std.dev.: %s%%",
-                            formatDouble(hashCollisionsAverage), formatDouble(hashCollisionsStdDevRatio * 100.0d)));
-                }
+        double hashCollisionsAverage = getOnlyElement(hashCollisionsAverages.values());
+        double hashCollisionsStdDev = getOnlyElement(collisionStats.getOperatorHashCollisionsStdDevs().values());
+        double expectedHashCollisionsAverage = getOnlyElement(collisionStats.getOperatorExpectedCollisionsAverages().values());
+        double hashCollisionsStdDevRatio = hashCollisionsStdDev / hashCollisionsAverage;
 
-                output.append("\n");
-            }
+        if (expectedHashCollisionsAverage != 0.0d) {
+            double hashCollisionsRatio = hashCollisionsAverage / expectedHashCollisionsAverage;
+            output.append(format(Locale.US, "Collisions avg.: %s (%s%% est.), Collisions std.dev.: %s%%\n",
+                    formatDouble(hashCollisionsAverage), formatDouble(hashCollisionsRatio * 100.0d), formatDouble(hashCollisionsStdDevRatio * 100.0d)));
+        }
+        else {
+            output.append(format(Locale.US, "Collisions avg.: %s, Collisions std.dev.: %s%%\n",
+                    formatDouble(hashCollisionsAverage), formatDouble(hashCollisionsStdDevRatio * 100.0d)));
         }
     }
 
@@ -214,6 +209,13 @@ public class TextRenderer
             return ImmutableMap.of(
                     "LookupJoinOperator", "Left (probe) ",
                     "HashBuilderOperator", "Right (build) ");
+        }
+
+        if (operators.contains("LookupJoinOperator") && operators.contains("DynamicFilterSourceOperator")) {
+            // join plan node
+            return ImmutableMap.of(
+                    "LookupJoinOperator", "Left (probe) ",
+                    "DynamicFilterSourceOperator", "Right (build) ");
         }
 
         return ImmutableMap.of();

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -270,16 +270,6 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    protected void assertExplainAnalyze(@Language("SQL") String query)
-    {
-        String value = (String) computeActual(query).getOnlyValue();
-
-        assertTrue(value.matches("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)"), format("Expected output to contain \"CPU:.*, Input:.*, Output\", but it is %s", value));
-
-        // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
-        // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
-    }
-
     protected void assertCreateTableAsSelect(@Language("SQL") String query, @Language("SQL") String rowCountQuery)
     {
         assertCreateTableAsSelect(getSession(), query, query, rowCountQuery);

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -26,7 +26,6 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.testing.DataProviders.toDataProvider;
 import static io.prestosql.testing.QueryAssertions.assertContains;
 import static io.prestosql.testing.assertions.Assert.assertEquals;
-import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -325,16 +324,6 @@ public abstract class AbstractTestIntegrationSmokeTest
         assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT * FROM orders");
         assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders");
         assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders WHERE orderkey < 0");
-    }
-
-    protected void assertExplainAnalyze(@Language("SQL") String query)
-    {
-        String value = (String) computeActual(query).getOnlyValue();
-
-        assertTrue(value.matches("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)"), format("Expected output to contain \"CPU:.*, Input:.*, Output\", but it is %s", value));
-
-        // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
-        // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
     }
 
     @Test

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -72,10 +72,12 @@ import static io.prestosql.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.prestosql.sql.ParsingUtil.createParsingOptions;
 import static io.prestosql.sql.SqlFormatter.formatSql;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestQueryFramework
 {
@@ -319,6 +321,16 @@ public abstract class AbstractTestQueryFramework
                 .map(row -> (String) row.getField(0))
                 .collect(toImmutableList());
         assertEquals(actual, expected);
+    }
+
+    protected void assertExplainAnalyze(@Language("SQL") String query)
+    {
+        String value = (String) computeActual(query).getOnlyValue();
+
+        assertTrue(value.matches("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)"), format("Expected output to contain \"CPU:.*, Input:.*, Output\", but it is %s", value));
+
+        // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
+        // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
     }
 
     protected MaterializedResult computeExpected(@Language("SQL") String sql, List<? extends Type> resultTypes)

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -325,7 +325,12 @@ public abstract class AbstractTestQueryFramework
 
     protected void assertExplainAnalyze(@Language("SQL") String query)
     {
-        String value = (String) computeActual(query).getOnlyValue();
+        assertExplainAnalyze(getSession(), query);
+    }
+
+    protected void assertExplainAnalyze(Session session, @Language("SQL") String query)
+    {
+        String value = (String) computeActual(session, query).getOnlyValue();
 
         assertTrue(value.matches("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)"), format("Expected output to contain \"CPU:.*, Input:.*, Output\", but it is %s", value));
 

--- a/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
@@ -19,6 +19,8 @@ import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import static io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
+
 public class TestDistributedEngineOnlyQueries
         extends AbstractTestEngineOnlyQueries
 {
@@ -100,5 +102,14 @@ public class TestDistributedEngineOnlyQueries
         assertQuery(
                 "SELECT cast(row(1) AS row(\"cross\" bigint)).\"cross\"",
                 "VALUES 1");
+    }
+
+    // explain analyze can only run on coordinator
+    @Test
+    public void testExplainAnalyze()
+    {
+        assertExplainAnalyze(
+                noJoinReordering(BROADCAST),
+                "EXPLAIN ANALYZE SELECT * FROM (SELECT nationkey, regionkey FROM nation GROUP BY nationkey, regionkey) a, nation b WHERE a.regionkey = b.regionkey");
     }
 }


### PR DESCRIPTION
Gather plan node auxiliary statistics from all operators
created for a given plan node. Previously, auxiliary
stats were only collected for input and output operator
for a given plan node. However, because creation of DynamicFilterSourceOperator
(input operator for join plan node) is conditional for some task
HashCollisionPlanNodeStats might be lost.