### PR TITLE
Ensure exactly single delivery of query completion event

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/DispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/DispatchQuery.java
@@ -20,14 +20,9 @@ import io.prestosql.execution.QueryTracker.TrackedQuery;
 public interface DispatchQuery
         extends TrackedQuery, ManagedQueryExecution
 {
-    enum DispatchStatus
-    {
-        FAILED, DISPATCHED
-    }
-
     void recordHeartbeat();
 
-    ListenableFuture<DispatchStatus> getDispatchedFuture();
+    ListenableFuture<?> getDispatchedFuture();
 
     DispatchInfo getDispatchInfo();
 

--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
-import static io.prestosql.dispatcher.DispatchQuery.DispatchStatus.FAILED;
 import static io.prestosql.memory.LocalMemoryManager.GENERAL_POOL;
 import static io.prestosql.server.DynamicFilterService.DynamicFiltersStats;
 import static io.prestosql.util.Failures.toFailure;
@@ -104,9 +103,9 @@ public class FailedDispatchQuery
     }
 
     @Override
-    public ListenableFuture<DispatchStatus> getDispatchedFuture()
+    public ListenableFuture<?> getDispatchedFuture()
     {
-        return immediateFuture(FAILED);
+        return immediateFuture(null);
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQueryFactory.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQueryFactory.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
+import static io.prestosql.util.Failures.toFailure;
 import static java.util.Objects.requireNonNull;
 
 public class FailedDispatchQueryFactory
@@ -54,6 +55,7 @@ public class FailedDispatchQueryFactory
         BasicQueryInfo queryInfo = failedDispatchQuery.getBasicQueryInfo();
 
         queryMonitor.queryCreatedEvent(queryInfo);
+        queryMonitor.queryImmediateFailureEvent(queryInfo, toFailure(throwable));
 
         return failedDispatchQuery;
     }

--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQueryFactory.java
@@ -38,7 +38,6 @@ import io.prestosql.util.StatementUtils;
 import javax.inject.Inject;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.util.StatementUtils.isTransactionControlStatement;
@@ -110,8 +109,6 @@ public class LocalDispatchQueryFactory
                 warningCollector,
                 StatementUtils.getQueryType(preparedQuery.getStatement().getClass()));
 
-        queryMonitor.queryCreatedEvent(stateMachine.getBasicQueryInfo(Optional.empty()));
-
         ListenableFuture<QueryExecution> queryExecutionFuture = executor.submit(() -> {
             QueryExecutionFactory<?> queryExecutionFactory = executionFactories.get(preparedQuery.getStatement().getClass());
             if (queryExecutionFactory == null) {
@@ -130,6 +127,7 @@ public class LocalDispatchQueryFactory
         return new LocalDispatchQuery(
                 stateMachine,
                 queryExecutionFuture,
+                queryMonitor,
                 clusterSizeMonitor,
                 executor,
                 queryManager::createQuery);

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -971,6 +971,7 @@ public class QueryStateMachine
     {
         AtomicBoolean done = new AtomicBoolean();
         StateChangeListener<Optional<QueryInfo>> fireOnceStateChangeListener = finalQueryInfo -> {
+            // QueryInfo.isPresent() does not mean this is a terminal state for finalQueryInfo state machine
             if (finalQueryInfo.isPresent() && done.compareAndSet(false, true)) {
                 stateChangeListener.stateChanged(finalQueryInfo.get());
             }

--- a/presto-tests/src/test/java/io/prestosql/execution/TestEventListenerBasic.java
+++ b/presto-tests/src/test/java/io/prestosql/execution/TestEventListenerBasic.java
@@ -36,7 +36,6 @@ import io.prestosql.testing.AbstractTestQueryFramework;
 import io.prestosql.testing.DistributedQueryRunner;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.QueryRunner;
-import io.prestosql.testng.services.Flaky;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
@@ -140,7 +139,6 @@ public class TestEventListenerBasic
     }
 
     @Test
-    @Flaky(issue = "https://github.com/prestosql/presto/issues/5922", match = "java.lang.IllegalArgumentException: expected one element but was: <.*>")
     public void testPlanningFailure()
             throws Exception
     {


### PR DESCRIPTION
Thoughtful part of this PR by @findepi. I did the final edit :)