### PR TITLE
Convert all code-block:: none to c-b:: text

### DIFF
--- a/presto-docs/src/main/sphinx/admin/dynamic-filtering.rst
+++ b/presto-docs/src/main/sphinx/admin/dynamic-filtering.rst
@@ -71,7 +71,7 @@ operator where ``df_370`` is associated with probe symbol ``ss_sold_date_sk``.
 This shows you that the planner is successful in pushing dynamic filters
 down to the connector in the query plan.
 
-.. code-block:: none
+.. code-block:: text
 
     ...
 
@@ -117,7 +117,7 @@ about dynamic filters in the QueryInfo JSON available through the
 In the ``queryStats`` section, statistics about dynamic filters collected
 by the coordinator can be found in the ``dynamicFiltersStats`` structure.
 
-.. code-block:: none
+.. code-block:: text
 
     "dynamicFiltersStats" : {
           "dynamicFilterDomainStats" : [ {
@@ -138,7 +138,7 @@ verified by looking at the operator statistics for that table scan.
 ``dynamicFilterSplitsProcessed`` records the number of splits
 processed after a dynamic filter is pushed down to the table scan.
 
-.. code-block:: none
+.. code-block:: text
 
     "operatorType" : "ScanFilterAndProjectOperator",
     "totalDrivers" : 1,

--- a/presto-docs/src/main/sphinx/admin/jmx.rst
+++ b/presto-docs/src/main/sphinx/admin/jmx.rst
@@ -7,7 +7,7 @@ Presto exposes a large number of different metrics via the Java Management Exten
 You have to enable JMX by setting the ports used by the RMI registry and server
 in the :ref:`config.properties file <config_properties>`:
 
-.. code-block:: none
+.. code-block:: text
 
     jmx.rmiregistry.port=9080
     jmx.rmiserver.port=9081

--- a/presto-docs/src/main/sphinx/admin/properties-node-scheduler.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-node-scheduler.rst
@@ -93,7 +93,7 @@ must be set to ``file``. Each line contains a mapping between a host name and a
 network location, separated by whitespace. Network location must begin with a leading
 ``/`` and segments are separated by a ``/``.
 
-.. code-block:: none
+.. code-block:: text
 
     192.168.0.1 /region1/rack1/machine1
     192.168.0.2 /region1/rack1/machine2

--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -13,7 +13,7 @@ The resource groups and associated selection rules are configured by a manager, 
 Add an ``etc/resource-groups.properties`` file with the following contents to enable
 the built-in manager that reads a JSON config file:
 
-.. code-block:: none
+.. code-block:: text
 
     resource-groups.configuration-manager=file
     resource-groups.config-file=etc/resource-groups.json

--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -10,7 +10,7 @@ characteristics. Session property managers are pluggable.
 Add an ``etc/session-property-config.properties`` file with the following contents to enable
 the built-in manager, that reads a JSON config file:
 
-.. code-block:: none
+.. code-block:: text
 
     session-property-config.configuration-manager=file
     session-property-manager.config-file=etc/session-property-config.json

--- a/presto-docs/src/main/sphinx/admin/tuning.rst
+++ b/presto-docs/src/main/sphinx/admin/tuning.rst
@@ -15,6 +15,6 @@ JVM Settings
 
 The following can be helpful for diagnosing garbage collection (GC) issues:
 
-.. code-block:: none
+.. code-block:: text
 
     -Xlog:gc*,safepoint::time,level,tags,tid

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -31,7 +31,7 @@ Create ``etc/catalog/accumulo.properties``
 to mount the ``accumulo`` connector as the ``accumulo`` catalog,
 replacing the ``accumulo.xxx`` properties as required:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=accumulo
     accumulo.instance=xxx
@@ -89,7 +89,7 @@ Simply issue a ``CREATE TABLE`` statement to create a new Presto/Accumulo table:
 
     DESCRIBE myschema.scientists;
 
-.. code-block:: none
+.. code-block:: text
 
       Column   |  Type   | Extra |                      Comment
     -----------+---------+-------+---------------------------------------------------
@@ -135,7 +135,7 @@ For example:
 
     DESCRIBE myschema.scientists;
 
-.. code-block:: none
+.. code-block:: text
 
       Column   |  Type   | Extra |                    Comment
     -----------+---------+-------+-----------------------------------------------
@@ -163,7 +163,7 @@ You can then issue ``INSERT`` statements to put data into Accumulo.
 
     SELECT * FROM myschema.scientists;
 
-.. code-block:: none
+.. code-block:: text
 
      recordkey |     name     | age |  birthday
     -----------+--------------+-----+------------
@@ -188,7 +188,7 @@ little younger.)
 
     SELECT * FROM myschema.scientists;
 
-.. code-block:: none
+.. code-block:: text
 
      recordkey |      name       | age |  birthday
     -----------+-----------------+-----+------------
@@ -249,7 +249,7 @@ should be using the default ``lexicoder`` serializer).
 After creating the table, we see there are an additional two Accumulo
 tables to store the index and metrics.
 
-.. code-block:: none
+.. code-block:: text
 
     root@default> tables
     accumulo.metadata
@@ -269,7 +269,7 @@ queries this index table
     ('row1', 'Grace Hopper', 109, DATE '1906-12-09'),
     ('row2', 'Alan Turing', 103, DATE '1912-06-23');
 
-.. code-block:: none
+.. code-block:: text
 
     root@default> scan -t myschema.scientists_idx
     -21011 metadata_date:row2 []
@@ -291,7 +291,7 @@ scans the data table.
 
     SELECT * FROM myschema.scientists WHERE age = 109;
 
-.. code-block:: none
+.. code-block:: text
 
      recordkey |     name     | age |  birthday
     -----------+--------------+-----+------------
@@ -374,7 +374,7 @@ After creating the table, usage of the table continues as usual:
 
     SELECT * FROM external_table;
 
-.. code-block:: none
+.. code-block:: text
 
      a | b |     c
     ---+---+------------
@@ -388,7 +388,7 @@ After creating the table, usage of the table continues as usual:
 
 After dropping the table, the table still exists in Accumulo because it is *external*.
 
-.. code-block:: none
+.. code-block:: text
 
     root@default> tables
     accumulo.metadata
@@ -547,7 +547,7 @@ specifying the fully-qualified Java class name in the connector configuration.
     ('row1', 'Grace Hopper', 109, DATE '1906-12-09' ),
     ('row2', 'Alan Turing', 103, DATE '1912-06-23' );
 
-.. code-block:: none
+.. code-block:: text
 
     root@default> scan -t myschema.scientists
     row1 metadata:age []    \x08\x80\x00\x00\x00\x00\x00\x00m
@@ -576,7 +576,7 @@ specifying the fully-qualified Java class name in the connector configuration.
     ('row1', 'Grace Hopper', 109, DATE '1906-12-09' ),
     ('row2', 'Alan Turing', 103, DATE '1912-06-23' );
 
-.. code-block:: none
+.. code-block:: text
 
     root@default> scan -t myschema.stringy_scientists
     row1 metadata:age []    109
@@ -611,7 +611,7 @@ the details of how it is stored.
 A root node in ZooKeeper holds all the mappings, and the format is as
 follows:
 
-.. code-block:: none
+.. code-block:: text
 
     /metadata-root/schema/table
 
@@ -656,7 +656,7 @@ when creating the external table.
 
     DESCRIBE foo.bar;
 
-.. code-block:: none
+.. code-block:: text
 
      Column |  Type   | Extra |               Comment
     --------+---------+-------+-------------------------------------
@@ -667,7 +667,7 @@ when creating the external table.
 2. Using the ZooKeeper CLI, delete the corresponding znode.  Note this uses the default ZooKeeper
 metadata root of ``/presto-accumulo``
 
-.. code-block:: none
+.. code-block:: text
 
     $ zkCli.sh
     [zk: localhost:2181(CONNECTED) 1] delete /presto-accumulo/foo/bar

--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -73,7 +73,7 @@ BigQuery connector as the ``bigquery`` catalog. Create the file with the
 following contents, replacing the connection properties as appropriate for
 your setup:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=bigquery
     bigquery.project-id=<your Google Cloud Platform project id>

--- a/presto-docs/src/main/sphinx/connector/blackhole.rst
+++ b/presto-docs/src/main/sphinx/connector/blackhole.rst
@@ -27,7 +27,7 @@ Configuration
 To configure the Black Hole connector, create a catalog properties file
 ``etc/catalog/blackhole.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=blackhole
 

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -18,7 +18,7 @@ To configure the Cassandra connector, create a catalog properties file
 replacing ``host1,host2`` with a comma-separated list of the Cassandra
 nodes, used to discovery the cluster topology:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=cassandra
     cassandra.contact-points=host1,host2
@@ -167,7 +167,7 @@ keyspace using Cassandra's cqlsh (CQL interactive terminal):
 
 .. _Getting Started: https://wiki.apache.org/cassandra/GettingStarted
 
-.. code-block:: none
+.. code-block:: text
 
     cqlsh> CREATE KEYSPACE mykeyspace
        ... WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
@@ -182,7 +182,7 @@ This table can be described in Presto::
 
     DESCRIBE cassandra.mykeyspace.users;
 
-.. code-block:: none
+.. code-block:: text
 
      Column  |  Type   | Extra | Comment
     ---------+---------+-------+---------

--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -19,7 +19,7 @@ To configure the Elasticsearch connector, create a catalog properties file
 ``etc/catalog/elasticsearch.properties`` with the following contents,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=elasticsearch
     elasticsearch.host=localhost

--- a/presto-docs/src/main/sphinx/connector/googlesheets.rst
+++ b/presto-docs/src/main/sphinx/connector/googlesheets.rst
@@ -11,7 +11,7 @@ Create ``etc/catalog/sheets.properties``
 to mount the Google Sheets connector as the ``sheets`` catalog,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=gsheets
     credentials-path=/path/to/google-sheets-credentials.json

--- a/presto-docs/src/main/sphinx/connector/hive-alluxio.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-alluxio.rst
@@ -22,7 +22,7 @@ so that the Alluxio properties file ``alluxio-site.properties`` can be loaded as
 a resource. Update the Presto :ref:`presto_jvm_config` file ``etc/jvm.config``
 to include the following:
 
-.. code-block:: none
+.. code-block:: text
 
   -Xbootclasspath/a:<path-to-alluxio-conf>
 
@@ -66,7 +66,7 @@ catalog, simply use the
 The appropriate Hive metastore location and Hive database name need to be
 provided.
 
-.. code-block:: none
+.. code-block:: text
 
     ./bin/alluxio table attachdb hive thrift://HOSTNAME:9083 hive_db_name
 
@@ -77,7 +77,7 @@ metastore type, and provide the location to the Alluxio cluster.
 For example, your ``etc/catalog/alluxio.properties`` should include
 the following:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=hive-hadoop2
     hive.metastore=alluxio

--- a/presto-docs/src/main/sphinx/connector/hive-azure.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-azure.rst
@@ -19,7 +19,7 @@ All configuration for the Azure storage driver is stored in the Hadoop
 ``core-site.xml`` configuration file. The path to the file needs to be
 configured in the the catalog properties file:
 
-.. code-block:: none
+.. code-block:: text
 
     hive.config.resources=<path_to_hadoop_core-site.xml>
 
@@ -131,19 +131,19 @@ different systems.
 
 ABFS URI:
 
-.. code-block:: none
+.. code-block:: text
 
     abfs[s]://file_system@account_name.dfs.core.windows.net/<path>/<path>/<file_name>
 
 ADLS Gen1 URI:
 
-.. code-block:: none
+.. code-block:: text
 
     adl://<data_lake_storage_gen1_name>.azuredatalakestore.net/<path>/<file_name>
 
 Azure Standard Blob URI:
 
-.. code-block:: none
+.. code-block:: text
 
     wasb[s]://container@account_name.blob.core.windows.net/<path>/<path>/<file_name>
 

--- a/presto-docs/src/main/sphinx/connector/hive-caching.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-caching.rst
@@ -76,7 +76,7 @@ Configuration
 The caching feature is part of the :doc:`/connector/hive` and
 can be activated in the catalog properties file:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=hive-hadoop2
     hive.cache.enabled=true

--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -210,7 +210,7 @@ This property is optional; no default value.
 Example configuration with ``NONE`` authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.metastore.authentication.type=NONE
 
@@ -221,7 +221,7 @@ metastore. Kerberos is not used.
 Example configuration with ``KERBEROS`` authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.metastore.authentication.type=KERBEROS
     hive.metastore.thrift.impersonation.enabled=true
@@ -321,7 +321,7 @@ may impact query execution performance.
 Example configuration with ``NONE`` authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.hdfs.authentication.type=NONE
 
@@ -334,7 +334,7 @@ mechanism. Kerberos is not used.
 Example configuration with ``KERBEROS`` authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.hdfs.authentication.type=KERBEROS
     hive.hdfs.presto.principal=hdfs@EXAMPLE.COM
@@ -371,7 +371,7 @@ HDFS Permissions and ACLs are explained in the `HDFS Permissions Guide
 ``NONE`` authentication with HDFS impersonation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.hdfs.authentication.type=NONE
     hive.hdfs.impersonation.enabled=true
@@ -386,7 +386,7 @@ section :ref:`configuring-hadoop-impersonation`. Kerberos is not used.
 ``KERBEROS`` Authentication With HDFS Impersonation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: none
+.. code-block:: text
 
     hive.hdfs.authentication.type=KERBEROS
     hive.hdfs.impersonation.enabled=true
@@ -413,7 +413,7 @@ Impersonation Accessing the Hive Metastore
 Presto supports impersonating the end user when accessing the Hive metastore.
 Metastore impersonation can be enabled with
 
-.. code-block:: none
+.. code-block:: text
 
     hive.metastore.thrift.impersonation.enabled=true
 

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -107,7 +107,7 @@ to mount the ``hive-hadoop2`` connector as the ``hive`` catalog,
 replacing ``example.net:9083`` with the correct host and port
 for your Hive metastore Thrift service:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://example.net:9083
@@ -130,7 +130,7 @@ federated HDFS or NameNode high availability, it is necessary to specify
 additional HDFS client options in order to access your HDFS cluster. To do so,
 add the ``hive.config.resources`` property to reference your HDFS config files:
 
-.. code-block:: none
+.. code-block:: text
 
     hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 
@@ -159,7 +159,7 @@ username by setting the ``HADOOP_USER_NAME`` system property in the
 Presto :ref:`presto_jvm_config`, replacing ``hdfs_user`` with the
 appropriate username:
 
-.. code-block:: none
+.. code-block:: text
 
     -DHADOOP_USER_NAME=hdfs_user
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -35,7 +35,7 @@ Configuration
 Iceberg supports the same metastore configuration properties as the Hive connector.
 At a minimum, ``hive.metastore.uri`` must be configured:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=iceberg
     hive.metastore.uri=thrift://localhost:9083

--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -18,13 +18,13 @@ Configuration
 To configure the JMX connector, create a catalog properties file
 ``etc/catalog/jmx.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=jmx
 
 To enable periodical dumps, define the following properties:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=jmx
     jmx.dump-tables=java.lang:type=Runtime,presto.execution.scheduler:name=NodeScheduler
@@ -38,7 +38,7 @@ and ``max-entries`` have default values of ``10s`` and ``86400`` accordingly.
 
 Commas in MBean names should be escaped in the following manner:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=jmx
     jmx.dump-tables=presto.memory:name=general\\,type=memorypool,\
@@ -61,7 +61,7 @@ following query shows the JVM version of every node::
     SELECT node, vmname, vmversion
     FROM jmx.current."java.lang:type=runtime";
 
-.. code-block:: none
+.. code-block:: text
 
                      node                 |              vmname               | vmversion
     --------------------------------------+-----------------------------------+-----------
@@ -74,7 +74,7 @@ for each node::
     SELECT openfiledescriptorcount, maxfiledescriptorcount
     FROM jmx.current."java.lang:type=operatingsystem";
 
-.. code-block:: none
+.. code-block:: text
 
      openfiledescriptorcount | maxfiledescriptorcount
     -------------------------+------------------------
@@ -88,7 +88,7 @@ returns information from the different Presto memory pools on each node::
     SELECT freebytes, node, object_name
     FROM jmx.current."presto.memory:*type=memorypool*";
 
-.. code-block:: none
+.. code-block:: text
 
      freebytes  |  node   |                       object_name
     ------------+---------+----------------------------------------------------------
@@ -103,7 +103,7 @@ timestamp column that stores the time at which the snapshot was taken::
 
     SELECT "timestamp", "uptime" FROM jmx.history."java.lang:type=runtime";
 
-.. code-block:: none
+.. code-block:: text
 
             timestamp        | uptime
     -------------------------+--------

--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -28,13 +28,13 @@ Download and extract `Apache Kafka <https://kafka.apache.org/>`_.
 
 Start ZooKeeper and the Kafka server:
 
-.. code-block:: none
+.. code-block:: text
 
     $ bin/zookeeper-server-start.sh config/zookeeper.properties
     [2013-04-22 15:01:37,495] INFO Reading configuration from: config/zookeeper.properties (org.apache.zookeeper.server.quorum.QuorumPeerConfig)
     ...
 
-.. code-block:: none
+.. code-block:: text
 
     $ bin/kafka-server-start.sh config/server.properties
     [2013-04-22 15:01:47,028] INFO Verifying properties (kafka.utils.VerifiableProperties)
@@ -48,14 +48,14 @@ Step 2: Load data
 
 Download the tpch-kafka loader from Maven Central:
 
-.. code-block:: none
+.. code-block:: text
 
     $ curl -o kafka-tpch https://repo1.maven.org/maven2/de/softwareforge/kafka_tpch_0811/1.0/kafka_tpch_0811-1.0.sh
     $ chmod 755 kafka-tpch
 
 Now run the ``kafka-tpch`` program to preload a number of topics with tpch data:
 
-.. code-block:: none
+.. code-block:: text
 
     $ ./kafka-tpch load --brokers localhost:9092 --prefix tpch. --tpch-type tiny
     2014-07-28T17:17:07.594-0700     INFO    main    io.airlift.log.Logging    Logging to stderr
@@ -94,7 +94,7 @@ In your Presto installation, add a catalog properties file
 ``etc/catalog/kafka.properties`` for the Kafka connector.
 This file lists the Kafka nodes and topics:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=kafka
     kafka.nodes=localhost:9092
@@ -103,7 +103,7 @@ This file lists the Kafka nodes and topics:
 
 Now start Presto:
 
-.. code-block:: none
+.. code-block:: text
 
     $ bin/launcher start
 
@@ -113,13 +113,13 @@ the tables are in the ``tpch`` schema. The connector is mounted into the
 
 Start the :doc:`Presto CLI </installation/cli>`:
 
-.. code-block:: none
+.. code-block:: text
 
     $ ./presto --catalog kafka --schema tpch
 
 List the tables to verify that things are working:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tpch> SHOW TABLES;
       Table
@@ -142,7 +142,7 @@ the messages. Without further configuration, the Kafka connector can access
 the data, and map it in raw form. However there are no actual columns besides the
 built-in ones:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tpch> DESCRIBE customer;
           Column       |  Type      | Extra |                   Comment
@@ -216,7 +216,7 @@ Add the following file as ``etc/kafka/tpch.customer.json`` and restart Presto:
 
 The customer table now has an additional column: ``kafka_key``.
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tpch> DESCRIBE customer;
           Column       |  Type      | Extra |                   Comment
@@ -331,7 +331,7 @@ are used for the key and the message.
 Now for all the fields in the JSON of the message, columns are defined and
 the sum query from earlier can operate on the ``account_balance`` column directly:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tpch> DESCRIBE customer;
           Column       |  Type      | Extra |                   Comment
@@ -387,7 +387,7 @@ Setup a live Twitter feed
 
 * Download the twistr tool
 
-.. code-block:: none
+.. code-block:: text
 
     $ curl -o twistr https://repo1.maven.org/maven2/de/softwareforge/twistr_kafka_0811/1.2/twistr_kafka_0811-1.2.sh
     $ chmod 755 twistr
@@ -398,7 +398,7 @@ Setup a live Twitter feed
 * Create a ``twistr.properties`` file and put the access and consumer key
   and secrets into it:
 
-.. code-block:: none
+.. code-block:: text
 
     twistr.access-token-key=...
     twistr.access-token-secret=...
@@ -411,7 +411,7 @@ Create a tweets table on Presto
 
 Add the tweets table to the ``etc/catalog/kafka.properties`` file:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=kafka
     kafka.nodes=localhost:9092
@@ -503,7 +503,7 @@ Feed live data
 
 Start the twistr tool:
 
-.. code-block:: none
+.. code-block:: text
 
     $ java -Dness.config.location=file:$(pwd) -Dness.config=twistr -jar ./twistr
 
@@ -512,7 +512,7 @@ into a Kafka topic called ``twitter_feed``.
 
 Now run queries against live data:
 
-.. code-block:: none
+.. code-block:: text
 
     $ ./presto-cli --catalog kafka --schema default
 
@@ -557,7 +557,7 @@ Epilogue: Time stamps
 The tweets feed, that was set up in the last step, contains a time stamp in
 RFC 2822 format as ``created_at`` attribute in each tweet.
 
-.. code-block:: none
+.. code-block:: text
 
     presto:default> SELECT DISTINCT json_extract_scalar(_message, '$.created_at')) AS raw_date
                  -> FROM tweets LIMIT 5;
