### PR TITLE
Move testInsertWithCoercion to engine-only tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,13 @@
 
             <dependency>
                 <groupId>io.prestosql</groupId>
+                <artifactId>presto-memory</artifactId>
+                <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestosql</groupId>
                 <artifactId>presto-memory-context</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/io/prestosql/plugin/accumulo/TestAccumuloDistributedQueries.java
@@ -161,12 +161,6 @@ public class TestAccumuloDistributedQueries
         assertUpdate("DROP TABLE test_insert");
     }
 
-    @Override
-    public void testInsertWithCoercion()
-    {
-        // Override because of non-canonical varchar mapping
-    }
-
     @Override // Overridden because we currently do not support arrays with null elements
     public void testInsertArray()
     {

--- a/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
+++ b/presto-cassandra/src/test/java/io/prestosql/plugin/cassandra/BaseCassandraDistributedQueries.java
@@ -83,15 +83,6 @@ public abstract class BaseCassandraDistributedQueries
     }
 
     @Override
-    public void testInsertWithCoercion()
-    {
-        // TODO
-        assertThatThrownBy(super::testInsertWithCoercion)
-                .hasMessage("unsupported type: decimal(5,3)");
-        throw new SkipException("TODO change test to use supported types");
-    }
-
-    @Override
     public void testInsertArray()
     {
         // TODO

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergDistributed.java
@@ -64,12 +64,6 @@ public class TestIcebergDistributed
     }
 
     @Override
-    public void testInsertWithCoercion()
-    {
-        // Iceberg does not support parameterized varchar
-    }
-
-    @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getPrestoTypeName();

--- a/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
+++ b/presto-kudu/src/test/java/io/prestosql/plugin/kudu/TestKuduDistributedQueries.java
@@ -117,12 +117,6 @@ public class TestKuduDistributedQueries
     }
 
     @Override
-    public void testInsertWithCoercion()
-    {
-        // Override because of non-canonical varchar mapping
-    }
-
-    @Override
     public void testDelete()
     {
         // TODO Support these test once kudu connector can create tables with default partitions

--- a/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/io/prestosql/plugin/mysql/TestMySqlDistributedQueries.java
@@ -121,12 +121,6 @@ public class TestMySqlDistributedQueries
     }
 
     @Override
-    public void testInsertWithCoercion()
-    {
-        // this connector uses a non-canonical type for varchar columns in tpch
-    }
-
-    @Override
     protected boolean isColumnNameRejected(Exception exception, String columnName, boolean delimited)
     {
         return nullToEmpty(exception.getMessage()).matches(".*(Incorrect column name).*");

--- a/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseTestOracleDistributedQueries.java
+++ b/presto-oracle/src/test/java/io/prestosql/plugin/oracle/BaseTestOracleDistributedQueries.java
@@ -281,46 +281,6 @@ public abstract class BaseTestOracleDistributedQueries
         // unicode not working correctly as one unicode char takes more than one byte
     }
 
-    @Test
-    @Override
-    public void testInsertWithCoercion()
-    {
-        assertUpdate("CREATE TABLE test_insert_with_coercion (" +
-                "tinyint_column TINYINT, " +
-                "integer_column INTEGER, " +
-                "decimal_column DECIMAL(5, 3), " +
-                "real_column REAL, " +
-                "char_column CHAR(3), " +
-                "bounded_varchar_column VARCHAR(3), " +
-                "unbounded_varchar_column VARCHAR, " +
-                "date_column DATE)");
-
-        assertUpdate("INSERT INTO test_insert_with_coercion (tinyint_column, integer_column, decimal_column, real_column) VALUES (1e0, 2e0, 3e0, 4e0)", 1);
-        assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST('aa     ' AS varchar), CAST('aa     ' AS varchar), CAST('aa     ' AS varchar))", 1);
-        assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (NULL, NULL, NULL)", 1);
-        assertUpdate("INSERT INTO test_insert_with_coercion (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST(NULL AS varchar), CAST(NULL AS varchar), CAST(NULL AS varchar))", 1);
-        // Note this case does not actually require coercion, because the `date_column` ends up as Oracle's DATE, which is mapped to Presto's TIMESTAMP.
-        // The test case is still retained for black box testing purposes.
-        assertUpdate("INSERT INTO test_insert_with_coercion (date_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')", 1);
-
-        // at oracle date field has time part to
-        assertQuery(
-                "SELECT * FROM test_insert_with_coercion",
-                "VALUES " +
-                        "(1, 2, 3, 4, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, 'aa ', 'aa ', 'aa     ', NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, TIMESTAMP '2019-11-18 22:13:40')");
-
-        // this wont fail
-        //assertQueryFails("INSERT INTO test_insert_with_coercion (integer_column) VALUES (3e9)", "Out of range for integer: 3.0E9");
-        assertQueryFails("INSERT INTO test_insert_with_coercion (char_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
-        assertQueryFails("INSERT INTO test_insert_with_coercion (bounded_varchar_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to varchar(3) on INSERT");
-
-        assertUpdate("DROP TABLE test_insert_with_coercion");
-    }
-
     @Override
     protected Optional<String> filterColumnNameTestData(String columnName)
     {

--- a/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorDistributedQueries.java
+++ b/presto-raptor-legacy/src/test/java/io/prestosql/plugin/raptor/legacy/TestRaptorDistributedQueries.java
@@ -52,12 +52,6 @@ public class TestRaptorDistributedQueries
     }
 
     @Override
