### PR TITLE
Adjust GroupedTopNRowNumberAccumulator memory diagram

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/GroupedTopNRowNumberAccumulator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/GroupedTopNRowNumberAccumulator.java
@@ -36,13 +36,13 @@ import static java.util.Objects.requireNonNull;
  *          |GroupIdToHeapBuffer |   |HeapNodeBuffer|
  *          +--------------------+   +--------------+
  * Group1+->+RootNodeIndex1+-------->+RowID1        |
- *          |HeapSize1           |   |LeftChild1+-----+
- *          |RootNodeIndex2      |   |RightChild1   | |
- *          |HeapSize2           |   |RowID2    <-----+
- *          |...                 |   |LeftChild2    |
- *          +--------------------+   |RightChild2   |
- *                                   |...           |
- *                                   +--------------+
+ *          |RootNodeIndex2      |   |LeftChild1+-----+
+ *          |...                 |   |RightChild1   | |
+ *          +--------------------+   |RowID2    <-----+
+ *          |HeapSize1           |   |LeftChild2    |
+ *          |HeapSize2           |   |RightChild2   |
+ *          |...                 |   |...           |
+ *          +--------------------+   +--------------+
  * </pre>
  */
 public class GroupedTopNRowNumberAccumulator


### PR DESCRIPTION
Update the diagram to properly reflect that GroupIdToHeapBuffer keeps
the node indices and heap sizes in separate buffers.