@@ -573,7 +573,7 @@ RFC 2822 format as ``created_at`` attribute in each tweet.
 The topic definition file for the tweets table contains a mapping onto a
 timestamp using the ``rfc2822`` converter:
 
-.. code-block:: none
+.. code-block:: text
 
     ...
     {
@@ -586,7 +586,7 @@ timestamp using the ``rfc2822`` converter:
 
 This allows the raw data to be mapped onto a Presto timestamp column:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:default> SELECT created_at, raw_date FROM (
                  ->   SELECT created_at, json_extract_scalar(_message, '$.created_at') AS raw_date

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -38,7 +38,7 @@ To configure the Kafka connector, create a catalog properties file
 ``etc/catalog/kafka.properties`` with the following contents,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=kafka
     kafka.table-names=table1,table2
@@ -193,7 +193,7 @@ name of the file can be arbitrary but must end in ``.json``. Place the
 file in the directory configured with the ``kafka.table-description-dir``
 property. The table definition file must be accessible from all Presto nodes.
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "tableName": ...,
@@ -242,7 +242,7 @@ Field           Required  Type           Description
 
 Each field definition is a JSON object:
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "name": ...,

--- a/presto-docs/src/main/sphinx/connector/kinesis.rst
+++ b/presto-docs/src/main/sphinx/connector/kinesis.rst
@@ -22,7 +22,7 @@ but cannot create streams or push data into existing streams.
 To configure the Kinesis connector, create a catalog properties file ``etc/catalog/kinesis.properties``
 with the following contents, replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=kinesis
     kinesis.access-key=XXXXXX
@@ -180,7 +180,7 @@ Table Definition
 A table definition file consists of a JSON definition for a table, which corresponds to one stream in Kinesis.
 The name of the file can be arbitrary but must end in ``.json``. The structure of the table definition is as follows:
 
-.. code-block:: none
+.. code-block:: text
 
   {
         "tableName": ...,
@@ -216,7 +216,7 @@ Field           Required  Type         Description
 Each field definition is a JSON object. At a minimum, a name, type, and mapping must be provided.
 The overall structure looks like this:
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "name": ...,

--- a/presto-docs/src/main/sphinx/connector/kudu.rst
+++ b/presto-docs/src/main/sphinx/connector/kudu.rst
@@ -102,7 +102,7 @@ Example
 
       DESCRIBE kudu.default.users;
 
-  .. code-block:: none
+  .. code-block:: text
 
          Column   |  Type   |                      Extra                      | Comment
       ------------+---------+-------------------------------------------------+---------

--- a/presto-docs/src/main/sphinx/connector/localfile.rst
+++ b/presto-docs/src/main/sphinx/connector/localfile.rst
@@ -11,7 +11,7 @@ Configuration
 To configure the local file connector, create a catalog properties file
 under ``etc/catalog`` named, for example, ``localfile.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=localfile
 

--- a/presto-docs/src/main/sphinx/connector/memory.rst
+++ b/presto-docs/src/main/sphinx/connector/memory.rst
@@ -12,7 +12,7 @@ Configuration
 To configure the Memory connector, create a catalog properties file
 ``etc/catalog/memory.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=memory
     memory.max-data-per-node=128MB

--- a/presto-docs/src/main/sphinx/connector/memsql.rst
+++ b/presto-docs/src/main/sphinx/connector/memsql.rst
@@ -15,7 +15,7 @@ mount the MemSQL connector as the ``memsql`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=memsql
     connection-url=jdbc:mariadb://example.net:3306

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -15,7 +15,7 @@ To configure the MongoDB connector, create a catalog properties file
 ``etc/catalog/mongodb.properties`` with the following contents,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=mongodb
     mongodb.seeds=host1,host:port
@@ -198,7 +198,7 @@ MongoDB maintains table definitions on the special collection where ``mongodb.sc
 
 A schema collection consists of a MongoDB document for a table.
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "table": ...,
@@ -220,7 +220,7 @@ Field           Required  Type           Description
 
 Each field definition:
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "name": ...,
@@ -256,7 +256,7 @@ MongoDB collection has the special field ``_id``. The connector tries to follow 
     INSERT INTO orders VALUES(2, 'good', 100.0, current_date);
     SELECT _id, * FROM orders;
 
-.. code-block:: none
+.. code-block:: text
 
                      _id                 | orderkey | orderstatus | totalprice | orderdate
     -------------------------------------+----------+-------------+------------+------------
@@ -268,7 +268,7 @@ MongoDB collection has the special field ``_id``. The connector tries to follow 
 
     SELECT _id, * FROM orders WHERE _id = ObjectId('55b151633864d6438c61a9ce');
 
-.. code-block:: none
+.. code-block:: text
 
                      _id                 | orderkey | orderstatus | totalprice | orderdate
     -------------------------------------+----------+-------------+------------+------------
@@ -281,7 +281,7 @@ You can render the ``_id`` field to readable values with a cast to ``VARCHAR``:
 
     SELECT CAST(_id AS VARCHAR), * FROM orders WHERE _id = ObjectId('55b151633864d6438c61a9ce');
 
-.. code-block:: none
+.. code-block:: text
 
                _id             | orderkey | orderstatus | totalprice | orderdate
     ---------------------------+----------+-------------+------------+------------

--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -15,7 +15,7 @@ mount the MySQL connector as the ``mysql`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=mysql
     connection-url=jdbc:mysql://example.net:3306

--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -13,7 +13,7 @@ To configure the Oracle connector as the ``oracle`` catalog, create a file named
 ``oracle.properties`` in ``etc/catalog``. Include the following connection
 properties in the file:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=oracle
     connection-url=jdbc:oracle:thin:@example.net:1521/ORCLCDB
@@ -38,7 +38,7 @@ them, change the properties in the catalog configuration file:
 
 To disable connection pooling, update properties to include the following:
 
-.. code-block:: none
+.. code-block:: text
 
     oracle.connection-pool.enabled=false
 
@@ -353,7 +353,7 @@ Synonyms
 Based on performance reasons, Presto disables support for Oracle ``SYNONYM``. To
 include ``SYNONYM``, add the following configuration property:
 
-.. code-block:: none
+.. code-block:: text
 
     oracle.synonyms.enabled=true
 

--- a/presto-docs/src/main/sphinx/connector/phoenix.rst
+++ b/presto-docs/src/main/sphinx/connector/phoenix.rst
@@ -19,7 +19,7 @@ To configure the Phoenix connector, create a catalog properties file
 replacing ``host1,host2,host3`` with a comma-separated list of the ZooKeeper
 nodes used for discovery of the HBase cluster:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=phoenix
     phoenix.connection-url=jdbc:phoenix:host1,host2,host3:2181:/hbase

--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -16,7 +16,7 @@ Configuration
 To configure the Pinot connector, create a catalog properties file
 e.g. ``etc/catalog/pinot.properties`` with at least the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=pinot
     pinot.controller-urls=host1:9000,host2:9000

--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -16,7 +16,7 @@ mount the PostgreSQL connector as the ``postgresql`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=postgresql
     connection-url=jdbc:postgresql://example.net:5432/database

--- a/presto-docs/src/main/sphinx/connector/prometheus.rst
+++ b/presto-docs/src/main/sphinx/connector/prometheus.rst
@@ -19,7 +19,7 @@ Create ``etc/catalog/prometheus.properties``
 to mount the Prometheus connector as the ``prometheus`` catalog,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=prometheus
     prometheus.uri=http://localhost:9090

--- a/presto-docs/src/main/sphinx/connector/redis.rst
+++ b/presto-docs/src/main/sphinx/connector/redis.rst
@@ -20,7 +20,7 @@ To configure the Redis connector, create a catalog properties file
 ``etc/catalog/redis.properties`` with the following content,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=redis
     redis.table-names=schema1.table1,schema1.table2
@@ -172,7 +172,7 @@ defines new columns that can be further queried from Presto.
 A table definition file consists of a JSON definition for a table. The
 name of the file can be arbitrary, but must end in ``.json``.
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "tableName": ...,
@@ -204,7 +204,7 @@ Please refer to the `Kafka connector`_ page for the description of the ``dataFor
 
 In addition to the above Kafka types, the Redis connector supports ``hash`` type for the ``value`` field which represent data stored in the Redis hash.
 
-.. code-block:: none
+.. code-block:: text
 
     {
         "tableName": ...,

--- a/presto-docs/src/main/sphinx/connector/redshift.rst
+++ b/presto-docs/src/main/sphinx/connector/redshift.rst
@@ -16,7 +16,7 @@ mount the Redshift connector as the ``redshift`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=redshift
     connection-url=jdbc:postgresql://example.net:5439/database

--- a/presto-docs/src/main/sphinx/connector/thrift.rst
+++ b/presto-docs/src/main/sphinx/connector/thrift.rst
@@ -21,7 +21,7 @@ To configure the Thrift connector, create a catalog properties file
 ``etc/catalog/thrift.properties`` with the following content,
 replacing the properties as appropriate:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=presto-thrift
     presto.thrift.client.addresses=host:port,host:port
@@ -62,7 +62,7 @@ Property Name                                  Description
 
 Comma-separated list of thrift servers in the form of ``host:port``. For example:
 
-.. code-block:: none
+.. code-block:: text
 
     presto.thrift.client.addresses=192.0.2.3:7777,192.0.2.4:7779
 

--- a/presto-docs/src/main/sphinx/connector/tpcds.rst
+++ b/presto-docs/src/main/sphinx/connector/tpcds.rst
@@ -17,7 +17,7 @@ Configuration
 To configure the TPCDS connector, create a catalog properties file
 ``etc/catalog/tpcds.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=tpcds
 
@@ -28,7 +28,7 @@ The TPCDS connector supplies several schemas::
 
     SHOW SCHEMAS FROM tpcds;
 
-.. code-block:: none
+.. code-block:: text
 
            Schema
     --------------------

--- a/presto-docs/src/main/sphinx/connector/tpch.rst
+++ b/presto-docs/src/main/sphinx/connector/tpch.rst
@@ -17,7 +17,7 @@ Configuration
 To configure the TPCH connector, create a catalog properties file
 ``etc/catalog/tpch.properties`` with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=tpch
 
@@ -28,7 +28,7 @@ The TPCH connector supplies several schemas::
 
     SHOW SCHEMAS FROM tpch;
 
-.. code-block:: none
+.. code-block:: text
 
            Schema
     --------------------

--- a/presto-docs/src/main/sphinx/develop/certificate-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/certificate-authenticator.rst
@@ -35,7 +35,7 @@ passed as a map to ``CertificateAuthenticatorFactory.create()``.
 
 Example configuration file:
 
-.. code-block:: none
+.. code-block:: text
 
     certificate-authenticator.name=custom
     custom-property1=custom-value1

--- a/presto-docs/src/main/sphinx/develop/event-listener.rst
+++ b/presto-docs/src/main/sphinx/develop/event-listener.rst
@@ -41,7 +41,7 @@ as a map to ``EventListenerFactory.create()``.
 
 Example configuration file:
 
-.. code-block:: none
+.. code-block:: text
 
     event-listener.name=custom-event-listener
     custom-property1=custom-value1

--- a/presto-docs/src/main/sphinx/develop/group-provider.rst
+++ b/presto-docs/src/main/sphinx/develop/group-provider.rst
@@ -34,7 +34,7 @@ The remaining properties are passed as a map to
 
 Example configuration file:
 
-.. code-block:: none
+.. code-block:: text
 
     group-provider.name=custom-group-provider
     custom-property1=custom-value1

--- a/presto-docs/src/main/sphinx/develop/password-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/password-authenticator.rst
@@ -35,7 +35,7 @@ passed as a map to ``PasswordAuthenticatorFactory.create()``.
 
 Example configuration file:
 
-.. code-block:: none
+.. code-block:: text
 
     password-authenticator.name=custom-access-control
     custom-property1=custom-value1

--- a/presto-docs/src/main/sphinx/develop/spi-overview.rst
+++ b/presto-docs/src/main/sphinx/develop/spi-overview.rst
@@ -26,7 +26,7 @@ a resource file named ``io.prestosql.spi.Plugin`` in the
 ``META-INF/services`` directory. The content of this file is a
 single line listing the name of the plugin class:
 
-.. code-block:: none
+.. code-block:: text
 
     com.example.plugin.ExamplePlugin
 

--- a/presto-docs/src/main/sphinx/develop/system-access-control.rst
+++ b/presto-docs/src/main/sphinx/develop/system-access-control.rst
@@ -46,7 +46,7 @@ as a map to ``SystemAccessControlFactory.create()``.
 
 Example configuration file:
 
-.. code-block:: none
+.. code-block:: text
 
     access-control.name=custom-access-control
     custom-property1=custom-value1

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -29,7 +29,7 @@ with a condition expressed using a ``WHERE`` clause. This is evaluated for each
 row before it is used in the aggregation and is supported for all aggregate
 functions.
 
-.. code-block:: none
+.. code-block:: text
 
     aggregate_function(...) FILTER (WHERE <condition>)
 
@@ -47,7 +47,7 @@ flowers, modifying the following query::
     FROM iris
     GROUP BY species;
 
-.. code-block:: none
+.. code-block:: text
 
     species    | count
     -----------+-------
@@ -63,7 +63,7 @@ If you just use a normal ``WHERE`` statement you loose information::
     WHERE petal_length_cm > 4
     GROUP BY species;
 
-.. code-block:: none
+.. code-block:: text
 
     species    | count
     -----------+-------
@@ -77,7 +77,7 @@ Using a filter you retain all information::
     FROM iris
     GROUP BY species;
 
-.. code-block:: none
+.. code-block:: text
 
     species    | count
     -----------+-------
@@ -327,7 +327,7 @@ Approximate Aggregate Functions
     for all ``value``\ s with a per-item weight of ``weight``. The algorithm
     is based loosely on:
 
-    .. code-block:: none
+    .. code-block:: text
 
         Yael Ben-Haim and Elad Tom-Tov, "A streaming parallel decision tree algorithm",
         J. Machine Learning Research 11 (2010), pp. 849--872.
@@ -379,7 +379,7 @@ Statistical Aggregate Functions
     Returns the excess kurtosis of all input values. Unbiased estimate using
     the following expression:
 
-    .. code-block:: none
+    .. code-block:: text
 
         kurtosis(x) = n(n+1)/((n-1)(n-2)(n-3))sum[(x_i-mean)^4]/stddev(x)^4-3(n-1)^2/((n-2)(n-3))
 

--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -142,7 +142,7 @@ Quantified Comparison Predicates: ALL, ANY and SOME
 The ``ALL``, ``ANY`` and ``SOME`` quantifiers can be used together with comparison operators in the
 following way:
 
-.. code-block:: none
+.. code-block:: text
 
     expression operator quantifier ( subquery )
 

--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -11,7 +11,7 @@ The standard SQL ``CASE`` expression has two forms.
 The "simple" form searches each ``value`` expression from left to right
 until it finds one that equals ``expression``:
 
-.. code-block:: none
+.. code-block:: text
 
     CASE expression
         WHEN value THEN result
@@ -33,7 +33,7 @@ returned if it exists, otherwise null is returned. Example::
 The "searched" form evaluates each boolean ``condition`` from left
 to right until one is true and returns the matching ``result``:
 
-.. code-block:: none
+.. code-block:: text
 
     CASE
         WHEN condition THEN result
@@ -59,7 +59,7 @@ IF
 The ``IF`` function is actually a language construct
 that is equivalent to the following ``CASE`` expression:
 
-.. code-block:: none
+.. code-block:: text
 
     CASE
         WHEN condition THEN true_value
@@ -127,7 +127,7 @@ Source table with some invalid data:
 
     SELECT * FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | origin_zip | packages | total_cost
     --------------+------------+----------+------------
@@ -143,7 +143,7 @@ Query failure without ``TRY``:
 
     SELECT CAST(origin_zip AS BIGINT) FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
     Query failed: Cannot cast 'P332a' to BIGINT
 
@@ -153,7 +153,7 @@ Query failure without ``TRY``:
 
     SELECT TRY(CAST(origin_zip AS BIGINT)) FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
      origin_zip
     ------------
@@ -169,7 +169,7 @@ Query failure without ``TRY``:
 
     SELECT total_cost / packages AS per_package FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
     Query failed: Division by zero
 
@@ -179,7 +179,7 @@ Default values with ``TRY`` and ``COALESCE``:
 
     SELECT COALESCE(TRY(total_cost / packages), 0) AS per_package FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
      per_package
     -------------

--- a/presto-docs/src/main/sphinx/functions/ml.rst
+++ b/presto-docs/src/main/sphinx/functions/ml.rst
@@ -28,7 +28,7 @@ numerical values, :func:`features`::
 
     SELECT features(1.0, 2.0, 3.0) AS features;
 
-.. code-block:: none
+.. code-block:: text
 
            features
     -----------------------
@@ -55,7 +55,7 @@ The function to train a classification model looks like as follows::
 
 It returns the trained model in a serialized format.
 
-.. code-block:: none
+.. code-block:: text
 
                           model
     -------------------------------------------------
@@ -75,7 +75,7 @@ the format of a nested query::
         iris
     ) t
 
-.. code-block:: none
+.. code-block:: text
 
      predicted_label
     -----------------
@@ -110,7 +110,7 @@ The way to use the model is similar to the classification case::
       FROM iris
     ) t;
 
-.. code-block:: none
+.. code-block:: text
 
      predicted_target
     -------------------

--- a/presto-docs/src/main/sphinx/functions/url.rst
+++ b/presto-docs/src/main/sphinx/functions/url.rst
@@ -9,7 +9,7 @@ The URL extraction functions extract components from HTTP URLs
 (or any valid URIs conforming to :rfc:`2396`).
 The following syntax is supported:
 
-.. code-block:: none
+.. code-block:: text
 
     [protocol:][//host[:port]][path][?query][#fragment]
 

--- a/presto-docs/src/main/sphinx/installation/cli.rst
+++ b/presto-docs/src/main/sphinx/installation/cli.rst
@@ -19,7 +19,7 @@ Installation
 Download :maven_download:`cli`, rename it to ``presto``,
 make it executable with ``chmod +x``, then run it:
 
-.. code-block:: none
+.. code-block:: text
 
     ./presto --server localhost:8080 --catalog hive --schema default
 
@@ -98,13 +98,13 @@ Examples
 
 Consider the following command run as shown, or with ``--output-format CSV``:
 
-.. code-block:: none
+.. code-block:: text
 
     presto --execute 'SELECT nationkey, name, regionkey FROM tpch.sf1.nation LIMIT 3'
 
 The output is as follows:
 
-.. code-block:: none
+.. code-block:: text
 
     "0","ALGERIA","0"
     "1","ARGENTINA","1"
@@ -120,7 +120,7 @@ The output with ``--output-format JSON`` is:
 
 The output with ``--output-format ALIGNED`` is:
 
-.. code-block:: none
+.. code-block:: text
 
     nationkey |   name    | regionkey
     ----------+-----------+----------
@@ -130,7 +130,7 @@ The output with ``--output-format ALIGNED`` is:
 
 The output with ``--output-format VERTICAL`` is:
 
-.. code-block:: none
+.. code-block:: text
 
     -[ RECORD 1 ]--------
     nationkey | 0
@@ -150,7 +150,7 @@ However, if you have an error in the query, such as incorrectly using
 ``region`` instead of ``regionkey``, the command has an exit status of 1
 and displays an error message (which is unaffected by the output format):
 
-.. code-block:: none
+.. code-block:: text
 
     Query 20200707_170726_00030_2iup9 failed: line 1:25: Column 'region' cannot be resolved
     SELECT nationkey, name, region FROM tpch.sf1.nation LIMIT 3
@@ -160,7 +160,7 @@ Troubleshooting
 
 If something goes wrong, you see an error message:
 
-.. code-block:: none
+.. code-block:: text
 
     $ presto
     presto> select count(*) from tpch.tiny.nations;
@@ -170,7 +170,7 @@ If something goes wrong, you see an error message:
 To view debug information, including the stack trace for failures, use the
 ``--debug`` option:
 
-.. code-block:: none
+.. code-block:: text
 
     $ presto --debug 
     presto> select count(*) from tpch.tiny.nations;

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -17,7 +17,7 @@ Linux Operating System
   depending on the workload. We recommend the following limits, which can
   typically be set in ``/etc/security/limits.conf``:
 
-  .. code-block:: none
+  .. code-block:: text
 
       presto soft nofile 131072
       presto hard nofile 131072
@@ -75,7 +75,7 @@ specific to each node. A *node* is a single installed instance of Presto
 on a machine. This file is typically created by the deployment system when
 Presto is first installed. The following is a minimal ``etc/node.properties``:
 
-.. code-block:: none
+.. code-block:: text
 
     node.environment=production
     node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
@@ -114,7 +114,7 @@ not be quoted.
 
 The following provides a good starting point for creating ``etc/jvm.config``:
 
-.. code-block:: none
+.. code-block:: text
 
     -server
     -Xmx16G
@@ -154,7 +154,7 @@ larger clusters.
 
 The following is a minimal configuration for the coordinator:
 
-.. code-block:: none
+.. code-block:: text
 
     coordinator=true
     node-scheduler.include-coordinator=false
@@ -167,7 +167,7 @@ The following is a minimal configuration for the coordinator:
 
 And this is a minimal configuration for the workers:
 
-.. code-block:: none
+.. code-block:: text
 
     coordinator=false
     http-server.http.port=8080
@@ -179,7 +179,7 @@ And this is a minimal configuration for the workers:
 Alternatively, if you are setting up a single machine for testing, that
 functions as both a coordinator and worker, use this configuration:
 
-.. code-block:: none
+.. code-block:: text
 
     coordinator=true
     node-scheduler.include-coordinator=true
@@ -245,7 +245,7 @@ which is typically the fully qualified name of the class that uses the logger.
 Loggers have a hierarchy based on the dots in the name, like Java packages.
 For example, consider the following log levels file:
 
-.. code-block:: none
+.. code-block:: text
 
     io.prestosql=INFO
 
@@ -270,7 +270,7 @@ in the ``etc/catalog`` directory.
 For example, create ``etc/catalog/jmx.properties`` with the following
 contents to mount the ``jmx`` connector as the ``jmx`` catalog:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=jmx
 
@@ -284,7 +284,7 @@ Running Presto
 The installation directory contains the launcher script in ``bin/launcher``.
 Presto can be started as a daemon by running the following:
 
-.. code-block:: none
+.. code-block:: text
 
     bin/launcher start
 
@@ -292,7 +292,7 @@ Alternatively, it can be run in the foreground, with the logs and other
 output written to stdout/stderr. Both streams should be captured
 if using a supervision system like daemontools:
 
-.. code-block:: none
+.. code-block:: text
 
     bin/launcher run
 

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -60,7 +60,7 @@ Connecting
 When your driver is loaded, registered and configured, you are ready to connect
 to Presto from your application. The following JDBC URL formats are supported:
 
-.. code-block:: none
+.. code-block:: text
 
     jdbc:presto://host:port
     jdbc:presto://host:port/catalog
@@ -68,7 +68,7 @@ to Presto from your application. The following JDBC URL formats are supported:
 
 The following is an example of a JDBC URL used to create a connection:
 
-.. code-block:: none
+.. code-block:: text
 
     jdbc:presto://example.net:8080/hive/sales
 

--- a/presto-docs/src/main/sphinx/migration/from-hive.rst
+++ b/presto-docs/src/main/sphinx/migration/from-hive.rst
@@ -116,7 +116,7 @@ Caution with datediff
 The Hive ``datediff`` function returns the difference between the two dates in
 days and is declared as:
 
-.. code-block:: none
+.. code-block:: text
 
     datediff(string enddate, string startdate)  -> integer
 

--- a/presto-docs/src/main/sphinx/optimizer/cost-in-explain.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-in-explain.rst
@@ -19,7 +19,7 @@ is printed.
 
 For example:
 
-.. code-block:: none
+.. code-block:: text
 
  presto:default> EXPLAIN SELECT comment FROM tpch.sf1.nation WHERE nationkey > 3;
 

--- a/presto-docs/src/main/sphinx/optimizer/pushdown.rst
+++ b/presto-docs/src/main/sphinx/optimizer/pushdown.rst
@@ -51,7 +51,7 @@ the ``count`` function, as this operation is now performed by the connector. You
 can see the ``count(*)`` function as part of the PostgreSQL ``TableScan``
 operator. This shows you that the pushdown was successful.
 
-.. code-block:: none
+.. code-block:: text
 
     Fragment 0 [SINGLE]
         Output layout: [regionkey_0, _presto_generated_1]
@@ -86,7 +86,7 @@ As a result, the explain plan shows the ``Aggregate`` operation being performed
 by Presto. This is a clear sign that now pushdown to the database is not
 performed, and instead Presto performs the aggregate processing.
 
-.. code-block:: none
+.. code-block:: text
 
  Fragment 0 [SINGLE]
      Output layout: [regionkey, count]

--- a/presto-docs/src/main/sphinx/release/release-0.54.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.54.rst
@@ -21,7 +21,7 @@ Release 0.54
   with the following contents to mount the ``example-http`` connector as the
   ``example`` catalog:
 
-  .. code-block:: none
+  .. code-block:: text
 
       connector.name=example-http
       metadata-uri=http://s3.amazonaws.com/presto-example/v1/example-metadata.json

--- a/presto-docs/src/main/sphinx/release/release-0.57.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.57.rst
@@ -34,7 +34,7 @@ All Hive connectors support reading data from
 This requires two additional catalog properties for the Hive connector
 to specify your AWS Access Key ID and Secret Access Key:
 
-.. code-block:: none
+.. code-block:: text
 
     hive.s3.aws-access-key=AKIAIOSFODNN7EXAMPLE
     hive.s3.aws-secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/presto-docs/src/main/sphinx/release/release-0.60.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.60.rst
@@ -32,7 +32,7 @@ connector. To add the ``tpch`` catalog to your system, create the catalog
 property file ``etc/catalog/tpch.properties`` on both the coordinator and workers
 with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=tpch
 

--- a/presto-docs/src/main/sphinx/release/release-0.61.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.61.rst
@@ -11,7 +11,7 @@ For example, as a top-level query::
 
    VALUES ('a', 1), ('b', 2);
 
-.. code-block:: none
+.. code-block:: text
 
     _col0 | _col1
    -------+-------
@@ -34,7 +34,7 @@ Alternatively, in the ``FROM`` clause::
     ) AS fruit (letter, fruit)
     USING (letter);
 
-.. code-block:: none
+.. code-block:: text
 
     letter | animal | letter |  fruit
    --------+--------+--------+---------

--- a/presto-docs/src/main/sphinx/release/release-0.69.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.69.rst
@@ -60,7 +60,7 @@ If you would like to experiment with the connector, create a catalog
 properties file such as ``etc/catalog/raptor.properties`` on both the
 coordinator and workers that contains the following:
 
-.. code-block:: none
+.. code-block:: text
 
     connector.name=raptor
     metadata.db.type=h2

--- a/presto-docs/src/main/sphinx/release/release-0.78.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.78.rst
@@ -23,7 +23,7 @@ can retrieve the properties for the catalog using
 Session properties can be set using the ``--session`` command line argument to
 the Presto CLI. For example:
 
-.. code-block:: none
+.. code-block:: text
 
     presto-cli --session color=red --session size=large
 

--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -57,7 +57,7 @@ metadata, such as ``CREATE``, ``INSERT`` or ``DELETE``, is prohibited.
 To use this plugin, add an ``etc/access-control.properties``
 file with the following contents:
 
-.. code-block:: none
+.. code-block:: text
 
    access-control.name=read-only
 

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -25,7 +25,7 @@ Additionally, each user needs a `keytab file
 keytab file can be created using :command:`kadmin` after you create the
 principal.
 
-.. code-block:: none
+.. code-block:: text
 
     kadmin
     > addprinc -randkey someuser@EXAMPLE.COM
@@ -49,7 +49,7 @@ coordinator, that does not require Kerberos authentication, invoking the CLI
 with Kerberos support enabled requires a number of additional command line
 options. The simplest way to invoke the CLI is with a wrapper script.
 
-.. code-block:: none
+.. code-block:: text
 
     #!/bin/bash
 
@@ -96,7 +96,7 @@ starting the CLI process. Doing so requires invoking the CLI JAR via ``java``
 instead of running the self-executable JAR directly. The self-executable jar
 file cannot pass the option to the JVM.
 
-.. code-block:: none
+.. code-block:: text
 
     #!/bin/bash
 

--- a/presto-docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/file-system-access-control.rst
@@ -14,7 +14,7 @@ For example, if a config file named ``rules.json``
 resides in ``etc``, add an ``etc/access-control.properties`` with the following
 contents:
 
-.. code-block:: none
+.. code-block:: text
 
    access-control.name=file
    security.config-file=etc/rules.json
@@ -30,7 +30,7 @@ By default, when a change is made to the JSON rules file, Presto must be restart
 to load the changes. There is an optional property to refresh the properties without requiring a
 Presto restart. The refresh period is specified in the ``etc/access-control.properties``:
 
-.. code-block:: none
+.. code-block:: text
 
    security.refresh-period=1s
 

--- a/presto-docs/src/main/sphinx/security/group-file.rst
+++ b/presto-docs/src/main/sphinx/security/group-file.rst
@@ -12,7 +12,7 @@ Group File Configuration
 Enable group file by creating an ``etc/group-provider.properties``
 file on the coordinator:
 
-.. code-block:: none
+.. code-block:: text
 
     group-provider.name=file
     file.group-file=/path/to/group.txt
@@ -37,6 +37,6 @@ File Format
 The group file contains a list of groups and members, one per line,
 separated by a colon. Users are separated by a comma.
 
-.. code-block:: none
+.. code-block:: text
 
     group_name:user_1,user_2,user_3

--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -11,14 +11,14 @@ Internal Authentication
 Requests between Presto nodes are authenticated using a shared secret. For secure
 internal communication, the shared secret must be configured on all nodes in the cluster:
 
-.. code-block:: none
+.. code-block:: text
 
     internal-communication.shared-secret=<secret>
 
 A large random key is recommended, and can be generated with the following Linux
 command:
 
-.. code-block:: none
+.. code-block:: text
 
     openssl rand 512 | base64
 
@@ -35,7 +35,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
 
 1. Disable HTTP endpoint.
 
-   .. code-block:: none
+   .. code-block:: text
 
        http-server.http.enabled=false
 
@@ -53,7 +53,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
      introduce themselves to the coordinator using the hostname taken from
      the system configuration (``hostname --fqdn``)
 
-     .. code-block:: none
+     .. code-block:: text
 
          node.internal-address-source=FQDN
 
@@ -62,7 +62,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
      make it easy to create the correct SSL/TLS certificates.
      e.g.: ``coordinator.example.com``, ``worker1.example.com``, ``worker2.example.com``.
 
-     .. code-block:: none
+     .. code-block:: text
 
          node.internal-address=<node fqdn>
 
@@ -74,7 +74,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
    and specify it for the client (see step #8 below). In most cases it is
    simpler to use a wildcard in the certificate as shown below.
 
-   .. code-block:: none
+   .. code-block:: text
 
        keytool -genkeypair -alias example.com -keyalg RSA -keystore keystore.jks
        Enter keystore password:
@@ -103,7 +103,7 @@ To enable SSL/TLS for Presto internal communication, do the following:
 
 5. Enable the HTTPS endpoint.
 
-   .. code-block:: none
+   .. code-block:: text
 
        http-server.https.enabled=true
        http-server.https.port=<https port>
@@ -112,19 +112,19 @@ To enable SSL/TLS for Presto internal communication, do the following:
 
 6. Change the discovery uri to HTTPS.
 
-   .. code-block:: none
+   .. code-block:: text
 
        discovery.uri=https://<coordinator fqdn>:<https port>
 
 7. Configure the internal communication to require HTTPS.
 
-   .. code-block:: none
+   .. code-block:: text
 
        internal-communication.https.required=true
 
 8. Configure the internal communication to use the Java keystore file.
 
-   .. code-block:: none
+   .. code-block:: text
 
        internal-communication.https.keystore.path=<keystore path>
        internal-communication.https.keystore.key=<keystore password>
@@ -158,7 +158,7 @@ to switch the random number generator algorithm to ``SHA1PRNG``, by setting it v
 ``http-server.https.secure-random-algorithm`` property in ``config.properties`` on the coordinator
 and all of the workers:
 
-.. code-block:: none
+.. code-block:: text
 
     http-server.https.secure-random-algorithm=SHA1PRNG
 
@@ -167,6 +167,6 @@ the blocking ``/dev/random`` device. For environments that do not have enough en
 the ``SHAPRNG`` algorithm, the source can be changed to ``/dev/urandom``
 by adding the ``java.security.egd`` property to ``jvm.config``:
 
-.. code-block:: none
+.. code-block:: text
 
     -Djava.security.egd=file:/dev/urandom

--- a/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
+++ b/presto-docs/src/main/sphinx/security/kerberos-configuration.fragment
@@ -6,7 +6,7 @@ to be a ``kdc`` entry in the ``[realms]`` section of the ``/etc/krb5.conf``
 file. You may also want to include an ``admin_server`` entry and ensure that
 the |subject_node| can reach the Kerberos admin server on port 749.
 
-.. code-block:: none
+.. code-block:: text
 
    [realms]
      PRESTO.EXAMPLE.COM = {

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -36,7 +36,7 @@ Server Config Properties
 The following is an example of the required properties that need to be added
 to the coordinator's ``config.properties`` file:
 
-.. code-block:: none
+.. code-block:: text
 
     http-server.authentication.type=PASSWORD
 
@@ -76,7 +76,7 @@ Password Authenticator Configuration
 Password authentication needs to be configured to use LDAP. Create an
 ``etc/password-authenticator.properties`` file on the coordinator. Example:
 
-.. code-block:: none
+.. code-block:: text
 
     password-authenticator.name=ldap
     ldap.url=ldaps://ldap-server:636
@@ -116,26 +116,26 @@ Based on the LDAP server implementation type, the property
 Active Directory
 ****************
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.user-bind-pattern=${USER}@<domain_name_of_the_server>
 
 Example:
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.user-bind-pattern=${USER}@corp.example.com
 
 OpenLDAP
 ********
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.user-bind-pattern=uid=${USER},<distinguished_name_of_the_user>
 
 Example:
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.user-bind-pattern=uid=${USER},OU=America,DC=corp,DC=example,DC=com
 
@@ -197,26 +197,26 @@ Property                                                Description
 Active Directory
 ****************
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.group-auth-pattern=(&(objectClass=<objectclass_of_user>)(sAMAccountName=${USER})(memberof=<dn_of_the_authorized_group>))
 
 Example:
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.group-auth-pattern=(&(objectClass=person)(sAMAccountName=${USER})(memberof=CN=AuthorizedGroup,OU=Asia,DC=corp,DC=example,DC=com))
 
 OpenLDAP
 ********
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.group-auth-pattern=(&(objectClass=<objectclass_of_user>)(uid=${USER})(memberof=<dn_of_the_authorized_group>))
 
 Example:
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.group-auth-pattern=(&(objectClass=inetOrgPerson)(uid=${USER})(memberof=CN=AuthorizedGroup,OU=Asia,DC=corp,DC=example,DC=com))
 
@@ -228,7 +228,7 @@ based on complex group authorization search queries. For example, if you want to
 authorize a user belonging to any one of multiple groups (in OpenLDAP), this
 property may be set as follows:
 
-.. code-block:: none
+.. code-block:: text
 
     ldap.group-auth-pattern=(&(|(memberOf=CN=normal_group,DC=corp,DC=com)(memberOf=CN=another_group,DC=com))(objectClass=inetOrgPerson)(uid=${USER}))
 
@@ -263,7 +263,7 @@ options. You can either use ``--keystore-*`` or ``--truststore-*`` properties
 to secure TLS connection. The simplest way to invoke the CLI is with a
 wrapper script.
 
-.. code-block:: none
+.. code-block:: text
 
     #!/bin/bash
 
@@ -316,7 +316,7 @@ SSL Debugging for Presto CLI
 If you encounter any SSL related errors when running Presto CLI, you can run CLI using ``-Djavax.net.debug=ssl``
 parameter for debugging. You should use the Presto CLI executable jar to enable this. E.g.:
 
-.. code-block:: none
+.. code-block:: text
 
     java -Djavax.net.debug=ssl \
     -jar \
@@ -349,7 +349,7 @@ The same LDAP server certificate on the Presto coordinator, running on JDK
 version >= 8u181, that was previously able to successfully connect to an
 LDAPS server, may now fail with the below error:
 
-.. code-block:: none
+.. code-block:: text
 
     javax.naming.CommunicationException: simple bind failed: ldapserver:636
     [Root exception is javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching ldapserver found.]

--- a/presto-docs/src/main/sphinx/security/password-file.rst
+++ b/presto-docs/src/main/sphinx/security/password-file.rst
@@ -17,7 +17,7 @@ Password Authenticator Configuration
 Enable password file authentication by creating an
 ``etc/password-authenticator.properties`` file on the coordinator:
 
-.. code-block:: none
+.. code-block:: text
 
     password-authenticator.name=file
     file.password-file=/path/to/password.db
@@ -47,14 +47,14 @@ separated by a colon. Passwords must be securely hashed using bcrypt or PBKDF2.
 
 bcrypt passwords start with ``$2y$`` and must use a minimum cost of ``8``:
 
-.. code-block:: none
+.. code-block:: text
 
     test:$2y$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa
 
 PBKDF2 passwords are composed of the iteration count, followed by the
 hex encoded salt and hash:
 
-.. code-block:: none
+.. code-block:: text
 
     test:1000:5b4240333032306164:f38d165fce8ce42f59d366139ef5d9e1ca1247f0e06e503ee1a611dd9ec40876bb5edb8409f5abe5504aab6628e70cfb3d3a18e99d70357d295002c3d0a308a0
 
@@ -69,13 +69,13 @@ than the default.
 
 Create an empty password file to get started:
 
-.. code-block:: none
+.. code-block:: text
 
     touch password.db
 
 Add or update the password for the user ``test``:
 
-.. code-block:: none
+.. code-block:: text
 
     htpasswd -B -C 10 password.db test
 

--- a/presto-docs/src/main/sphinx/security/secrets.rst
+++ b/presto-docs/src/main/sphinx/security/secrets.rst
@@ -20,7 +20,7 @@ Ansible, often used for virtual machines, and Kubernetes for container usage.
 Setting an environment variable can be done manually on the command line as
 well.
 
-.. code-block:: none
+.. code-block:: text
 
     export DB_PASSWORD=my-super-secret-pwd
 

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -36,7 +36,7 @@ Kerberos using `kadmin
 In addition, the Presto coordinator needs a `keytab file
 <http://web.mit.edu/kerberos/krb5-devel/doc/basic/keytab_def.html>`_. After you create the principal, you can create the keytab file using :command:`kadmin`
 
-.. code-block:: none
+.. code-block:: text
 
     kadmin
     > addprinc -randkey presto@EXAMPLE.COM
@@ -48,6 +48,7 @@ In addition, the Presto coordinator needs a `keytab file
 
 Java Keystore File for TLS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 When using Kerberos authentication, access to the Presto coordinator should be
 through HTTPS. You can do it by creating a :ref:`server_java_keystore` on the
 coordinator.
@@ -79,7 +80,7 @@ config.properties
 Kerberos authentication is configured in the coordinator node's
 :file:`config.properties` file. The entries that need to be added are listed below.
 
-.. code-block:: none
+.. code-block:: text
 
     http-server.authentication.type=KERBEROS
 
@@ -140,7 +141,7 @@ Property                                                  Description
     ``http-server.https.excluded-cipher`` property to an empty list in order to
     override the default exclusions.
 
-    .. code-block:: none
+    .. code-block:: text
 
         http-server.https.included-cipher=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256
         http-server.https.excluded-cipher=
@@ -182,7 +183,7 @@ Kerberos Verification
 Ensure that you can connect to the KDC from the Presto coordinator using
 :command:`telnet`.
 
-.. code-block:: none
+.. code-block:: text
 
     $ telnet kdc.example.com 88
 
@@ -192,7 +193,7 @@ Verify that the keytab file can be used to successfully obtain a ticket using
 `klist
 <http://web.mit.edu/kerberos/krb5-1.12/doc/user/user_commands/klist.html>`_
 
-.. code-block:: none
+.. code-block:: text
 
     $ kinit -kt /etc/presto/presto.keytab presto@EXAMPLE.COM
     $ klist
@@ -210,7 +211,7 @@ You can enable additional Kerberos debugging information for the Presto
 coordinator process by adding the following lines to the Presto ``jvm.config``
 file
 
-.. code-block:: none
+.. code-block:: text
 
     -Dsun.security.krb5.debug=true
     -Dlog.enable-console=true

--- a/presto-docs/src/main/sphinx/security/tls.rst
+++ b/presto-docs/src/main/sphinx/security/tls.rst
@@ -21,7 +21,7 @@ be used in the certificate. In this case, it should be the unqualified hostname
 of the Presto coordinator. In the following example, you can see this in the prompt
 that confirms the information is correct:
 
-.. code-block:: none
+.. code-block:: text
 
     keytool -genkeypair -alias presto -keyalg RSA -keystore keystore.jks
     Enter keystore password:
@@ -64,7 +64,7 @@ In the example, we are going to import ``presto_certificate.cer`` to a custom
 truststore ``presto_trust.jks``, and you get a prompt asking if the certificate
 can be trusted or not.
 
-.. code-block:: none
+.. code-block:: text
 
     $ keytool -import -v -trustcacerts -alias presto_trust -file presto_certificate.cer -keystore presto_trust.jks -keypass <truststore_pass>
 
@@ -79,6 +79,6 @@ Java Keystore File Verification
 Verify the password for a keystore file and view its contents using `keytool
 <https://docs.oracle.com/en/java/javase/11/tools/keytool.html>`_.
 
-.. code-block:: none
+.. code-block:: text
 
     $ keytool -list -v -keystore /etc/presto/presto.jks

--- a/presto-docs/src/main/sphinx/sql/alter-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-schema.rst
@@ -5,7 +5,7 @@ ALTER SCHEMA
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     ALTER SCHEMA name RENAME TO new_name
     ALTER SCHEMA name SET AUTHORIZATION ( user | USER user | ROLE role )

--- a/presto-docs/src/main/sphinx/sql/alter-table.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-table.rst
@@ -5,7 +5,7 @@ ALTER TABLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     ALTER TABLE [ IF EXISTS ] name RENAME TO new_name
     ALTER TABLE [ IF EXISTS ] name ADD COLUMN [ IF NOT EXISTS ] column_name data_type

--- a/presto-docs/src/main/sphinx/sql/alter-view.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-view.rst
@@ -5,7 +5,7 @@ ALTER VIEW
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     ALTER VIEW name RENAME TO new_name
     ALTER VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )

