### PR TITLE
Remove legacy-generic-column-mapping JDBC config property

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig.LegacyGenericColumnMapping;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
@@ -69,7 +68,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.plugin.jdbc.BaseJdbcConfig.LEGACY_GENERIC_COLUMN_MAPPING;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.prestosql.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.prestosql.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
@@ -118,7 +116,6 @@ public abstract class BaseJdbcClient
 {
     private static final Logger log = Logger.get(BaseJdbcClient.class);
 
-    @Deprecated
     private static final Map<Type, WriteMapping> WRITE_MAPPINGS = ImmutableMap.<Type, WriteMapping>builder()
             .put(BOOLEAN, WriteMapping.booleanMapping("boolean", booleanWriteFunction()))
             .put(BIGINT, WriteMapping.longMapping("bigint", bigintWriteFunction()))
@@ -134,7 +131,6 @@ public abstract class BaseJdbcClient
     protected final ConnectionFactory connectionFactory;
     protected final String identifierQuote;
     protected final Set<String> jdbcTypesMappedToVarchar;
-    private final LegacyGenericColumnMapping legacyGenericColumnMapping;
     protected final boolean caseInsensitiveNameMatching;
     protected final Cache<JdbcIdentity, Map<String, String>> remoteSchemaNames;
     protected final Cache<RemoteTableNameCacheKey, Map<String, String>> remoteTableNames;
@@ -145,7 +141,6 @@ public abstract class BaseJdbcClient
                 identifierQuote,
                 connectionFactory,
                 config.getJdbcTypesMappedToVarchar(),
-                config.getLegacyGenericColumnMapping(),
                 requireNonNull(config, "config is null").isCaseInsensitiveNameMatching(),
                 config.getCaseInsensitiveNameMatchingCacheTtl());
     }
@@ -154,7 +149,6 @@ public abstract class BaseJdbcClient
             String identifierQuote,
             ConnectionFactory connectionFactory,
             Set<String> jdbcTypesMappedToVarchar,
-            LegacyGenericColumnMapping legacyGenericColumnMapping,
             boolean caseInsensitiveNameMatching,
             Duration caseInsensitiveNameMatchingCacheTtl)
     {
@@ -163,9 +157,8 @@ public abstract class BaseJdbcClient
         this.jdbcTypesMappedToVarchar = ImmutableSortedSet.orderedBy(CASE_INSENSITIVE_ORDER)
                 .addAll(requireNonNull(jdbcTypesMappedToVarchar, "jdbcTypesMappedToVarchar is null"))
                 .build();
-        this.legacyGenericColumnMapping = requireNonNull(legacyGenericColumnMapping, "legacyGenericColumnMapping is null");
-
         requireNonNull(caseInsensitiveNameMatchingCacheTtl, "caseInsensitiveNameMatchingCacheTtl is null");
+
         this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
         CacheBuilder<Object, Object> remoteNamesCacheBuilder = CacheBuilder.newBuilder()
                 .expireAfterWrite(caseInsensitiveNameMatchingCacheTtl.toMillis(), MILLISECONDS);
@@ -350,32 +343,13 @@ public abstract class BaseJdbcClient
         if (mapping.isPresent()) {
             return mapping;
         }
-
-        mapping = jdbcTypeToPrestoType(typeHandle);
-        if (mapping.isPresent()) {
-            switch (legacyGenericColumnMapping) {
-                case ENABLE:
-                    return mapping;
-                case THROW:
-                    throw new IllegalStateException(format(
-                            "Column type %s is not explicitly mapped by the connector, and used to be mapped to %s by deprecated generic mappings. " +
-                                    "You can set '%s' to '%s' to temporarily restore the legacy mapping, or to '%s' to suppress this message.",
-                            typeHandle,
-                            mapping.get().getType(),
-                            LEGACY_GENERIC_COLUMN_MAPPING,
-                            LegacyGenericColumnMapping.ENABLE.name(),
-                            LegacyGenericColumnMapping.IGNORE.name()));
-                case IGNORE:
-                    break;
-                default:
-                    throw new IllegalStateException("Unexpected legacy mapping: " + legacyGenericColumnMapping);
-            }
+        Optional<ColumnMapping> connectorMapping = jdbcTypeToPrestoType(typeHandle);
+        if (connectorMapping.isPresent()) {
+            return connectorMapping;
         }
-
         if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
             return mapToUnboundedVarchar(typeHandle);
         }
-
         return Optional.empty();
     }
 
