### PR TITLE
Add SQL literals-based type mapping tests

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/query/QueryAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/QueryAssertions.java
@@ -272,7 +272,7 @@ public class QueryAssertions
         public QueryAssert matches(MaterializedResult expected)
         {
             return satisfies(actual -> {
-                assertTypes(expected, actual);
+                assertTypes(actual, expected.getTypes());
 
                 ListAssert<MaterializedRow> assertion = assertThat(actual.getMaterializedRows())
                         .as("Rows")
@@ -296,7 +296,7 @@ public class QueryAssertions
         public QueryAssert containsAll(MaterializedResult expected)
         {
             return satisfies(actual -> {
-                assertTypes(expected, actual);
+                assertTypes(actual, expected.getTypes());
 
                 assertThat(actual.getMaterializedRows())
                         .as("Rows")
@@ -305,11 +305,27 @@ public class QueryAssertions
             });
         }
 
-        private static void assertTypes(MaterializedResult expected, MaterializedResult actual)
+        public QueryAssert hasOutputTypes(List<Type> expectedTypes)
+        {
+            return satisfies(actual -> {
+                assertTypes(actual, expectedTypes);
+            });
+        }
+
+        public QueryAssert outputHasType(int index, Type expectedType)
+        {
+            return satisfies(actual -> {
+                assertThat(actual.getTypes())
+                        .as("Output types")
+                        .element(index).isEqualTo(expectedType);
+            });
+        }
+
+        private static void assertTypes(MaterializedResult actual, List<Type> expectedTypes)
         {
             assertThat(actual.getTypes())
                     .as("Output types")
-                    .isEqualTo(expected.getTypes());
+                    .isEqualTo(expectedTypes);
         }
 
         public QueryAssert returnsEmptyResult()

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -35,6 +35,7 @@ import io.prestosql.testing.datatype.CreateAsSelectDataSetup;
 import io.prestosql.testing.datatype.DataSetup;
 import io.prestosql.testing.datatype.DataType;
 import io.prestosql.testing.datatype.DataTypeTest;
+import io.prestosql.testing.datatype.SqlDataTypeTest;
 import io.prestosql.testing.sql.JdbcSqlExecutor;
 import io.prestosql.testing.sql.PrestoSqlExecutor;
 import io.prestosql.testing.sql.TestTable;
@@ -44,7 +45,6 @@ import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.SQLException;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -102,7 +102,6 @@ import static io.prestosql.testing.datatype.DataType.timeDataType;
 import static io.prestosql.testing.datatype.DataType.timestampDataType;
 import static io.prestosql.testing.datatype.DataType.varbinaryDataType;
 import static io.prestosql.testing.datatype.DataType.varcharDataType;
-import static io.prestosql.testing.sql.TestTable.randomTableSuffix;
 import static io.prestosql.type.JsonType.JSON;
 import static io.prestosql.type.UuidType.UUID;
 import static java.lang.String.format;
@@ -1027,77 +1026,83 @@ public class TestPostgreSqlTypeMapping
      */
     @Test
     public void testTimeCoercion()
-            throws SQLException
     {
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00'", "TIME '00:00:00'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.123456'", "TIME '00:00:00.123456'");
-        testCreateTableAsAndInsertConsistency("TIME '12:34:56'", "TIME '12:34:56'");
-        testCreateTableAsAndInsertConsistency("TIME '12:34:56.123456'", "TIME '12:34:56.123456'");
+        SqlDataTypeTest.create()
 
-        // Cases which require using PGobject instead of e.g. LocalTime with PostgreSQL JDBC driver
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.000000'", "TIME '23:59:59.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.900000'", "TIME '23:59:59.900000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.990000'", "TIME '23:59:59.990000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999000'", "TIME '23:59:59.999000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999900'", "TIME '23:59:59.999900'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999990'", "TIME '23:59:59.999990'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999'", "TIME '23:59:59.999999'");
+                .addRoundTrip("TIME '00:00:00'", "TIME '00:00:00'")
+                .addRoundTrip("TIME '00:00:00.000000'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.123456'", "TIME '00:00:00.123456'")
+                .addRoundTrip("TIME '12:34:56'", "TIME '12:34:56'")
+                .addRoundTrip("TIME '12:34:56.123456'", "TIME '12:34:56.123456'")
 
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59'", "TIME '23:59:59'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9'", "TIME '23:59:59.9'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99'", "TIME '23:59:59.99'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999'", "TIME '23:59:59.999'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999'", "TIME '23:59:59.9999'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99999'", "TIME '23:59:59.99999'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999'", "TIME '23:59:59.999999'");
+                // Cases which require using PGobject instead of e.g. LocalTime with PostgreSQL JDBC driver
+                .addRoundTrip("TIME '23:59:59.000000'", "TIME '23:59:59.000000'")
+                .addRoundTrip("TIME '23:59:59.900000'", "TIME '23:59:59.900000'")
+                .addRoundTrip("TIME '23:59:59.990000'", "TIME '23:59:59.990000'")
+                .addRoundTrip("TIME '23:59:59.999000'", "TIME '23:59:59.999000'")
+                .addRoundTrip("TIME '23:59:59.999900'", "TIME '23:59:59.999900'")
+                .addRoundTrip("TIME '23:59:59.999990'", "TIME '23:59:59.999990'")
+                .addRoundTrip("TIME '23:59:59.999999'", "TIME '23:59:59.999999'")
 
-        // round down
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000001'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000000001'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '12:34:56.1234561'", "TIME '12:34:56.123456'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999994'", "TIME '23:59:59.999999'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999499999'", "TIME '23:59:59.999999'");
+                .addRoundTrip("TIME '23:59:59'", "TIME '23:59:59'")
+                .addRoundTrip("TIME '23:59:59.9'", "TIME '23:59:59.9'")
+                .addRoundTrip("TIME '23:59:59.99'", "TIME '23:59:59.99'")
+                .addRoundTrip("TIME '23:59:59.999'", "TIME '23:59:59.999'")
+                .addRoundTrip("TIME '23:59:59.9999'", "TIME '23:59:59.9999'")
+                .addRoundTrip("TIME '23:59:59.99999'", "TIME '23:59:59.99999'")
+                .addRoundTrip("TIME '23:59:59.999999'", "TIME '23:59:59.999999'")
 
-        // round down, maximal value
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000004'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000049'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000449'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000004449'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000044449'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000444449'", "TIME '00:00:00.000000'");
+                // round down
+                .addRoundTrip("TIME '00:00:00.0000001'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000000001'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '12:34:56.1234561'", "TIME '12:34:56.123456'")
+                .addRoundTrip("TIME '23:59:59.9999994'", "TIME '23:59:59.999999'")
+                .addRoundTrip("TIME '23:59:59.999999499999'", "TIME '23:59:59.999999'")
 
-        // round up, minimal value
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000005'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000050'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000500'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000005000'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000050000'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000500000'", "TIME '00:00:00.000001'");
+                // round down, maximal value
+                .addRoundTrip("TIME '00:00:00.0000004'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.00000049'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.0000004449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.00000044449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000444449'", "TIME '00:00:00.000000'")
 
-        // round up, maximal value
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000009'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000099'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000999'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.0000009999'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.00000099999'", "TIME '00:00:00.000001'");
-        testCreateTableAsAndInsertConsistency("TIME '00:00:00.000000999999'", "TIME '00:00:00.000001'");
+                // round up, minimal value
+                .addRoundTrip("TIME '00:00:00.0000005'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000050'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000500'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.0000005000'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000050000'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000500000'", "TIME '00:00:00.000001'")
 
-        // round up to next day, minimal value
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999995'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99999950'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999500'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999995000'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99999950000'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999500000'", "TIME '00:00:00.000000'");
+                // round up, maximal value
+                .addRoundTrip("TIME '00:00:00.0000009'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000099'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.0000009999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000099999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000999999'", "TIME '00:00:00.000001'")
 
-        // round up to next day, maximal value
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999999'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99999999'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999999'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.9999999999'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.99999999999'", "TIME '00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIME '23:59:59.999999999999'", "TIME '00:00:00.000000'");
+                // round up to next day, minimal value
+                .addRoundTrip("TIME '23:59:59.9999995'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999950'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999500'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.9999995000'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999950000'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999500000'", "TIME '00:00:00.000000'")
+
+                // round up to next day, maximal value
+                .addRoundTrip("TIME '23:59:59.9999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.9999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999999999'", "TIME '00:00:00.000000'")
+
+                // CTAS with Presto, where the coercion is done by the connector
+                .execute(getQueryRunner(), prestoCreateAsSelect(getSession(), "test_time_coercion"))
+                // INSERT with Presto, where the coercion is done by the engine
+                .execute(getQueryRunner(), prestoCreateAndInsert(getSession(), "test_time_coercion"));
     }
 
     @Test
@@ -1202,50 +1207,56 @@ public class TestPostgreSqlTypeMapping
      */
     @Test
     public void testTimestampCoercion()
-            throws SQLException
     {
-        // precision 0 ends up as precision 0
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00'");
+        SqlDataTypeTest.create()
 
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1'", "TIMESTAMP '1970-01-01 00:00:00.1'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.9'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123'", "TIMESTAMP '1970-01-01 00:00:00.123'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123000'", "TIMESTAMP '1970-01-01 00:00:00.123000'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.999'", "TIMESTAMP '1970-01-01 00:00:00.999'");
-        // max supported precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456'", "TIMESTAMP '1970-01-01 00:00:00.123456'");
+                // precision 0 ends up as precision 0
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00'")
 
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.1'", "TIMESTAMP '2020-09-27 12:34:56.1'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.9'", "TIMESTAMP '2020-09-27 12:34:56.9'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123'", "TIMESTAMP '2020-09-27 12:34:56.123'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123000'", "TIMESTAMP '2020-09-27 12:34:56.123000'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.999'", "TIMESTAMP '2020-09-27 12:34:56.999'");
-        // max supported precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123456'", "TIMESTAMP '2020-09-27 12:34:56.123456'");
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1'", "TIMESTAMP '1970-01-01 00:00:00.1'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.9'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123'", "TIMESTAMP '1970-01-01 00:00:00.123'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123000'", "TIMESTAMP '1970-01-01 00:00:00.123000'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.999'", "TIMESTAMP '1970-01-01 00:00:00.999'")
+                // max supported precision
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456'", "TIMESTAMP '1970-01-01 00:00:00.123456'")
 
-        // round down
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1234561'", "TIMESTAMP '1970-01-01 00:00:00.123456'");
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.1'", "TIMESTAMP '2020-09-27 12:34:56.1'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.9'", "TIMESTAMP '2020-09-27 12:34:56.9'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123'", "TIMESTAMP '2020-09-27 12:34:56.123'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123000'", "TIMESTAMP '2020-09-27 12:34:56.123000'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.999'", "TIMESTAMP '2020-09-27 12:34:56.999'")
+                // max supported precision
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123456'", "TIMESTAMP '2020-09-27 12:34:56.123456'")
 
-        // nanoc round up, end result rounds down
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456499'", "TIMESTAMP '1970-01-01 00:00:00.123456'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456499999'", "TIMESTAMP '1970-01-01 00:00:00.123456'");
+                // round down
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1234561'", "TIMESTAMP '1970-01-01 00:00:00.123456'")
 
-        // round up
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1234565'", "TIMESTAMP '1970-01-01 00:00:00.123457'");
+                // nanoc round up, end result rounds down
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456499'", "TIMESTAMP '1970-01-01 00:00:00.123456'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456499999'", "TIMESTAMP '1970-01-01 00:00:00.123456'")
 
-        // max precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.111222333444'", "TIMESTAMP '1970-01-01 00:00:00.111222'");
+                // round up
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1234565'", "TIMESTAMP '1970-01-01 00:00:00.123457'")
 
-        // round up to next second
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.9999995'", "TIMESTAMP '1970-01-01 00:00:01.000000'");
+                // max precision
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.111222333444'", "TIMESTAMP '1970-01-01 00:00:00.111222'")
 
-        // round up to next day
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 23:59:59.9999995'", "TIMESTAMP '1970-01-02 00:00:00.000000'");
+                // round up to next second
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.9999995'", "TIMESTAMP '1970-01-01 00:00:01.000000'")
 
-        // negative epoch
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.9999995'", "TIMESTAMP '1970-01-01 00:00:00.000000'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.999999499999'", "TIMESTAMP '1969-12-31 23:59:59.999999'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.9999994'", "TIMESTAMP '1969-12-31 23:59:59.999999'");
+                // round up to next day
+                .addRoundTrip("TIMESTAMP '1970-01-01 23:59:59.9999995'", "TIMESTAMP '1970-01-02 00:00:00.000000'")
+
+                // negative epoch
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.9999995'", "TIMESTAMP '1970-01-01 00:00:00.000000'")
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.999999499999'", "TIMESTAMP '1969-12-31 23:59:59.999999'")
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.9999994'", "TIMESTAMP '1969-12-31 23:59:59.999999'")
+
+                // CTAS with Presto, where the coercion is done by the connector
+                .execute(getQueryRunner(), prestoCreateAsSelect(getSession(), "test_timestamp_coercion"))
+                // INSERT with Presto, where the coercion is done by the engine
+                .execute(getQueryRunner(), prestoCreateAndInsert(getSession(), "test_timestamp_coercion"));
     }
 
     @Test(dataProvider = "testTimestampDataProvider")
@@ -1382,49 +1393,55 @@ public class TestPostgreSqlTypeMapping
      */
     @Test
     public void testTimestampWithTimeZoneCoercion()
-            throws SQLException
     {
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00 UTC'", "TIMESTAMP '1970-01-01 00:00:00 UTC'");
+        SqlDataTypeTest.create()
 
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1 UTC'", "TIMESTAMP '1970-01-01 00:00:00.1 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.9 UTC'", "TIMESTAMP '1970-01-01 00:00:00.9 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123000 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123000 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.999 UTC'", "TIMESTAMP '1970-01-01 00:00:00.999 UTC'");
-        // max supported precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'");
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00 UTC'", "TIMESTAMP '1970-01-01 00:00:00 UTC'")
 
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.1 UTC'", "TIMESTAMP '2020-09-27 12:34:56.1 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.9 UTC'", "TIMESTAMP '2020-09-27 12:34:56.9 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123000 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123000 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.999 UTC'", "TIMESTAMP '2020-09-27 12:34:56.999 UTC'");
-        // max supported precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '2020-09-27 12:34:56.123456 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123456 UTC'");
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1 UTC'", "TIMESTAMP '1970-01-01 00:00:00.1 UTC'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.9 UTC'", "TIMESTAMP '1970-01-01 00:00:00.9 UTC'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123 UTC'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123000 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123000 UTC'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.999 UTC'", "TIMESTAMP '1970-01-01 00:00:00.999 UTC'")
+                // max supported precision
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'")
 
-        // round down
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1234561 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'");
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.1 UTC'", "TIMESTAMP '2020-09-27 12:34:56.1 UTC'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.9 UTC'", "TIMESTAMP '2020-09-27 12:34:56.9 UTC'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123 UTC'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123000 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123000 UTC'")
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.999 UTC'", "TIMESTAMP '2020-09-27 12:34:56.999 UTC'")
+                // max supported precision
+                .addRoundTrip("TIMESTAMP '2020-09-27 12:34:56.123456 UTC'", "TIMESTAMP '2020-09-27 12:34:56.123456 UTC'")
 
-        // nanoc round up, end result rounds down
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456499 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.123456499999 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'");
+                // round down
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1234561 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'")
 
-        // round up
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.1234565 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123457 UTC'");
+                // nanoc round up, end result rounds down
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456499 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'")
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.123456499999 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123456 UTC'")
 
-        // max precision
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.111222333444 UTC'", "TIMESTAMP '1970-01-01 00:00:00.111222 UTC'");
+                // round up
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.1234565 UTC'", "TIMESTAMP '1970-01-01 00:00:00.123457 UTC'")
 
-        // round up to next second
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 00:00:00.9999995 UTC'", "TIMESTAMP '1970-01-01 00:00:01.000000 UTC'");
+                // max precision
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.111222333444 UTC'", "TIMESTAMP '1970-01-01 00:00:00.111222 UTC'")
 
-        // round up to next day
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1970-01-01 23:59:59.9999995 UTC'", "TIMESTAMP '1970-01-02 00:00:00.000000 UTC'");
+                // round up to next second
+                .addRoundTrip("TIMESTAMP '1970-01-01 00:00:00.9999995 UTC'", "TIMESTAMP '1970-01-01 00:00:01.000000 UTC'")
 
-        // negative epoch
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.9999995 UTC'", "TIMESTAMP '1970-01-01 00:00:00.000000 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.999999499999 UTC'", "TIMESTAMP '1969-12-31 23:59:59.999999 UTC'");
-        testCreateTableAsAndInsertConsistency("TIMESTAMP '1969-12-31 23:59:59.9999994 UTC'", "TIMESTAMP '1969-12-31 23:59:59.999999 UTC'");
+                // round up to next day
+                .addRoundTrip("TIMESTAMP '1970-01-01 23:59:59.9999995 UTC'", "TIMESTAMP '1970-01-02 00:00:00.000000 UTC'")
+
+                // negative epoch
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.9999995 UTC'", "TIMESTAMP '1970-01-01 00:00:00.000000 UTC'")
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.999999499999 UTC'", "TIMESTAMP '1969-12-31 23:59:59.999999 UTC'")
+                .addRoundTrip("TIMESTAMP '1969-12-31 23:59:59.9999994 UTC'", "TIMESTAMP '1969-12-31 23:59:59.999999 UTC'")
+
+                // CTAS with Presto, where the coercion is done by the connector
+                .execute(getQueryRunner(), prestoCreateAsSelect(getSession(), "test_timestamp_tz_coercion"))
+                // INSERT with Presto, where the coercion is done by the engine
+                .execute(getQueryRunner(), prestoCreateAndInsert(getSession(), "test_timestamp_tz_coercion"));
     }
 
     @Test(dataProvider = "trueFalse", dataProviderClass = DataProviders.class)
@@ -1662,25 +1679,6 @@ public class TestPostgreSqlTypeMapping
                     "SELECT * FROM " + table.getName(),
                     format("VALUES ('1', NULL), ('2', %s), ('3', NULL), ('5', NULL)", prestoValue));
         }
-    }
-
-    private void testCreateTableAsAndInsertConsistency(String inputLiteral, String expectedResult)
-            throws SQLException
-    {
-        String tableName = "test_ctas_and_insert_" + randomTableSuffix();
-
-        // CTAS
-        assertUpdate("CREATE TABLE " + tableName + " AS SELECT " + inputLiteral + " a", 1);
-        assertThat(query("SELECT a FROM " + tableName))
-                .matches("VALUES " + expectedResult);
-
-        // INSERT as a control query, where the coercion is done by the engine
-        postgreSqlServer.execute("DELETE FROM tpch." + tableName);
-        assertUpdate("INSERT INTO " + tableName + " (a) VALUES (" + inputLiteral + ")", 1);
-        assertThat(query("SELECT a FROM " + tableName))
-                .matches("VALUES " + expectedResult);
-
-        assertUpdate("DROP TABLE " + tableName);
     }
 
     public static DataType<ZonedDateTime> timestampWithTimeZoneDataType(int precision, boolean insertWithPresto)

