### PR TITLE
Fix typo: picoSecond -> picosecond

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimeWithTimeZoneToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/TimeWithTimeZoneToTimestampCast.java
@@ -62,7 +62,7 @@ public final class TimeWithTimeZoneToTimestampCast
     {
         // source precision > 9
         // target precision <= 6
-        long picos = time.getPicoSeconds();
+        long picos = time.getPicoseconds();
         picos = round(picos, (int) (12 - targetPrecision));
 
         return calculateEpochMicros(session, picos);
@@ -94,7 +94,7 @@ public final class TimeWithTimeZoneToTimestampCast
     {
         // source precision > 9
         // target precision > 6
-        long picos = time.getPicoSeconds();
+        long picos = time.getPicoseconds();
         picos = round(picos, (int) (12 - targetPrecision));
 
         long epochMicros = calculateEpochMicros(session, picos);

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/ToIso8601.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamptz/ToIso8601.java
@@ -71,10 +71,10 @@ public final class ToIso8601
         return utf8Slice(format((int) precision, timestamp.getEpochMillis(), timestamp.getPicosOfMilli(), getTimeZoneKey(timestamp.getTimeZoneKey()).getZoneId()));
     }
 
-    private static String format(int precision, long epochMillis, int picoSecondOfMilli, ZoneId zoneId)
+    private static String format(int precision, long epochMillis, int picosOfMilli, ZoneId zoneId)
     {
         LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zoneId);
-        long picoFraction = ((long) getMillisOfSecond(epochMillis)) * PICOSECONDS_PER_MILLISECOND + picoSecondOfMilli;
+        long picoFraction = ((long) getMillisOfSecond(epochMillis)) * PICOSECONDS_PER_MILLISECOND + picosOfMilli;
 
         ZoneOffset offset = zoneId.getRules().getValidOffsets(dateTime).get(0);
         if (offset.getTotalSeconds() % 60 != 0) {

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/AtTimeZone.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/AtTimeZone.java
@@ -77,7 +77,7 @@ public class AtTimeZone
         }
 
         int offsetMinutes = getOffsetMinutes(session.getStart(), zoneKey);
-        long picos = time.getPicoSeconds() - (time.getOffsetMinutes() - offsetMinutes) * PICOSECONDS_PER_MINUTE;
+        long picos = time.getPicoseconds() - (time.getOffsetMinutes() - offsetMinutes) * PICOSECONDS_PER_MINUTE;
         return new LongTimeWithTimeZone(floorMod(picos, PICOSECONDS_PER_DAY), offsetMinutes);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/AtTimeZoneWithOffset.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/AtTimeZoneWithOffset.java
@@ -54,7 +54,7 @@ public class AtTimeZoneWithOffset
             @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long zoneOffset)
     {
         int offsetMinutes = getZoneOffsetMinutes(zoneOffset);
-        long picos = time.getPicoSeconds() - (time.getOffsetMinutes() - offsetMinutes) * PICOSECONDS_PER_MINUTE;
+        long picos = time.getPicoseconds() - (time.getOffsetMinutes() - offsetMinutes) * PICOSECONDS_PER_MINUTE;
         return new LongTimeWithTimeZone(floorMod(picos, PICOSECONDS_PER_DAY), getZoneOffsetMinutes(zoneOffset));
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/DateAdd.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/DateAdd.java
@@ -73,7 +73,7 @@ public class DateAdd
             @SqlType(StandardTypes.BIGINT) long value,
             @SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        long picos = add(time.getPicoSeconds(), unit, value);
+        long picos = add(time.getPicoseconds(), unit, value);
 
         return new LongTimeWithTimeZone(picos, time.getOffsetMinutes());
     }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/DateTrunc.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/DateTrunc.java
@@ -54,7 +54,7 @@ public final class DateTrunc
             @SqlType("varchar(x)") Slice unit,
             @SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return new LongTimeWithTimeZone(truncate(time.getPicoSeconds(), unit), time.getOffsetMinutes());
+        return new LongTimeWithTimeZone(truncate(time.getPicoseconds(), unit), time.getOffsetMinutes());
     }
 
     private static long truncate(long picos, Slice unit)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractHour.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractHour.java