@@ -909,33 +883,6 @@ public abstract class BaseJdbcClient
     @Override
     public WriteMapping toWriteMapping(ConnectorSession session, Type type)
     {
-        WriteMapping writeMapping = legacyToWriteMapping(type);
-        if (writeMapping != null) {
-            switch (legacyGenericColumnMapping) {
-                case ENABLE:
-                    return writeMapping;
-                case THROW:
-                    throw new IllegalStateException(format(
-                            "Presto type %s is not explicitly mapped by the connector, and used to be mapped to %s by deprecated generic mappings. " +
-                                    "You can set '%s' to '%s' to temporarily restore the legacy mapping, or to '%s' to suppress this message.",
-                            type,
-                            writeMapping.getDataType(),
-                            LEGACY_GENERIC_COLUMN_MAPPING,
-                            LegacyGenericColumnMapping.ENABLE.name(),
-                            LegacyGenericColumnMapping.IGNORE.name()));
-                case IGNORE:
-                    break;
-                default:
-                    throw new IllegalStateException("Unexpected legacy mapping: " + legacyGenericColumnMapping);
-            }
-        }
-        throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
-    }
-
-    @Deprecated
-    @Nullable
-    private WriteMapping legacyToWriteMapping(Type type)
-    {
         if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             String dataType;
@@ -963,7 +910,7 @@ public abstract class BaseJdbcClient
         if (writeMapping != null) {
             return writeMapping;
         }
-        return null;
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
     }
 
     protected Function<String, String> tryApplyLimit(OptionalLong limit)

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcConfig.java
@@ -20,7 +20,6 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
-import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 
 import java.util.Set;
@@ -30,23 +29,10 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class BaseJdbcConfig
 {
-    public static final String LEGACY_GENERIC_COLUMN_MAPPING = "legacy-generic-column-mapping";
-
-    public enum LegacyGenericColumnMapping
-    {
-        // Enable legacy column mapping
-        ENABLE,
-        // Detect when legacy column mapping would be effective and report (throw)
-        THROW,
-        // Ignore columns not explicitly mapped
-        IGNORE,
-    }
-
     private String connectionUrl;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private Set<String> jdbcTypesMappedToVarchar = ImmutableSet.of();
-    private LegacyGenericColumnMapping legacyGenericColumnMapping = LegacyGenericColumnMapping.ENABLE; // TODO change to THROW
     private Duration metadataCacheTtl = new Duration(0, MINUTES);
     private boolean cacheMissing;
 
@@ -98,27 +84,6 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setJdbcTypesMappedToVarchar(String jdbcTypesMappedToVarchar)
     {
         this.jdbcTypesMappedToVarchar = ImmutableSet.copyOf(Splitter.on(",").omitEmptyStrings().trimResults().split(nullToEmpty(jdbcTypesMappedToVarchar)));
-        return this;
-    }
-
-    /**
-     * @deprecated Fallback flag, to be removed after some time.
-     */
-    @Deprecated
-    @Nonnull
-    public LegacyGenericColumnMapping getLegacyGenericColumnMapping()
-    {
-        return legacyGenericColumnMapping;
-    }
-
-    /**
-     * @deprecated Fallback flag, to be removed after some time.
-     */
-    @Config(LEGACY_GENERIC_COLUMN_MAPPING)
-    @Deprecated
-    public BaseJdbcConfig setLegacyGenericColumnMapping(LegacyGenericColumnMapping legacyGenericColumnMapping)
-    {
-        this.legacyGenericColumnMapping = legacyGenericColumnMapping;
         return this;
     }
 

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestBaseJdbcConfig.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.jdbc;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig.LegacyGenericColumnMapping;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -38,7 +37,6 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setJdbcTypesMappedToVarchar("")
-                .setLegacyGenericColumnMapping(LegacyGenericColumnMapping.ENABLE)
                 .setMetadataCacheTtl(Duration.valueOf("0m"))
                 .setCacheMissing(false));
     }