--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -5,7 +5,7 @@ ANALYZE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     ANALYZE table_name [ WITH ( property_name = expression [, ...] ) ]
 

--- a/presto-docs/src/main/sphinx/sql/call.rst
+++ b/presto-docs/src/main/sphinx/sql/call.rst
@@ -5,7 +5,7 @@ CALL
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CALL procedure_name ( [ name => ] expression [, ...] )
 

--- a/presto-docs/src/main/sphinx/sql/comment.rst
+++ b/presto-docs/src/main/sphinx/sql/comment.rst
@@ -5,7 +5,7 @@ COMMENT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     COMMENT ON ( TABLE | COLUMN ) name IS 'comments'
 

--- a/presto-docs/src/main/sphinx/sql/commit.rst
+++ b/presto-docs/src/main/sphinx/sql/commit.rst
@@ -5,7 +5,7 @@ COMMIT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     COMMIT [ WORK ]
 

--- a/presto-docs/src/main/sphinx/sql/create-role.rst
+++ b/presto-docs/src/main/sphinx/sql/create-role.rst
@@ -5,7 +5,7 @@ CREATE ROLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CREATE ROLE role_name
     [ WITH ADMIN ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]

--- a/presto-docs/src/main/sphinx/sql/create-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/create-schema.rst
@@ -5,7 +5,7 @@ CREATE SCHEMA
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CREATE SCHEMA [ IF NOT EXISTS ] schema_name
     [ AUTHORIZATION ( user | USER user | ROLE role ) ]

