### PR TITLE
Restore name normalization in JdbcMetadata.getColumnHandles

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcMetadata.java
@@ -354,7 +354,7 @@ public class JdbcMetadata
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return jdbcClient.getColumns(session, (JdbcTableHandle) tableHandle).stream()
-                .collect(toImmutableMap(JdbcColumnHandle::getColumnName, identity()));
+                .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
     }
 
     @Override


### PR DESCRIPTION
Going through `ColumnMetadata` makes the name normalized to lowercase
(as should be returned by the method), while
`JdbcColumnHandle.getColumnName` returns the name as it is reported by
the remote database.

This also fixes `TestJdbcMetadata`.
