### PR TITLE
Use Supplier to pass a name to isDeleteTarget

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Streams;
+import io.prestosql.metadata.MetadataUtil;
 import io.prestosql.metadata.NewTableLayout;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.metadata.ResolvedFunction;
@@ -79,6 +80,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -219,9 +221,9 @@ public class Analysis
         this.target = Optional.empty();
     }
 
-    public boolean isDeleteTarget(QualifiedObjectName name)
+    public boolean isDeleteTarget(Supplier<QualifiedObjectName> name)
     {
-        return "DELETE".equals(updateType) && Optional.of(name).equals(target);
+        return "DELETE".equals(updateType) && Optional.of(name.get()).equals(target);
     }
 
     public boolean isSkipMaterializedViewRefresh()

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -203,7 +203,7 @@ class RelationPlanner
             }
 
             List<Symbol> outputSymbols = outputSymbolsBuilder.build();
-            boolean isDeleteTarget = analysis.isDeleteTarget(createQualifiedObjectName(session, node, node.getName()));
+            boolean isDeleteTarget = analysis.isDeleteTarget(() -> createQualifiedObjectName(session, node, node.getName()));
             PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isDeleteTarget);
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);


### PR DESCRIPTION
This is a workaround to problem with `createQualifiedObjectName` failing
with "Catalog must be specified when session catalog is not set"
exception when called for Table object during process of Hive view
expansion and when session catalog is not set.

The problem comes from fact that main query and query being view
definitition are parsed in different contexts and then merged without
augmentation into single AST tree.

Issue: https://github.com/prestosql/presto/issues/6294