### PR TITLE
Display ellipsis in all queries

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/QueryList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryList.jsx
@@ -31,6 +31,7 @@ import {
 
 export class QueryListItem extends React.Component {
     static stripQueryTextWhitespace(queryText) {
+        const maxLines = 6;
         const lines = queryText.split("\n");
         let minLeadingWhitespace = -1;
         for (let i = 0; i < lines.length; i++) {
@@ -56,9 +57,12 @@ export class QueryListItem extends React.Component {
 
             if (trimmedLine.length > 0) {
                 formattedQueryText += trimmedLine;
-
-                if (i < (lines.length - 1)) {
+                if (i < (maxLines - 1)) {
                     formattedQueryText += "\n";
+                }
+                else {
+                    formattedQueryText += "\n...";
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Previously, the Query List panel on the UI was adding ellipsis only on query string length. This causes querys with multiple lines to not be truncated, and appear incomplete on the query list.
This Pull Request fix this issue https://github.com/prestosql/presto/issues/2886

Now a query with more lines than the ' maxLines ' will end on the maxLines + 1 th line, followed by a new line and ...

the code below is an example of the expected output.

```
select (
c.name,
c.address,
c.nationkey,
c.phone,c.name
)
... 