### PR TITLE
Make CachingJdbcClient caches session-aware and fix caches invalidation

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/CachingJdbcClient.java
@@ -62,6 +62,7 @@ public class CachingJdbcClient
         implements JdbcClient
 {
     private static final Object NULL_MARKER = new Object();
+    private static final Duration CACHING_DISABLED = Duration.valueOf("0ms");
 
     private final JdbcClient delegate;
     private final boolean cacheMissing;
@@ -90,6 +91,11 @@ public class CachingJdbcClient
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
                 .expireAfterWrite(metadataCachingTtl.toMillis(), TimeUnit.MILLISECONDS)
                 .recordStats();
+
+        if (metadataCachingTtl.equals(CACHING_DISABLED)) {
+            // Disables the cache entirely
+            cacheBuilder.maximumSize(0);
+        }
 
         schemaNamesCache = cacheBuilder.build();
         tableNamesCache = cacheBuilder.build();

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TransactionCachingJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TransactionCachingJdbcClient.java
@@ -22,6 +22,7 @@ import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.statistics.TableStatistics;
 
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -33,7 +34,9 @@ public class TransactionCachingJdbcClient
 
     public TransactionCachingJdbcClient(JdbcClient delegate, Duration cachingTtl)
     {
-        super(delegate, cachingTtl, true);
+        // session stays the same per transaction, therefore session properties don't need to
+        // be a part of cache keys in CachingJdbcClient
+        super(delegate, Set.of(), cachingTtl, true);
         this.statisticsCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cachingTtl.toMillis(), MILLISECONDS)
                 .build();

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestCachingJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestCachingJdbcClient.java
@@ -56,7 +56,7 @@ public class TestCachingJdbcClient
 
     private CachingJdbcClient createCachingJdbcClient(boolean cacheMissing)
     {
-        return new CachingJdbcClient(database.getJdbcClient(), FOREVER, cacheMissing);
+        return new CachingJdbcClient(database.getJdbcClient(), Set.of(), FOREVER, cacheMissing);
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
`BaseJdbcClient.getColumns` calls `toPrestoType` which can return different type mapping based on a session properties. Columns cache created in `CachingJdbcClient` can be broken due to not taking session properties into account.

Fixes https://github.com/prestosql/presto/issues/6106
Fixes https://github.com/prestosql/presto/issues/6166