### PR TITLE
Efficiently enumerate symlinked files from manifest

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -141,6 +141,8 @@ public class HiveConfig
 
     private HiveTimestampPrecision timestampPrecision = HiveTimestampPrecision.MILLISECONDS;
 
+    private boolean optimizeSymlinkListing = true;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1007,6 +1009,19 @@ public class HiveConfig
     public HiveConfig setTimestampPrecision(HiveTimestampPrecision timestampPrecision)
     {
         this.timestampPrecision = timestampPrecision;
+        return this;
+    }
+
+    public boolean isOptimizeSymlinkListing()
+    {
+        return this.optimizeSymlinkListing;
+    }
+
+    @Config("hive.optimize-symlink-listing")
+    @ConfigDescription("Optimize listing for SymlinkTextFormat tables with files in a single directory")
+    public HiveConfig setOptimizeSymlinkListing(boolean optimizeSymlinkListing)
+    {
+        this.optimizeSymlinkListing = optimizeSymlinkListing;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -94,6 +94,7 @@ public final class HiveSessionProperties
     private static final String TIMESTAMP_PRECISION = "timestamp_precision";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "experimental_parquet_optimized_writer_enabled";
     private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
+    private static final String OPTIMIZE_SYMLINK_LISTING = "optimize_symlink_listing";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -390,6 +391,11 @@ public final class HiveSessionProperties
                         DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT,
                         "Duration to wait for completion of dynamic filters during split generation for probe side table",
                         hiveConfig.getDynamicFilteringProbeBlockingTimeout(),
+                        false),
+                booleanProperty(
+                        OPTIMIZE_SYMLINK_LISTING,
+                        "Optimize listing for SymlinkTextFormat tables with files in a single directory",
+                        hiveConfig.isOptimizeSymlinkListing(),
                         false));
     }
 
@@ -665,5 +671,10 @@ public final class HiveSessionProperties
     public static Duration getDynamicFilteringProbeBlockingTimeout(ConnectorSession session)
     {
         return session.getProperty(DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT, Duration.class);
+    }
+
+    public static boolean isOptimizeSymlinkListing(ConnectorSession session)
+    {
+        return session.getProperty(OPTIMIZE_SYMLINK_LISTING, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -67,6 +67,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMA
 import static io.prestosql.plugin.hive.HivePartition.UNPARTITIONED_ID;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getDynamicFilteringProbeBlockingTimeout;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isIgnoreAbsentPartitions;
+import static io.prestosql.plugin.hive.HiveSessionProperties.isOptimizeSymlinkListing;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isPartitionUseColumnNames;
 import static io.prestosql.plugin.hive.TableToPartitionMapping.mapColumnsByIndex;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getProtectMode;
@@ -236,6 +237,7 @@ public class HiveSplitManager
                 concurrency,
                 recursiveDfsWalkerEnabled,
                 !hiveTable.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session),
+                isOptimizeSymlinkListing(session),
                 metastore.getValidWriteIds(session, hiveTable)
                         .map(validTxnWriteIdList -> validTxnWriteIdList.getTableValidWriteIdList(table.getDatabaseName() + "." + table.getTableName())));
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -99,7 +99,8 @@ public class TestHiveConfig
                 .setPartitionUseColumnNames(false)
                 .setProjectionPushdownEnabled(true)
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(0, TimeUnit.MINUTES))
-                .setTimestampPrecision(HiveTimestampPrecision.MILLISECONDS));
+                .setTimestampPrecision(HiveTimestampPrecision.MILLISECONDS)
+                .setOptimizeSymlinkListing(true));
     }
 
     @Test
@@ -170,6 +171,7 @@ public class TestHiveConfig
                 .put("hive.projection-pushdown-enabled", "false")
                 .put("hive.dynamic-filtering-probe-blocking-timeout", "10s")
                 .put("hive.timestamp-precision", "NANOSECONDS")
+                .put("hive.optimize-symlink-listing", "false")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -236,7 +238,8 @@ public class TestHiveConfig
                 .setPartitionUseColumnNames(true)
                 .setProjectionPushdownEnabled(false)
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(10, TimeUnit.SECONDS))
-                .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS);
+                .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS)
+                .setOptimizeSymlinkListing(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestParquetSymlinkInputFormat.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestParquetSymlinkInputFormat.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import com.google.inject.name.Named;
+import io.prestosql.tempto.hadoop.hdfs.HdfsClient;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+
+import static com.google.common.io.Resources.getResource;
+import static io.prestosql.tempto.assertions.QueryAssert.Row.row;
+import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
+import static io.prestosql.tests.TestGroups.AVRO;
+import static io.prestosql.tests.TestGroups.STORAGE_FORMATS;
+import static io.prestosql.tests.utils.QueryExecutors.onHive;
+import static io.prestosql.tests.utils.QueryExecutors.onPresto;
+import static java.lang.String.format;
+
+public class TestParquetSymlinkInputFormat
+{
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @Inject
+    @Named("databases.hive.warehouse_directory_path")
+    private String warehouseDirectory;
+
+    @Test(groups = STORAGE_FORMATS)
+    public void testSymlinkTable()
+            throws Exception
+    {
+        String table = "test_parquet_symlink";
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        onHive().executeQuery("" +
+                "CREATE TABLE " + table +
+                "(value int) " +
+                "ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'");
+
+        String tableRoot = warehouseDirectory + '/' + table;
+        String dataDir = warehouseDirectory + "/data_test_parquet_symlink";
+
+        saveResourceOnHdfs("data.parquet", dataDir + "/data.parquet");
+        hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/data.parquet", dataDir));
+        assertThat(onPresto().executeQuery("SELECT * FROM " + table)).containsExactly(row(42));
+
+        onHive().executeQuery("DROP TABLE " + table);
+        hdfsClient.delete(dataDir);
+    }
+
+    @Test(groups = {AVRO, STORAGE_FORMATS})
+    public void testSymlinkTableWithMultipleParentDirectories()
+            throws Exception
+    {
+        String table = "test_parquet_symlink_with_multiple_parents";
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        onHive().executeQuery("" +
+                "CREATE TABLE " + table +
+                "(value int) " +
+                "ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'");
+
+        String tableRoot = warehouseDirectory + '/' + table;
+        String dataDir = warehouseDirectory + "/data_test_parquet_symlink_with_multiple_parents";
+        String anotherDataDir = warehouseDirectory + "/data2_test_parquet_symlink_with_multiple_parents";
+
+        saveResourceOnHdfs("data.parquet", dataDir + "/data.parquet");
+        saveResourceOnHdfs("data.parquet", anotherDataDir + "/data.parquet");
+        hdfsClient.saveFile(dataDir + "/dontread.txt", "This file will cause an error if read as avro.");
+        hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/data.parquet\nhdfs:%s/data.parquet", dataDir, anotherDataDir));
+        assertThat(onPresto().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactly(row(2));
+
+        onHive().executeQuery("DROP TABLE " + table);
+        hdfsClient.delete(dataDir);
+        hdfsClient.delete(anotherDataDir);
+    }
+
+    private void saveResourceOnHdfs(String resource, String location)
+            throws IOException
+    {
+        hdfsClient.delete(location);
+        try (InputStream inputStream = getResource(Paths.get("io/prestosql/tests/hive/data/single_int_column/", resource).toString()).openStream()) {
+            hdfsClient.saveFile(location, inputStream);
+        }
+    }
+}


### PR DESCRIPTION
Get file statuses in bulk when symlinked
files have single common parent directlory.

Supersedes https://github.com/prestosql/presto/pull/5349