--- a/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/io/prestosql/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -21,8 +21,6 @@ import io.prestosql.Session;
 import io.prestosql.plugin.jdbc.UnsupportedTypeHandling;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.CharType;
-import io.prestosql.spi.type.DoubleType;
-import io.prestosql.spi.type.RealType;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.testing.AbstractTestQueryFramework;
@@ -79,7 +77,12 @@ import static io.prestosql.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_AR
 import static io.prestosql.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_JSON;
 import static io.prestosql.plugin.postgresql.PostgreSqlConfig.ArrayMapping.DISABLED;
 import static io.prestosql.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.Chars.padSpaces;
+import static io.prestosql.spi.type.DoubleType.DOUBLE;
+import static io.prestosql.spi.type.IntegerType.INTEGER;
+import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
@@ -181,15 +184,15 @@ public class TestPostgreSqlTypeMapping
     @Test
     public void testBasicTypes()
     {
-        DataTypeTest.create(true)
-                .addRoundTrip(booleanDataType(), true)
-                .addRoundTrip(booleanDataType(), false)
-                .addRoundTrip(bigintDataType(), 123_456_789_012L)
-                .addRoundTrip(integerDataType(), 1_234_567_890)
-                .addRoundTrip(smallintDataType(), (short) 32_456)
-                .addRoundTrip(doubleDataType(), 123.45d)
-                .addRoundTrip(realDataType(), 123.45f)
-                .addRoundTrip(dataType("tinyint", SMALLINT, Object::toString, result -> (short) result), (byte) 5)
+        SqlDataTypeTest.create()
+                .addRoundTrip("boolean", "true", BOOLEAN)
+                .addRoundTrip("boolean", "false", BOOLEAN)
+                .addRoundTrip("bigint", "123456789012", BIGINT)
+                .addRoundTrip("integer", "123456789", INTEGER)
+                .addRoundTrip("smallint", "32456", SMALLINT, "SMALLINT '32456'")
+                .addRoundTrip("tinyint", "5", SMALLINT, "SMALLINT '5'")
+                .addRoundTrip("double", "123.45", DOUBLE, "DOUBLE '123.45'")
+                .addRoundTrip("real", "123.45", REAL, "REAL '123.45'")
                 .execute(getQueryRunner(), prestoCreateAsSelect("test_basic_types"));
     }
 
