### PR TITLE
Decrease refresh thread count for metastore cache

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -336,7 +336,7 @@ Property Name                                      Description                  
                                         if it is older than this but is not yet expired, allowing
                                         subsequent accesses to see fresh data.
 
-``hive.metastore-refresh-max-threads``  Maximum threads used to refresh cached metastore data.        100
+``hive.metastore-refresh-max-threads``  Maximum threads used to refresh cached metastore data.        10
 
 ``hive.metastore-timeout``              Timeout for Hive metastore requests.                         ``10s``
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -28,7 +28,7 @@ public class CachingHiveMetastoreConfig
     private Duration metastoreCacheTtl = new Duration(0, TimeUnit.SECONDS);
     private Optional<Duration> metastoreRefreshInterval = Optional.empty();
     private long metastoreCacheMaximumSize = 10000;
-    private int maxMetastoreRefreshThreads = 100;
+    private int maxMetastoreRefreshThreads = 10;
 
     @NotNull
     public Duration getMetastoreCacheTtl()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -33,7 +33,7 @@ public class TestCachingHiveMetastoreConfig
                 .setMetastoreCacheTtl(new Duration(0, TimeUnit.SECONDS))
                 .setMetastoreRefreshInterval(null)
                 .setMetastoreCacheMaximumSize(10000)
-                .setMaxMetastoreRefreshThreads(100));
+                .setMaxMetastoreRefreshThreads(10));
     }
 
     @Test


### PR DESCRIPTION
Using too many threads can overwhelm the metastore.