### PR TITLE
Remove columns cache in JDBC

### DIFF
--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestCachingJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestCachingJdbcClient.java
@@ -142,7 +142,7 @@ public class TestCachingJdbcClient
     }
 
     @Test
-    public void testColumnsCached()
+    public void testColumnsNotCached()
     {
         JdbcTableHandle table = getAnyTable(schema);
 
@@ -151,7 +151,7 @@ public class TestCachingJdbcClient
         jdbcClient.dropColumn(SESSION, table, phantomColumn);
 
         assertThat(jdbcClient.getColumns(SESSION, table)).doesNotContain(phantomColumn);
-        assertThat(cachingJdbcClient.getColumns(SESSION, table)).contains(phantomColumn);
+        assertThat(cachingJdbcClient.getColumns(SESSION, table)).doesNotContain(phantomColumn);
     }
 
     private JdbcTableHandle getAnyTable(String schema)


### PR DESCRIPTION
The cache had two problems:

- cache key included identity, but not session properties, and session
  properties may affect Type in JdbcColumnHandle objects kept in the
  cache
- the invalidation occurred for current user only, it should invalidate
  for all users instead.