### PR TITLE
Rename assertExplainAnalyze to assertExplainAnalyzeSucceeds

### DIFF
--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseTestOracleDistributedQueries.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseTestOracleDistributedQueries.java
@@ -169,7 +169,7 @@ public abstract class BaseTestOracleDistributedQueries
                         "SELECT DATE '2000-01-01', 1234567890, 1.23",
                 "SELECT count(*) + 1 FROM orders");
 
-        assertExplainAnalyze("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT orderstatus FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT orderstatus FROM orders");
         assertQuery("SELECT * from " + tableName, "SELECT orderstatus FROM orders");
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -265,7 +265,7 @@ public abstract class AbstractTestDistributedQueries
                         "SELECT DATE '2000-01-01', 1234567890, 1.23",
                 "SELECT count(*) + 1 FROM orders");
 
-        assertExplainAnalyze("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT orderstatus FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT orderstatus FROM orders");
         assertQuery("SELECT * from " + tableName, "SELECT orderstatus FROM orders");
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -750,13 +750,13 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("DROP TABLE " + tableName);
 
         // test EXPLAIN ANALYZE with CTAS
-        assertExplainAnalyze("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT CAST(orderstatus AS VARCHAR(15)) orderstatus FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE CREATE TABLE " + tableName + " AS SELECT CAST(orderstatus AS VARCHAR(15)) orderstatus FROM orders");
         assertQuery("SELECT * from " + tableName, "SELECT orderstatus FROM orders");
         // check that INSERT works also
-        assertExplainAnalyze("EXPLAIN ANALYZE INSERT INTO " + tableName + " SELECT clerk FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE INSERT INTO " + tableName + " SELECT clerk FROM orders");
         assertQuery("SELECT * from " + tableName, "SELECT orderstatus FROM orders UNION ALL SELECT clerk FROM orders");
         // check DELETE works with EXPLAIN ANALYZE
-        assertExplainAnalyze("EXPLAIN ANALYZE DELETE FROM " + tableName + " WHERE TRUE");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE DELETE FROM " + tableName + " WHERE TRUE");
         assertQuery("SELECT COUNT(*) from " + tableName, "SELECT 0");
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -300,30 +300,30 @@ public abstract class AbstractTestIntegrationSmokeTest
     @Test
     public void testExplainAnalyze()
     {
-        assertExplainAnalyze("EXPLAIN ANALYZE SELECT * FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE SELECT count(*), clerk FROM orders GROUP BY clerk");
-        assertExplainAnalyze(
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SELECT * FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SELECT count(*), clerk FROM orders GROUP BY clerk");
+        assertExplainAnalyzeSucceeds(
                 "EXPLAIN ANALYZE SELECT x + y FROM (" +
                         "   SELECT orderdate, COUNT(*) x FROM orders GROUP BY orderdate) a JOIN (" +
                         "   SELECT orderdate, COUNT(*) y FROM orders GROUP BY orderdate) b ON a.orderdate = b.orderdate");
-        assertExplainAnalyze("EXPLAIN ANALYZE SELECT count(*), clerk FROM orders GROUP BY clerk UNION ALL SELECT sum(orderkey), clerk FROM orders GROUP BY clerk");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SELECT count(*), clerk FROM orders GROUP BY clerk UNION ALL SELECT sum(orderkey), clerk FROM orders GROUP BY clerk");
 
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW COLUMNS FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE EXPLAIN SELECT count(*) FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE EXPLAIN ANALYZE SELECT count(*) FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW FUNCTIONS");
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW TABLES");
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW SCHEMAS");
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW CATALOGS");
-        assertExplainAnalyze("EXPLAIN ANALYZE SHOW SESSION");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW COLUMNS FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE EXPLAIN SELECT count(*) FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE EXPLAIN ANALYZE SELECT count(*) FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW FUNCTIONS");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW TABLES");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW SCHEMAS");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW CATALOGS");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE SHOW SESSION");
     }
 
     @Test
     public void testExplainAnalyzeVerbose()
     {
-        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT * FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders");
-        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders WHERE orderkey < 0");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE VERBOSE SELECT * FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders");
+        assertExplainAnalyzeSucceeds("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders WHERE orderkey < 0");
     }
 
     @Test

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -328,12 +328,9 @@ public abstract class AbstractTestQueryFramework
         assertEquals(actual, expected);
     }
 
-    protected void assertExplainAnalyze(@Language("SQL") String query)
+    protected void assertExplainAnalyzeSucceeds(@Language("SQL") String query)
     {
         String value = (String) computeActual(query).getOnlyValue();
-
-        // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
-        // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
         assertThat(value).containsPattern("CPU:.*, Input:.*, Output");
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -332,7 +332,7 @@ public abstract class AbstractTestQueryFramework
 
         // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
         // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
-        assertThat(value).containsPattern("(?s:.*)CPU:.*, Input:.*, Output(?s:.*)");
+        assertThat(value).containsPattern("CPU:.*, Input:.*, Output");
 
         for (String expectedExplainRegExp : expectedExplainRegExps) {
             assertThat(value).containsPattern(expectedExplainRegExp);

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueryFramework.java
@@ -59,6 +59,8 @@ import org.testng.annotations.BeforeClass;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
+import javax.ws.rs.HEAD;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -131,7 +133,12 @@ public abstract class AbstractTestQueryFramework
 
     protected Object computeScalar(@Language("SQL") String sql)
     {
-        return computeActual(sql).getOnlyValue();
+        return computeScalar(getSession(), sql);
+    }
+
+    protected Object computeScalar(Session session, @Language("SQL") String sql)
+    {
+        return computeActual(session, sql).getOnlyValue();
     }
 
     protected AssertProvider<QueryAssert> query(@Language("SQL") String sql)
@@ -321,22 +328,13 @@ public abstract class AbstractTestQueryFramework
         assertEquals(actual, expected);
     }
 
-    protected void assertExplainAnalyze(@Language("SQL") String query, @Language("RegExp") String... expectedExplainRegExps)
+    protected void assertExplainAnalyze(@Language("SQL") String query)
     {
-        assertExplainAnalyze(getSession(), query, expectedExplainRegExps);
-    }
-
-    protected void assertExplainAnalyze(Session session, @Language("SQL") String query, @Language("RegExp") String... expectedExplainRegExps)
-    {
-        String value = (String) computeActual(session, query).getOnlyValue();
+        String value = (String) computeActual(query).getOnlyValue();
 
         // TODO: check that rendered plan is as expected, once stats are collected in a consistent way
         // assertTrue(value.contains("Cost: "), format("Expected output to contain \"Cost: \", but it is %s", value));
         assertThat(value).containsPattern("CPU:.*, Input:.*, Output");
-
-        for (String expectedExplainRegExp : expectedExplainRegExps) {
-            assertThat(value).containsPattern(expectedExplainRegExp);
-        }
     }
 
     protected MaterializedResult computeExpected(@Language("SQL") String sql, List<? extends Type> resultTypes)


### PR DESCRIPTION
The method does not (and in general it cannot) validate any
properties of `EXPLAIN ANALYZE` other than that it does not fail.