### PR TITLE
Fix TIMESTAMP [TZ] in JDBC when nanos overflow

### DIFF
--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -341,9 +341,7 @@ public abstract class BaseTestJdbcResultSet
                             .hasMessage("Expected value to be a date but is: 2018-02-13 13:14:15.111111111111");
                     assertThatThrownBy(() -> rs.getTime(column))
                             .isInstanceOf(IllegalArgumentException.class) // TODO (https://github.com/prestosql/presto/issues/5315) SQLException
-                            .hasMessage(serverSupportsVariablePrecisionTimestamp()
-                                    ? "Expected column to be a time type but is timestamp(12)"
-                                    : "Expected column to be a time type but is timestamp");
+                            .hasMessage("Expected column to be a time type but is timestamp(12)");
                     assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(2018, 2, 13, 13, 14, 15, 111_111_111)));
                 });
             }
@@ -356,9 +354,7 @@ public abstract class BaseTestJdbcResultSet
                             .hasMessage("Expected value to be a date but is: 2018-02-13 13:14:15.555555555555");
                     assertThatThrownBy(() -> rs.getTime(column))
                             .isInstanceOf(IllegalArgumentException.class) // TODO (https://github.com/prestosql/presto/issues/5315) SQLException
-                            .hasMessage(serverSupportsVariablePrecisionTimestamp()
-                                    ? "Expected column to be a time type but is timestamp(12)"
-                                    : "Expected column to be a time type but is timestamp");
+                            .hasMessage("Expected column to be a time type but is timestamp(12)");
                     assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(2018, 2, 13, 13, 14, 15, 555_555_556)));
                 });
             }
@@ -456,9 +452,7 @@ public abstract class BaseTestJdbcResultSet
                             .hasMessage("Expected value to be a date but is: +123456-01-23 01:23:45.123456789");
                     assertThatThrownBy(() -> rs.getTime(column))
                             .isInstanceOf(IllegalArgumentException.class) // TODO (https://github.com/prestosql/presto/issues/5315) SQLException
-                            .hasMessage(serverSupportsVariablePrecisionTimestamp()
-                                    ? "Expected column to be a time type but is timestamp(9)"
-                                    : "Expected column to be a time type but is timestamp");
+                            .hasMessage("Expected column to be a time type but is timestamp(9)");
                     assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(123456, 1, 23, 1, 23, 45, 123_456_789)));
                 });
             }
@@ -515,9 +509,7 @@ public abstract class BaseTestJdbcResultSet
                             .hasMessage("Expected value to be a date but is: +12345-01-23 01:23:45.123456789 Europe/Warsaw");
                     assertThatThrownBy(() -> rs.getTime(column))
                             .isInstanceOf(IllegalArgumentException.class) // TODO (https://github.com/prestosql/presto/issues/5315) SQLException
-                            .hasMessage(serverSupportsVariablePrecisionTimestampWithTimeZone()
-                                    ? "Expected column to be a time type but is timestamp with time zone(9)" // TODO (https://github.com/prestosql/presto/issues/5317) placement of precision parameter
-                                    : "Expected column to be a time type but is timestamp with time zone");
+                            .hasMessage("Expected column to be a time type but is timestamp with time zone(9)"); // TODO (https://github.com/prestosql/presto/issues/5317) placement of precision parameter
                     assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(12345, 1, 22, 18, 23, 45, 123_456_789)));
                 });
             }

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -456,6 +456,14 @@ public abstract class BaseTestJdbcResultSet
                     assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(123456, 1, 23, 1, 23, 45, 123_456_789)));
                 });
             }
+        }
+    }
+
+    @Test
+    public void testTimestampWithTimeZone()
+            throws Exception
+    {
+        try (ConnectedStatement connectedStatement = newStatement()) {
             checkRepresentation(connectedStatement.getStatement(), "TIMESTAMP '2018-02-13 13:14:15.227 Europe/Warsaw'", Types.TIMESTAMP /* TODO TIMESTAMP_WITH_TIMEZONE */, (rs, column) -> {
                 assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(2018, 2, 13, 6, 14, 15, 227_000_000))); // TODO this should represent TIMESTAMP '2018-02-13 13:14:15.227 Europe/Warsaw'
                 assertThatThrownBy(() -> rs.getDate(column))

--- a/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/io/prestosql/jdbc/BaseTestJdbcResultSet.java
@@ -631,7 +631,9 @@ public abstract class BaseTestJdbcResultSet
             // array or array
             checkRepresentation(connectedStatement.getStatement(), "ARRAY[NULL, ARRAY[NULL, BIGINT '1', 2]]", Types.ARRAY, (rs, column) -> {
                 assertEquals(rs.getArray(column).getArray(), new Object[] {null, asList(null, 1L, 2L)});
-                assertEquals(((Array) rs.getObject(column)).getArray(), new Object[] {null, asList(null, 1L, 2L)}); // TODO (https://github.com/prestosql/presto/issues/6049) subject to change
+                assertEquals(
+                        ((Array) rs.getObject(column)).getArray(),
+                        new Object[] {null, asList(null, 1L, 2L)}); // TODO (https://github.com/prestosql/presto/issues/6049) subject to change
                 assertEquals(rs.getObject(column, List.class), asList(null, asList(null, 1L, 2L)));
             });
 


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/6147 