@@ -1879,7 +1882,7 @@ public class TestPostgreSqlTypeMapping
 
     private static DataType<Float> postgreSqlRealDataType()
     {
-        return dataType("real", RealType.REAL,
+        return dataType("real", REAL,
                 value -> {
                     if (Float.isFinite(value)) {
                         return value.toString();
@@ -1895,7 +1898,7 @@ public class TestPostgreSqlTypeMapping
 
     private static DataType<Double> postgreSqlDoubleDataType()
     {
-        return dataType("double precision", DoubleType.DOUBLE,
+        return dataType("double precision", DOUBLE,
                 value -> {
                     if (Double.isFinite(value)) {
                         return value.toString();

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/ColumnSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/ColumnSetup.java
@@ -13,11 +13,11 @@
  */
 package io.prestosql.testing.datatype;
 
-import io.prestosql.testing.sql.TestTable;
+import java.util.Optional;
 
-import java.util.List;
-
-public interface DataSetup
+public interface ColumnSetup
 {
-    TestTable setupTestTable(List<ColumnSetup> inputs);
+    Optional<String> getDeclaredType();
+
+    String getInputLiteral();
 }

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndInsertDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndInsertDataSetup.java
@@ -13,13 +13,11 @@
  */
 package io.prestosql.testing.datatype;
 
-import com.google.common.base.Joiner;
 import io.prestosql.testing.sql.SqlExecutor;
 import io.prestosql.testing.sql.TestTable;
 
 import java.util.List;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -63,9 +61,9 @@ public class CreateAndInsertDataSetup
 
     private void insertRows(TestTable testTable, List<ColumnSetup> inputs)
     {
-        Stream<String> literals = inputs.stream()
-                .map(ColumnSetup::getInputLiteral);
-        String valueLiterals = Joiner.on(", ").join(literals.iterator());
+        String valueLiterals = inputs.stream()
+                .map(ColumnSetup::getInputLiteral)
+                .collect(joining(", "));
         sqlExecutor.execute(format("INSERT INTO %s VALUES(%s)", testTable.getName(), valueLiterals));
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndPrestoInsertDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndPrestoInsertDataSetup.java
@@ -40,7 +40,7 @@ public class CreateAndPrestoInsertDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<DataTypeTest.Input<?>> inputs)
+    public TestTable setupTestTable(List<ColumnSetup> inputs)
     {
         TestTable testTable = createTestTable(inputs);
         try {
@@ -53,23 +53,23 @@ public class CreateAndPrestoInsertDataSetup
         return testTable;
     }
 
-    private void insertRows(TestTable testTable, List<DataTypeTest.Input<?>> inputs)
+    private void insertRows(TestTable testTable, List<ColumnSetup> inputs)
     {
         Stream<String> literals = inputs.stream()
-                .map(DataTypeTest.Input::toLiteral);
+                .map(ColumnSetup::getInputLiteral);
         String valueLiterals = Joiner.on(", ").join(literals.iterator());
         prestoSqlExecutor.execute(format("INSERT INTO %s VALUES(%s)", testTable.getName(), valueLiterals));
     }
 
-    private TestTable createTestTable(List<DataTypeTest.Input<?>> inputs)
+    private TestTable createTestTable(List<ColumnSetup> inputs)
     {
         return new TestTable(sqlExecutor, tableNamePrefix, "(" + columnDefinitions(inputs) + ")");
     }
 
-    private String columnDefinitions(List<DataTypeTest.Input<?>> inputs)
+    private String columnDefinitions(List<ColumnSetup> inputs)
     {
         List<String> columnTypeDefinitions = inputs.stream()
-                .map(DataTypeTest.Input::getInsertType)
+                .map(input -> input.getDeclaredType().orElseThrow(() -> new IllegalArgumentException("declared type not set")))
                 .collect(toList());
         Stream<String> columnDefinitions = range(0, columnTypeDefinitions.size())
                 .mapToObj(i -> format("col_%d %s", i, columnTypeDefinitions.get(i)));

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndPrestoInsertDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAndPrestoInsertDataSetup.java
@@ -13,15 +13,14 @@
  */
 package io.prestosql.testing.datatype;
 
-import com.google.common.base.Joiner;
 import io.prestosql.testing.sql.PrestoSqlExecutor;
 import io.prestosql.testing.sql.SqlExecutor;
 import io.prestosql.testing.sql.TestTable;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 
@@ -55,9 +54,9 @@ public class CreateAndPrestoInsertDataSetup
 
     private void insertRows(TestTable testTable, List<ColumnSetup> inputs)
     {
-        Stream<String> literals = inputs.stream()
-                .map(ColumnSetup::getInputLiteral);
-        String valueLiterals = Joiner.on(", ").join(literals.iterator());
+        String valueLiterals = inputs.stream()
+                .map(ColumnSetup::getInputLiteral)
+                .collect(joining(", "));
         prestoSqlExecutor.execute(format("INSERT INTO %s VALUES(%s)", testTable.getName(), valueLiterals));
     }
 
@@ -71,8 +70,8 @@ public class CreateAndPrestoInsertDataSetup
         List<String> columnTypeDefinitions = inputs.stream()
                 .map(input -> input.getDeclaredType().orElseThrow(() -> new IllegalArgumentException("declared type not set")))
                 .collect(toList());
-        Stream<String> columnDefinitions = range(0, columnTypeDefinitions.size())
-                .mapToObj(i -> format("col_%d %s", i, columnTypeDefinitions.get(i)));
-        return Joiner.on(",\n").join(columnDefinitions.iterator());
+        return range(0, columnTypeDefinitions.size())
+                .mapToObj(i -> format("col_%d %s", i, columnTypeDefinitions.get(i)))
+                .collect(joining(",\n"));
     }
 }

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAsSelectDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAsSelectDataSetup.java
@@ -37,7 +37,7 @@ public class CreateAsSelectDataSetup
     }
 
     @Override
-    public TestTable setupTestTable(List<DataTypeTest.Input<?>> inputs)
+    public TestTable setupTestTable(List<ColumnSetup> inputs)
     {
         List<String> columnValues = inputs.stream()
                 .map(this::literalInExplicitCast)
@@ -48,8 +48,11 @@ public class CreateAsSelectDataSetup
         return new TestTable(sqlExecutor, tableNamePrefix, "AS SELECT " + selectBody);
     }
 
-    private String literalInExplicitCast(DataTypeTest.Input<?> input)
+    private String literalInExplicitCast(ColumnSetup input)
     {
-        return format("CAST(%s AS %s)", input.toLiteral(), input.getInsertType());
+        return format(
+                "CAST(%s AS %s)",
+                input.getInputLiteral(),
+                input.getDeclaredType().orElseThrow(() -> new IllegalArgumentException("declared type not set")));
     }
 }

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAsSelectDataSetup.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/CreateAsSelectDataSetup.java
@@ -13,13 +13,12 @@
  */
 package io.prestosql.testing.datatype;
 
-import com.google.common.base.Joiner;
 import io.prestosql.testing.sql.SqlExecutor;
 import io.prestosql.testing.sql.TestTable;
 
 import java.util.List;
-import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 
@@ -41,9 +40,9 @@ public class CreateAsSelectDataSetup
         List<String> columnValues = inputs.stream()
                 .map(this::format)
                 .collect(toList());
-        Stream<String> columnValuesWithNames = range(0, columnValues.size())
-                .mapToObj(i -> String.format("%s col_%d", columnValues.get(i), i));
-        String selectBody = Joiner.on(",\n").join(columnValuesWithNames.iterator());
+        String selectBody = range(0, columnValues.size())
+                .mapToObj(i -> String.format("%s col_%d", columnValues.get(i), i))
+                .collect(joining(",\n"));
         return new TestTable(sqlExecutor, tableNamePrefix, "AS SELECT " + selectBody);
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/DataTypeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/DataTypeTest.java
@@ -22,6 +22,7 @@ import io.prestosql.testing.sql.TestTable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -133,6 +134,7 @@ public class DataTypeTest
     }
 
     public static class Input<T>
+            implements ColumnSetup
     {
         private final DataType<T> dataType;
         private final T value;
@@ -150,6 +152,12 @@ public class DataTypeTest
             return useInWhereClause;
         }
 
+        @Override
+        public Optional<String> getDeclaredType()
+        {
+            return Optional.of(getInsertType());
+        }
+
         public String getInsertType()
         {
             return dataType.getInsertType();
@@ -163,6 +171,12 @@ public class DataTypeTest
         Object toPrestoQueryResult()
         {
             return dataType.toPrestoQueryResult(value);
+        }
+
+        @Override
+        public String getInputLiteral()
+        {
+            return toLiteral();
         }
 
         public String toLiteral()

--- a/presto-testing/src/main/java/io/prestosql/testing/datatype/SqlDataTypeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/datatype/SqlDataTypeTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.testing.datatype;
+
+import io.prestosql.Session;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.query.QueryAssertions;
+import io.prestosql.sql.query.QueryAssertions.QueryAssert;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.QueryRunner;
+import io.prestosql.testing.sql.TestTable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SqlDataTypeTest
+{
+    public static SqlDataTypeTest create()
+    {
+        return new SqlDataTypeTest();
+    }
+
+    private final List<TestCase> testCases = new ArrayList<>();
+
+    private SqlDataTypeTest() {}
+
+    public SqlDataTypeTest addRoundTrip(String literal)
+    {
+        return addRoundTrip(literal, literal);
+    }
+
+    public SqlDataTypeTest addRoundTrip(String inputLiteral, String expectedLiteral)
+    {
+        testCases.add(new TestCase(Optional.empty(), inputLiteral, Optional.empty(), expectedLiteral));
+        return this;
+    }
+
+    public SqlDataTypeTest addRoundTrip(String inputType, String literal, Type expectedType)
+    {
+        return addRoundTrip(inputType, literal, expectedType, literal);
+    }
+
+    public SqlDataTypeTest addRoundTrip(String inputType, String inputLiteral, Type expectedType, String expectedLiteral)
+    {
+        testCases.add(new TestCase(Optional.of(inputType), inputLiteral, Optional.of(expectedType), expectedLiteral));
+        return this;
+    }
+
+    public SqlDataTypeTest execute(QueryRunner queryRunner, DataSetup dataSetup)
+    {
+        return execute(queryRunner, queryRunner.getDefaultSession(), dataSetup);
+    }
+
+    public SqlDataTypeTest execute(QueryRunner queryRunner, Session session, DataSetup dataSetup)
+    {
+        checkState(!testCases.isEmpty(), "No test cases");
+        try (TestTable testTable = dataSetup.setupTestTable(unmodifiableList(testCases))) {
+            verifySelect(queryRunner, session, testTable);
+            verifyPredicate(queryRunner, session, testTable);
+        }
+        return this;
+    }
+
+    private void verifySelect(QueryRunner queryRunner, Session session, TestTable testTable)
+    {
+        @SuppressWarnings("resource") // Closing QueryAssertions would close the QueryRunner
+        QueryAssertions queryAssertions = new QueryAssertions(queryRunner);
+
+        QueryAssert assertion = assertThat(queryAssertions.query(session, "SELECT * FROM " + testTable.getName()));
+        MaterializedResult expected = queryRunner.execute(session, testCases.stream()
+                .map(TestCase::getExpectedLiteral)
+                .collect(joining(",", "VALUES (", ")")));
+
+        // Verify types if specified
+        for (int column = 0; column < testCases.size(); column++) {
+            TestCase testCase = testCases.get(column);
+            if (testCase.getExpectedType().isPresent()) {
+                Type expectedType = testCase.getExpectedType().get();
+                assertion.outputHasType(column, expectedType);
+                assertThat(expected.getTypes())
+                        .as("Expected literal type (check consistency of expected type and expected literal)")
+                        .element(column).isEqualTo(expectedType);
+            }
+        }
+
+        assertion.matches(expected);
+    }
+
+    private void verifyPredicate(QueryRunner queryRunner, Session session, TestTable testTable)
+    {
+        String queryWithAll = "SELECT 'all found' FROM " + testTable.getName() + " WHERE " +
+                IntStream.range(0, testCases.size())
+                        .mapToObj(this::getPredicate)
+                        .collect(joining(" AND "));
+
+        MaterializedResult result = queryRunner.execute(session, queryWithAll);
+        if (result.getOnlyColumnAsSet().equals(Set.of("all found"))) {
+            return;
+        }
+
+        @SuppressWarnings("resource") // Closing QueryAssertions would close the QueryRunner
+        QueryAssertions queryAssertions = new QueryAssertions(queryRunner);
+
+        for (int column = 0; column < testCases.size(); column++) {
+            assertThat(queryAssertions.query(session, "SELECT 'found' FROM " + testTable.getName() + " WHERE " + getPredicate(column)))
+                    .matches("VALUES 'found'");
+        }
+    }
+
+    private String getPredicate(int column)
+    {
+        return format("col_%s IS NOT DISTINCT FROM %s", column, testCases.get(column).getExpectedLiteral());
+    }
+
+    private static class TestCase
+            implements ColumnSetup
+    {
+        private final Optional<String> declaredType;
+        private final String inputLiteral;
+        private final Optional<Type> expectedType;
+        private final String expectedLiteral;
+
+        public TestCase(Optional<String> declaredType, String inputLiteral, Optional<Type> expectedType, String expectedLiteral)
+        {
+            this.declaredType = requireNonNull(declaredType, "declaredType is null");
+            this.expectedType = requireNonNull(expectedType, "expectedType is null");
+            this.inputLiteral = requireNonNull(inputLiteral, "inputLiteral is null");
+            this.expectedLiteral = requireNonNull(expectedLiteral, "expectedLiteral is null");
+        }
+
+        @Override
+        public Optional<String> getDeclaredType()
+        {
+            return declaredType;
+        }
+
+        @Override
+        public String getInputLiteral()
+        {
+            return inputLiteral;
+        }
+
+        public Optional<Type> getExpectedType()
+        {
+            return expectedType;
+        }
+
+        public String getExpectedLiteral()
+        {
+            return expectedLiteral;
+        }
+    }
+}


### PR DESCRIPTION
This generalizes the approach already used in some existing tests, e.g.
`TestPostgreSqlTypeMapping.testTimeCoercion`,
`TestPostgreSqlTypeMapping.testTimestampCoercion`.

It has some advantages over `testCreateTableAsAndInsertConsistency` used
there:

- `SqlDataTypeTest` is meant to be reused, not copied
- `SqlDataTypeTest` verifies predicate pushdown correctness (something
  that `DataTypeTest` does but `testCreateTableAsAndInsertConsistency`
  did not do)
- `SqlDataTypeTest` supports explicit result type verifications
- `SqlDataTypeTest` is faster, as saves round trip times, by creating a
  test table once, and verifying results in bulk

It has also advantages over existing `DataTypeTest`:

- `SqlDataTypeTest` is based in SQL literals, so supports anything that
  can be expressed in SQL, including date/time types with picoseconds
- `SqlDataTypeTest` avoids coupling inserted and expected values, making
  unifications like `DataType#toPrestoQueryResult` redundant
- oh, and `SqlDataTypeTest` makes all `DataType` structures redundant.
  Tests are simple again.