@@ -41,6 +41,6 @@ public class ExtractHour
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return time.getPicoSeconds() / PICOSECONDS_PER_HOUR;
+        return time.getPicoseconds() / PICOSECONDS_PER_HOUR;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractMillisecond.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractMillisecond.java
@@ -42,6 +42,6 @@ public class ExtractMillisecond
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return (time.getPicoSeconds() / PICOSECONDS_PER_MILLISECOND) % MILLISECONDS_PER_SECOND;
+        return (time.getPicoseconds() / PICOSECONDS_PER_MILLISECOND) % MILLISECONDS_PER_SECOND;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractMinute.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractMinute.java
@@ -42,6 +42,6 @@ public class ExtractMinute
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return (time.getPicoSeconds() / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
+        return (time.getPicoseconds() / PICOSECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractSecond.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/ExtractSecond.java
@@ -42,6 +42,6 @@ public class ExtractSecond
     @SqlType(StandardTypes.BIGINT)
     public static long extract(@SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return (time.getPicoSeconds() / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE;
+        return (time.getPicoseconds() / PICOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneOperators.java
@@ -59,7 +59,7 @@ public final class TimeWithTimeZoneOperators
      */
     static long normalize(LongTimeWithTimeZone time)
     {
-        return floorMod(time.getPicoSeconds() - time.getOffsetMinutes() * PICOSECONDS_PER_MINUTE, PICOSECONDS_PER_DAY);
+        return floorMod(time.getPicoseconds() - time.getOffsetMinutes() * PICOSECONDS_PER_MINUTE, PICOSECONDS_PER_DAY);
     }
 
     @ScalarOperator(ADD)
@@ -85,7 +85,7 @@ public final class TimeWithTimeZoneOperators
                 @SqlType("time(p) with time zone") LongTimeWithTimeZone time,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            long picos = TimeOperators.add(time.getPicoSeconds(), interval * PICOSECONDS_PER_MILLISECOND);
+            long picos = TimeOperators.add(time.getPicoseconds(), interval * PICOSECONDS_PER_MILLISECOND);
             return new LongTimeWithTimeZone(picos, time.getOffsetMinutes());
         }
     }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimeCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimeCast.java
@@ -46,7 +46,7 @@ public final class TimeWithTimeZoneToTimeCast
             @LiteralParameter("targetPrecision") long targetPrecision,
             @SqlType("time(sourcePrecision) with time zone") LongTimeWithTimeZone timestamp)
     {
-        return convert(targetPrecision, timestamp.getPicoSeconds());
+        return convert(targetPrecision, timestamp.getPicoseconds());
     }
 
     private static long convert(long targetPrecision, long picos)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimeWithTimeZoneCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimeWithTimeZoneCast.java
@@ -64,7 +64,7 @@ public final class TimeWithTimeZoneToTimeWithTimeZoneCast
             @LiteralParameter("targetPrecision") long targetPrecision,
             @SqlType("time(sourcePrecision) with time zone") LongTimeWithTimeZone timestamp)
     {
-        long nanos = round(timestamp.getPicoSeconds(), (int) (MAX_PRECISION - targetPrecision)) / PICOSECONDS_PER_NANOSECOND;
+        long nanos = round(timestamp.getPicoseconds(), (int) (MAX_PRECISION - targetPrecision)) / PICOSECONDS_PER_NANOSECOND;
 
         return packTimeWithTimeZone(nanos % NANOSECONDS_PER_DAY, timestamp.getOffsetMinutes());
     }
@@ -76,7 +76,7 @@ public final class TimeWithTimeZoneToTimeWithTimeZoneCast
             @SqlType("time(sourcePrecision) with time zone") LongTimeWithTimeZone timestamp)
     {
         return new LongTimeWithTimeZone(
-                round(timestamp.getPicoSeconds(), (int) (MAX_PRECISION - targetPrecision)) % PICOSECONDS_PER_DAY,
+                round(timestamp.getPicoseconds(), (int) (MAX_PRECISION - targetPrecision)) % PICOSECONDS_PER_DAY,
                 timestamp.getOffsetMinutes());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimestampWithTimeZoneCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToTimestampWithTimeZoneCast.java
@@ -65,7 +65,7 @@ public final class TimeWithTimeZoneToTimestampWithTimeZoneCast
     {
         // source precision > 9
         // target precision <= 3
-        long picos = normalizeAndRound(targetPrecision, time.getPicoSeconds(), time.getOffsetMinutes());
+        long picos = normalizeAndRound(targetPrecision, time.getPicoseconds(), time.getOffsetMinutes());
 
         return packDateTimeWithZone(calculateEpochMillis(session, picos), getTimeZoneKeyForOffset(time.getOffsetMinutes()));
     }
@@ -96,7 +96,7 @@ public final class TimeWithTimeZoneToTimestampWithTimeZoneCast
     {
         // source precision > 9
         // target precision > 3
-        long picos = normalizeAndRound(targetPrecision, time.getPicoSeconds(), time.getOffsetMinutes());
+        long picos = normalizeAndRound(targetPrecision, time.getPicoseconds(), time.getOffsetMinutes());
 
         return LongTimestampWithTimeZone.fromEpochMillisAndFraction(
                 calculateEpochMillis(session, picos),

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToVarcharCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timetz/TimeWithTimeZoneToVarcharCast.java
@@ -55,7 +55,7 @@ public final class TimeWithTimeZoneToVarcharCast
     @SqlType("varchar(x)")
     public static Slice cast(@LiteralParameter("p") long precision, @SqlType("time(p) with time zone") LongTimeWithTimeZone time)
     {
-        return formatAsString((int) precision, time.getPicoSeconds(), time.getOffsetMinutes());
+        return formatAsString((int) precision, time.getPicoseconds(), time.getOffsetMinutes());
     }
 
     // Can't name this format() because we can't have a qualified reference to String.format() below

--- a/presto-main/src/main/java/io/prestosql/type/DateTimes.java
+++ b/presto-main/src/main/java/io/prestosql/type/DateTimes.java
@@ -303,11 +303,11 @@ public final class DateTimes
         return formatTimestamp(precision, dateTime, picoFraction, yearToSecondFormatter, builder -> {});
     }
 
-    public static String formatTimestampWithTimeZone(int precision, long epochMillis, int picoSecondOfMilli, ZoneId zoneId)
+    public static String formatTimestampWithTimeZone(int precision, long epochMillis, int picosOfMilli, ZoneId zoneId)
     {
         Instant instant = Instant.ofEpochMilli(epochMillis);
         LocalDateTime dateTime = LocalDateTime.ofInstant(instant, zoneId);
-        long picoFraction = ((long) getMillisOfSecond(epochMillis)) * PICOSECONDS_PER_MILLISECOND + picoSecondOfMilli;
+        long picoFraction = ((long) getMillisOfSecond(epochMillis)) * PICOSECONDS_PER_MILLISECOND + picosOfMilli;
 
         return formatTimestamp(precision, dateTime, picoFraction, TIMESTAMP_FORMATTER, builder -> builder.append(" ").append(zoneId));
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimeWithTimeZone.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimeWithTimeZone.java
@@ -20,18 +20,18 @@ import static io.prestosql.spi.type.TimeWithTimeZoneTypes.normalize;
 public final class LongTimeWithTimeZone
         implements Comparable<LongTimeWithTimeZone>
 {
-    private final long picoSeconds;
+    private final long picoseconds;
     private final int offsetMinutes;
 
-    public LongTimeWithTimeZone(long picoSeconds, int offsetMinutes)
+    public LongTimeWithTimeZone(long picoseconds, int offsetMinutes)
     {
-        this.picoSeconds = picoSeconds;
+        this.picoseconds = picoseconds;
         this.offsetMinutes = offsetMinutes;
     }
 
-    public long getPicoSeconds()
+    public long getPicoseconds()
     {
-        return picoSeconds;
+        return picoseconds;
     }
 
     public int getOffsetMinutes()
@@ -49,13 +49,13 @@ public final class LongTimeWithTimeZone
             return false;
         }
         LongTimeWithTimeZone that = (LongTimeWithTimeZone) o;
-        return picoSeconds == that.picoSeconds && offsetMinutes == that.offsetMinutes;
+        return picoseconds == that.picoseconds && offsetMinutes == that.offsetMinutes;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(picoSeconds, offsetMinutes);
+        return Objects.hash(picoseconds, offsetMinutes);
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimeWithTimeZoneType.java
@@ -112,7 +112,7 @@ class LongTimeWithTimeZoneType
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
         LongTimeWithTimeZone timestamp = (LongTimeWithTimeZone) value;
-        blockBuilder.writeLong(timestamp.getPicoSeconds());
+        blockBuilder.writeLong(timestamp.getPicoseconds());
         blockBuilder.writeInt(timestamp.getOffsetMinutes());
         blockBuilder.closeEntry();
     }
@@ -141,9 +141,9 @@ class LongTimeWithTimeZoneType
     private static boolean equalOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return equal(
-                left.getPicoSeconds(),
+                left.getPicoseconds(),
                 left.getOffsetMinutes(),
-                right.getPicoSeconds(),
+                right.getPicoseconds(),
                 right.getOffsetMinutes());
     }
 
@@ -165,7 +165,7 @@ class LongTimeWithTimeZoneType
     @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(LongTimeWithTimeZone value)
     {
-        return hashCodeOperator(value.getPicoSeconds(), value.getOffsetMinutes());
+        return hashCodeOperator(value.getPicoseconds(), value.getOffsetMinutes());
     }
 
     @ScalarOperator(HASH_CODE)
@@ -182,7 +182,7 @@ class LongTimeWithTimeZoneType
     @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(LongTimeWithTimeZone value)
     {
-        return xxHash64(value.getPicoSeconds(), value.getOffsetMinutes());
+        return xxHash64(value.getPicoseconds(), value.getOffsetMinutes());
     }
 
     @ScalarOperator(XX_HASH_64)
@@ -200,9 +200,9 @@ class LongTimeWithTimeZoneType
     private static long comparisonOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return comparison(
-                left.getPicoSeconds(),
+                left.getPicoseconds(),
                 left.getOffsetMinutes(),
-                right.getPicoSeconds(),
+                right.getPicoseconds(),
                 right.getOffsetMinutes());
     }
 
