### PR TITLE
Remove EnvironmentContext use from HiveMetastoreClosure

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetastoreClosure.java
@@ -32,7 +32,6 @@ import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 
 import java.util.List;
 import java.util.Map;
@@ -351,8 +350,8 @@ public class HiveMetastoreClosure
         delegate.addDynamicPartitions(identity, dbName, tableName, partitionNames, transactionId, writeId, operation);
     }
 
-    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context, PrincipalPrivileges principalPrivileges)
+    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, PrincipalPrivileges principalPrivileges)
     {
-        delegate.alterTransactionalTable(identity, table, transactionId, writeId, context, principalPrivileges);
+        delegate.alterTransactionalTable(identity, table, transactionId, writeId, principalPrivileges);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HiveMetastore.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 
 import java.util.List;
 import java.util.Map;
@@ -193,7 +192,7 @@ public interface HiveMetastore
         throw new UnsupportedOperationException();
     }
 
-    default void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context, PrincipalPrivileges principalPrivileges)
+    default void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ValidTxnWriteIdList;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -3039,7 +3038,7 @@ public class SemiTransactionalHiveMetastore
         {
             undo = true;
             if (transaction.isTransactional()) {
-                metastore.alterTransactionalTable(identity, newTable, transaction.getAcidTransactionId(), transaction.getWriteId(), new EnvironmentContext(), principalPrivileges);
+                metastore.alterTransactionalTable(identity, newTable, transaction.getAcidTransactionId(), transaction.getWriteId(), principalPrivileges);
             }
             else {
                 metastore.replaceTable(identity, newTable.getDatabaseName(), newTable.getTableName(), newTable, principalPrivileges);
@@ -3053,7 +3052,7 @@ public class SemiTransactionalHiveMetastore
             }
 
             if (transaction.isTransactional()) {
-                metastore.alterTransactionalTable(identity, oldTable, transaction.getAcidTransactionId(), transaction.getWriteId(), new EnvironmentContext(), principalPrivileges);
+                metastore.alterTransactionalTable(identity, oldTable, transaction.getAcidTransactionId(), transaction.getWriteId(), principalPrivileges);
             }
             else {
                 metastore.replaceTable(identity, oldTable.getDatabaseName(), oldTable.getTableName(), oldTable, principalPrivileges);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -51,7 +51,6 @@ import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -1009,10 +1008,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context, PrincipalPrivileges principalPrivileges)
+    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, PrincipalPrivileges principalPrivileges)
     {
         try {
-            delegate.alterTransactionalTable(identity, table, transactionId, writeId, context, principalPrivileges);
+            delegate.alterTransactionalTable(identity, table, transactionId, writeId, principalPrivileges);
         }
         finally {
             identity = updateIdentity(identity);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -39,7 +39,6 @@ import io.prestosql.spi.security.RoleGrant;
 import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 
 import javax.inject.Inject;
@@ -547,8 +546,8 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context, PrincipalPrivileges principalPrivileges)
+    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, PrincipalPrivileges principalPrivileges)
     {
-        delegate.alterTransactionalTable(identity, toMetastoreApiTable(table, principalPrivileges), transactionId, writeId, context);
+        delegate.alterTransactionalTable(identity, toMetastoreApiTable(table, principalPrivileges), transactionId, writeId);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -1161,7 +1161,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context)
+    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId)
     {
         try {
             retry()
@@ -1169,7 +1169,7 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("alterTransactionalTable", stats.getAlterTransactionalTable().wrap(() -> {
                         try (ThriftMetastoreClient client = createMetastoreClient(identity)) {
-                            client.alterTransactionalTable(table, transactionId, writeId, context);
+                            client.alterTransactionalTable(table, transactionId, writeId, new EnvironmentContext());
                         }
                         return null;
                     }));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -30,7 +30,6 @@ import io.prestosql.spi.statistics.ColumnStatisticType;
 import io.prestosql.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -58,7 +57,7 @@ public interface ThriftMetastore
 
     void alterTable(HiveIdentity identity, String databaseName, String tableName, Table table);
 
-    void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context);
+    void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId);
 
     List<String> getAllDatabases();
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -35,7 +35,6 @@ import io.prestosql.spi.type.Type;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
@@ -285,7 +284,7 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId, EnvironmentContext context)
+    public void alterTransactionalTable(HiveIdentity identity, Table table, long transactionId, long writeId)
     {
         alterTable(identity, table.getDbName(), table.getTableName(), table);
     }


### PR DESCRIPTION
The `EnvironmentContext` is thrift API-specific and should not be used
in `HiveMetastoreClosure` which needs to be metastore-agnostic.

Anyway, the `EnvironmentContext` was effectively unused, so the change
can be viewed as a trivial refactor.