### PR TITLE
Change metric property to "catalog" for consistency

### DIFF
--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/jmx/ConnectorObjectNameGeneratorModule.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/jmx/ConnectorObjectNameGeneratorModule.java
@@ -73,7 +73,7 @@ public class ConnectorObjectNameGeneratorModule
             return new ObjectNameBuilder(toDomain(type))
                     .withProperties(ImmutableMap.<String, String>builder()
                             .put("type", type.getSimpleName())
-                            .put("name", catalogName)
+                            .put("catalog", catalogName)
                             .build())
                     .build();
         }


### PR DESCRIPTION
There are two `generatedNameOf` methods in `ConnectorObjectNameGeneratorModule`. One of them was adding `catalog` property, the other was adding `name` property. This PR makes both methods add `catalog` property for consistency.

**This is backward incompatible change!!**

The idea later on is that all connectors should inject `ConnectorObjectNameGeneratorModule` so that JMX metrics names are consistent. Also, this would simplify code as no explicit `catalogName` would need to be passed to various connector modules that bind JMX metrics via:
```
        newExporter(binder).export(...)
                .as(generator -> generator.generatedNameOf(..., catalogName.get().toString()));
```