### PR TITLE
Use DockerImageName in TestingMemSqlServer

### DIFF
--- a/presto-memsql/pom.xml
+++ b/presto-memsql/pom.xml
@@ -145,6 +145,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestingMemSqlServer.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestingMemSqlServer.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.memsql;
 
 import com.google.common.collect.ImmutableSet;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -40,7 +41,7 @@ public class TestingMemSqlServer
 
     public TestingMemSqlServer(String dockerImageName)
     {
-        super(dockerImageName);
+        super(DockerImageName.parse(dockerImageName));
         start();
     }
 


### PR DESCRIPTION
`JdbcDatabaseContainer(String dockerImageName)` is deprecated. 

https://github.com/testcontainers/testcontainers-java/blob/1e597ccd4fa1a7113d3077599e0b13237c1fef51/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java#L42-L47