--- a/presto-docs/src/main/sphinx/sql/create-table-as.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table-as.rst
@@ -5,7 +5,7 @@ CREATE TABLE AS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CREATE TABLE [ IF NOT EXISTS ] table_name [ ( column_alias, ... ) ]
     [ COMMENT table_comment ]

--- a/presto-docs/src/main/sphinx/sql/create-table.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table.rst
@@ -5,7 +5,7 @@ CREATE TABLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CREATE TABLE [ IF NOT EXISTS ]
     table_name (

--- a/presto-docs/src/main/sphinx/sql/create-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-view.rst
@@ -5,7 +5,7 @@ CREATE VIEW
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     CREATE [ OR REPLACE ] VIEW view_name
     [ SECURITY { DEFINER | INVOKER } ]

--- a/presto-docs/src/main/sphinx/sql/deallocate-prepare.rst
+++ b/presto-docs/src/main/sphinx/sql/deallocate-prepare.rst
@@ -5,7 +5,7 @@ DEALLOCATE PREPARE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DEALLOCATE PREPARE statement_name
 

--- a/presto-docs/src/main/sphinx/sql/delete.rst
+++ b/presto-docs/src/main/sphinx/sql/delete.rst
@@ -5,7 +5,7 @@ DELETE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DELETE FROM table_name [ WHERE condition ]
 

--- a/presto-docs/src/main/sphinx/sql/describe-input.rst
+++ b/presto-docs/src/main/sphinx/sql/describe-input.rst
@@ -5,7 +5,7 @@ DESCRIBE INPUT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DESCRIBE INPUT statement_name
 
@@ -30,7 +30,7 @@ Prepare and describe a query with three parameters:
 
     DESCRIBE INPUT my_select1;
 
-.. code-block:: none
+.. code-block:: text
 
      Position | Type
     --------------------
@@ -50,7 +50,7 @@ Prepare and describe a query with no parameters:
 
     DESCRIBE INPUT my_select2;
 
-.. code-block:: none
+.. code-block:: text
 
      Position | Type
     -----------------

--- a/presto-docs/src/main/sphinx/sql/describe-output.rst
+++ b/presto-docs/src/main/sphinx/sql/describe-output.rst
@@ -5,7 +5,7 @@ DESCRIBE OUTPUT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DESCRIBE OUTPUT statement_name
 
@@ -28,7 +28,7 @@ Prepare and describe a query with four output columns::
 
    DESCRIBE OUTPUT my_select1;
 
-.. code-block:: none
+.. code-block:: text
 
      Column Name | Catalog | Schema | Table  |  Type   | Type Size | Aliased
     -------------+---------+--------+--------+---------+-----------+---------
@@ -47,7 +47,7 @@ Prepare and describe a query whose output columns are expressions::
 
     DESCRIBE OUTPUT my_select2;
 
-.. code-block:: none
+.. code-block:: text
 
      Column Name | Catalog | Schema | Table |  Type  | Type Size | Aliased
     -------------+---------+--------+-------+--------+-----------+---------
@@ -64,7 +64,7 @@ Prepare and describe a row count query::
 
     DESCRIBE OUTPUT my_create;
 
-.. code-block:: none
+.. code-block:: text
 
      Column Name | Catalog | Schema | Table |  Type  | Type Size | Aliased
     -------------+---------+--------+-------+--------+-----------+---------

--- a/presto-docs/src/main/sphinx/sql/describe.rst
+++ b/presto-docs/src/main/sphinx/sql/describe.rst
@@ -5,7 +5,7 @@ DESCRIBE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DESCRIBE table_name
 

--- a/presto-docs/src/main/sphinx/sql/drop-role.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-role.rst
@@ -5,7 +5,7 @@ DROP ROLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DROP ROLE role_name
 

--- a/presto-docs/src/main/sphinx/sql/drop-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-schema.rst
@@ -5,7 +5,7 @@ DROP SCHEMA
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DROP SCHEMA [ IF EXISTS ] schema_name
 

--- a/presto-docs/src/main/sphinx/sql/drop-table.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-table.rst
@@ -5,7 +5,7 @@ DROP TABLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DROP TABLE  [ IF EXISTS ] table_name
 

--- a/presto-docs/src/main/sphinx/sql/drop-view.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-view.rst
@@ -5,7 +5,7 @@ DROP VIEW
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     DROP VIEW [ IF EXISTS ] view_name
 

--- a/presto-docs/src/main/sphinx/sql/execute.rst
+++ b/presto-docs/src/main/sphinx/sql/execute.rst
@@ -5,7 +5,7 @@ EXECUTE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     EXECUTE statement_name [ USING parameter1 [ , parameter2, ... ] ]
 

--- a/presto-docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/explain-analyze.rst
@@ -5,7 +5,7 @@ EXPLAIN ANALYZE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     EXPLAIN ANALYZE [VERBOSE] statement
 
@@ -32,7 +32,7 @@ some additional statistics (e.g: average input per node instance, average number
 relevant plan nodes). Such statistics are useful when one wants to detect data anomalies for a query
 (skewness, abnormal hash collisions).
 
-.. code-block:: none
+.. code-block:: text
 
     presto:sf1> EXPLAIN ANALYZE SELECT count(*), clerk FROM orders WHERE orderdate > date '1995-01-01' GROUP BY clerk;
 
@@ -75,7 +75,7 @@ relevant plan nodes). Such statistics are useful when one wants to detect data a
 When the ``VERBOSE`` option is used, some operators may report additional information.
 For example, the window function operator will output the following:
 
