### PR TITLE
Fix assertion message in assertDynamicFiltering

### DIFF
--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationDynamicFilter.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduIntegrationDynamicFilter.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.kudu;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
 import io.prestosql.Session;
 import io.prestosql.execution.Lifespan;
 import io.prestosql.execution.QueryStats;
@@ -173,7 +174,7 @@ public class TestKuduIntegrationDynamicFilter
         ResultWithQueryId<MaterializedResult> result = runner.executeWithQueryId(session, selectQuery);
 
         assertEquals(result.getResult().getRowCount(), expectedRowCount);
-        assertEquals(getOperatorRowsRead(runner, result.getQueryId()).toArray(), expectedOperatorRowsRead);
+        assertEquals(getOperatorRowsRead(runner, result.getQueryId()), Ints.asList(expectedOperatorRowsRead));
     }
 
     private Session withBroadcastJoin()

--- a/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/io/prestosql/plugin/memory/TestMemorySmoke.java
@@ -14,6 +14,7 @@
 package io.prestosql.plugin.memory;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
 import io.prestosql.Session;
 import io.prestosql.execution.QueryStats;
 import io.prestosql.metadata.QualifiedObjectName;
@@ -322,7 +323,7 @@ public class TestMemorySmoke
         ResultWithQueryId<MaterializedResult> result = getDistributedQueryRunner().executeWithQueryId(session, selectQuery);
 
         assertEquals(result.getResult().getRowCount(), expectedRowCount);
-        assertEquals(getOperatorRowsRead(getDistributedQueryRunner(), result.getQueryId()).toArray(), expectedOperatorRowsRead);
+        assertEquals(getOperatorRowsRead(getDistributedQueryRunner(), result.getQueryId()), Ints.asList(expectedOperatorRowsRead));
     }
 
     private Session withBroadcastJoin()


### PR DESCRIPTION
`assertEquals` produces useless message for arrays, so use lists
instead.

see https://github.com/prestosql/presto/issues/6266 for example