### PR TITLE
Avoid repeatedly setting memory limits in QueryContext

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
@@ -145,16 +145,15 @@ public class SqlTaskManager
         SqlTaskExecutionFactory sqlTaskExecutionFactory = new SqlTaskExecutionFactory(taskNotificationExecutor, taskExecutor, planner, splitMonitor, config);
 
         this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");
-        DataSize maxQueryUserMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
+        DataSize maxQueryMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
         DataSize maxQueryTotalMemoryPerNode = nodeMemoryConfig.getMaxQueryTotalMemoryPerNode();
         DataSize maxQuerySpillPerNode = nodeSpillConfig.getQueryMaxSpillPerNode();
 
-        DataSize maxQueryMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
         queryMaxMemoryPerNode = maxQueryMemoryPerNode.toBytes();
-        queryMaxTotalMemoryPerNode = maxQueryMemoryPerNode.toBytes();
+        queryMaxTotalMemoryPerNode = maxQueryTotalMemoryPerNode.toBytes();
 
         queryContexts = CacheBuilder.newBuilder().weakValues().build(CacheLoader.from(
-                queryId -> createQueryContext(queryId, localMemoryManager, localSpillManager, gcMonitor, maxQueryUserMemoryPerNode, maxQueryTotalMemoryPerNode, maxQuerySpillPerNode)));
+                queryId -> createQueryContext(queryId, localMemoryManager, localSpillManager, gcMonitor, maxQueryMemoryPerNode, maxQueryTotalMemoryPerNode, maxQuerySpillPerNode)));
 
         tasks = CacheBuilder.newBuilder().build(CacheLoader.from(
                 taskId -> createSqlTask(

--- a/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlTaskManager.java
@@ -378,7 +378,7 @@ public class SqlTaskManager
         if (!queryContext.isMemoryLimitsInitialized()) {
             long sessionQueryMaxMemoryPerNode = getQueryMaxMemoryPerNode(session).toBytes();
             long sessionQueryTotalMaxMemoryPerNode = getQueryMaxTotalMemoryPerNode(session).toBytes();
-            // Session property query_max_memory_per_node is used to only decrease memory limit
+            // Session properties are only allowed to decrease memory limits, not increase them
             queryContext.initializeMemoryLimits(
                     resourceOvercommit(session),
                     min(sessionQueryMaxMemoryPerNode, queryMaxMemoryPerNode),

--- a/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
+++ b/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
@@ -126,7 +126,7 @@ public class QueryContext
         checkArgument(maxTotalMemory >= 0, "maxTotalMemory must be >= 0, found: %s", maxTotalMemory);
         this.resourceOverCommit = resourceOverCommit;
         if (resourceOverCommit) {
-            // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local general pool.
+            // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local memory pool.
             // The coordinator will kill the query if the cluster runs out of memory.
             this.maxUserMemory = memoryPool.getMaxBytes();
             this.maxTotalMemory = memoryPool.getMaxBytes();
@@ -148,7 +148,7 @@ public class QueryContext
      * Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
      * calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively.
      *
-     * @see this##updateSystemMemory(long) for details.
+     * @see this#updateSystemMemory(String, long) for details.
      */
     private synchronized ListenableFuture<?> updateUserMemory(String allocationTag, long delta)
     {

--- a/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
+++ b/presto-main/src/main/java/io/prestosql/memory/QueryContext.java
@@ -144,6 +144,18 @@ public class QueryContext
         return queryMemoryContext;
     }
 
+    @VisibleForTesting
+    public synchronized long getMaxUserMemory()
+    {
+        return maxUserMemory;
+    }
+
+    @VisibleForTesting
+    public synchronized long getMaxTotalMemory()
+    {
+        return maxTotalMemory;
+    }
+
     /**
      * Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
      * calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively.


### PR DESCRIPTION
Extracted relevant changes from https://github.com/prestodb/presto/pull/15522

Synchronizing on the `QueryContext` as part of every task update adds contention to the already heavily contended `QueryContext` instance lock (since each memory tracking update must synchronize as well). This change checks whether the memory limit initialization is necessary before synchronizing to avoid adding the extra contention after they
have been set at least once successfully.