### PR TITLE
Add legacy hive view translation property to config property table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -310,6 +310,10 @@ Property Name                                      Description                  
                                                    can be used to use a different location for each user.
 
 ``hive.translate-hive-views``                      Enable translation for Hive views. (experimental)            ``false``
+
+``hive.legacy-hive-view-translation``              Use the legacy algorithm to translate Hive views. You can    ``false``
+                                                   alternatively set the ``legacy_hive_view_translation``
+                                                   session property to ``true``.
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties


### PR DESCRIPTION
Added entry in hive configuration property table to explain use of hive.legacy-hive-view-translation as per issue.