### PR TITLE
Accept LocalDate as prepared statement parameter

### DIFF
--- a/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoPreparedStatement.java
+++ b/presto-jdbc/src/main/java/io/prestosql/jdbc/PrestoPreparedStatement.java
@@ -538,6 +538,9 @@ public class PrestoPreparedStatement
         else if (x instanceof Date) {
             setDate(parameterIndex, (Date) x);
         }
+        else if (x instanceof LocalDate) {
+            setAsDate(parameterIndex, x);
+        }
         else if (x instanceof Time) {
             setTime(parameterIndex, (Time) x);
         }


### PR DESCRIPTION
Based on https://github.com/prestosql/presto/pull/6300.

Implements https://github.com/prestosql/presto/issues/6299 for `LocalDate`