### PR TITLE
Add server SSL debug sectn; edit debug for Presto

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -236,6 +236,8 @@ The above configuration properties are a minimal set to help you get started.
 Please see :doc:`/admin` and :doc:`/security` for a more comprehensive list.
 In particular, see :doc:`/admin/resource-groups` for configuring queuing policies.
 
+.. _log-levels:
+
 Log Levels
 ^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -310,11 +310,21 @@ Java Keystore File Verification
 Verify the password for a keystore file and view its contents using
 :ref:`troubleshooting_keystore`.
 
+Debug Presto to LDAP Server Issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you need to debug issues with Presto communicating with the LDAP server,
+you can change the :ref:`log level <log-levels>` for the LDAP authenticator:
+
+.. code-block:: none
+
+    io.prestosql.plugin.password=DEBUG
+
 SSL Debugging for Presto CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you encounter any SSL related errors when running Presto CLI, you can run CLI using ``-Djavax.net.debug=ssl``
-parameter for debugging. You should use the Presto CLI executable jar to enable this. E.g.:
+If you encounter any SSL related errors when running the Presto CLI, you can run
+the CLI using the ``-Djavax.net.debug=ssl`` parameter for debugging. Use the
+Presto CLI executable JAR to enable this. For example:
 
 .. code-block:: none
 


### PR DESCRIPTION
On request, added missing info on logging.properties entry to aid SSL debugging.

Plus minor English cleanup of the next section, SSL debugging for the CLI.