### PR TITLE
Update AWS SDK to 1.11.921

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dep.antlr.version>4.9</dep.antlr.version>
         <dep.airlift.version>201</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.11.749</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.11.921</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.17.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>


### PR DESCRIPTION
We believe we are observing
https://issues.apache.org/jira/browse/HTTPCORE-567 regarding
http connection leased by AWS S3 client at one of Presto installations.
Bumping AWS SDK pulls in newer httpclient dependency which should be
free of that issue.