### PR TITLE
Add Kafka tests against latest 5.5.2

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -28,6 +28,8 @@ See the :doc:`kafka-tutorial`.
 .. note::
 
     The minimum supported Kafka broker version is 0.10.0.
+    The connector is tested against Confluent Kafka versions 5.2.1 and 5.5.2,
+    but any intermediate or newer versions are expected to work.
 
 Configuration
 -------------

--- a/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaDistributedLatest.java
+++ b/presto-kafka/src/test/java/io/prestosql/plugin/kafka/TestKafkaDistributedLatest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kafka;
+
+import io.prestosql.testing.AbstractTestQueries;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.kafka.TestingKafka;
+import io.prestosql.tpch.TpchTable;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@Test
+public class TestKafkaDistributedLatest
+        extends AbstractTestQueries
+{
+    private TestingKafka testingKafka;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = new TestingKafka("5.5.2");
+        return KafkaQueryRunner.builder(testingKafka)
+                .setTables(TpchTable.getTables())
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        if (testingKafka != null) {
+            testingKafka.close();
+            testingKafka = null;
+        }
+    }
+}

--- a/presto-testing-kafka/src/main/java/io/prestosql/testing/kafka/TestingKafka.java
+++ b/presto-testing-kafka/src/main/java/io/prestosql/testing/kafka/TestingKafka.java
@@ -35,7 +35,12 @@ public class TestingKafka
 
     public TestingKafka()
     {
-        container = new KafkaContainer("5.4.1")
+        this("5.2.1");
+    }
+
+    public TestingKafka(String confluentPlatformVersion)
+    {
+        container = new KafkaContainer(confluentPlatformVersion)
                 .withNetwork(Network.SHARED)
                 .withNetworkAliases("kafka");
     }


### PR DESCRIPTION
This commit downgrades the base Kafka tests to 5.2.1 to align with the version used in the product tests and adds another test class against the latest Confluent Kafka version 5.5.2.

Relates to #5804