### PR TITLE
Remove default implementation of JDBC type mappings

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -116,6 +116,10 @@ public abstract class BaseJdbcClient
 {
     private static final Logger log = Logger.get(BaseJdbcClient.class);
 
+    /**
+     * @deprecated To be removed after {{@link #legacyToWriteMapping} is removed.
+     */
+    @Deprecated
     private static final Map<Type, WriteMapping> WRITE_MAPPINGS = ImmutableMap.<Type, WriteMapping>builder()
             .put(BOOLEAN, WriteMapping.booleanMapping("boolean", booleanWriteFunction()))
             .put(BIGINT, WriteMapping.longMapping("bigint", bigintWriteFunction()))
@@ -336,8 +340,11 @@ public abstract class BaseJdbcClient
                 null);
     }
 
-    @Override
-    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    /**
+     * @deprecated Each connector should provide its own explicit type mapping, along with respective tests.
+     */
+    @Deprecated
+    protected Optional<ColumnMapping> legacyToPrestoType(ConnectorSession session, @SuppressWarnings("unused") Connection connection, JdbcTypeHandle typeHandle)
     {
         Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
         if (mapping.isPresent()) {
@@ -880,8 +887,11 @@ public abstract class BaseJdbcClient
         }
     }
 
-    @Override
-    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    /**
+     * @deprecated Each connector should provide its own explicit type mapping, along with respective tests.
+     */
+    @Deprecated
+    protected WriteMapping legacyToWriteMapping(@SuppressWarnings("unused") ConnectorSession session, Type type)
     {
         if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcClient.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestingH2JdbcClient.java
@@ -19,7 +19,9 @@ import io.prestosql.plugin.jdbc.expression.ImplementCountAll;
 import io.prestosql.spi.connector.AggregateFunction;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.type.Type;
 
+import java.sql.Connection;
 import java.sql.Types;
 import java.util.Map;
 import java.util.Optional;
@@ -45,5 +47,17 @@ class TestingH2JdbcClient
     {
         return new AggregateFunctionRewriter(this::quoted, ImmutableSet.of(new ImplementCountAll(BIGINT_TYPE_HANDLE)))
                 .rewrite(session, aggregate, assignments);
+    }
+
+    @Override
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        return legacyToPrestoType(session, connection, typeHandle);
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        return legacyToWriteMapping(session, type);
     }
 }

--- a/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
+++ b/presto-druid/src/main/java/io/prestosql/plugin/druid/DruidJdbcClient.java
@@ -25,10 +25,12 @@ import io.prestosql.plugin.jdbc.JdbcTableHandle;
 import io.prestosql.plugin.jdbc.JdbcTypeHandle;
 import io.prestosql.plugin.jdbc.QueryBuilder;
 import io.prestosql.plugin.jdbc.RemoteTableName;
+import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
@@ -142,7 +144,15 @@ public class DruidJdbcClient
                 }
                 return Optional.of(defaultVarcharColumnMapping(columnSize));
         }
-        return super.toPrestoType(session, connection, typeHandle);
+        // TODO implement proper type mapping
+        return legacyToPrestoType(session, connection, typeHandle);
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        // TODO implement proper type mapping
+        return legacyToWriteMapping(session, type);
     }
 
     // Druid doesn't like table names to be qualified with catalog names in the SQL query.

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -159,7 +159,7 @@ public class MemSqlClient
         }
 
         // TODO add explicit mappings
-        return super.toPrestoType(session, connection, typeHandle);
+        return legacyToPrestoType(session, connection, typeHandle);
     }
 
     @Override
@@ -281,7 +281,7 @@ public class MemSqlClient
         }
 
         // TODO add explicit mappings
-        return super.toWriteMapping(session, type);
+        return legacyToWriteMapping(session, type);
     }
 
     @Override