-.. code-block:: none
+.. code-block:: text
 
     EXPLAIN ANALYZE VERBOSE SELECT count(clerk) OVER() FROM orders WHERE orderdate > date '1995-01-01';
 

--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -5,7 +5,7 @@ EXPLAIN
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     EXPLAIN [ ( option [, ...] ) ] statement
 
@@ -49,7 +49,7 @@ EXPLAIN (TYPE LOGICAL)
 
 Logical plan:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tiny> EXPLAIN (TYPE LOGICAL) SELECT regionkey, count(*) FROM nation GROUP BY 1;
                                                        Query Plan
@@ -88,7 +88,7 @@ EXPLAIN (TYPE DISTRIBUTED)
 
 Distributed plan:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tiny> EXPLAIN (TYPE DISTRIBUTED) SELECT regionkey, count(*) FROM nation GROUP BY 1;
                                                   Query Plan
@@ -139,7 +139,7 @@ EXPLAIN (TYPE VALIDATE)
 
 Validate:
 
-.. code-block:: none
+.. code-block:: text
 
     presto:tiny> EXPLAIN (TYPE VALIDATE) SELECT regionkey, count(*) FROM nation GROUP BY 1;
      Valid
@@ -151,7 +151,7 @@ EXPLAIN (TYPE IO)
 
 IO:
 
