### PR TITLE
Reduce unexpected Integer object creation

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/LookupJoinPageBuilder.java
+++ b/presto-main/src/main/java/io/prestosql/operator/LookupJoinPageBuilder.java
@@ -145,7 +145,7 @@ public class LookupJoinPageBuilder
     {
         int position = probe.getPosition();
         verify(position >= 0);
-        int previousPosition = probeIndexBuilder.isEmpty() ? -1 : probeIndexBuilder.get(probeIndexBuilder.size() - 1);
+        int previousPosition = probeIndexBuilder.isEmpty() ? -1 : probeIndexBuilder.getInt(probeIndexBuilder.size() - 1);
         // positions to be appended should be in ascending order
         verify(previousPosition <= position);
         isSequentialProbeIndices &= position == previousPosition + 1 || previousPosition == -1;

--- a/presto-main/src/main/java/io/prestosql/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/io/prestosql/operator/SortedPositionLinks.java
@@ -115,19 +115,19 @@ public final class SortedPositionLinks
 
                 sortedPositionLinks[key] = new int[positions.size()];
                 for (int i = 0; i < positions.size(); i++) {
-                    sortedPositionLinks[key][i] = positions.get(i);
+                    sortedPositionLinks[key][i] = positions.getInt(i);
                 }
 
                 // ArrayPositionsLinks.Builder::link builds position links from
                 // tail to head, so we must add them in descending order to have
                 // smallest element as a head
                 for (int i = positions.size() - 2; i >= 0; i--) {
-                    arrayPositionLinksFactoryBuilder.link(positions.get(i), positions.get(i + 1));
+                    arrayPositionLinksFactoryBuilder.link(positions.getInt(i), positions.getInt(i + 1));
                 }
 
                 // add link from starting position to position links chain
                 if (!positions.isEmpty()) {
-                    arrayPositionLinksFactoryBuilder.link(key, positions.get(0));
+                    arrayPositionLinksFactoryBuilder.link(key, positions.getInt(0));
                 }
             }
 


### PR DESCRIPTION
By accident, I found unexpected Integer object creation from `IntArrayList.get` investigating another performance issue. 

This might give a little gain around building join table.

<img width="916" alt="Screen Shot 2020-12-02 at 2 32 23 PM" src="https://user-images.githubusercontent.com/725129/100833565-917ff200-34ad-11eb-941b-411cf8eb002c.png">
