### PR TITLE
Verify before getting element from a list

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/SignatureBinder.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/SignatureBinder.java
@@ -855,6 +855,14 @@ public class SignatureBinder
                             return SolverReturnStatus.UNSOLVABLE;
                         }
                         TypeSignature typeSignature = type.get().getTypeSignature();
+                        verify(
+                                i < typeSignature.getParameters().size(),
+                                "Expected type signature %s of type %s (coerced %s to %s base name) to have parameter count greater than %s",
+                                typeSignature,
+                                type.get(),
+                                actualType,
+                                formalTypeSignature,
+                                i);
                         originalTypeTypeParametersBuilder.add(TypeSignatureParameter.numericParameter(typeSignature.getParameters().get(i).getLongLiteral()));
                     }
                 }


### PR DESCRIPTION
We are witnessing spurious `ArrayIndexOutOfBoundsException` when
accessing type parameter. Add verification that will produce more useful
failure message.

For https://github.com/prestosql/presto/issues/5758