### PR TITLE
Fix 'testCreateExternalTableWithFieldSeparator' flakiness

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -3620,7 +3620,7 @@ public class TestHiveIntegrationSmokeTest
             throws Exception
     {
         testCreateExternalTable(
-                "test_create_external",
+                "test_create_external_with_field_separator",
                 "helloXworld\nbyeXworld",
                 "VALUES ('hello', 'world'), ('bye', 'world')",
                 ImmutableList.of("textfile_field_separator = 'X'"));


### PR DESCRIPTION
Sometimes it fails (probably when running in parallel with the previous test, which uses the same table name).