### PR TITLE
Limit number of threads created by TestSqlStageExecution

### DIFF
--- a/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestSqlStageExecution.java
@@ -58,7 +58,7 @@ import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.prestosql.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static io.prestosql.sql.planner.plan.ExchangeNode.Type.REPARTITION;
-import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertFalse;
@@ -73,7 +73,7 @@ public class TestSqlStageExecution
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+        executor = newFixedThreadPool(100, daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
     }
 


### PR DESCRIPTION
Previously, the `testFinalStageInfoInternal` (which is called by
`testFinalStageInfo` 10 times), would create 1 million of tasks without
bounding the number of threads created in any visible manner.

On CI, this would sometimes lead to errors like

    java.lang.OutOfMemoryError: unable to create new native thread
            at java.lang.Thread.start0(Native Method)
            at java.lang.Thread.start(Thread.java:717)
            at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:957)
            at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1378)
            at io.prestosql.execution.StateMachine.safeExecute(StateMachine.java:320)
            at io.prestosql.execution.StateMachine.fireStateChanged(StateMachine.java:224)
            at io.prestosql.execution.StateMachine.compareAndSet(StateMachine.java:214)
            at io.prestosql.execution.StateMachine.setIf(StateMachine.java:171)
            at io.prestosql.execution.TaskStateMachine.transitionToDoneState(TaskStateMachine.java:116)
            at io.prestosql.execution.TaskStateMachine.abort(TaskStateMachine.java:102)
            at io.prestosql.execution.MockRemoteTaskFactory$MockRemoteTask.abort(MockRemoteTaskFactory.java:405)
            at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:407)
            at io.prestosql.execution.SqlStageExecution.abort(SqlStageExecution.java:253)
            at io.prestosql.execution.TestSqlStageExecution.testFinalStageInfoInternal(TestSqlStageExecution.java:146)
            at io.prestosql.execution.TestSqlStageExecution.testFinalStageInfo(TestSqlStageExecution.java:92)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
            at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
            at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
            at java.util.concurrent.FutureTask.run(FutureTask.java:266)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
            at java.lang.Thread.run(Thread.java:748)

Hopefully fixes https://github.com/prestosql/presto/issues/2929