### PR TITLE
Use Node as isDeleteTarget argument

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
@@ -98,6 +98,7 @@ public class Analysis
     private final Statement root;
     private final Map<NodeRef<Parameter>, Expression> parameters;
     private String updateType;
+    // TODO Reference by NodeRef instead name so we can distinguish actual target from other references to same table in the query
     private Optional<QualifiedObjectName> target = Optional.empty();
     private boolean skipMaterializedViewRefresh;
 
@@ -219,8 +220,9 @@ public class Analysis
         this.target = Optional.empty();
     }
 
-    public boolean isDeleteTarget(QualifiedObjectName name)
+    public boolean isDeleteTarget(Table table)
     {
+        QualifiedObjectName name = tables.get(NodeRef.of(table)).getName();
         return "DELETE".equals(updateType) && Optional.of(name).equals(target);
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -88,7 +88,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toSqlType;
@@ -203,7 +202,7 @@ class RelationPlanner
             }
 
             List<Symbol> outputSymbols = outputSymbolsBuilder.build();
-            boolean isDeleteTarget = analysis.isDeleteTarget(createQualifiedObjectName(session, node, node.getName()));
+            boolean isDeleteTarget = analysis.isDeleteTarget(node);
             PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isDeleteTarget);
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -36,6 +36,14 @@ databases:
     jdbc_password: "***empty***"
     jdbc_pooling: false
 
+  presto_no_default_catalog:
+    host: ${databases.presto.host}
+    jdbc_driver_class: ${databases.presto.jdbc_driver_class}
+    jdbc_url: jdbc:presto://${databases.presto.host}:${databases.presto.port}
+    jdbc_user: ${databases.presto.jdbc_user}
+    jdbc_password: ${databases.presto.jdbc_password}
+    jdbc_pooling: ${databases.presto.${databases.presto.jdbc_user}}
+
   presto_tpcds:
     host: localhost
     jdbc_driver_class: ${databases.presto.jdbc_driver_class}


### PR DESCRIPTION
Fixes: https://github.com/prestosql/presto/issues/6294
Replaces: https://github.com/prestosql/presto/pull/6288

As a followup we probably should pursue an approach to store `Analysis.target` as a `NodeRef` instead `QualifiedObjectName`. There is a chance that a single query contains a table that is a delete target more than once. We should not treat all those occurrences as delete target.