@@ -225,9 +225,9 @@ class LongTimeWithTimeZoneType
     private static boolean lessThanOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return lessThan(
-                left.getPicoSeconds(),
+                left.getPicoseconds(),
                 left.getOffsetMinutes(),
-                right.getPicoSeconds(),
+                right.getPicoseconds(),
                 right.getOffsetMinutes());
     }
 
@@ -250,9 +250,9 @@ class LongTimeWithTimeZoneType
     private static boolean lessThanOrEqualOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return lessThanOrEqual(
-                left.getPicoSeconds(),
+                left.getPicoseconds(),
                 left.getOffsetMinutes(),
-                right.getPicoSeconds(),
+                right.getPicoseconds(),
                 right.getOffsetMinutes());
     }
 

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestamp.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestamp.java
@@ -23,7 +23,7 @@ public final class LongTimestamp
     private static final int PICOSECONDS_PER_MICROSECOND = 1_000_000;
 
     private final long epochMicros;
-    private final int picosOfMicro; // number of picoSeconds of the microsecond corresponding to epochMicros. It represents an increment towards the positive side.
+    private final int picosOfMicro; // number of picoseconds of the microsecond corresponding to epochMicros. It represents an increment towards the positive side.
 
     public LongTimestamp(long epochMicros, int picosOfMicro)
     {

--- a/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZone.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/LongTimestampWithTimeZone.java
@@ -21,7 +21,7 @@ public final class LongTimestampWithTimeZone
         implements Comparable<LongTimestampWithTimeZone>
 {
     private final long epochMillis;
-    private final int picosOfMilli; // number of picoSeconds of the millisecond corresponding to epochMillis
+    private final int picosOfMilli; // number of picoseconds of the millisecond corresponding to epochMillis
     private final short timeZoneKey;
 
     public static LongTimestampWithTimeZone fromEpochSecondsAndFraction(long epochSecond, long fractionInPicos, TimeZoneKey timeZoneKey)

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TimeWithTimeZoneTypes.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TimeWithTimeZoneTypes.java
@@ -58,6 +58,6 @@ public final class TimeWithTimeZoneTypes
      */
     static long normalize(LongTimeWithTimeZone time)
     {
-        return floorMod(time.getPicoSeconds() - time.getOffsetMinutes() * PICOSECONDS_PER_MINUTE, PICOSECONDS_PER_DAY);
+        return floorMod(time.getPicoseconds() - time.getOffsetMinutes() * PICOSECONDS_PER_MINUTE, PICOSECONDS_PER_DAY);
     }
 }


### PR DESCRIPTION
Also, change `picosecondOfMilli` to `picosOfMilli` as we usually write
this.