### PR TITLE
Test multiple set sizes in testLargeIn

### DIFF
--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcDistributedQueries.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestJdbcDistributedQueries.java
@@ -30,7 +30,7 @@ public class TestJdbcDistributedQueries
     }
 
     @Override
-    public void testLargeIn()
+    public void testLargeIn(int valuesCount)
     {
     }
 }

--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
@@ -130,7 +130,7 @@ public class TestMemSqlDistributedQueries
     }
 
     @Override
-    public void testLargeIn()
+    public void testLargeIn(int valuesCount)
     {
         // Caused by: java.sql.SQLException: Thread stack overrun:  Used: 1048713 of a 1048576 stack. Use 'memsqld --thread_stack=#' to specify a bigger stack if needed.
         throw new SkipException("MemSQL's default thread stack is not large enough");

--- a/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
+++ b/presto-memsql/src/test/java/io/prestosql/plugin/memsql/TestMemSqlDistributedQueries.java
@@ -130,13 +130,6 @@ public class TestMemSqlDistributedQueries
     }
 
     @Override
-    public void testLargeIn(int valuesCount)
-    {
-        // Caused by: java.sql.SQLException: Thread stack overrun:  Used: 1048713 of a 1048576 stack. Use 'memsqld --thread_stack=#' to specify a bigger stack if needed.
-        throw new SkipException("MemSQL's default thread stack is not large enough");
-    }
-
-    @Override
     public void testInsertUnicode()
     {
         // MemSQL's utf8 encoding is 3 bytes and truncates strings upon encountering a 4 byte sequence

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixDistributedQueries.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixDistributedQueries.java
@@ -75,13 +75,6 @@ public class TestPhoenixDistributedQueries
     }
 
     @Override
-    public void testLargeIn(int valuesCount)
-    {
-        // TODO https://github.com/prestosql/presto/issues/1641
-        throw new SkipException("test disabled");
-    }
-
-    @Override
     public void testRenameTable()
     {
         // Phoenix does not support renaming tables

--- a/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixDistributedQueries.java
+++ b/presto-phoenix/src/test/java/io/prestosql/plugin/phoenix/TestPhoenixDistributedQueries.java
@@ -75,7 +75,7 @@ public class TestPhoenixDistributedQueries
     }
 
     @Override
-    public void testLargeIn()
+    public void testLargeIn(int valuesCount)
     {
         // TODO https://github.com/prestosql/presto/issues/1641
         throw new SkipException("test disabled");

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.tests.QueryTemplate;
 import io.prestosql.tpch.TpchTable;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -652,10 +653,10 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT orderkey FROM orders WHERE totalprice IN (1, 2, 3)");
     }
 
-    @Test
-    public void testLargeIn()
+    @Test(dataProvider = "largeInValuesCount")
+    public void testLargeIn(int valuesCount)
     {
-        String longValues = range(0, 5000)
+        String longValues = range(0, valuesCount)
                 .mapToObj(Integer::toString)
                 .collect(joining(", "));
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (" + longValues + ")");
@@ -663,6 +664,17 @@ public abstract class AbstractTestQueries
 
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (mod(1000, orderkey), " + longValues + ")");
         assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (mod(1000, orderkey), " + longValues + ")");
+    }
+
+    @DataProvider
+    public static Object[][] largeInValuesCount()
+    {
+        return new Object[][] {
+                {200},
+                {500},
+                {1000},
+                {5000}
+        };
     }
 
     @Test

--- a/presto-tests/src/test/java/io/prestosql/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestQueryPlanDeterminism.java
@@ -271,7 +271,7 @@ public class TestQueryPlanDeterminism
     }
 
     @Override
-    public void testLargeIn()
+    public void testLargeIn(int valuesCount)
     {
         // testLargeIn is expensive
         throw new SkipException("Skipping testLargeIn");


### PR DESCRIPTION
It is possible that connector has mechanisms which ensure that very
large value sets (>5000) work fine, yet it would still fail for smaller,
yet not tiny sets. Adding coverage for that.