### PR TITLE
Refactor TypeCoercion.coerceTypeBase

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
+++ b/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
@@ -292,196 +292,193 @@ public final class TypeCoercion
             return Optional.of(sourceType);
         }
 
-        switch (sourceTypeName) {
-            case UnknownType.NAME: {
-                switch (resultTypeBase) {
-                    case StandardTypes.BOOLEAN:
-                    case StandardTypes.BIGINT:
-                    case StandardTypes.INTEGER:
-                    case StandardTypes.DOUBLE:
-                    case StandardTypes.REAL:
-                    case StandardTypes.VARBINARY:
-                    case StandardTypes.DATE:
-                    case StandardTypes.TIME:
-                    case StandardTypes.TIME_WITH_TIME_ZONE:
-                    case StandardTypes.TIMESTAMP:
-                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                    case StandardTypes.HYPER_LOG_LOG:
-                    case SetDigestType.NAME:
-                    case StandardTypes.P4_HYPER_LOG_LOG:
-                    case StandardTypes.JSON:
-                    case StandardTypes.INTERVAL_YEAR_TO_MONTH:
-                    case StandardTypes.INTERVAL_DAY_TO_SECOND:
-                    case JoniRegexpType.NAME:
-                    case JsonPathType.NAME:
-                    case ColorType.NAME:
-                    case CodePointsType.NAME:
-                        return Optional.of(lookupType.apply(new TypeSignature(resultTypeBase)));
-                    case StandardTypes.VARCHAR:
-                        return Optional.of(createVarcharType(0));
-                    case StandardTypes.CHAR:
-                        return Optional.of(createCharType(0));
-                    case StandardTypes.DECIMAL:
-                        return Optional.of(createDecimalType(1, 0));
-                    default:
-                        return Optional.empty();
-                }
+        if (UnknownType.NAME.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.BOOLEAN:
+                case StandardTypes.BIGINT:
+                case StandardTypes.INTEGER:
+                case StandardTypes.DOUBLE:
+                case StandardTypes.REAL:
+                case StandardTypes.VARBINARY:
+                case StandardTypes.DATE:
+                case StandardTypes.TIME:
+                case StandardTypes.TIME_WITH_TIME_ZONE:
+                case StandardTypes.TIMESTAMP:
+                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                case StandardTypes.HYPER_LOG_LOG:
+                case SetDigestType.NAME:
+                case StandardTypes.P4_HYPER_LOG_LOG:
+                case StandardTypes.JSON:
+                case StandardTypes.INTERVAL_YEAR_TO_MONTH:
+                case StandardTypes.INTERVAL_DAY_TO_SECOND:
+                case JoniRegexpType.NAME:
+                case JsonPathType.NAME:
+                case ColorType.NAME:
+                case CodePointsType.NAME:
+                    return Optional.of(lookupType.apply(new TypeSignature(resultTypeBase)));
+                case StandardTypes.VARCHAR:
+                    return Optional.of(createVarcharType(0));
+                case StandardTypes.CHAR:
+                    return Optional.of(createCharType(0));
+                case StandardTypes.DECIMAL:
+                    return Optional.of(createDecimalType(1, 0));
+                default:
+                    return Optional.empty();
             }
-            case StandardTypes.TINYINT: {
-                switch (resultTypeBase) {
-                    case StandardTypes.SMALLINT:
-                        return Optional.of(SMALLINT);
-                    case StandardTypes.INTEGER:
-                        return Optional.of(INTEGER);
-                    case StandardTypes.BIGINT:
-                        return Optional.of(BIGINT);
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    case StandardTypes.DECIMAL:
-                        return Optional.of(createDecimalType(3, 0));
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.SMALLINT: {
-                switch (resultTypeBase) {
-                    case StandardTypes.INTEGER:
-                        return Optional.of(INTEGER);
-                    case StandardTypes.BIGINT:
-                        return Optional.of(BIGINT);
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    case StandardTypes.DECIMAL:
-                        return Optional.of(createDecimalType(5, 0));
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.INTEGER: {
-                switch (resultTypeBase) {
-                    case StandardTypes.BIGINT:
-                        return Optional.of(BIGINT);
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    case StandardTypes.DECIMAL:
-                        return Optional.of(createDecimalType(10, 0));
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.BIGINT: {
-                switch (resultTypeBase) {
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    case StandardTypes.DECIMAL:
-                        return Optional.of(createDecimalType(19, 0));
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.DECIMAL: {
-                switch (resultTypeBase) {
-                    case StandardTypes.REAL:
-                        return Optional.of(REAL);
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.REAL: {
-                switch (resultTypeBase) {
-                    case StandardTypes.DOUBLE:
-                        return Optional.of(DOUBLE);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.DATE: {
-                switch (resultTypeBase) {
-                    case StandardTypes.TIMESTAMP:
-                        return Optional.of(createTimestampType(0));
-                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                        return Optional.of(TIMESTAMP_WITH_TIME_ZONE);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.TIME: {
-                switch (resultTypeBase) {
-                    case StandardTypes.TIME_WITH_TIME_ZONE:
-                        return Optional.of(TIME_WITH_TIME_ZONE);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.TIMESTAMP: {
-                switch (resultTypeBase) {
-                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                        return Optional.of(createTimestampWithTimeZoneType(((TimestampType) sourceType).getPrecision()));
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.VARCHAR: {
-                switch (resultTypeBase) {
-                    case StandardTypes.CHAR:
-                        VarcharType varcharType = (VarcharType) sourceType;
-                        if (varcharType.isUnbounded()) {
-                            return Optional.of(createCharType(CharType.MAX_LENGTH));
-                        }
-
-                        return Optional.of(createCharType(Math.min(CharType.MAX_LENGTH, varcharType.getBoundedLength())));
-                    case JoniRegexpType.NAME:
-                        return Optional.of(JONI_REGEXP);
-                    case Re2JRegexpType.NAME:
-                        return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
-                    case JsonPathType.NAME:
-                        return Optional.of(JSON_PATH);
-                    case CodePointsType.NAME:
-                        return Optional.of(CODE_POINTS);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.CHAR: {
-                switch (resultTypeBase) {
-                    case StandardTypes.VARCHAR:
-                        // CHAR could be coercible to VARCHAR, but they cannot be both coercible to each other.
-                        // VARCHAR to CHAR coercion provides natural semantics when comparing VARCHAR literals to CHAR columns.
-                        // WITH CHAR to VARCHAR coercion one would need to pad literals with spaces: char_column_len_5 = 'abc  ', so we would not run unmodified TPC-DS queries.
-                        return Optional.empty();
-                    case JoniRegexpType.NAME:
-                        return Optional.of(JONI_REGEXP);
-                    case Re2JRegexpType.NAME:
-                        return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
-                    case JsonPathType.NAME:
-                        return Optional.of(JSON_PATH);
-                    case CodePointsType.NAME:
-                        return Optional.of(CODE_POINTS);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            case StandardTypes.P4_HYPER_LOG_LOG: {
-                switch (resultTypeBase) {
-                    case StandardTypes.HYPER_LOG_LOG:
-                        return Optional.of(HYPER_LOG_LOG);
-                    default:
-                        return Optional.empty();
-                }
-            }
-            default:
-                return Optional.empty();
         }
+        if (StandardTypes.TINYINT.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.SMALLINT:
+                    return Optional.of(SMALLINT);
+                case StandardTypes.INTEGER:
+                    return Optional.of(INTEGER);
+                case StandardTypes.BIGINT:
+                    return Optional.of(BIGINT);
+                case StandardTypes.REAL:
+                    return Optional.of(REAL);
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                case StandardTypes.DECIMAL:
+                    return Optional.of(createDecimalType(3, 0));
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.SMALLINT.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.INTEGER:
+                    return Optional.of(INTEGER);
+                case StandardTypes.BIGINT:
+                    return Optional.of(BIGINT);
+                case StandardTypes.REAL:
+                    return Optional.of(REAL);
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                case StandardTypes.DECIMAL:
+                    return Optional.of(createDecimalType(5, 0));
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.INTEGER.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.BIGINT:
+                    return Optional.of(BIGINT);
+                case StandardTypes.REAL:
+                    return Optional.of(REAL);
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                case StandardTypes.DECIMAL:
+                    return Optional.of(createDecimalType(10, 0));
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.BIGINT.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.REAL:
+                    return Optional.of(REAL);
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                case StandardTypes.DECIMAL:
+                    return Optional.of(createDecimalType(19, 0));
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.DECIMAL.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.REAL:
+                    return Optional.of(REAL);
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.REAL.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.DOUBLE:
+                    return Optional.of(DOUBLE);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.DATE.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.TIMESTAMP:
+                    return Optional.of(createTimestampType(0));
+                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                    return Optional.of(TIMESTAMP_WITH_TIME_ZONE);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.TIME.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.TIME_WITH_TIME_ZONE:
+                    return Optional.of(TIME_WITH_TIME_ZONE);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.TIMESTAMP.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                    return Optional.of(createTimestampWithTimeZoneType(((TimestampType) sourceType).getPrecision()));
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.VARCHAR.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.CHAR:
+                    VarcharType varcharType = (VarcharType) sourceType;
+                    if (varcharType.isUnbounded()) {
+                        return Optional.of(createCharType(CharType.MAX_LENGTH));
+                    }
+
+                    return Optional.of(createCharType(Math.min(CharType.MAX_LENGTH, varcharType.getBoundedLength())));
+                case JoniRegexpType.NAME:
+                    return Optional.of(JONI_REGEXP);
+                case Re2JRegexpType.NAME:
+                    return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
+                case JsonPathType.NAME:
+                    return Optional.of(JSON_PATH);
+                case CodePointsType.NAME:
+                    return Optional.of(CODE_POINTS);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.CHAR.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.VARCHAR:
+                    // CHAR could be coercible to VARCHAR, but they cannot be both coercible to each other.
+                    // VARCHAR to CHAR coercion provides natural semantics when comparing VARCHAR literals to CHAR columns.
+                    // WITH CHAR to VARCHAR coercion one would need to pad literals with spaces: char_column_len_5 = 'abc  ', so we would not run unmodified TPC-DS queries.
+                    return Optional.empty();
+                case JoniRegexpType.NAME:
+                    return Optional.of(JONI_REGEXP);
+                case Re2JRegexpType.NAME:
+                    return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
+                case JsonPathType.NAME:
+                    return Optional.of(JSON_PATH);
+                case CodePointsType.NAME:
+                    return Optional.of(CODE_POINTS);
+                default:
+                    return Optional.empty();
+            }
+        }
+        if (StandardTypes.P4_HYPER_LOG_LOG.equals(sourceTypeName)) {
+            switch (resultTypeBase) {
+                case StandardTypes.HYPER_LOG_LOG:
+                    return Optional.of(HYPER_LOG_LOG);
+                default:
+                    return Optional.empty();
+            }
+        }
+        return Optional.empty();
     }
 
     public static boolean isCovariantTypeBase(String typeBase)


### PR DESCRIPTION
This is just a refactor done with IntelliJ:

- replace `switch` with `if` statements
- remove redundant `else`.

This potentially fixes rare failures in function resolution.

Maybe fixes https://github.com/prestosql/presto/issues/5758

Credits to @kasiafi for the idea, but all bugs are mine.