--- a/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
+++ b/presto-memsql/src/main/java/io/prestosql/plugin/memsql/MemSqlClient.java
@@ -306,13 +306,13 @@ public class MemSqlClient
         if (typeName.equalsIgnoreCase("tinyint unsigned")) {
             return Optional.of(smallintColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("smallint unsigned")) {
+        if (typeName.equalsIgnoreCase("smallint unsigned")) {
             return Optional.of(integerColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("int unsigned")) {
+        if (typeName.equalsIgnoreCase("int unsigned")) {
             return Optional.of(bigintColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("bigint unsigned")) {
+        if (typeName.equalsIgnoreCase("bigint unsigned")) {
             return Optional.of(decimalColumnMapping(createDecimalType(20)));
         }
 

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -491,13 +491,13 @@ public class MySqlClient
         if (typeName.equalsIgnoreCase("tinyint unsigned")) {
             return Optional.of(smallintColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("smallint unsigned")) {
+        if (typeName.equalsIgnoreCase("smallint unsigned")) {
             return Optional.of(integerColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("int unsigned")) {
+        if (typeName.equalsIgnoreCase("int unsigned")) {
             return Optional.of(bigintColumnMapping());
         }
-        else if (typeName.equalsIgnoreCase("bigint unsigned")) {
+        if (typeName.equalsIgnoreCase("bigint unsigned")) {
             return Optional.of(decimalColumnMapping(createDecimalType(20)));
         }
 

--- a/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/io/prestosql/plugin/mysql/MySqlClient.java
@@ -305,7 +305,7 @@ public class MySqlClient
         }
 
         // TODO add explicit mappings
-        return super.toPrestoType(session, connection, typeHandle);
+        return legacyToPrestoType(session, connection, typeHandle);
     }
 
     @Override
@@ -383,7 +383,7 @@ public class MySqlClient
             return WriteMapping.sliceMapping("json", varcharWriteFunction());
         }
 
-        return super.toWriteMapping(session, type);
+        return legacyToWriteMapping(session, type);
     }
 
     @Override

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixClient.java
@@ -383,7 +383,7 @@ public class PhoenixClient
                             return arrayColumnMapping(session, prestoArrayType, jdbcTypeName);
                         });
         }
-        return super.toPrestoType(session, connection, typeHandle);
+        return legacyToPrestoType(session, connection, typeHandle);
     }
 
     @Override
@@ -455,7 +455,7 @@ public class PhoenixClient
             String elementWriteName = getArrayElementPhoenixTypeName(session, this, elementType);
             return WriteMapping.objectMapping(elementDataType + " ARRAY", arrayWriteFunction(session, elementType, elementWriteName));
         }
-        return super.toWriteMapping(session, type);
+        return legacyToWriteMapping(session, type);
     }
 
     @Override

--- a/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/io/prestosql/plugin/postgresql/PostgreSqlClient.java
@@ -468,7 +468,7 @@ public class PostgreSqlClient
         }
 
         // TODO support PostgreSQL's TIME WITH TIME ZONE explicitly, otherwise predicate pushdown for these types may be incorrect
-        return super.toPrestoType(session, connection, typeHandle);
+        return legacyToPrestoType(session, connection, typeHandle);
     }
 
     private Optional<ColumnMapping> arrayToPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
@@ -613,7 +613,7 @@ public class PostgreSqlClient
             String elementDataType = toWriteMapping(session, elementType).getDataType();
             return WriteMapping.objectMapping(elementDataType + "[]", arrayWriteFunction(session, elementType, getArrayElementPgTypeName(session, this, elementType)));
         }
-        return super.toWriteMapping(session, type);
+        return legacyToWriteMapping(session, type);
     }
 
     @Override

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -15,12 +15,16 @@ package io.prestosql.plugin.redshift;
 
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.ColumnMapping;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcColumnHandle;
 import io.prestosql.plugin.jdbc.JdbcTableHandle;
+import io.prestosql.plugin.jdbc.JdbcTypeHandle;
+import io.prestosql.plugin.jdbc.WriteMapping;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.type.Type;
 
 import javax.inject.Inject;
 
@@ -64,6 +68,20 @@ public class RedshiftClient
         PreparedStatement statement = connection.prepareStatement(sql);
         statement.setFetchSize(1000);
         return statement;
+    }
+
+    @Override
+    public Optional<ColumnMapping> toPrestoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        // TODO implement proper type mapping
+        return legacyToPrestoType(session, connection, typeHandle);
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        // TODO implement proper type mapping
+        return legacyToWriteMapping(session, type);
     }
 
     @Override

--- a/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/io/prestosql/plugin/sqlserver/SqlServerClient.java
@@ -181,7 +181,7 @@ public class SqlServerClient
 
         // TODO how to provide SIMPLIFY_UNSUPPORTED_PUSHDOWN in most readable & maintainable way?
         return toColumnMapping(typeHandle)
-                .or(() -> super.toPrestoType(session, connection, typeHandle))
+                .or(() -> legacyToPrestoType(session, connection, typeHandle))
                 .map(columnMapping -> new ColumnMapping(
                         columnMapping.getType(),
                         columnMapping.getReadFunction(),
@@ -318,7 +318,7 @@ public class SqlServerClient
         }
 
         // TODO implement proper type mapping
-        return super.toWriteMapping(session, type);
+        return legacyToWriteMapping(session, type);
     }
 
     @Override


### PR DESCRIPTION
This is just a refactor. `BaseJdbcClient` no longer provides default
implementation of `toPrestoType` and `toWriteMapping`. Instead, it
provides these as a separate function that a connector may or may not
call. Notably, `OracleClient` does not use these methods, because the
Oracle connector covers all its mappings explicitly. Same should be
applied to all other connectors.

This supersedes previous approach (https://github.com/prestosql/presto/pull/4940, https://github.com/prestosql/presto/pull/6222).