### PR TITLE
Fix terminal width detection in the CLI

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ConsolePrinter.java
@@ -13,15 +13,10 @@
  */
 package io.prestosql.cli;
 
-import org.jline.terminal.Terminal;
-
-import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UncheckedIOException;
 
 import static io.prestosql.cli.TerminalUtils.isRealTerminal;
 import static java.util.Objects.requireNonNull;
-import static org.jline.terminal.TerminalBuilder.terminal;
 
 public class ConsolePrinter
 {
@@ -73,16 +68,6 @@ public class ConsolePrinter
             }
             out.flush();
             lines = 0;
-        }
-    }
-
-    public int getWidth()
-    {
-        try (Terminal terminal = terminal()) {
-            return terminal.getWidth();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-cli/src/main/java/io/prestosql/cli/InputReader.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/InputReader.java
@@ -20,7 +20,6 @@ import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.impl.completer.AggregateCompleter;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.AttributedString;
 
 import java.io.Closeable;
@@ -42,12 +41,8 @@ public class InputReader
     public InputReader(Path historyFile, Completer... completers)
             throws IOException
     {
-        Terminal terminal = TerminalBuilder.builder()
-                .name("Presto")
-                .build();
-
         reader = LineReaderBuilder.builder()
-                .terminal(terminal)
+                .terminal(TerminalUtils.getTerminal())
                 .variable(HISTORY_FILE, historyFile)
                 .variable(SECONDARY_PROMPT_PATTERN, colored("%P -> "))
                 .variable(BLINK_MATCHING_PAREN, 0)

--- a/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/StatusPrinter.java
@@ -43,6 +43,7 @@ import static io.prestosql.cli.FormatUtils.formatProgressBar;
 import static io.prestosql.cli.FormatUtils.formatTime;
 import static io.prestosql.cli.FormatUtils.pluralize;
 import static io.prestosql.cli.TerminalUtils.isRealTerminal;
+import static io.prestosql.cli.TerminalUtils.terminalWidth;
 import static java.lang.Character.toUpperCase;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -245,7 +246,7 @@ Spilled: 20GB
             // blank line
             reprintLine("");
 
-            int terminalWidth = console.getWidth();
+            int terminalWidth = terminalWidth();
 
             if (terminalWidth < 75) {
                 reprintLine("WARNING: Terminal");

--- a/presto-cli/src/main/java/io/prestosql/cli/TerminalUtils.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/TerminalUtils.java
@@ -14,30 +14,53 @@
 package io.prestosql.cli;
 
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 
 import java.io.IOException;
-
-import static org.jline.terminal.TerminalBuilder.terminal;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 
 public class TerminalUtils
 {
-    private static final boolean REAL_TERMINAL = detectRealTerminal();
+    private static final Terminal TERMINAL_INSTANCE = createTerminal();
 
     private TerminalUtils() {}
 
-    public static boolean isRealTerminal()
+    public static Terminal getTerminal()
     {
-        return REAL_TERMINAL;
+        return TERMINAL_INSTANCE;
     }
 
-    private static boolean detectRealTerminal()
+    private static Terminal createTerminal()
     {
-        try (Terminal terminal = terminal()) {
-            return !Terminal.TYPE_DUMB.equals(terminal.getType()) &&
-                    !Terminal.TYPE_DUMB_COLOR.equals(terminal.getType());
+        try {
+            return TerminalBuilder.builder()
+                    .name("Presto")
+                    .build();
         }
         catch (IOException e) {
-            return false;
+            throw new UncheckedIOException(e);
         }
+    }
+
+    public static boolean isRealTerminal(Terminal terminal)
+    {
+        return !Terminal.TYPE_DUMB.equals(terminal.getType()) &&
+                !Terminal.TYPE_DUMB_COLOR.equals(terminal.getType());
+    }
+
+    public static boolean isRealTerminal()
+    {
+        return isRealTerminal(getTerminal());
+    }
+
+    public static int terminalWidth()
+    {
+        return getTerminal().getWidth();
+    }
+
+    public static Charset terminalEncoding()
+    {
+        return getTerminal().encoding();
     }
 }

--- a/presto-cli/src/test/java/io/prestosql/cli/TestInsecureQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestInsecureQueryRunner.java
@@ -15,7 +15,6 @@ package io.prestosql.cli;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.jline.terminal.Terminal;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -31,11 +30,11 @@ import java.security.SecureRandom;
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static io.prestosql.cli.ClientOptions.OutputFormat.CSV;
+import static io.prestosql.cli.TerminalUtils.getTerminal;
 import static io.prestosql.cli.TestQueryRunner.createClientSession;
 import static io.prestosql.cli.TestQueryRunner.createQueryRunner;
 import static io.prestosql.cli.TestQueryRunner.createResults;
 import static io.prestosql.cli.TestQueryRunner.nullPrintStream;
-import static org.jline.terminal.TerminalBuilder.terminal;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
@@ -73,10 +72,8 @@ public class TestInsecureQueryRunner
 
         QueryRunner queryRunner = createQueryRunner(createClientSession(server), true);
 
-        try (Terminal terminal = terminal()) {
-            try (Query query = queryRunner.startQuery("query with insecure mode")) {
-                query.renderOutput(terminal, nullPrintStream(), nullPrintStream(), CSV, false, false);
-            }
+        try (Query query = queryRunner.startQuery("query with insecure mode")) {
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
         }
 
         assertEquals(server.takeRequest().getPath(), "/v1/statement");

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -25,7 +25,6 @@ import io.prestosql.client.QueryResults;
 import io.prestosql.client.StatementStats;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.jline.terminal.Terminal;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -42,9 +41,9 @@ import static com.google.common.net.HttpHeaders.LOCATION;
 import static com.google.common.net.HttpHeaders.SET_COOKIE;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.prestosql.cli.ClientOptions.OutputFormat.CSV;
+import static io.prestosql.cli.TerminalUtils.getTerminal;
 import static io.prestosql.client.ClientStandardTypes.BIGINT;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.jline.terminal.TerminalBuilder.terminal;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -87,13 +86,11 @@ public class TestQueryRunner
 
         QueryRunner queryRunner = createQueryRunner(createClientSession(server), false);
 
-        try (Terminal terminal = terminal()) {
-            try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {
-                query.renderOutput(terminal, nullPrintStream(), nullPrintStream(), CSV, false, false);
-            }
-            try (Query query = queryRunner.startQuery("second query should carry the cookie")) {
-                query.renderOutput(terminal, nullPrintStream(), nullPrintStream(), CSV, false, false);
-            }
+        try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
+        }
+        try (Query query = queryRunner.startQuery("second query should carry the cookie")) {
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, false, false);
         }
 
         assertNull(server.takeRequest().getHeader("Cookie"));


### PR DESCRIPTION
Since JLine 3.14.0 only one system Terminal can exist at once. When trying to create another system Terminal instance, a dumb terminal will be created instead that reports its width as zero. To avoid that, we create a Terminal instance only once.

Supersedes https://github.com/prestosql/presto/pull/6113

Repro case:

```
package pl.wendigo.jline;

import java.io.IOException;
import java.io.UncheckedIOException;

import static java.lang.String.format;
import static org.jline.terminal.TerminalBuilder.terminal;

public class Terminal
{
    public static void main(String[] args)
    {
        try {
            System.out.println(format("Terminal width is %d", terminal().getWidth()));
            System.out.println(format("Terminal width is %d", terminal().getWidth()));
        }
        catch (IOException e) {
            throw new UncheckedIOException(e);
        }
    }
}
```

will result in:

```
Terminal width is 313
Nov 27, 2020 12:35:49 PM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
Terminal width is 0
```