-.. code-block:: none
+.. code-block:: text
 
 
     presto:hive> EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_lineitem SELECT * FROM lineitem WHERE shipdate = '2020-02-01' AND quantity > 10;

--- a/presto-docs/src/main/sphinx/sql/grant-roles.rst
+++ b/presto-docs/src/main/sphinx/sql/grant-roles.rst
@@ -5,7 +5,7 @@ GRANT ROLES
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     GRANT role [, ...]
     TO ( user | USER user | ROLE role) [, ...]

--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -5,7 +5,7 @@ GRANT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     GRANT ( privilege [, ...] | ( ALL PRIVILEGES ) )
     ON ( table_name | TABLE table_name | SCHEMA schema_name)

--- a/presto-docs/src/main/sphinx/sql/insert.rst
+++ b/presto-docs/src/main/sphinx/sql/insert.rst
@@ -5,7 +5,7 @@ INSERT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     INSERT INTO table_name [ ( column [, ... ] ) ] query
 

--- a/presto-docs/src/main/sphinx/sql/prepare.rst
+++ b/presto-docs/src/main/sphinx/sql/prepare.rst
@@ -5,7 +5,7 @@ PREPARE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     PREPARE statement_name FROM statement
 

--- a/presto-docs/src/main/sphinx/sql/reset-session.rst
+++ b/presto-docs/src/main/sphinx/sql/reset-session.rst
@@ -5,7 +5,7 @@ RESET SESSION
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     RESET SESSION name
     RESET SESSION catalog.name