-    public void testInsertWithCoercion()
-    {
-        // No support for char type
-    }
-
-    @Override
     public void testCreateSchema()
     {
         // schema creation is not supported

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestDistributedQueries.java
@@ -551,43 +551,6 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
-    public void testInsertWithCoercion()
-    {
-        String tableName = "test_insert_with_coercion_" + randomTableSuffix();
-
-        assertUpdate("CREATE TABLE " + tableName + " (" +
-                "tinyint_column TINYINT, " +
-                "integer_column INTEGER, " +
-                "decimal_column DECIMAL(5, 3), " +
-                "real_column REAL, " +
-                "char_column CHAR(3), " +
-                "bounded_varchar_column VARCHAR(3), " +
-                "unbounded_varchar_column VARCHAR, " +
-                "date_column DATE)");
-
-        assertUpdate("INSERT INTO " + tableName + " (tinyint_column, integer_column, decimal_column, real_column) VALUES (1e0, 2e0, 3e0, 4e0)", 1);
-        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST('aa     ' AS varchar), CAST('aa     ' AS varchar), CAST('aa     ' AS varchar))", 1);
-        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (NULL, NULL, NULL)", 1);
-        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST(NULL AS varchar), CAST(NULL AS varchar), CAST(NULL AS varchar))", 1);
-        assertUpdate("INSERT INTO " + tableName + " (date_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')", 1);
-
-        assertQuery(
-                "SELECT * FROM " + tableName,
-                "VALUES " +
-                        "(1, 2, 3, 4, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, 'aa ', 'aa ', 'aa     ', NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
-                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, DATE '2019-11-18')");
-
-        assertQueryFails("INSERT INTO " + tableName + " (integer_column) VALUES (3e9)", "Out of range for integer: 3.0E9");
-        assertQueryFails("INSERT INTO " + tableName + " (char_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
-        assertQueryFails("INSERT INTO " + tableName + " (bounded_varchar_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to varchar(3) on INSERT");
-
-        assertUpdate("DROP TABLE " + tableName);
-    }
-
-    @Test
     public void testInsertUnicode()
     {
         String tableName = "test_insert_unicode_" + randomTableSuffix();

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -184,6 +184,13 @@
 
         <dependency>
             <groupId>io.prestosql</groupId>
+            <artifactId>presto-memory</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
             <artifactId>presto-resource-group-managers</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
@@ -14,8 +14,8 @@
 package io.prestosql.tests;
 
 import io.prestosql.Session;
+import io.prestosql.plugin.memory.MemoryQueryRunner;
 import io.prestosql.testing.QueryRunner;
-import io.prestosql.tests.tpch.TpchQueryRunnerBuilder;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
@@ -32,7 +32,18 @@ public class TestDistributedEngineOnlyQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return TpchQueryRunnerBuilder.builder().build();
+        return MemoryQueryRunner.createQueryRunner();
+    }
+
+    /**
+     * Ensure the tests are run with {@link io.prestosql.testing.DistributedQueryRunner}. E.g. {@link io.prestosql.testing.LocalQueryRunner} takes some
+     * shortcuts, not exercising certain aspects.
+     */
+    @Test
+    public void ensureDistributedQueryRunner()
+    {
+        assertThat(getQueryRunner().getNodeCount()).as("query runner node count")
+                .isGreaterThanOrEqualTo(3);
     }
 
     @Test

--- a/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestDistributedEngineOnlyQueries.java
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime;
 
 import static io.prestosql.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.prestosql.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
+import static io.prestosql.testing.sql.TestTable.randomTableSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDistributedEngineOnlyQueries
@@ -158,5 +159,42 @@ public class TestDistributedEngineOnlyQueries
         assertExplainAnalyze(
                 "EXPLAIN ANALYZE SELECT nationkey FROM nation GROUP BY nationkey",
                 "Collisions avg\\.: .* \\(.* est\\.\\), Collisions std\\.dev\\.: .*");
+    }
+
+    @Test
+    public void testInsertWithCoercion()
+    {
+        String tableName = "test_insert_with_coercion_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (" +
+                "tinyint_column tinyint, " +
+                "integer_column integer, " +
+                "decimal_column decimal(5, 3), " +
+                "real_column real, " +
+                "char_column char(3), " +
+                "bounded_varchar_column varchar(3), " +
+                "unbounded_varchar_column varchar, " +
+                "date_column date)");
+
+        assertUpdate("INSERT INTO " + tableName + " (tinyint_column, integer_column, decimal_column, real_column) VALUES (1e0, 2e0, 3e0, 4e0)", 1);
+        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST('aa     ' AS varchar), CAST('aa     ' AS varchar), CAST('aa     ' AS varchar))", 1);
+        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (NULL, NULL, NULL)", 1);
+        assertUpdate("INSERT INTO " + tableName + " (char_column, bounded_varchar_column, unbounded_varchar_column) VALUES (CAST(NULL AS varchar), CAST(NULL AS varchar), CAST(NULL AS varchar))", 1);
+        assertUpdate("INSERT INTO " + tableName + " (date_column) VALUES (TIMESTAMP '2019-11-18 22:13:40')", 1);
+
+        assertQuery(
+                "SELECT * FROM " + tableName,
+                "VALUES " +
+                        "(1, 2, 3, 4, NULL, NULL, NULL, NULL), " +
+                        "(NULL, NULL, NULL, NULL, 'aa ', 'aa ', 'aa     ', NULL), " +
+                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
+                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL), " +
+                        "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, DATE '2019-11-18')");
+
+        assertQueryFails("INSERT INTO " + tableName + " (integer_column) VALUES (3e9)", "Out of range for integer: 3.0E9");
+        assertQueryFails("INSERT INTO " + tableName + " (char_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
+        assertQueryFails("INSERT INTO " + tableName + " (bounded_varchar_column) VALUES ('abcd')", "\\QCannot truncate non-space characters when casting from varchar(4) to varchar(3) on INSERT");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 }


### PR DESCRIPTION
The coercion during insert is applied exclusively by the engine, so
there currently is no need to exercise the test against connectors.