@@ -51,7 +49,6 @@ public class TestBaseJdbcConfig
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .put("jdbc-types-mapped-to-varchar", "mytype,struct_type1")
-                .put("legacy-generic-column-mapping", "IGNORE")
                 .put("metadata.cache-ttl", "1s")
                 .put("metadata.cache-missing", "true")
                 .build();
@@ -61,7 +58,6 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
                 .setJdbcTypesMappedToVarchar("mytype, struct_type1")
-                .setLegacyGenericColumnMapping(LegacyGenericColumnMapping.IGNORE)
                 .setMetadataCacheTtl(Duration.valueOf("1s"))
                 .setCacheMissing(true);
 

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
@@ -194,7 +194,6 @@ public class PhoenixClient
                 ESCAPE_CHARACTER,
                 connectionFactory,
                 ImmutableSet.of(),
-                config.getLegacyGenericColumnMapping(),
                 config.isCaseInsensitiveNameMatching(),
                 config.getCaseInsensitiveNameMatchingCacheTtl());
         this.configuration = new Configuration(false);

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConfig.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixConfig.java
@@ -19,10 +19,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig.LegacyGenericColumnMapping;
 
-import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
@@ -33,7 +30,6 @@ public class PhoenixConfig
 {
     private String connectionUrl;
     private List<String> resourceConfigFiles = ImmutableList.of();
-    private LegacyGenericColumnMapping legacyGenericColumnMapping = LegacyGenericColumnMapping.ENABLE;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
 
@@ -60,27 +56,6 @@ public class PhoenixConfig
     public PhoenixConfig setResourceConfigFiles(String files)
     {
         this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
-        return this;
-    }
-
-    /**
-     * @deprecated Fallback flag, to be removed after some time.
-     */
-    @Deprecated
-    @Nonnull
-    public LegacyGenericColumnMapping getLegacyGenericColumnMapping()
-    {
-        return legacyGenericColumnMapping;
-    }
-
-    /**
-     * @deprecated Fallback flag, to be removed after some time.
-     */
-    @Config(BaseJdbcConfig.LEGACY_GENERIC_COLUMN_MAPPING)
-    @Deprecated
-    public PhoenixConfig setLegacyGenericColumnMapping(LegacyGenericColumnMapping legacyGenericColumnMapping)
-    {
-        this.legacyGenericColumnMapping = legacyGenericColumnMapping;
         return this;
     }
 

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixConfig.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixConfig.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.phoenix;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
-import io.prestosql.plugin.jdbc.BaseJdbcConfig.LegacyGenericColumnMapping;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -37,7 +36,6 @@ public class TestPhoenixConfig
         assertRecordedDefaults(recordDefaults(PhoenixConfig.class)
                 .setConnectionUrl(null)
                 .setResourceConfigFiles("")
-                .setLegacyGenericColumnMapping(LegacyGenericColumnMapping.ENABLE)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
     }
@@ -51,7 +49,6 @@ public class TestPhoenixConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("phoenix.connection-url", "jdbc:phoenix:localhost:2181:/hbase")
                 .put("phoenix.config.resources", configFile.toString())
-                .put("legacy-generic-column-mapping", "IGNORE")
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .build();
@@ -59,7 +56,6 @@ public class TestPhoenixConfig
         PhoenixConfig expected = new PhoenixConfig()
                 .setConnectionUrl("jdbc:phoenix:localhost:2181:/hbase")
                 .setResourceConfigFiles(configFile.toString())
-                .setLegacyGenericColumnMapping(LegacyGenericColumnMapping.IGNORE)
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS));
 


### PR DESCRIPTION
This reverts most of "Deprecate legacy generic type mappings" commit
(e370b7eedb28422c6ef033d7379a2b0152e9aec3) (https://github.com/prestosql/presto/pull/4940).

Removing legacy mapping will be much harder for some connectors than the
others. For example, PostgreSQL probably has all mappings complete and
is well tested while SQL Server relies on legacy mappings and has few
tests yet. This means the legacy flag will be around for some time and
thus should not be applied on the base JDBC level. This needs to be done
on per-connector basis.