--- a/presto-docs/src/main/sphinx/sql/revoke-roles.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke-roles.rst
@@ -5,7 +5,7 @@ REVOKE ROLES
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     REVOKE
     [ ADMIN OPTION FOR ]

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -5,7 +5,7 @@ REVOKE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     REVOKE [ GRANT OPTION FOR ]
     ( privilege [, ...] | ALL PRIVILEGES )

--- a/presto-docs/src/main/sphinx/sql/rollback.rst
+++ b/presto-docs/src/main/sphinx/sql/rollback.rst
@@ -5,7 +5,7 @@ ROLLBACK
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     ROLLBACK [ WORK ]
 

--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -5,7 +5,7 @@ SELECT
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     [ WITH [ RECURSIVE ] with_query [, ...] ]
     SELECT [ ALL | DISTINCT ] select_expression [, ...]
@@ -21,18 +21,18 @@ Synopsis
 
 where ``from_item`` is one of
 
-.. code-block:: none
+.. code-block:: text
 
     table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
 
-.. code-block:: none
+.. code-block:: text
 
     from_item join_type from_item
       [ ON join_condition | USING ( join_column [, ...] ) ]
 
 and ``join_type`` is one of
 
-.. code-block:: none
+.. code-block:: text
 
     [ INNER ] JOIN
     LEFT [ OUTER ] JOIN
@@ -42,7 +42,7 @@ and ``join_type`` is one of
 
 and ``grouping_element`` is one of
 
-.. code-block:: none
+.. code-block:: text
 
     ()
     expression
@@ -115,7 +115,7 @@ step relation.
 The following listing shows a simple example, that displays a commonly used
 form of a single query in the list:
 
-.. code-block:: none
+.. code-block:: text
 
     WITH RECURSIVE t(n) AS (
         VALUES (1)
@@ -169,7 +169,7 @@ SELECT Clause
 The ``SELECT`` clause specifies the output of the query. Each ``select_expression``
 defines a column or columns to be included in the result.
 
-.. code-block:: none
+.. code-block:: text
 
     SELECT [ ALL | DISTINCT ] select_expression [, ...]
 
@@ -185,19 +185,19 @@ Select expressions
 
 Each ``select_expression`` must be in one of the following forms:
 
-.. code-block:: none
+.. code-block:: text
 
     expression [ [ AS ] column_alias ]
 
-.. code-block:: none
+.. code-block:: text
 
     row_expression.* [ AS ( column_alias [, ...] ) ]
 
-.. code-block:: none
+.. code-block:: text
 
     relation.*
 
-.. code-block:: none
+.. code-block:: text
 
     *
 
@@ -224,7 +224,7 @@ or row field names::
 
     SELECT (CAST(ROW(1, true) AS ROW(field1 bigint, field2 boolean))).* AS (alias1, alias2);
 
-.. code-block:: none
+.. code-block:: text
 
      alias1 | alias2
     --------+--------
@@ -235,7 +235,7 @@ Otherwise, the existing names are used::
 
     SELECT (CAST(ROW(1, true) AS ROW(field1 bigint, field2 boolean))).*;
 
-.. code-block:: none
+.. code-block:: text
 
      field1 | field2
     --------+--------
@@ -246,7 +246,7 @@ and in their absence, anonymous columns are produced::
 
     SELECT (ROW(1, true)).*;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0 | _col1
     -------+-------
@@ -277,7 +277,7 @@ row counts for the ``customer`` table using the input column ``mktsegment``::
 
     SELECT count(*) FROM customer GROUP BY mktsegment;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -317,7 +317,7 @@ The columns not part of a given sublist of grouping columns are set to ``NULL``.
 
     SELECT * FROM shipping;
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | origin_zip | destination_state | destination_zip | package_weight
     --------------+------------+-------------------+-----------------+----------------
@@ -338,7 +338,7 @@ The columns not part of a given sublist of grouping columns are set to ``NULL``.
         (origin_state, origin_zip),
         (destination_state));
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | origin_zip | destination_state | _col0
     --------------+------------+-------------------+-------
