### PR TITLE
Improve reporting of multiple SQLExceptions in JdbcPageSink#finish

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcPageSink.java
@@ -165,6 +165,14 @@ public class JdbcPageSink
             throw new PrestoException(JDBC_NON_TRANSIENT_ERROR, e);
         }
         catch (SQLException e) {
+            // Convert chained SQLExceptions to suppressed exceptions so they are visible in the stack trace
+            SQLException nextException = e.getNextException();
+            while (nextException != null) {
+                if (e != nextException) {
+                    e.addSuppressed(new Exception("Next SQLException", nextException));
+                }
+                nextException = nextException.getNextException();
+            }
             throw new PrestoException(JDBC_ERROR, "Failed to insert data: " + firstNonNull(e.getMessage(), e), e);
         }
         // the committer does not need any additional info


### PR DESCRIPTION
When we encounter a SQLException it can have multiple different
exceptions (which do not have a causal relationship). Throwing just the
first exception leads to omitting useful information from other
exceptions.

This change adds each SQLException as a suppressed exception to the
original SQLException before throwing so that the stack trace contains
more information.

Before:

```
java.lang.AssertionError: Execution of 'actual' query failed: CREATE TABLE test_table_x6r4b AS SELECT '‚òÉ' unicode
	at org.testng.Assert.fail(Assert.java:83)
	... 30 more
Caused by: java.lang.RuntimeException: Failed to insert data: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_04ff943132b0497db9bf2618edb23192" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at io.prestosql.testing.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:115)
	at io.prestosql.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:462)
	at io.prestosql.testing.QueryAssertions.assertQuery(QueryAssertions.java:147)
	... 29 more
Caused by: io.prestosql.spi.PrestoException: Failed to insert data: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_04ff943132b0497db9bf2618edb23192" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at io.prestosql.plugin.jdbc.JdbcPageSink.finish(JdbcPageSink.java:168)
	at io.prestosql.operator.TableWriterOperator.finish(TableWriterOperator.java:208)
	... 11 more
Caused by: java.sql.BatchUpdateException: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_04ff943132b0497db9bf2618edb23192" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at org.postgresql.jdbc2.AbstractJdbc2Statement$BatchResultHandler.handleError(AbstractJdbc2Statement.java:2743)
	at org.postgresql.core.v3.QueryExecutorImpl$1.handleError(QueryExecutorImpl.java:461)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1928)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:405)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeBatch(AbstractJdbc2Statement.java:2892)
	at io.prestosql.plugin.jdbc.JdbcPageSink.finish(JdbcPageSink.java:160)
	... 12 more
```

After:

```
java.lang.AssertionError: Execution of 'actual' query failed: CREATE TABLE test_table_12unp AS SELECT '‚òÉ' unicode
	at org.testng.Assert.fail(Assert.java:83)
	... 30 more
Caused by: java.lang.RuntimeException: Failed to insert data: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_839be71779604fcc9bcf9109d3b844cb" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at io.prestosql.testing.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:115)
	at io.prestosql.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:462)
	at io.prestosql.testing.QueryAssertions.assertQuery(QueryAssertions.java:147)
	... 29 more
Caused by: io.prestosql.spi.PrestoException: Failed to insert data: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_839be71779604fcc9bcf9109d3b844cb" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at io.prestosql.plugin.jdbc.JdbcPageSink.finish(JdbcPageSink.java:168)
	at io.prestosql.operator.TableWriterOperator.finish(TableWriterOperator.java:208)
	... 11 more
Caused by: java.sql.BatchUpdateException: Batch entry 0 INSERT INTO "testdb"."test_schema"."tmp_presto_839be71779604fcc9bcf9109d3b844cb" ("unicode") VALUES ('‚òÉ') was aborted.  Call getNextException to see the cause.
	at org.postgresql.jdbc2.AbstractJdbc2Statement$BatchResultHandler.handleError(AbstractJdbc2Statement.java:2743)
	at org.postgresql.core.v3.QueryExecutorImpl$1.handleError(QueryExecutorImpl.java:461)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1928)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:405)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeBatch(AbstractJdbc2Statement.java:2892)
	at io.prestosql.plugin.jdbc.JdbcPageSink.finish(JdbcPageSink.java:161)
	... 12 more
	Suppressed: org.postgresql.util.PSQLException: ERROR: Value too long for character type
  Detail:
  -----------------------------------------------
  error:  Value too long for character type
  code:      8001
  context:   Value too long for type character varying(1)
  query:     885252
  location:  string.cpp:175
  process:   padbmaster [pid=19949]
  -----------------------------------------------

		at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2198)
		at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1927)
		... 15 more
```