@@ -397,7 +397,7 @@ is equivalent to::
         ()
     );
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | destination_state | _col0
     --------------+-------------------+-------
@@ -425,7 +425,7 @@ columns. For example, the query::
     FROM shipping
     GROUP BY ROLLUP (origin_state, origin_zip);
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | origin_zip | _col2
     --------------+------------+-------
@@ -474,7 +474,7 @@ is logically equivalent to::
         (origin_state, destination_state)
     );
 
-.. code-block:: none
+.. code-block:: text
 
      origin_state | destination_state | origin_zip | _col3
     --------------+-------------------+------------+-------
@@ -567,7 +567,7 @@ below::
         (destination_state)
     );
 
-.. code-block:: none
+.. code-block:: text
 
     origin_state | origin_zip | destination_state | _col3 | _col4
     --------------+------------+-------------------+-------+-------
@@ -606,7 +606,7 @@ with an account balance greater than the specified value::
     HAVING sum(acctbal) > 5700000
     ORDER BY totalbal DESC;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0 | mktsegment | nationkey | totalbal
     -------+------------+-----------+----------
@@ -625,15 +625,15 @@ Set Operations
 ``UNION``  ``INTERSECT`` and ``EXCEPT`` are all set operations.  These clauses are used
 to combine the results of more than one select statement into a single result set:
 
-.. code-block:: none
+.. code-block:: text
 
     query UNION [ALL | DISTINCT] query
 
-.. code-block:: none
+.. code-block:: text
 
     query INTERSECT [DISTINCT] query
 
-.. code-block:: none
+.. code-block:: text
 
     query EXCEPT [DISTINCT] query
 
@@ -663,7 +663,7 @@ that selects the value ``42``::
     UNION
     SELECT 42;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -679,7 +679,7 @@ selects the values ``42`` and ``13``::
     UNION
     SELECT * FROM (VALUES 42, 13);
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -693,7 +693,7 @@ selects the values ``42`` and ``13``::
     UNION ALL
     SELECT * FROM (VALUES 42, 13);
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -715,7 +715,7 @@ is only in the result set of the first query, it is not included in the final re
     INTERSECT
     SELECT 13;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -735,7 +735,7 @@ is also in the result set of the second query, it is not included in the final r
     EXCEPT
     SELECT 13;
 
-.. code-block:: none
+.. code-block:: text
 
      _col0
     -------
@@ -750,7 +750,7 @@ ORDER BY Clause
 The ``ORDER BY`` clause is used to sort a result set by one or more
 output expressions:
 
-.. code-block:: none
+.. code-block:: text
 
     ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...]
 
@@ -798,7 +798,7 @@ OFFSET Clause
 The ``OFFSET`` clause is used to discard a number of leading rows
 from the result set:
 
-.. code-block:: none
+.. code-block:: text
 
     OFFSET count [ ROW | ROWS ]
 
@@ -808,7 +808,7 @@ leading rows are discarded::
 
     SELECT name FROM nation ORDER BY name OFFSET 22;
 
-.. code-block:: none
+.. code-block:: text
 
           name
     ----------------
@@ -827,11 +827,11 @@ LIMIT or FETCH FIRST Clauses
 The ``LIMIT`` or ``FETCH FIRST`` clause restricts the number of rows
 in the result set.
 
-.. code-block:: none
+.. code-block:: text
 
     LIMIT { count | ALL }
 
-.. code-block:: none
+.. code-block:: text
 
     FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES }
 
@@ -841,7 +841,7 @@ exactly which rows are returned is arbitrary)::
 
     SELECT orderdate FROM orders LIMIT 5;
 
-.. code-block:: none
+.. code-block:: text
 
      orderdate
     ------------
@@ -862,7 +862,7 @@ If the count is not specified in the ``FETCH FIRST`` clause, it defaults to ``1`
 
     SELECT orderdate FROM orders FETCH FIRST ROW ONLY;
 
-.. code-block:: none
+.. code-block:: text
 
      orderdate
     ------------
@@ -874,7 +874,7 @@ is evaluated after the ``OFFSET`` clause::
 
     SELECT * FROM (VALUES 5, 2, 4, 1, 3) t(x) ORDER BY x OFFSET 2 LIMIT 2;
 
-.. code-block:: none
+.. code-block:: text
 
      x
     ---
@@ -897,7 +897,7 @@ as established by the ordering in the ``ORDER BY`` clause. The result set is sor
     FROM nation 
     ORDER BY regionkey FETCH FIRST ROW WITH TIES;
 
-.. code-block:: none
+.. code-block:: text
 
         name    | regionkey
     ------------+-----------
@@ -984,7 +984,7 @@ Using multiple columns::
     ) AS x (numbers, animals)
     CROSS JOIN UNNEST(numbers, animals) AS t (n, a);
 
-.. code-block:: none
+.. code-block:: text
 
       numbers  |     animals      |  n   |  a
     -----------+------------------+------+------
@@ -1006,7 +1006,7 @@ Using multiple columns::
     ) AS x (numbers)
     CROSS JOIN UNNEST(numbers) WITH ORDINALITY AS t (n, a);
 
-.. code-block:: none
+.. code-block:: text
 
       numbers  | n | a
     -----------+---+---
@@ -1047,7 +1047,7 @@ so a cross join between the two tables produces 125 rows::
     CROSS JOIN region AS r
     ORDER BY 1, 2;
 
-.. code-block:: none
+.. code-block:: text
 
          nation     |   region
     ----------------+-------------

--- a/presto-docs/src/main/sphinx/sql/set-role.rst
+++ b/presto-docs/src/main/sphinx/sql/set-role.rst
@@ -5,7 +5,7 @@ SET ROLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SET ROLE ( role | ALL | NONE )
 

--- a/presto-docs/src/main/sphinx/sql/set-session.rst
+++ b/presto-docs/src/main/sphinx/sql/set-session.rst
@@ -5,7 +5,7 @@ SET SESSION
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SET SESSION name = expression
     SET SESSION catalog.name = expression

--- a/presto-docs/src/main/sphinx/sql/show-catalogs.rst
+++ b/presto-docs/src/main/sphinx/sql/show-catalogs.rst
@@ -5,7 +5,7 @@ SHOW CATALOGS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW CATALOGS [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/show-columns.rst
+++ b/presto-docs/src/main/sphinx/sql/show-columns.rst
@@ -5,7 +5,7 @@ SHOW COLUMNS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW COLUMNS FROM table [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/show-create-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/show-create-schema.rst
@@ -5,7 +5,7 @@ SHOW CREATE SCHEMA
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW CREATE SCHEMA schema_name
 

--- a/presto-docs/src/main/sphinx/sql/show-create-table.rst
+++ b/presto-docs/src/main/sphinx/sql/show-create-table.rst
@@ -5,7 +5,7 @@ SHOW CREATE TABLE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW CREATE TABLE table_name
 
@@ -21,7 +21,7 @@ Show the SQL that can be run to create the ``orders`` table::
 
     SHOW CREATE TABLE sf1.orders;
 
-.. code-block:: none
+.. code-block:: text
 
                   Create Table
     -----------------------------------------

--- a/presto-docs/src/main/sphinx/sql/show-create-view.rst
+++ b/presto-docs/src/main/sphinx/sql/show-create-view.rst
@@ -5,7 +5,7 @@ SHOW CREATE VIEW
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW CREATE VIEW view_name
 

--- a/presto-docs/src/main/sphinx/sql/show-functions.rst
+++ b/presto-docs/src/main/sphinx/sql/show-functions.rst
@@ -5,7 +5,7 @@ SHOW FUNCTIONS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW FUNCTIONS [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/show-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-grants.rst
@@ -5,7 +5,7 @@ SHOW GRANTS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW GRANTS [ ON [ TABLE ] table_name ]
 

--- a/presto-docs/src/main/sphinx/sql/show-role-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-role-grants.rst
@@ -5,7 +5,7 @@ SHOW ROLE GRANTS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW ROLE GRANTS [ FROM catalog ]
 

--- a/presto-docs/src/main/sphinx/sql/show-roles.rst
+++ b/presto-docs/src/main/sphinx/sql/show-roles.rst
@@ -5,7 +5,7 @@ SHOW ROLES
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW [CURRENT] ROLES [ FROM catalog ]
 

--- a/presto-docs/src/main/sphinx/sql/show-schemas.rst
+++ b/presto-docs/src/main/sphinx/sql/show-schemas.rst
@@ -5,7 +5,7 @@ SHOW SCHEMAS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW SCHEMAS [ FROM catalog ] [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/show-session.rst
+++ b/presto-docs/src/main/sphinx/sql/show-session.rst
@@ -5,7 +5,7 @@ SHOW SESSION
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW SESSION [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/show-stats.rst
+++ b/presto-docs/src/main/sphinx/sql/show-stats.rst
@@ -5,7 +5,7 @@ SHOW STATS
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW STATS FOR table
     SHOW STATS FOR ( SELECT * FROM table [ WHERE condition ] )

--- a/presto-docs/src/main/sphinx/sql/show-tables.rst
+++ b/presto-docs/src/main/sphinx/sql/show-tables.rst
@@ -5,7 +5,7 @@ SHOW TABLES
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     SHOW TABLES [ FROM schema ] [ LIKE pattern ]
 

--- a/presto-docs/src/main/sphinx/sql/start-transaction.rst
+++ b/presto-docs/src/main/sphinx/sql/start-transaction.rst
@@ -5,13 +5,13 @@ START TRANSACTION
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     START TRANSACTION [ mode [, ...] ]
 
 where ``mode`` is one of
 
-.. code-block:: none
+.. code-block:: text
 
     ISOLATION LEVEL { READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE }
     READ { ONLY | WRITE }

--- a/presto-docs/src/main/sphinx/sql/use.rst
+++ b/presto-docs/src/main/sphinx/sql/use.rst
@@ -5,7 +5,7 @@ USE
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     USE catalog.schema
     USE schema

--- a/presto-docs/src/main/sphinx/sql/values.rst
+++ b/presto-docs/src/main/sphinx/sql/values.rst
@@ -5,14 +5,14 @@ VALUES
 Synopsis
 --------
 
-.. code-block:: none
+.. code-block:: text
 
     VALUES row [, ...]
 
 
 where ``row`` is a single expression or
 
-.. code-block:: none
+.. code-block:: text
 
     ( column_expression [, ...] )
 


### PR DESCRIPTION
Research determined that none  is not a supported argument for the Sphinx code-block: directive. To have Sphinx apply no source code coloring, use code-block: text. This was determined when trying to use the doc8 command line tool to validate RST files.